### PR TITLE
[M] Set the default consumer window size to zero in broker.xml (ENT-3066)

### DIFF
--- a/server/src/main/resources/broker.xml
+++ b/server/src/main/resources/broker.xml
@@ -186,6 +186,12 @@
                 <!-- By default, Artemis will page messages when the queue address is full. -->
                 <page-size-bytes>1048576</page-size-bytes>
 
+                <!--
+                    Default the consumer window size to zero so we don't have a single thread grabbing
+                    a ton of job messages and choking out other threads that are waiting for work.
+                -->
+                <default-consumer-window-size>0</default-consumer-window-size>
+
                 <!-- Redelivery config -->
                 <redelivery-delay>30000</redelivery-delay>
                 <max-redelivery-delay>3600000</max-redelivery-delay>


### PR DESCRIPTION
- Set the default-consumer-window-size setting to zero for the job
  address in broker.xml to prevent a single consumer from grabbing
  multiple job messages while other threads are waiting for work