### PR TITLE
[M] Fixed hash collision resolution bug with branding (ENT-3304)

### DIFF
--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -1415,20 +1415,31 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
     /**
      * Partitions the given collection using the value returned by the getInBlockSize() method as
-     * the partition size. This method is provided as a utility method to avoid referencing a very
-     * long constant name used in many curators. Callers which need this behavior with a custom
-     * size can simulate the behavior by using the <tt>Iterables.partition</tt> method directly:
-     * <pre>
-     *  {@code Iterable<List<String>> blocks = ', 'entityIds, blockSize); }
-     * </pre>
+     * the partition size.
      *
      * @param collection
      *  The collection to partition
      *
      * @return
-     *  An iterable collection of lists containing the partitioned data in the provided collection
+     *  An iterable collection of lists containing the partitioned data from the provided collection
      */
     protected <T> Iterable<List<T>> partition(Iterable<T> collection) {
-        return Iterables.partition(collection, this.getInBlockSize());
+        return this.partition(collection, this.getInBlockSize());
+    }
+
+    /**
+     * Partitions the given collection using the provided block size.
+     *
+     * @param collection
+     *  The collection to partition
+     *
+     * @param blockSize
+     *  The maximum size of the blocks to build when partitioning the collection
+     *
+     * @return
+     *  An iterable collection of lists containing the partitioned data from the provided collection
+     */
+    protected <T> Iterable<List<T>> partition(Iterable<T> collection, int blockSize) {
+        return Iterables.partition(collection, blockSize);
     }
 }

--- a/server/src/main/java/org/candlepin/model/Branding.java
+++ b/server/src/main/java/org/candlepin/model/Branding.java
@@ -167,15 +167,10 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
 
         Branding that = (Branding) anObject;
 
-        // We're only interested in ensuring the mapping between the two objects is the same.
-        String thisProductUuid = this.getProduct() != null ? this.getProduct().getUuid() : null;
-        String thatProductUuid = that.getProduct() != null ? that.getProduct().getUuid() : null;
-
         return new EqualsBuilder()
             .append(this.name, that.name)
             .append(this.productId, that.productId)
             .append(this.type, that.type)
-            .append(thisProductUuid, thatProductUuid)
             .isEquals();
     }
 
@@ -185,7 +180,6 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
             .append(this.name)
             .append(this.productId)
             .append(this.type)
-            .append(this.getProduct() != null ? this.getProduct().getUuid() : null)
             .toHashCode();
     }
 

--- a/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -17,10 +17,8 @@ package org.candlepin.model;
 import com.google.common.collect.Iterables;
 import com.google.inject.persist.Transactional;
 
-import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Disjunction;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
@@ -32,6 +30,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,6 +38,14 @@ import java.util.Set;
 import javax.inject.Singleton;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+
 
 /**
  * The OwnerContentCurator provides functionality for managing the mapping between owners and
@@ -345,12 +352,16 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
      *  A mapping of Red Hat content IDs to content versions to fetch
      *
      * @return
-     *  a criteria for fetching content by version
+     *  a mapping of Red Hat content IDs to candidate alternate versions
      */
     @SuppressWarnings("checkstyle:indentation")
-    public CandlepinQuery<Content> getContentByVersions(Owner owner, Map<String, Integer> contentVersions) {
+    public Map<String, List<Content>> getContentByVersions(Owner owner,
+        Map<String, Integer> contentVersions) {
+
+        Map<String, List<Content>> contentMap = new HashMap<>();
+
         if (contentVersions == null || contentVersions.isEmpty()) {
-            return this.cpQueryFactory.<Content>buildQuery();
+            return contentMap;
         }
 
         // Impl note:
@@ -363,33 +374,52 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
         // content we filter don't have any data in their collections; but we're only using one
         // additional query in those cases, versus n additional in the normal case.
 
-        Disjunction disjunction = Restrictions.disjunction();
-        Criteria uuidCriteria = this.createSecureCriteria("oc")
-            .createAlias("oc.content", "c")
-            .add(disjunction)
-            .setProjection(Projections.distinct(Projections.property("c.uuid")));
+        Set<String> uuids = new HashSet<>();
 
-        for (Map.Entry<String, Integer> entry : contentVersions.entrySet()) {
-            disjunction.add(Restrictions.and(
-                Restrictions.eq("c.id", entry.getKey()),
-                Restrictions.eq("c.entityVersion", entry.getValue())
-            ));
+        EntityManager entityManager = this.getEntityManager();
+        CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<String> query = builder.createQuery(String.class);
+
+        Root<OwnerContent> root = query.from(OwnerContent.class);
+        Join<OwnerContent, Content> content = root.join(OwnerContent_.content);
+
+        query.select(content.get(Content_.uuid))
+            .orderBy(builder.asc(content.get(Content_.id)), builder.desc(content.get(Content_.created)));
+
+        int blockSize = (this.getQueryParameterLimit() - 1) / 2;
+        for (List<Map.Entry<String, Integer>> block : this.partition(contentVersions.entrySet(), blockSize)) {
+            Predicate[] predicates = new Predicate[block.size()];
+            int index = 0;
+
+            for (Map.Entry<String, Integer> entry : block) {
+                predicates[index++] = builder.and(
+                    builder.equal(content.get(Content_.id), entry.getKey()),
+                    builder.equal(content.get(Content_.entityVersion), entry.getValue()));
+            }
+
+            Predicate predicate = builder.or(predicates);
+
+            query.where(owner == null ?
+                builder.or(predicates) :
+                builder.and(builder.notEqual(root.get(OwnerContent_.ownerId), owner.getId()), predicate));
+
+            uuids.addAll(entityManager.createQuery(query)
+                .getResultList());
         }
-
-        if (owner != null) {
-            uuidCriteria.add(Restrictions.not(Restrictions.eq("oc.owner", owner)));
-        }
-
-        List<String> uuids = uuidCriteria.list();
 
         if (uuids != null && !uuids.isEmpty()) {
-            DetachedCriteria criteria = this.createSecureDetachedCriteria(Content.class, null)
-                .add(CPRestrictions.in("uuid", uuids));
+            String jpql = "SELECT c FROM Content c WHERE c.uuid IN (:content_uuids)";
+            TypedQuery<Content> cquery = entityManager.createQuery(jpql, Content.class);
 
-            return this.cpQueryFactory.<Content>buildQuery(this.currentSession(), criteria);
+            for (List<String> block : this.partition(uuids)) {
+                for (Content element : cquery.setParameter("content_uuids", block).getResultList()) {
+                    contentMap.computeIfAbsent(element.getId(), k -> new LinkedList<>())
+                        .add(element);
+                }
+            }
         }
 
-        return this.cpQueryFactory.<Content>buildQuery();
+        return contentMap;
     }
 
     /**

--- a/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -14,12 +14,7 @@
  */
 package org.candlepin.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
@@ -31,9 +26,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 
 
 /**
@@ -597,32 +593,35 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         Owner owner2 = this.createOwner();
         Owner owner3 = this.createOwner();
 
-        Content content1 = this.createContent("p1", "p1", owner1);
-        Content content2 = this.createContent("p1", "p1", owner2);
-        Content content3 = this.createContent("p1", "p1", owner3);
-        Content content4 = this.createContent("p2", "p2", owner2);
+        Content content1 = this.createContent("c1", "c1", owner1);
+        Content content2 = this.createContent("c1", "c1", owner2);
+        Content content3 = this.createContent("c1", "c1", owner3);
+        Content content4 = this.createContent("c2", "c2", owner2);
 
-        List<Content> contentList1 = this.ownerContentCurator.getContentByVersions(owner1,
-            Collections.<String, Integer>singletonMap(content1.getId(), content1.getEntityVersion())).list();
+        Map<String, List<Content>> contentMap1 = this.ownerContentCurator.getContentByVersions(owner1,
+            Collections.<String, Integer>singletonMap(content1.getId(), content1.getEntityVersion()));
+        Map<String, List<Content>> contentMap2 = this.ownerContentCurator.getContentByVersions(owner2,
+            Collections.<String, Integer>singletonMap(content2.getId(), content2.getEntityVersion()));
 
-        List<Content> contentList2 = this.ownerContentCurator.getContentByVersions(owner2,
-            Collections.<String, Integer>singletonMap(content2.getId(), content2.getEntityVersion())).list();
+        // contentMap1 should contain only content2 and content3
+        // contentMap2 should contain only content1 and content3
 
-        // contentList1 should contain only content2 and content3
-        // contentList2 should contain only content1 and content3
+        assertEquals(1, contentMap1.size());
+        assertNotNull(contentMap1.get("c1"));
+        assertEquals(1, contentMap2.size());
+        assertNotNull(contentMap2.get("c1"));
 
-        assertEquals(2, contentList1.size());
-        assertEquals(2, contentList2.size());
+        List<String> uuidList1 = contentMap1.values()
+            .stream()
+            .flatMap(List::stream)
+            .map(Content::getUuid)
+            .collect(Collectors.toList());
 
-        List<String> uuidList1 = new LinkedList<>();
-        for (Content content : contentList1) {
-            uuidList1.add(content.getUuid());
-        }
-
-        List<String> uuidList2 = new LinkedList<>();
-        for (Content content : contentList2) {
-            uuidList2.add(content.getUuid());
-        }
+        List<String> uuidList2 = contentMap2.values()
+            .stream()
+            .flatMap(List::stream)
+            .map(Content::getUuid)
+            .collect(Collectors.toList());
 
         assertEquals(Arrays.asList(content2.getUuid(), content3.getUuid()), uuidList1);
         assertEquals(Arrays.asList(content1.getUuid(), content3.getUuid()), uuidList2);
@@ -634,31 +633,34 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         Owner owner2 = this.createOwner();
         Owner owner3 = this.createOwner();
 
-        Content content1 = this.createContent("p1", "p1", owner1);
-        Content content2 = this.createContent("p1", "p1", owner2);
-        Content content3 = this.createContent("p1", "p1", owner3);
-        Content content4 = this.createContent("p2", "p2", owner2);
+        Content content1 = this.createContent("c1", "c1", owner1);
+        Content content2 = this.createContent("c1", "c1", owner2);
+        Content content3 = this.createContent("c1", "c1", owner3);
+        Content content4 = this.createContent("c2", "c2", owner2);
 
-        List<Content> contentList1 = this.ownerContentCurator.getContentByVersions(null,
-            Collections.<String, Integer>singletonMap(content1.getId(), content1.getEntityVersion())).list();
+        Map<String, List<Content>> contentMap1 = this.ownerContentCurator.getContentByVersions(null,
+            Collections.<String, Integer>singletonMap(content1.getId(), content1.getEntityVersion()));
+        Map<String, List<Content>> contentMap2 = this.ownerContentCurator.getContentByVersions(null,
+            Collections.<String, Integer>singletonMap(content2.getId(), content2.getEntityVersion()));
 
-        List<Content> contentList2 = this.ownerContentCurator.getContentByVersions(null,
-            Collections.<String, Integer>singletonMap(content2.getId(), content2.getEntityVersion())).list();
+        // Both maps should contain both contents 1, 2 and 3
 
-        // Both lists should contain both content1, 2 and 3
+        assertEquals(1, contentMap1.size());
+        assertNotNull(contentMap1.get("c1"));
+        assertEquals(1, contentMap2.size());
+        assertNotNull(contentMap2.get("c1"));
 
-        assertEquals(3, contentList1.size());
-        assertEquals(3, contentList2.size());
+        List<String> uuidList1 = contentMap1.values()
+            .stream()
+            .flatMap(List::stream)
+            .map(Content::getUuid)
+            .collect(Collectors.toList());
 
-        List<String> uuidList1 = new LinkedList<>();
-        for (Content content : contentList1) {
-            uuidList1.add(content.getUuid());
-        }
-
-        List<String> uuidList2 = new LinkedList<>();
-        for (Content content : contentList2) {
-            uuidList2.add(content.getUuid());
-        }
+        List<String> uuidList2 = contentMap2.values()
+            .stream()
+            .flatMap(List::stream)
+            .map(Content::getUuid)
+            .collect(Collectors.toList());
 
         // We're counting on .equals not caring about order here
         assertEquals(Arrays.asList(content1.getUuid(), content2.getUuid(), content3.getUuid()), uuidList1);
@@ -671,53 +673,74 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         Owner owner2 = this.createOwner();
         Owner owner3 = this.createOwner();
 
-        Content p1 = this.createContent("p1", "p1", owner1);
-        Content p2 = this.createContent("p1", "p1", owner2);
-        Content p3 = this.createContent("p1", "p1", owner3);
-        Content p4 = this.createContent("p2", "p2", owner1);
-        Content p5 = this.createContent("p2", "p2", owner2);
-        Content p6 = this.createContent("p2", "p2", owner3);
-        Content p7 = this.createContent("p3", "p3", owner1);
-        Content p8 = this.createContent("p3", "p3", owner2);
-        Content p9 = this.createContent("p3", "p3", owner3);
+        Content c1 = this.createContent("c1", "c1", owner1);
+        Content c2 = this.createContent("c1", "c1", owner2);
+        Content c3 = this.createContent("c1", "c1", owner3);
+        Content c4 = this.createContent("c2", "c2", owner1);
+        Content c5 = this.createContent("c2", "c2", owner2);
+        Content c6 = this.createContent("c2", "c2", owner3);
+        Content c7 = this.createContent("c3", "c3", owner1);
+        Content c8 = this.createContent("c3", "c3", owner2);
+        Content c9 = this.createContent("c3", "c3", owner3);
 
         Map<String, Integer> versions = new HashMap<>();
-        versions.put(p1.getId(), p1.getEntityVersion());
-        versions.put(p4.getId(), p4.getEntityVersion());
-        versions.put("bad_id", p7.getEntityVersion());
+        versions.put(c1.getId(), c1.getEntityVersion());
+        versions.put(c4.getId(), c4.getEntityVersion());
+        versions.put("bad_id", c7.getEntityVersion());
 
-        List<Content> contentList1 = this.ownerContentCurator.getContentByVersions(owner1, versions).list();
-        List<Content> contentList2 = this.ownerContentCurator.getContentByVersions(owner2, versions).list();
-        List<Content> contentList3 = this.ownerContentCurator.getContentByVersions(null, versions).list();
+        Map<String, List<Content>> contentMap1 = this.ownerContentCurator
+            .getContentByVersions(owner1, versions);
+        Map<String, List<Content>> contentMap2 = this.ownerContentCurator
+            .getContentByVersions(owner2, versions);
+        Map<String, List<Content>> contentMap3 = this.ownerContentCurator
+            .getContentByVersions(null, versions);
 
-        // List 1 should contain content 2, 3, 5 and 6
-        // List 2 should contain content 1, 3, 4 and 6
-        // List 3 should contain content 1 through 6
+        // Map 1 should contain contents with ids "c1" or "c2" not owned by owner 1: (c2, c3, c5, c6)
+        // Map 2 should contain contents with ids "c1" or "c2" not owned by owner 2: (c1, c3, c4, c6)
+        // Map 3 should contain all contents with ids "c1" or "c2": (c1, c2, c3, c4, c5, c6)
 
-        assertEquals(4, contentList1.size());
-        assertEquals(4, contentList2.size());
-        assertEquals(6, contentList3.size());
+        assertEquals(2, contentMap1.size());
+        assertEquals(2, contentMap2.size());
+        assertEquals(2, contentMap3.size());
 
-        List<String> uuidList1 = new LinkedList<>();
-        for (Content content : contentList1) {
-            uuidList1.add(content.getUuid());
-        }
+        assertNotNull(contentMap1.get("c1"));
+        assertEquals(2, contentMap1.get("c1").size());
+        assertNotNull(contentMap1.get("c2"));
+        assertEquals(2, contentMap1.get("c2").size());
 
-        List<String> uuidList2 = new LinkedList<>();
-        for (Content content : contentList2) {
-            uuidList2.add(content.getUuid());
-        }
+        assertNotNull(contentMap2.get("c1"));
+        assertEquals(2, contentMap2.get("c1").size());
+        assertNotNull(contentMap2.get("c2"));
+        assertEquals(2, contentMap2.get("c2").size());
 
-        List<String> uuidList3 = new LinkedList<>();
-        for (Content content : contentList3) {
-            uuidList3.add(content.getUuid());
-        }
+        assertNotNull(contentMap3.get("c1"));
+        assertEquals(3, contentMap3.get("c1").size());
+        assertNotNull(contentMap3.get("c2"));
+        assertEquals(3, contentMap3.get("c2").size());
+
+        List<String> uuidList1 = contentMap1.values()
+            .stream()
+            .flatMap(List::stream)
+            .map(Content::getUuid)
+            .collect(Collectors.toList());
+
+        List<String> uuidList2 = contentMap2.values()
+            .stream()
+            .flatMap(List::stream)
+            .map(Content::getUuid)
+            .collect(Collectors.toList());
+
+        List<String> uuidList3 = contentMap3.values()
+            .stream()
+            .flatMap(List::stream)
+            .map(Content::getUuid)
+            .collect(Collectors.toList());
 
         // We're counting on .equals not caring about order here
-        assertEquals(Arrays.asList(p2.getUuid(), p3.getUuid(), p5.getUuid(), p6.getUuid()), uuidList1);
-        assertEquals(Arrays.asList(p1.getUuid(), p3.getUuid(), p4.getUuid(), p6.getUuid()), uuidList2);
+        assertEquals(Arrays.asList(c2.getUuid(), c3.getUuid(), c5.getUuid(), c6.getUuid()), uuidList1);
+        assertEquals(Arrays.asList(c1.getUuid(), c3.getUuid(), c4.getUuid(), c6.getUuid()), uuidList2);
         assertEquals(
-            Arrays.asList(p1.getUuid(), p2.getUuid(), p3.getUuid(), p4.getUuid(), p5.getUuid(), p6.getUuid()),
+            Arrays.asList(c1.getUuid(), c2.getUuid(), c3.getUuid(), c4.getUuid(), c5.getUuid(), c6.getUuid()),
             uuidList3
         );
     }
@@ -726,19 +749,20 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
     public void testGetContentByVersionsNoVersionInfo() {
         Owner owner1 = this.createOwner();
 
-        List<Content> contentList1 = this.ownerContentCurator.getContentByVersions(owner1, null).list();
-        assertEquals(0, contentList1.size());
+        Map<String, List<Content>> contentMap1 = this.ownerContentCurator
+            .getContentByVersions(owner1, null);
+        assertEquals(0, contentMap1.size());
 
-        List<Content> contentList2 = this.ownerContentCurator.getContentByVersions(owner1,
-            Collections.<String, Integer>emptyMap()).list();
-        assertEquals(0, contentList2.size());
+        Map<String, List<Content>> contentMap2 = this.ownerContentCurator
+            .getContentByVersions(owner1, Collections.<String, Integer>emptyMap());
+        assertEquals(0, contentMap2.size());
 
-        List<Content> contentList3 = this.ownerContentCurator.getContentByVersions(null, null).list();
-        assertEquals(0, contentList3.size());
+        Map<String, List<Content>> contentMap3 = this.ownerContentCurator.getContentByVersions(null, null);
+        assertEquals(0, contentMap3.size());
 
-        List<Content> contentList4 = this.ownerContentCurator.getContentByVersions(null,
-            Collections.<String, Integer>emptyMap()).list();
-        assertEquals(0, contentList4.size());
+        Map<String, List<Content>> contentMap4 = this.ownerContentCurator
+            .getContentByVersions(null, Collections.<String, Integer>emptyMap());
+        assertEquals(0, contentMap4.size());
     }
 
     @Test


### PR DESCRIPTION
- Branding.equals no longer checks the product UUID reference
  as part of the equality check
- Fixed a bug in the product and content version lookups that
  would cause JDBC failures if too many versions were matched
  or requested