### PR TITLE
ENT-3109: Create Jenkins job for translation extraction

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -101,6 +101,14 @@ pipeline {
                         sh 'sh jenkins/candlepin-validate-text.sh'
                     }
                 }
+                stage('gettext') {
+                    agent { label 'docker' }
+                    steps {
+                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
+                        checkout scm
+                        sh 'sh jenkins/get-text.sh'
+                    }
+                }
             }
         }
     }

--- a/jenkins/get-text.sh
+++ b/jenkins/get-text.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -x
+
+env | sort
+echo
+
+# The docker container test script will know to copy out
+echo "Using workspace: $WORKSPACE"
+mkdir -p $WORKSPACE/artifacts/
+
+# make selinux happy via http://stackoverflow.com/a/24334000
+chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
+
+# Run the gettext to extract strings for translation from source java files
+./docker/test -p -c "cp-test -g -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
+RETVAL=$?
+sudo chown -R jenkins:jenkins $WORKSPACE/artifacts
+exit $RETVAL


### PR DESCRIPTION
 (gettext/msgattrib)
 - Updated the `Jenkinsfile` to execute the gettext stage
 - A script to call cp-test gettext task
