### PR TITLE
[M] 1905199: Fixed bug with state filtering validation during job cleanup (ENT-3330)

### DIFF
--- a/server/src/main/java/org/candlepin/async/JobManager.java
+++ b/server/src/main/java/org/candlepin/async/JobManager.java
@@ -1788,11 +1788,8 @@ public class JobManager implements ModeChangeListener {
         states = stateStream.filter(state -> state != null && state.isTerminal())
             .collect(Collectors.toSet());
 
-        queryBuilder.setJobStates(states);
-
-        // Add any other sanity restrictions deemed necessary here
-
-        return this.jobCurator.deleteJobs(queryBuilder);
+        // Only delete jobs if we haven't filtered out every state provided
+        return !states.isEmpty() ? this.jobCurator.deleteJobs(queryBuilder.setJobStates(states)) : 0;
     }
 
     /**


### PR DESCRIPTION
- Fixed a bug that would cause job cleanup to match all jobs if
  only non-terminal states were provided to the job cleanup
  operation