### PR TITLE
1884047: Unable to unschedule trigger while deleting job crash during startup (ENT-3129)

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -912,7 +912,18 @@ public class JobManager implements ModeChangeListener {
 
         // Unschedule dead/invalid jobs
         for (JobKey key : unschedule) {
-            this.scheduler.deleteJob(key);
+            List<Trigger> jobTriggers = (List<Trigger>) this.scheduler.getTriggersOfJob(key);
+
+            if (!jobTriggers.isEmpty()) {
+                this.scheduler.unscheduleJobs(jobTriggers
+                    .stream()
+                    .map(Trigger::getKey)
+                    .collect(Collectors.toList()));
+            }
+            else {
+                this.scheduler.deleteJob(key);
+            }
+
             log.info("Removed existing schedule for job: {}", key.getName());
         }
 


### PR DESCRIPTION
Since original bug was harder to reproduce locally, judging form the exception trace the crash happens around ```deleteJob()``` area.
This PR has minor update to efficiently unschedule (& delete) quartz jobs using Trigger-keys. Internally ```unscheduleJobs()``` is a bulk operation which faster & efficient. We can leverage this as all of our Quartz job are non-durable which means job gets automatically deleted from the scheduler once there are no longer any active triggers associated with it.