### PR TITLE
[M] Added support for cloud registration (ENT-3213) (ENT-3214)

### DIFF
--- a/common/src/main/java/org/candlepin/common/exceptions/NotImplementedException.java
+++ b/common/src/main/java/org/candlepin/common/exceptions/NotImplementedException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.common.exceptions;
+
+import javax.ws.rs.core.Response.Status;
+
+
+/**
+ * NotImplementedException
+ * Represents a Not Implemented (HTTP 501) error.
+ */
+public class NotImplementedException extends CandlepinException {
+    public NotImplementedException(String message) {
+        super(Status.NOT_IMPLEMENTED, message);
+    }
+
+    public NotImplementedException(String message, Throwable cause) {
+        super(Status.NOT_IMPLEMENTED, message, cause);
+    }
+}

--- a/server/src/main/java/org/candlepin/auth/CloudRegistrationAuth.java
+++ b/server/src/main/java/org/candlepin/auth/CloudRegistrationAuth.java
@@ -1,0 +1,316 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.auth;
+
+import org.candlepin.auth.permissions.OwnerPermission;
+import org.candlepin.auth.permissions.Permission;
+import org.candlepin.common.config.Configuration;
+import org.candlepin.common.config.ConversionException;
+import org.candlepin.common.resteasy.auth.AuthUtil;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.pki.CertificateReader;
+import org.candlepin.service.CloudRegistrationAdapter;
+import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
+import org.candlepin.service.exception.MalformedCloudRegistrationException;
+import org.candlepin.service.model.CloudRegistrationInfo;
+import org.candlepin.util.Util;
+
+import org.jboss.resteasy.spi.HttpRequest;
+import org.keycloak.TokenVerifier;
+import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.KeyUtils;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.AsymmetricSignatureSignerContext;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.representations.JsonWebToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xnap.commons.i18n.I18n;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.ws.rs.core.Context;
+
+
+
+/**
+ * AuthenticationProvider that accepts an {@link AccessToken} generated from an earlier call to the
+ * CloudRegistration authorize endpoint
+ */
+public class CloudRegistrationAuth implements AuthProvider {
+    private static Logger log = LoggerFactory.getLogger(CloudRegistrationAuth.class);
+
+    private static final String TOKEN_ALGORITHM = Algorithm.RS512;
+    private static final String TOKEN_SUBJECT_DEFAULT = "cloud_auth";
+    private static final String AUTH_TYPE = "Bearer";
+    private static final String TOKEN_TYPE = "CP-Cloud-Registration";
+
+    @Context private ServletRequest servletRequest;
+    @Context private ServletResponse servletResponse;
+
+    private final Configuration config;
+    private final Provider<I18n> i18nProvider;
+    private final CertificateReader certificateReader;
+    private final CloudRegistrationAdapter cloudRegistrationAdapter;
+    private final OwnerCurator ownerCurator;
+
+    private final boolean enabled;
+    private final String jwtIssuer;
+    private final int jwtTokenTTL; // seconds
+
+    private final X509Certificate certificate;
+    private final PublicKey publicKey;
+    private final PrivateKey privateKey;
+
+
+    @Inject
+    public CloudRegistrationAuth(Configuration config, Provider<I18n> i18nProvider,
+        CertificateReader certificateReader, CloudRegistrationAdapter cloudRegistrationAdapter,
+        OwnerCurator ownerCurator) {
+
+        this.config = Objects.requireNonNull(config);
+        this.i18nProvider = Objects.requireNonNull(i18nProvider);
+        this.certificateReader = Objects.requireNonNull(certificateReader);
+        this.cloudRegistrationAdapter = Objects.requireNonNull(cloudRegistrationAdapter);
+        this.ownerCurator = Objects.requireNonNull(ownerCurator);
+
+        // Pre-parse config values we'll be using a bunch
+        try {
+            this.enabled = this.config.getBoolean(ConfigProperties.CLOUD_AUTHENTICATION);
+
+            this.jwtIssuer = this.config.getProperty(ConfigProperties.JWT_ISSUER);
+            this.jwtTokenTTL = this.config.getInt(ConfigProperties.JWT_TOKEN_TTL);
+        }
+        catch (ConversionException e) {
+            // Try to pretty up the exception for easy debugging
+            throw new RuntimeException("Invalid value(s) found while parsing JWT configuration", e);
+        }
+
+        // Fetch our keys
+        try {
+            this.certificate = this.certificateReader.getCACert();
+            this.publicKey = this.certificate.getPublicKey();
+            this.privateKey = this.certificateReader.getCaKey();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Unable to load public and private keys", e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Principal getPrincipal(HttpRequest httpRequest) {
+        if (!this.enabled) {
+            // If cloud auth isn't enabled, don't even attempt to validate anything
+            return null;
+        }
+
+        String auth = AuthUtil.getHeader(httpRequest, "Authorization");
+        if (auth.isEmpty()) {
+            // Auth header is empty; no type or token provided
+            return null;
+        }
+
+        String[] authChunks = auth.split(" ");
+        if (!AUTH_TYPE.equalsIgnoreCase(authChunks[0]) || authChunks.length != 2) {
+            // Not a type we handle; ignore it and hope another auth filter picks it up
+            return null;
+        }
+
+        try {
+            TokenVerifier<JsonWebToken> verifier = TokenVerifier.create(authChunks[1], JsonWebToken.class)
+                .publicKey(publicKey)
+                .verify();
+
+            JsonWebToken token = verifier.getToken();
+            String[] audiences = token.getAudience();
+
+            // Verify that the token is active and hasn't expired
+            if (!token.isActive()) {
+                throw new VerificationException("Token is not active or has expired");
+            }
+
+            // Verify the token has the JWT type we're expecting
+            if (TOKEN_TYPE.equalsIgnoreCase(token.getType())) {
+                // Pull the subject (username) and owner key(s) out of the token
+                String subject = token.getSubject();
+                String ownerKey = audiences != null && audiences.length > 0 ? audiences[0] : null;
+
+                if (subject == null || subject.isEmpty()) {
+                    throw new VerificationException("Token contains an invalid subject: " + subject);
+                }
+
+                if (ownerKey == null || ownerKey.isEmpty()) {
+                    throw new VerificationException("Token contains an invalid audience: " + ownerKey);
+                }
+
+                return this.createCloudUserPrincipal(subject, ownerKey);
+            }
+        }
+        catch (VerificationException e) {
+            log.debug("Cloud registration token validation failed:", e);
+
+            // Impl note:
+            // Since we're using a common/standard auth type (bearer), we can't immediately fail
+            // out here, as it's possible the token will be verified by another provider
+        }
+
+        return null;
+    }
+
+    /**
+     * Creates a dummy user principal with the minimum amount of information and access to complete
+     * a user registration. The username of the principal will be the subject provided.
+     *
+     * @param subject
+     *  the subject for which to create the principal; will be used as the username
+     *
+     * @param ownerKey
+     *  the key of an organization in which the principal will have authorization to register
+     *  clients
+     *
+     * @return
+     *  a minimal UserPrincipal representing the cloud registration token
+     */
+    private UserPrincipal createCloudUserPrincipal(String subject, String ownerKey) {
+        Owner owner = this.ownerCurator.getByKey(ownerKey);
+        if (owner == null) {
+            // If the owner does not exist, we might be creating it on client registration, so
+            // make a fake owner to pass into our permission object
+            owner = new Owner(ownerKey, ownerKey);
+        }
+
+        List<Permission> permissions = Arrays.asList(
+            new OwnerPermission(owner, Access.CREATE)
+            // Add any additional permissions here as needed
+        );
+
+        return new UserPrincipal(subject, permissions, false);
+    }
+
+    /**
+     * Validates the provided cloud registration information, and generates a registration token if
+     * valid
+     *
+     * @param principal
+     *  the principal for which to generate the token
+     *
+     * @param cloudRegistrationInfo
+     *  The registration information to validate
+     *
+     * @throws UnsupportedOperationException
+     *  if the current Candlepin configuration does not support cloud registration
+     *
+     * @throws CloudRegistrationAuthorizationException
+     *  if cloud registration is not permitted for the cloud provider or account holder specified by
+     *  the cloud registration details
+     *
+     * @throws MalformedCloudRegistrationException
+     *  if the cloud registration details are null, incomplete, or malformed
+     *
+     * @return
+     *  a registration token to be used for completing registration for the client identified by the
+     *  specified cloud registration details
+     */
+    public String generateRegistrationToken(Principal principal, CloudRegistrationInfo cloudRegistrationInfo)
+        throws CloudRegistrationAuthorizationException, MalformedCloudRegistrationException {
+
+        if (principal == null) {
+            throw new IllegalArgumentException("principal is null");
+        }
+
+        if (cloudRegistrationInfo == null) {
+            throw new IllegalArgumentException("cloudRegistrationInfo is null");
+        }
+
+        String ownerKey = this.cloudRegistrationAdapter.resolveCloudRegistrationData(cloudRegistrationInfo);
+        if (ownerKey == null) {
+            String errmsg = this.i18nProvider.get()
+                .tr("cloud provider or account details could not be resolved to an organization");
+
+            throw new CloudRegistrationAuthorizationException(errmsg);
+        }
+
+        return this.buildRegistrationToken(principal, ownerKey);
+    }
+
+    /**
+     * Creates a new cloud registration token for the specific owner key. The owner/organization
+     * will be set as the subject of the token, and need not explicitly exist locally in Candlepin.
+     *
+     * @param principal
+     *  the principal for which the token will be generated
+     *
+     * @param ownerKey
+     *  The key of the owner/organization for which the token will be generated
+     *
+     * @return
+     *  an encrypted JWT token string
+     */
+    private String buildRegistrationToken(Principal principal, String ownerKey) {
+        String keyId = KeyUtils.createKeyId(this.publicKey);
+
+        // Try to use the username present in the principal; otherwise use the default
+        String username = principal.getUsername();
+        if (username == null) {
+            username = TOKEN_SUBJECT_DEFAULT;
+        }
+
+        KeyWrapper wrapper = new KeyWrapper();
+        wrapper.setAlgorithm(TOKEN_ALGORITHM);
+        wrapper.setCertificate(this.certificate);
+        wrapper.setKid(keyId);
+        wrapper.setPrivateKey(this.privateKey);
+        wrapper.setPublicKey(this.publicKey);
+        wrapper.setUse(KeyUse.SIG);
+        wrapper.setType(KeyType.RSA);
+
+        int ctSeconds = (int) (System.currentTimeMillis() / 1000);
+
+        JsonWebToken token = new JsonWebToken()
+            .id(Util.generateUUID())
+            .type(TOKEN_TYPE)
+            .issuer(this.jwtIssuer)
+            .subject(username)
+            .audience(ownerKey)
+            .issuedAt(ctSeconds)
+            .expiration(ctSeconds + this.jwtTokenTTL)
+            .notBefore(ctSeconds);
+
+        return new JWSBuilder()
+            .kid(keyId)
+            .type("JWT")
+            .jsonContent(token)
+            .sign(new AsymmetricSignatureSignerContext(wrapper));
+    }
+
+}

--- a/server/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
@@ -29,6 +29,9 @@ import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 
 import java.io.Serializable;
+import java.util.Objects;
+
+
 
 /**
  * A permission represents an owner to be accessed in some fashion, and a verb which
@@ -50,7 +53,9 @@ public class OwnerPermission implements Permission, Serializable {
     public boolean canAccess(Object target, SubResource subResource, Access requiredAccess) {
         if (target instanceof Owned) {
             // First make sure the owner matches:
-            if (owner.getId().equals(((Owned) target).getOwnerId()) && access.provides(requiredAccess)) {
+            if (Objects.equals(owner.getId(), ((Owned) target).getOwnerId()) &&
+                access.provides(requiredAccess)) {
+
                 return true;
             }
         }

--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -135,6 +135,11 @@ public class ConfigProperties {
     public static final String OAUTH_AUTHENTICATION = "candlepin.auth.oauth.enable";
     public static final String BASIC_AUTHENTICATION = "candlepin.auth.basic.enable";
     public static final String KEYCLOAK_AUTHENTICATION = "candlepin.auth.keycloak.enable";
+    public static final String CLOUD_AUTHENTICATION = "candlepin.auth.cloud.enable";
+
+    // JWT configuration
+    public static final String JWT_ISSUER = "candlepin.jwt.issuer";
+    public static final String JWT_TOKEN_TTL = "candlepin.jwt.token_ttl";
 
     /**
      * A possibility to enable Suspend Mode. By default, the suspend mode is enabled
@@ -359,6 +364,9 @@ public class ConfigProperties {
         {
             this.put(CANDLEPIN_URL, "https://localhost");
 
+            this.put(JWT_ISSUER, "Candlepin");
+            this.put(JWT_TOKEN_TTL, "600"); // seconds
+
             this.put(CA_KEY, "/etc/candlepin/certs/candlepin-ca.key");
             this.put(CA_CERT, "/etc/candlepin/certs/candlepin-ca.crt");
             this.put(CA_CERT_UPSTREAM, "/etc/candlepin/certs/upstream");
@@ -368,7 +376,6 @@ public class ConfigProperties {
             this.put(CPM_PROVIDER, "artemis");
 
             this.put(ACTIVEMQ_ENABLED, "true");
-
             this.put(ACTIVEMQ_EMBEDDED, "true");
 
             // TODO: Delete the above configuration and only use EMBEDDED_BROKER going forward.
@@ -435,6 +442,8 @@ public class ConfigProperties {
             this.put(OAUTH_AUTHENTICATION, "false");
             this.put(KEYCLOAK_AUTHENTICATION, "false");
             this.put(BASIC_AUTHENTICATION, "true");
+            this.put(CLOUD_AUTHENTICATION, "false");
+
             this.put(AUTH_OVER_HTTP, "false");
             // By default, environments should be hidden so clients do not need to
             // submit one when registering.

--- a/server/src/main/java/org/candlepin/dto/api/v1/CloudRegistrationDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/CloudRegistrationDTO.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.CandlepinDTO;
+import org.candlepin.service.model.CloudRegistrationInfo;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+
+
+/**
+ * The CloudRegistrationDTO contains fields for performing automatic cloud-based registration.
+ */
+public class CloudRegistrationDTO extends CandlepinDTO<CloudRegistrationDTO>
+    implements CloudRegistrationInfo {
+
+    private String type;
+    private String metadata;
+    private String signature;
+
+    /**
+     * Creates a new CloudRegistrationDTO instance with no values set
+     */
+    public CloudRegistrationDTO() {
+        // Intentionally left empty
+    }
+
+    /**
+     * Initializes a new CloudRegistrationDTO instance which is a shallow copy of the provided
+     * source entity.
+     *
+     * @param source
+     *  The source entity to copy
+     */
+    public CloudRegistrationDTO(CloudRegistrationDTO source) {
+        this.populate(source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getType() {
+        return this.type;
+    }
+
+    /**
+     * Sets or clears the cloud provider type
+     *
+     * @param type
+     *  the cloud provider type
+     *
+     * @return
+     *  a reference to this CloudRegistrationDTO
+     */
+    public CloudRegistrationDTO setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getMetadata() {
+        return this.metadata;
+    }
+
+    /**
+     * Sets or clears the registration metadata
+     *
+     * @param metadata
+     *  the cloud registration metadata, such as the account holder identifiers or licenses
+     *
+     * @return
+     *  a reference to this CloudRegistrationDTO
+     */
+    public CloudRegistrationDTO setMetadata(String metadata) {
+        this.metadata = metadata;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getSignature() {
+        return this.signature;
+    }
+
+    /**
+     * Sets or clears the cloud provider's signature
+     *
+     * @param signature
+     *  the cloud provider's signature
+     *
+     * @return
+     *  a reference to this CloudRegistrationDTO
+     */
+    public CloudRegistrationDTO setSignature(String signature) {
+        this.signature = signature;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return String.format("CloudRegistrationDTO [type: %s, metadata: %s]",
+            this.getType(), this.getMetadata());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof CloudRegistrationDTO) {
+            CloudRegistrationDTO that = (CloudRegistrationDTO) obj;
+
+            EqualsBuilder builder = new EqualsBuilder()
+                .append(this.getType(), that.getType())
+                .append(this.getMetadata(), that.getMetadata())
+                .append(this.getSignature(), that.getSignature());
+
+            return builder.isEquals();
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(this.getType())
+            .append(this.getMetadata())
+            .append(this.getSignature());
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CloudRegistrationDTO populate(CloudRegistrationDTO source) {
+        if (source == null) {
+            throw new IllegalArgumentException("source is null");
+        }
+
+        this.setType(source.getType());
+        this.setMetadata(source.getMetadata());
+        this.setSignature(source.getSignature());
+
+        return this;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -119,6 +119,7 @@ import org.candlepin.resource.ActivationKeyResource;
 import org.candlepin.resource.AdminResource;
 import org.candlepin.resource.CdnResource;
 import org.candlepin.resource.CertificateSerialResource;
+import org.candlepin.resource.CloudRegistrationResource;
 import org.candlepin.resource.ConsumerContentOverrideResource;
 import org.candlepin.resource.ConsumerResource;
 import org.candlepin.resource.ConsumerTypeResource;
@@ -324,6 +325,7 @@ public class CandlepinModule extends AbstractModule {
         bind(AdminResource.class);
         bind(CdnResource.class);
         bind(CertificateSerialResource.class);
+        bind(CloudRegistrationResource.class);
         bind(CrlResource.class);
         bind(ConsumerContentOverrideResource.class);
         bind(ConsumerResource.class);

--- a/server/src/main/java/org/candlepin/guice/DefaultConfig.java
+++ b/server/src/main/java/org/candlepin/guice/DefaultConfig.java
@@ -16,6 +16,7 @@ package org.candlepin.guice;
 
 import org.candlepin.pki.SubjectKeyIdentifierWriter;
 import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
+import org.candlepin.service.CloudRegistrationAdapter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.service.ExportExtensionAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
@@ -23,6 +24,7 @@ import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.impl.DefaultCloudRegistrationAdapter;
 import org.candlepin.service.impl.DefaultEntitlementCertServiceAdapter;
 import org.candlepin.service.impl.DefaultExportExtensionAdapter;
 import org.candlepin.service.impl.DefaultIdentityCertServiceAdapter;
@@ -55,5 +57,6 @@ class DefaultConfig extends AbstractModule {
         bind(ManifestFileService.class).to(DBManifestService.class);
         bind(ExportExtensionAdapter.class).to(DefaultExportExtensionAdapter.class);
         bind(SubscriptionServiceAdapter.class).to(ImportSubscriptionServiceAdapter.class);
+        bind(CloudRegistrationAdapter.class).to(DefaultCloudRegistrationAdapter.class);
     }
 }

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -199,9 +199,13 @@ public class Owner extends AbstractHibernateObject<Owner>
 
     /**
      * @param id the id to set
+     *
+     * @return
+     *  a reference to this Owner instnace
      */
-    public void setId(String id) {
+    public Owner setId(String id) {
         this.id = id;
+        return this;
     }
 
     @InfoProperty("key")
@@ -210,8 +214,9 @@ public class Owner extends AbstractHibernateObject<Owner>
         return key;
     }
 
-    public void setKey(String key) {
+    public Owner setKey(String key) {
         this.key = key;
+        return this;
     }
 
     /**
@@ -225,9 +230,13 @@ public class Owner extends AbstractHibernateObject<Owner>
 
     /**
      * @param displayName the name to set
+     *
+     * @return
+     *  a reference to this Owner instnace
      */
-    public void setDisplayName(String displayName) {
+    public Owner setDisplayName(String displayName) {
         this.displayName = displayName;
+        return this;
     }
 
     /**
@@ -239,9 +248,13 @@ public class Owner extends AbstractHibernateObject<Owner>
 
     /**
      * @param contentPrefix the prefix to set
+     *
+     * @return
+     *  a reference to this Owner instnace
      */
-    public void setContentPrefix(String contentPrefix) {
+    public Owner setContentPrefix(String contentPrefix) {
         this.contentPrefix = contentPrefix;
+        return this;
     }
 
     /**
@@ -253,9 +266,13 @@ public class Owner extends AbstractHibernateObject<Owner>
 
     /**
      * @param lastRefreshed the date to set the lastRefreshed value to
+     *
+     * @return
+     *  a reference to this Owner instnace
      */
-    public void setLastRefreshed(Date lastRefreshed) {
+    public Owner setLastRefreshed(Date lastRefreshed) {
         this.lastRefreshed = lastRefreshed;
+        return this;
     }
 
     /**
@@ -268,9 +285,13 @@ public class Owner extends AbstractHibernateObject<Owner>
 
     /**
      * @param consumers the consumers to set
+     *
+     * @return
+     *  a reference to this Owner instnace
      */
-    public void setConsumers(Set<Consumer> consumers) {
+    public Owner setConsumers(Set<Consumer> consumers) {
         this.consumers = consumers;
+        return this;
     }
 
     /**
@@ -283,9 +304,13 @@ public class Owner extends AbstractHibernateObject<Owner>
 
     /**
      * @param entitlementPools the entitlementPools to set
+     *
+     * @return
+     *  a reference to this Owner instnace
      */
-    public void setPools(Set<Pool> entitlementPools) {
+    public Owner setPools(Set<Pool> entitlementPools) {
         this.pools = entitlementPools;
+        return this;
     }
 
     /**
@@ -385,12 +410,17 @@ public class Owner extends AbstractHibernateObject<Owner>
 
     /**
      * @param upstream the upstream consumer to set
+     *
+     * @return
+     *  a reference to this Owner instnace
      */
-    public void setUpstreamConsumer(UpstreamConsumer upstream) {
+    public Owner setUpstreamConsumer(UpstreamConsumer upstream) {
         this.upstreamConsumer = upstream;
         if (upstream != null) {
             upstream.setOwnerId(id);
         }
+
+        return this;
     }
 
     /**
@@ -406,7 +436,7 @@ public class Owner extends AbstractHibernateObject<Owner>
     }
 
     /**
-     * @return the
+     * @return the upstream consumer for this owner
      */
     public UpstreamConsumer getUpstreamConsumer() {
         return upstreamConsumer;
@@ -417,19 +447,21 @@ public class Owner extends AbstractHibernateObject<Owner>
         return "/owners/" + getKey();
     }
 
-    public void setHref(String href) {
+    public Owner setHref(String href) {
         /*
          * No-op, here to aid with updating objects which have nested objects
          * that were originally sent down to the client in HATEOAS form.
          */
+        return this;
     }
 
     public Owner getParentOwner() {
         return parentOwner;
     }
 
-    public void setParentOwner(Owner parentOwner) {
+    public Owner setParentOwner(Owner parentOwner) {
         this.parentOwner = parentOwner;
+        return this;
     }
 
     /**
@@ -454,9 +486,13 @@ public class Owner extends AbstractHibernateObject<Owner>
 
     /**
      * @param activationKeys the activationKeys to set
+     *
+     * @return
+     *  a reference to this Owner instnace
      */
-    public void setActivationKeys(Set<ActivationKey> activationKeys) {
+    public Owner setActivationKeys(Set<ActivationKey> activationKeys) {
         this.activationKeys = activationKeys;
+        return this;
     }
 
     @XmlTransient
@@ -464,28 +500,32 @@ public class Owner extends AbstractHibernateObject<Owner>
         return environments;
     }
 
-    public void setEnvironments(Set<Environment> environments) {
+    public Owner setEnvironments(Set<Environment> environments) {
         this.environments = environments;
+        return this;
     }
 
     public String getDefaultServiceLevel() {
         return defaultServiceLevel;
     }
 
-    public void setDefaultServiceLevel(String defaultServiceLevel) {
+    public Owner setDefaultServiceLevel(String defaultServiceLevel) {
         this.defaultServiceLevel = defaultServiceLevel;
+        return this;
     }
 
     public String getLogLevel() {
         return logLevel;
     }
 
-    public void setLogLevel(String logLevel) {
+    public Owner setLogLevel(String logLevel) {
         this.logLevel = logLevel != null && !logLevel.isEmpty() ? logLevel : null;
+        return this;
     }
 
-    public void setLogLevel(Level logLevel) {
+    public Owner setLogLevel(Level logLevel) {
         this.setLogLevel(logLevel != null ? logLevel.name() : null);
+        return this;
     }
 
     @Override
@@ -505,8 +545,9 @@ public class Owner extends AbstractHibernateObject<Owner>
         return this.autobindDisabled != null ? this.autobindDisabled.booleanValue() : false;
     }
 
-    public void setAutobindDisabled(boolean autobindDisabled) {
+    public Owner setAutobindDisabled(boolean autobindDisabled) {
         this.autobindDisabled = autobindDisabled;
+        return this;
     }
 
     /**
@@ -521,8 +562,9 @@ public class Owner extends AbstractHibernateObject<Owner>
            this.autobindHypervisorDisabled.booleanValue() : false;
     }
 
-    public void setAutobindHypervisorDisabled(boolean autobindHypervisorDisabled) {
+    public Owner setAutobindHypervisorDisabled(boolean autobindHypervisorDisabled) {
         this.autobindHypervisorDisabled = autobindHypervisorDisabled;
+        return this;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/User.java
+++ b/server/src/main/java/org/candlepin/model/User.java
@@ -147,9 +147,13 @@ public class User extends AbstractHibernateObject implements UserInfo {
 
     /**
      * @param id the id to set
+     *
+     * @return
+     *  a reference to this User
      */
-    public void setId(String id) {
+    public User setId(String id) {
         this.id = id;
+        return this;
     }
 
     /**
@@ -161,9 +165,13 @@ public class User extends AbstractHibernateObject implements UserInfo {
 
     /**
      * @param username the login to set
+     *
+     * @return
+     *  a reference to this User
      */
-    public void setUsername(String username) {
+    public User setUsername(String username) {
         this.username = username;
+        return this;
     }
 
     /**
@@ -175,17 +183,25 @@ public class User extends AbstractHibernateObject implements UserInfo {
 
     /**
      * Sets the hashed password value.
+     *
+     * @return
+     *  a reference to this User
      */
-    public void setHashedPassword(String hashedPassword) {
+    public User setHashedPassword(String hashedPassword) {
         this.hashedPassword = hashedPassword;
+        return this;
     }
 
     /**
      * @param password the password to set
+     *
+     * @return
+     *  a reference to this User
      */
     @JsonProperty
-    public void setPassword(String password) {
+    public User setPassword(String password) {
         this.hashedPassword = Util.hash(password);
+        return this;
     }
 
     /**
@@ -243,9 +259,13 @@ public class User extends AbstractHibernateObject implements UserInfo {
 
     /**
      * @param superAdmin if the user should have the SUPER_ADMIN role
+     *
+     * @return
+     *  a reference to this User
      */
-    public void setSuperAdmin(boolean superAdmin) {
+    public User setSuperAdmin(boolean superAdmin) {
         this.superAdmin = superAdmin;
+        return this;
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
+++ b/server/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resource;
+
+import org.candlepin.auth.CloudRegistrationAuth;
+import org.candlepin.auth.Principal;
+import org.candlepin.common.auth.SecurityHole;
+import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.common.exceptions.NotAuthorizedException;
+import org.candlepin.common.exceptions.NotImplementedException;
+import org.candlepin.dto.api.v1.CloudRegistrationDTO;
+import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
+import org.candlepin.service.exception.MalformedCloudRegistrationException;
+
+
+import com.google.inject.Inject;
+
+import org.xnap.commons.i18n.I18n;
+
+import java.util.Objects;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+
+
+
+/**
+ * End point(s) for cloud registration token generation
+ */
+@Path("/cloud")
+public class CloudRegistrationResource {
+    private final CloudRegistrationAuth cloudRegistrationAuth;
+
+    private final I18n i18n;
+
+    @Inject
+    public CloudRegistrationResource(I18n i18n, CloudRegistrationAuth cloudRegistrationAuth) {
+        this.i18n = Objects.requireNonNull(i18n);
+        this.cloudRegistrationAuth = Objects.requireNonNull(cloudRegistrationAuth);
+    }
+
+    @POST
+    @Path("authorize")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @SecurityHole(noAuth = true)
+    public String authorize(CloudRegistrationDTO cloudRegDTO,
+        @Context Principal principal) {
+
+        try {
+            return this.cloudRegistrationAuth.generateRegistrationToken(principal, cloudRegDTO);
+        }
+        catch (UnsupportedOperationException e) {
+            String errmsg = this.i18n.tr("Cloud registration is not supported by this Candlepin instance");
+            throw new NotImplementedException(errmsg);
+        }
+        catch (CloudRegistrationAuthorizationException e) {
+            throw new NotAuthorizedException(e.getMessage());
+        }
+        catch (MalformedCloudRegistrationException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+}

--- a/server/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
+++ b/server/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
@@ -16,6 +16,7 @@ package org.candlepin.resteasy.filter;
 
 import org.candlepin.auth.AuthProvider;
 import org.candlepin.auth.BasicAuth;
+import org.candlepin.auth.CloudRegistrationAuth;
 import org.candlepin.auth.KeycloakAuth;
 import org.candlepin.auth.NoAuthPrincipal;
 import org.candlepin.auth.OAuth;
@@ -81,6 +82,7 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         DeletedConsumerCurator deletedConsumerCurator,
         Injector injector,
         AnnotationLocator annotationLocator) {
+
         this.consumerCurator = consumerCurator;
         this.injector = injector;
         this.config = config;
@@ -101,18 +103,27 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         if (config.getBoolean(ConfigProperties.KEYCLOAK_AUTHENTICATION)) {
             providers.add(injector.getInstance(KeycloakAuth.class));
         }
+
+        // Check if the cloud provider/jwt auth should be enabled
+        if (config.getBoolean(ConfigProperties.CLOUD_AUTHENTICATION)) {
+            providers.add(injector.getInstance(CloudRegistrationAuth.class));
+        }
+
         // use oauth
         if (config.getBoolean(ConfigProperties.OAUTH_AUTHENTICATION)) {
             providers.add(injector.getInstance(OAuth.class));
         }
+
         // http basic auth access
         if (config.getBoolean(ConfigProperties.BASIC_AUTHENTICATION)) {
             providers.add(injector.getInstance(BasicAuth.class));
         }
+
         // consumer certificates
         if (config.getBoolean(ConfigProperties.SSL_AUTHENTICATION)) {
             providers.add(injector.getInstance(SSLAuth.class));
         }
+
         // trusted headers
         if (config.getBoolean(ConfigProperties.TRUSTED_AUTHENTICATION)) {
             providers.add(injector.getInstance(TrustedConsumerAuth.class));

--- a/server/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
+++ b/server/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service;
+
+import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
+import org.candlepin.service.exception.MalformedCloudRegistrationException;
+import org.candlepin.service.model.CloudRegistrationInfo;
+
+
+
+/**
+ * The Cloud Registration Adapter provides the interface for verifying and resolving cloud
+ * registration to a specific organization.
+ */
+public interface CloudRegistrationAdapter {
+
+    /**
+     * Resolves the cloud registration details to a specific organization.
+     *
+     * @param cloudRegInfo
+     *  A CloudRegistrationInfo instance which contains the cloud provider details to process
+     *
+     * @throws MalformedCloudRegistrationException
+     *  if the cloud registration info is null, incomplete, or invalid
+     *
+     * @throws CloudRegistrationAuthorizationException
+     *  if cloud registration is not permitted for the provider or account holder
+     *
+     * @return
+     *  the owner key of the owner (organization) to which the cloud user will be registered
+     */
+    String resolveCloudRegistrationData(CloudRegistrationInfo cloudRegInfo)
+        throws CloudRegistrationAuthorizationException, MalformedCloudRegistrationException;
+
+}

--- a/server/src/main/java/org/candlepin/service/exception/CloudRegistrationAuthorizationException.java
+++ b/server/src/main/java/org/candlepin/service/exception/CloudRegistrationAuthorizationException.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception;
+
+
+
+/**
+ * The CloudRegistrationAuthorizationException is used to reject a registration attempt for a
+ * cloud provider or account holder.
+ */
+public class CloudRegistrationAuthorizationException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public CloudRegistrationAuthorizationException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public CloudRegistrationAuthorizationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationAuthorizationException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationAuthorizationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/server/src/main/java/org/candlepin/service/exception/MalformedCloudRegistrationException.java
+++ b/server/src/main/java/org/candlepin/service/exception/MalformedCloudRegistrationException.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception;
+
+
+
+/**
+ * The MalformedCloudRegistrationException is used to denote malformed or incomplete cloud
+ * registration details
+ */
+public class MalformedCloudRegistrationException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public MalformedCloudRegistrationException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public MalformedCloudRegistrationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public MalformedCloudRegistrationException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public MalformedCloudRegistrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/server/src/main/java/org/candlepin/service/impl/DefaultCloudRegistrationAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultCloudRegistrationAdapter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.impl;
+
+import org.candlepin.service.CloudRegistrationAdapter;
+import org.candlepin.service.model.CloudRegistrationInfo;
+
+
+
+/**
+ * The default implementation of the {@link CloudRegistrationAdapter}.
+ *
+ * This implementation always throws an UnsupportedOperationException from all of its methods.
+ */
+public class DefaultCloudRegistrationAdapter implements CloudRegistrationAdapter {
+
+    @Override
+    public String resolveCloudRegistrationData(CloudRegistrationInfo cloudRegInfo) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/server/src/main/java/org/candlepin/service/model/CloudRegistrationInfo.java
+++ b/server/src/main/java/org/candlepin/service/model/CloudRegistrationInfo.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.model;
+
+
+
+/**
+ * The CloudRegistrationInfo represents a minimal set of cloud registration information to be used
+ * for authenticating a given cloud provider and user account for automatic registration in
+ * Candlepin.
+ *
+ * Data which is not set or does not change should be represented by null values. To explicitly
+ * clear a value, an empty string or non-null "empty" value should be used instead.
+ */
+public interface CloudRegistrationInfo {
+
+    /**
+     * Fetches the cloud provider type.
+     *
+     * @return
+     *  the cloud provider type, or null if the provider type has not been set
+     */
+    String getType();
+
+    /**
+     * Fetches the metadata for the cloud provider, such as the user's account identifiers.
+     *
+     * @return
+     *  the cloud provider metadata, or null of the metadata has not been set
+     */
+    String getMetadata();
+
+    /**
+     * Fetches the signature to use for verifying the identity of the cloud provider.
+     *
+     * @return
+     *  the cloud provider's signature, or null if the signature has not been set
+     */
+    String getSignature();
+
+}

--- a/server/src/test/java/org/candlepin/auth/CloudRegistrationAuthTest.java
+++ b/server/src/test/java/org/candlepin/auth/CloudRegistrationAuthTest.java
@@ -1,0 +1,462 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.auth;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+
+import org.candlepin.common.config.Configuration;
+import org.candlepin.config.CandlepinCommonTestConfig;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.dto.api.v1.CloudRegistrationDTO;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.pki.CertificateReader;
+import org.candlepin.pki.impl.JSSPrivateKeyReader;
+import org.candlepin.service.CloudRegistrationAdapter;
+import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
+import org.candlepin.service.model.CloudRegistrationInfo;
+import org.candlepin.util.Util;
+
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.common.util.KeyUtils;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.AsymmetricSignatureSignerContext;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.representations.JsonWebToken;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.inject.Provider;
+
+
+
+
+/**
+ * Test suite for the CloudRegistrationAuth class
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class CloudRegistrationAuthTest {
+    private static final String TOKEN_TYPE = "CP-Cloud-Registration";
+
+    private Configuration config;
+    private I18n i18n;
+    private Provider<I18n> i18nProvider;
+    private CertificateReader certificateReader;
+    private CloudRegistrationAdapter mockCloudRegistrationAdapter;
+    private OwnerCurator mockOwnerCurator;
+
+
+    @BeforeEach
+    public void init() {
+        this.config = new CandlepinCommonTestConfig();
+        this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
+        this.i18nProvider = () -> i18n;
+        this.certificateReader = this.setupCertificateReader();
+
+        this.mockCloudRegistrationAdapter = mock(CloudRegistrationAdapter.class);
+        this.mockOwnerCurator = mock(OwnerCurator.class);
+
+        Map<String, Owner> ownerCache = new HashMap<>();
+
+        doAnswer(iom -> {
+            String ownerKey = (String) iom.getArguments()[0];
+            return ownerCache.computeIfAbsent(ownerKey, key -> new Owner(key, key)
+                .setId(Util.generateUUID()));
+        }).when(this.mockOwnerCurator).getByKey(anyString());
+
+        doAnswer(iom -> {
+            CloudRegistrationInfo cinfo = (CloudRegistrationInfo) iom.getArguments()[0];
+            return cinfo != null ? cinfo.getType() : null;
+        }).when(this.mockCloudRegistrationAdapter)
+            .resolveCloudRegistrationData(any(CloudRegistrationInfo.class));
+
+        // Default the cloud auth feature to true for most tests
+        this.config.setProperty(ConfigProperties.CLOUD_AUTHENTICATION, "true");
+    }
+
+    private CertificateReader setupCertificateReader() {
+        try {
+            ClassLoader loader = getClass().getClassLoader();
+            String caCert = loader.getResource("test-ca.crt").toURI().getPath();
+            String caKey = loader.getResource("test-ca.key").toURI().getPath();
+
+            this.config.setProperty(ConfigProperties.CA_CERT, caCert);
+            this.config.setProperty(ConfigProperties.CA_KEY, caKey);
+            this.config.setProperty(ConfigProperties.CA_KEY_PASSWORD, "password");
+
+            return new CertificateReader(config, new JSSPrivateKeyReader());
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CloudRegistrationAuth buildAuthProvider() {
+        return new CloudRegistrationAuth(this.config, this.i18nProvider, this.certificateReader,
+            this.mockCloudRegistrationAdapter, this.mockOwnerCurator);
+    }
+
+    private CloudRegistrationInfo buildCloudRegistrationInfo(String type, String metadata, String signature) {
+        return new CloudRegistrationDTO()
+            .setType(type)
+            .setMetadata(metadata)
+            .setSignature(signature);
+    }
+
+    private MockHttpRequest buildHttpRequest() {
+        try {
+            return MockHttpRequest.create("GET", "http://localhost/candlepin/status");
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private int getCurrentSeconds() {
+        return  (int) (System.currentTimeMillis() / 1000);
+    }
+
+    private String buildMalformedToken(JsonWebToken token) {
+        X509Certificate certificate;
+        PublicKey publicKey;
+        PrivateKey privateKey;
+
+        // Fetch our keys
+        try {
+            certificate = this.certificateReader.getCACert();
+            publicKey = certificate.getPublicKey();
+            privateKey = this.certificateReader.getCaKey();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Unable to load public and private keys", e);
+        }
+
+        String keyId = KeyUtils.createKeyId(publicKey);
+
+        KeyWrapper wrapper = new KeyWrapper();
+        wrapper.setAlgorithm(Algorithm.RS512);
+        wrapper.setCertificate(certificate);
+        wrapper.setKid(keyId);
+        wrapper.setPrivateKey(privateKey);
+        wrapper.setPublicKey(publicKey);
+        wrapper.setUse(KeyUse.SIG);
+        wrapper.setType(KeyType.RSA);
+
+        int ctSeconds = this.getCurrentSeconds();
+
+        token.id(Util.generateUUID())
+            .issuer("candlepin-test");
+
+        return new JWSBuilder()
+            .kid(keyId)
+            .type("JWT")
+            .jsonContent(token)
+            .sign(new AsymmetricSignatureSignerContext(wrapper));
+    }
+
+    @Test
+    public void testGenerateRegistrationToken() {
+        Principal principal = mock(Principal.class);
+        CloudRegistrationInfo cloudRegInfo = this.buildCloudRegistrationInfo("test_type", "metadata", "sig");
+        CloudRegistrationAuth provider = this.buildAuthProvider();
+
+        String token = provider.generateRegistrationToken(principal, cloudRegInfo);
+
+        assertNotNull(token);
+        assertFalse(token.isEmpty());
+
+        verify(this.mockCloudRegistrationAdapter, times(1)).resolveCloudRegistrationData(eq(cloudRegInfo));
+    }
+
+    @Test
+    public void testGenerateRegistrationTokenFailsOnResolutionFailure() {
+        Principal principal = mock(Principal.class);
+        CloudRegistrationInfo cloudRegInfo = this.buildCloudRegistrationInfo("test_type", "metadata", "sig");
+        CloudRegistrationAuth provider = this.buildAuthProvider();
+
+        doReturn(null).when(this.mockCloudRegistrationAdapter).resolveCloudRegistrationData(eq(cloudRegInfo));
+
+        assertThrows(CloudRegistrationAuthorizationException.class,
+            () -> provider.generateRegistrationToken(principal, cloudRegInfo));
+
+        verify(this.mockCloudRegistrationAdapter, times(1)).resolveCloudRegistrationData(eq(cloudRegInfo));
+    }
+
+    @Test
+    public void testGenerateRegistrationTokenRequiresPrincipal() {
+        CloudRegistrationInfo cloudRegInfo = this.buildCloudRegistrationInfo("test_type", "metadata", "sig");
+        CloudRegistrationAuth provider = this.buildAuthProvider();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> provider.generateRegistrationToken(null, cloudRegInfo));
+
+        verify(this.mockCloudRegistrationAdapter, never())
+            .resolveCloudRegistrationData(any(CloudRegistrationInfo.class));
+    }
+
+    @Test
+    public void testGenerateRegistrationTokenRequiresCloudRegistrationData() {
+        Principal principal = mock(Principal.class);
+        CloudRegistrationAuth provider = this.buildAuthProvider();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> provider.generateRegistrationToken(principal, null));
+
+        verify(this.mockCloudRegistrationAdapter, never())
+            .resolveCloudRegistrationData(any(CloudRegistrationInfo.class));
+    }
+
+    @Test
+    public void testGetPrincipal() {
+        CloudRegistrationInfo cloudRegInfo = this.buildCloudRegistrationInfo("test_type", "metadata", "sig");
+        CloudRegistrationAuth provider = this.buildAuthProvider();
+        String token = provider.generateRegistrationToken(mock(Principal.class), cloudRegInfo);
+
+        MockHttpRequest request = this.buildHttpRequest();
+        request.header("Authorization", "Bearer " + token);
+
+        Principal principal = provider.getPrincipal(request);
+
+        assertNotNull(principal);
+        assertTrue(principal instanceof UserPrincipal);
+
+        // Test note:
+        // The owner key resolves to the cloud registration type due to the mock adapter implementation
+        // we've defined in our test init, which *always* uses the type as the owner key. In the real
+        // implementation, this isn't guaranteed.
+        String ownerKey = cloudRegInfo.getType();
+        Owner owner = this.mockOwnerCurator.getByKey(ownerKey);
+
+        assertTrue(principal.canAccess(owner, SubResource.CONSUMERS, Access.CREATE));
+    }
+
+    @Test
+    public void testGetPrincipalAbortsWhenDisabled() {
+        this.config.setProperty(ConfigProperties.CLOUD_AUTHENTICATION, "false");
+
+        CloudRegistrationInfo cloudRegInfo = this.buildCloudRegistrationInfo("test_type", "metadata", "sig");
+        CloudRegistrationAuth provider = this.buildAuthProvider();
+        String token = provider.generateRegistrationToken(mock(Principal.class), cloudRegInfo);
+
+        MockHttpRequest request = this.buildHttpRequest();
+        request.header("Authorization", "Bearer " + token);
+
+        Principal principal = provider.getPrincipal(request);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testGetPrincipalAbortsIfHeaderIsAbsent() {
+        MockHttpRequest request = this.buildHttpRequest();
+
+        Principal principal = this.buildAuthProvider()
+            .getPrincipal(request);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testGetPrincipalAbortsIfAuthenticationIsWrongType() {
+        CloudRegistrationInfo cloudRegInfo = this.buildCloudRegistrationInfo("test_type", "metadata", "sig");
+        CloudRegistrationAuth provider = this.buildAuthProvider();
+        String token = provider.generateRegistrationToken(mock(Principal.class), cloudRegInfo);
+
+        MockHttpRequest request = this.buildHttpRequest();
+        request.header("Authorization", "Potato " + token);
+
+        Principal principal = provider.getPrincipal(request);
+
+        assertNull(principal);
+    }
+
+    /**
+     * This test is to verify that the token generation method provided by this test suite will
+     * generate a valid token if properly populated. This test must pass for the malformed token
+     * tests to be considered valid.
+     */
+    @Test
+    public void testGetPrincipalAcceptsTestToken() {
+        String ownerKey = "test_org";
+        int ctSeconds = this.getCurrentSeconds() - 5;
+
+        String token = this.buildMalformedToken(new JsonWebToken()
+            .type(TOKEN_TYPE)
+            .subject("test_subject")
+            .audience(ownerKey)
+            .issuedAt(ctSeconds)
+            .notBefore(ctSeconds)
+            .expiration(ctSeconds + 300));
+
+        MockHttpRequest request = this.buildHttpRequest();
+        request.header("Authorization", "Bearer " + token);
+
+        Principal principal = this.buildAuthProvider()
+            .getPrincipal(request);
+
+        assertNotNull(principal);
+        assertTrue(principal instanceof UserPrincipal);
+
+        // Test note:
+        // The owner key resolves to the cloud registration type due to the mock adapter implementation
+        // we've defined in our test init, which *always* uses the type as the owner key. In the real
+        // implementation, this isn't guaranteed.
+        Owner owner = this.mockOwnerCurator.getByKey(ownerKey);
+        assertTrue(principal.canAccess(owner, SubResource.CONSUMERS, Access.CREATE));
+    }
+
+    @Test
+    public void testGetPrincipalIgnoresTokensWithWrongType() {
+        int ctSeconds = this.getCurrentSeconds() - 5;
+
+        String token = this.buildMalformedToken(new JsonWebToken()
+            .type("invalid_token_type")
+            .subject("test_subject")
+            .audience("test_org")
+            .issuedAt(ctSeconds)
+            .notBefore(ctSeconds)
+            .expiration(ctSeconds + 300));
+
+        MockHttpRequest request = this.buildHttpRequest();
+        request.header("Authorization", "Bearer " + token);
+
+        Principal principal = this.buildAuthProvider()
+            .getPrincipal(request);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testGetPrincipalIgnoresTokensLackingType() {
+        int ctSeconds = this.getCurrentSeconds() - 5;
+
+        String token = this.buildMalformedToken(new JsonWebToken()
+            .subject("test_subject")
+            .audience("test_org")
+            .issuedAt(ctSeconds)
+            .notBefore(ctSeconds)
+            .expiration(ctSeconds + 300));
+
+        MockHttpRequest request = this.buildHttpRequest();
+        request.header("Authorization", "Bearer " + token);
+
+        Principal principal = this.buildAuthProvider()
+            .getPrincipal(request);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testGetPrincipalIgnoresTokensLackingSubject() {
+        int ctSeconds = this.getCurrentSeconds() - 5;
+
+        String token = this.buildMalformedToken(new JsonWebToken()
+            .type(TOKEN_TYPE)
+            .audience("test_org")
+            .issuedAt(ctSeconds)
+            .notBefore(ctSeconds)
+            .expiration(ctSeconds + 300));
+
+        MockHttpRequest request = this.buildHttpRequest();
+        request.header("Authorization", "Bearer " + token);
+
+        Principal principal = this.buildAuthProvider()
+            .getPrincipal(request);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testGetPrincipalIgnoresTokensLackingAudience() {
+        int ctSeconds = this.getCurrentSeconds() - 5;
+
+        String token = this.buildMalformedToken(new JsonWebToken()
+            .type(TOKEN_TYPE)
+            .subject("test_subject")
+            .issuedAt(ctSeconds)
+            .notBefore(ctSeconds)
+            .expiration(ctSeconds + 300));
+
+        MockHttpRequest request = this.buildHttpRequest();
+        request.header("Authorization", "Bearer " + token);
+
+        Principal principal = this.buildAuthProvider()
+            .getPrincipal(request);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testGetPrincipalIgnoresExpiredTokens() {
+        int ctSeconds = this.getCurrentSeconds();
+
+        String token = this.buildMalformedToken(new JsonWebToken()
+            .type(TOKEN_TYPE)
+            .subject("test_subject")
+            .audience("test_org")
+            .issuedAt(ctSeconds - 15)
+            .notBefore(ctSeconds - 15)
+            .expiration(ctSeconds - 10));
+
+        MockHttpRequest request = this.buildHttpRequest();
+        request.header("Authorization", "Bearer " + token);
+
+        Principal principal = this.buildAuthProvider()
+            .getPrincipal(request);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testGetPrincipalIgnoresInactiveTokens() {
+        int ctSeconds = this.getCurrentSeconds();
+
+        String token = this.buildMalformedToken(new JsonWebToken()
+            .type(TOKEN_TYPE)
+            .subject("test_subject")
+            .audience("test_org")
+            .issuedAt(ctSeconds + 15)
+            .notBefore(ctSeconds + 15)
+            .expiration(ctSeconds + 25));
+
+        MockHttpRequest request = this.buildHttpRequest();
+        request.header("Authorization", "Bearer " + token);
+
+        Principal principal = this.buildAuthProvider()
+            .getPrincipal(request);
+
+        assertNull(principal);
+    }
+}

--- a/server/src/test/java/org/candlepin/dto/api/v1/CloudRegistrationDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/CloudRegistrationDTOTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.AbstractDTOTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+
+/**
+ * Test suite for the CloudRegistrationDTO class
+ */
+public class CloudRegistrationDTOTest extends AbstractDTOTest<CloudRegistrationDTO> {
+
+    protected Map<String, Object> values;
+
+    public CloudRegistrationDTOTest() {
+        super(CloudRegistrationDTO.class);
+
+        this.values = new HashMap<>();
+        this.values.put("Type", "test_type");
+        this.values.put("Metadata", "test_metadata");
+        this.values.put("Signature", "test_signature");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getInputValueForMutator(String field) {
+        return this.values.get(field);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Object getOutputValueForAccessor(String field, Object input) {
+        // Nothing to do here
+        return input;
+    }
+}

--- a/server/src/test/java/org/candlepin/resource/CloudRegistrationResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/CloudRegistrationResourceTest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.auth.CloudRegistrationAuth;
+import org.candlepin.auth.Principal;
+import org.candlepin.auth.UserPrincipal;
+import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.common.exceptions.NotAuthorizedException;
+import org.candlepin.common.exceptions.NotImplementedException;
+import org.candlepin.dto.api.v1.CloudRegistrationDTO;
+import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
+import org.candlepin.service.exception.MalformedCloudRegistrationException;
+import org.candlepin.service.model.CloudRegistrationInfo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.util.Locale;
+
+
+
+/**
+ * Test suite for the CloudRegistrationResource class
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class CloudRegistrationResourceTest {
+
+    private I18n i18n;
+    private CloudRegistrationAuth mockCloudRegistrationAuth;
+
+
+    @BeforeEach
+    public void init() {
+        this.i18n = I18nFactory.getI18n(this.getClass(), Locale.US, I18nFactory.FALLBACK);
+        this.mockCloudRegistrationAuth = mock(CloudRegistrationAuth.class);
+    }
+
+    private CloudRegistrationResource buildResource() {
+        return new CloudRegistrationResource(this.i18n, this.mockCloudRegistrationAuth);
+    }
+
+    private Principal buildPrincipal() {
+        return new UserPrincipal("test_user", null, false);
+    }
+
+    @Test
+    public void testAuthorize() {
+        String token = "test-token";
+
+        CloudRegistrationResource resource = this.buildResource();
+        Principal principal = this.buildPrincipal();
+
+        CloudRegistrationDTO dto = new CloudRegistrationDTO()
+            .setType("test-type")
+            .setMetadata("test-metadata")
+            .setSignature("test-signature");
+
+        doReturn(token).when(this.mockCloudRegistrationAuth)
+            .generateRegistrationToken(eq(principal), eq(dto));
+
+        String output = resource.authorize(dto, principal);
+
+        assertEquals(token, output);
+    }
+
+    @Test
+    public void testAuthorizeFailsGracefullyWhenNotImplemented() {
+        CloudRegistrationResource resource = this.buildResource();
+        Principal principal = this.buildPrincipal();
+
+        doThrow(new UnsupportedOperationException()).when(this.mockCloudRegistrationAuth)
+            .generateRegistrationToken(eq(principal), any(CloudRegistrationInfo.class));
+
+        assertThrows(NotImplementedException.class,
+            () -> resource.authorize(new CloudRegistrationDTO(), principal));
+    }
+
+    @Test
+    public void testAuthorizeFailsGracefullyWhenAuthenticationFails() {
+        CloudRegistrationResource resource = this.buildResource();
+        Principal principal = this.buildPrincipal();
+
+        doThrow(new CloudRegistrationAuthorizationException()).when(this.mockCloudRegistrationAuth)
+            .generateRegistrationToken(eq(principal), any(CloudRegistrationInfo.class));
+
+        assertThrows(NotAuthorizedException.class,
+            () -> resource.authorize(new CloudRegistrationDTO(), principal));
+    }
+
+    @Test
+    public void testAuthorizeFailsGracefullyWithMalformedInput() {
+        CloudRegistrationResource resource = this.buildResource();
+        Principal principal = this.buildPrincipal();
+
+        doThrow(new MalformedCloudRegistrationException()).when(this.mockCloudRegistrationAuth)
+            .generateRegistrationToken(eq(principal), any(CloudRegistrationInfo.class));
+
+        assertThrows(BadRequestException.class,
+            () -> resource.authorize(new CloudRegistrationDTO(), principal));
+    }
+
+}


### PR DESCRIPTION
- Added support for automated cloud registration via JWT tokens
- Added the CloudRegistrationAdapter and CloudRegistrationInfo
  adapter and interface for allowing service adapters to implement
  the organization resolution logic for cloud registration details
- Added new JWT configurations for controlling the issuer name and
  TTL
- Updated the mutators in Owner to return itself for fluent-style
  method chaining
- Updated KeycloakAuth to no longer end authentication on
  unsupported auth types, or failed authentication in general