### PR TITLE
Figure out candlepin version through spec file

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -278,7 +278,7 @@ fi
 # Check if we need to use Java 11, otherwie auto detect Java version.
 # Candlepin support Java 11 from 3.2.0 & onwards.
 
-CANDLEPIN_BASE_VERSION=$(git describe --abbrev=0 | awk -F"-" '{print $2}')
+CANDLEPIN_BASE_VERSION=$(grep "Version:" server/candlepin.spec.tmpl | awk -F"Version: " '{print $2}')
 JAVA_11_SUPPORTED_VERSION=3.2.0
 
 echo "Base version of candlepin: " $CANDLEPIN_BASE_VERSION


### PR DESCRIPTION
- Don't try to find out candlepin version through git tag
  because we might be in a detached HEAD