### PR TITLE
ENT-3286: Manifest delete takes 24 hours or more in large environment (60k consumers in owner)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -40,7 +40,6 @@ import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
-import org.candlepin.model.OwnerContentCurator;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.Pool;
@@ -103,6 +102,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -114,38 +114,35 @@ import javax.ws.rs.core.MediaType;
  * PoolManager
  */
 public class CandlepinPoolManager implements PoolManager {
-    private I18n i18n;
 
-    private PoolCurator poolCurator;
-    private static Logger log = LoggerFactory.getLogger(CandlepinPoolManager.class);
-
+    private static final Logger log = LoggerFactory.getLogger(CandlepinPoolManager.class);
     private static final int MAX_ENTITLE_RETRIES = 3;
 
-    private EventSink sink;
-    private EventFactory eventFactory;
-    private Configuration config;
-    private Enforcer enforcer;
-    private PoolRules poolRules;
-    private EntitlementCurator entitlementCurator;
-    private ConsumerCurator consumerCurator;
-    private ConsumerTypeCurator consumerTypeCurator;
-    private EntitlementCertificateCurator entitlementCertificateCurator;
-    private EntitlementCertificateGenerator ecGenerator;
-    private ComplianceRules complianceRules;
-    private SystemPurposeComplianceRules systemPurposeComplianceRules;
-    private ProductCurator productCurator;
-    private ProductManager productManager;
-    private AutobindRules autobindRules;
-    private ActivationKeyRules activationKeyRules;
-    private ContentManager contentManager;
-    private OwnerContentCurator ownerContentCurator;
-    private OwnerCurator ownerCurator;
-    private OwnerProductCurator ownerProductCurator;
-    private CdnCurator cdnCurator;
-    private OwnerManager ownerManager;
-    private BindChainFactory bindChainFactory;
-
-    @Inject protected JsonProvider jsonProvider;
+    private final I18n i18n;
+    private final PoolCurator poolCurator;
+    private final EventSink sink;
+    private final EventFactory eventFactory;
+    private final Configuration config;
+    private final Enforcer enforcer;
+    private final PoolRules poolRules;
+    private final EntitlementCurator entitlementCurator;
+    private final ConsumerCurator consumerCurator;
+    private final ConsumerTypeCurator consumerTypeCurator;
+    private final EntitlementCertificateCurator entitlementCertificateCurator;
+    private final EntitlementCertificateGenerator ecGenerator;
+    private final ComplianceRules complianceRules;
+    private final SystemPurposeComplianceRules systemPurposeComplianceRules;
+    private final ProductCurator productCurator;
+    private final ProductManager productManager;
+    private final AutobindRules autobindRules;
+    private final ActivationKeyRules activationKeyRules;
+    private final ContentManager contentManager;
+    private final OwnerCurator ownerCurator;
+    private final OwnerProductCurator ownerProductCurator;
+    private final CdnCurator cdnCurator;
+    private final OwnerManager ownerManager;
+    private final BindChainFactory bindChainFactory;
+    private final JsonProvider jsonProvider;
 
     /**
      * @param poolCurator
@@ -173,40 +170,39 @@ public class CandlepinPoolManager implements PoolManager {
         ProductCurator productCurator,
         ProductManager productManager,
         ContentManager contentManager,
-        OwnerContentCurator ownerContentCurator,
         OwnerCurator ownerCurator,
         OwnerProductCurator ownerProductCurator,
         OwnerManager ownerManager,
         CdnCurator cdnCurator,
         I18n i18n,
-        BindChainFactory bindChainFactory) {
+        BindChainFactory bindChainFactory,
+        JsonProvider jsonProvider) {
 
-        this.poolCurator = poolCurator;
-        this.sink = sink;
-        this.eventFactory = eventFactory;
-        this.config = config;
-        this.entitlementCurator = entitlementCurator;
-        this.consumerCurator = consumerCurator;
-        this.consumerTypeCurator = consumerTypeCurator;
-        this.enforcer = enforcer;
-        this.poolRules = poolRules;
-        this.entitlementCertificateCurator = entitlementCertCurator;
-        this.ecGenerator = ecGenerator;
-        this.complianceRules = complianceRules;
-        this.systemPurposeComplianceRules = systemPurposeComplianceRules;
-        this.productCurator = productCurator;
-        this.autobindRules = autobindRules;
-        this.activationKeyRules = activationKeyRules;
-        this.productCurator = productCurator;
-        this.productManager = productManager;
-        this.contentManager = contentManager;
-        this.ownerContentCurator = ownerContentCurator;
-        this.ownerCurator = ownerCurator;
-        this.ownerProductCurator = ownerProductCurator;
-        this.ownerManager = ownerManager;
-        this.cdnCurator = cdnCurator;
-        this.i18n = i18n;
-        this.bindChainFactory = bindChainFactory;
+        this.poolCurator = Objects.requireNonNull(poolCurator);
+        this.sink = Objects.requireNonNull(sink);
+        this.eventFactory = Objects.requireNonNull(eventFactory);
+        this.config = Objects.requireNonNull(config);
+        this.entitlementCurator = Objects.requireNonNull(entitlementCurator);
+        this.consumerCurator = Objects.requireNonNull(consumerCurator);
+        this.consumerTypeCurator = Objects.requireNonNull(consumerTypeCurator);
+        this.enforcer = Objects.requireNonNull(enforcer);
+        this.poolRules = Objects.requireNonNull(poolRules);
+        this.entitlementCertificateCurator = Objects.requireNonNull(entitlementCertCurator);
+        this.ecGenerator = Objects.requireNonNull(ecGenerator);
+        this.complianceRules = Objects.requireNonNull(complianceRules);
+        this.systemPurposeComplianceRules = Objects.requireNonNull(systemPurposeComplianceRules);
+        this.productCurator = Objects.requireNonNull(productCurator);
+        this.autobindRules = Objects.requireNonNull(autobindRules);
+        this.activationKeyRules = Objects.requireNonNull(activationKeyRules);
+        this.productManager = Objects.requireNonNull(productManager);
+        this.contentManager = Objects.requireNonNull(contentManager);
+        this.ownerCurator = Objects.requireNonNull(ownerCurator);
+        this.ownerProductCurator = Objects.requireNonNull(ownerProductCurator);
+        this.ownerManager = Objects.requireNonNull(ownerManager);
+        this.cdnCurator = Objects.requireNonNull(cdnCurator);
+        this.i18n = Objects.requireNonNull(i18n);
+        this.bindChainFactory = Objects.requireNonNull(bindChainFactory);
+        this.jsonProvider = Objects.requireNonNull(jsonProvider);
     }
 
     /*
@@ -639,10 +635,7 @@ public class CandlepinPoolManager implements PoolManager {
         overflowing = poolCurator.lock(overflowing);
 
         List<Entitlement> overFlowingEnts = this.poolCurator.retrieveOrderedEntitlementsOf(overflowing);
-        Map<String, List<Entitlement>> entMap = new HashMap<>();
-        for (Entitlement entitlement : overFlowingEnts) {
-            entMap.computeIfAbsent(entitlement.getPool().getId(), k -> new ArrayList<>()).add(entitlement);
-        }
+        Map<String, List<Entitlement>> entMap = groupByPoolId(overFlowingEnts);
 
         for (Pool pool : overflowing) {
             // we then start revoking the existing entitlements
@@ -665,6 +658,11 @@ public class CandlepinPoolManager implements PoolManager {
 
         // revoke the entitlements amassed above
         return revokeEntitlements(entitlementsToRevoke);
+    }
+
+    private Map<String, List<Entitlement>> groupByPoolId(Collection<Entitlement> entitlements) {
+        return entitlements.stream()
+            .collect(Collectors.groupingBy(entitlement -> entitlement.getPool().getId()));
     }
 
     /**
@@ -1468,7 +1466,7 @@ public class CandlepinPoolManager implements PoolManager {
     private void logPools(Collection<Pool> pools) {
         if (log.isDebugEnabled()) {
             for (Pool p : pools) {
-                log.debug("   " + p);
+                log.debug("   {}",  p);
             }
         }
     }
@@ -1660,7 +1658,7 @@ public class CandlepinPoolManager implements PoolManager {
 
         ValidationResult result = enforcer.update(consumer, entitlement, change);
         if (!result.isSuccessful()) {
-            log.warn("Entitlement not updated: {} for pool: {}", result.getErrors().toString(), pool.getId());
+            log.warn("Entitlement not updated: {} for pool: {}", result.getErrors(), pool.getId());
 
             Map<String, ValidationResult> errorMap = new HashMap<>();
             errorMap.put(pool.getId(), result);
@@ -1864,8 +1862,9 @@ public class CandlepinPoolManager implements PoolManager {
         Set<Pool> poolsToDelete = this.poolCurator.listBySourceEntitlements(entsToRevoke);
 
         log.debug("Found {} additional pools to delete from source entitlements", poolsToDelete.size());
+        List<String> poolIdsToDelete = getPoolIds(poolsToDelete);
         if (log.isTraceEnabled()) {
-            log.trace("Additional pool IDs: {}", getPoolIds(poolsToDelete));
+            log.trace("Additional pool IDs: {}", poolIdsToDelete);
         }
 
         Set<Pool> poolsToLock = new HashSet<>(poolsToDelete);
@@ -1893,6 +1892,7 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         log.debug("Adjusting consumed quantities on pools");
+        Set<Consumer> consumersToUpdate = new HashSet<>();
         List<Pool> poolsToSave = new ArrayList<>();
         Set<String> entIdsToRevoke = new HashSet<>();
         for (Entitlement ent : entsToRevoke) {
@@ -1919,10 +1919,11 @@ public class CandlepinPoolManager implements PoolManager {
             }
 
             consumer.setEntitlementCount(consumer.getEntitlementCount() - entQuantity);
-            consumerCurator.update(consumer);
+            consumersToUpdate.add(consumer);
             poolsToSave.add(pool);
         }
 
+        consumerCurator.bulkUpdate(consumersToUpdate, false);
         poolCurator.updateAll(poolsToSave, false, false);
 
         /*
@@ -1937,49 +1938,57 @@ public class CandlepinPoolManager implements PoolManager {
 
         log.info("Starting batch delete of pools");
         poolCurator.batchDelete(poolsToDelete, alreadyDeletedPools);
-        for (Pool pool : poolsToDelete) {
-            this.sink.queueEvent(this.eventFactory.poolDeleted(pool));
-        }
+        firePoolDeletedEvents(poolsToDelete);
         log.info("Starting batch delete of entitlements");
         entitlementCurator.batchDelete(entsToRevoke);
         log.info("Starting delete flush");
         entitlementCurator.flush();
         log.info("All deletes flushed successfully");
 
-        Map<Consumer, List<Entitlement>> consumerSortedEntitlements = entitlementCurator
-            .getDistinctConsumers(entsToRevoke);
+        updateStackingEntitlements(entsToRevoke, alreadyDeletedPools);
+        postUnbind(entsToRevoke);
 
-        filterAndUpdateStackingEntitlements(consumerSortedEntitlements, alreadyDeletedPools);
+        if (regenCertsAndStatuses) {
+            Set<Consumer> consumers = consumersOf(entsToRevoke);
+            recomputeStatusForConsumers(consumers);
+        }
+        else {
+            log.info("Regeneration and status computation was not requested finishing batch revoke");
+        }
+        sendDeletedEvents(entsToRevoke);
+        return poolsToDelete;
+    }
 
-        // post unbind actions
+    private Set<Consumer> consumersOf(List<Entitlement> entitlements) {
+        return entitlements.stream()
+            .map(Entitlement::getConsumer)
+            .collect(Collectors.toSet());
+    }
+
+    private void firePoolDeletedEvents(Set<Pool> poolsToDelete) {
+        for (Pool pool : poolsToDelete) {
+            this.sink.queueEvent(this.eventFactory.poolDeleted(pool));
+        }
+    }
+
+    private void postUnbind(List<Entitlement> entsToRevoke) {
         for (Entitlement ent : entsToRevoke) {
             enforcer.postUnbind(ent.getConsumer(), this, ent);
         }
+    }
 
-        if (!regenCertsAndStatuses) {
-            log.info("Regeneration and status computation was not requested finishing batch revoke");
-
-            sendDeletedEvents(entsToRevoke);
-            return poolsToDelete;
-        }
-
-        log.info("Recomputing status for {} consumers.", consumerSortedEntitlements.size());
+    private void recomputeStatusForConsumers(Set<Consumer> consumers) {
+        log.info("Recomputing status for {} consumers.", consumers.size());
         int i = 1;
-        for (Consumer consumer : consumerSortedEntitlements.keySet()) {
+        for (Consumer consumer : consumers) {
             if (i++ % 1000 == 0) {
                 consumerCurator.flush();
             }
-
             complianceRules.getStatus(consumer);
             systemPurposeComplianceRules.getStatus(consumer, consumer.getEntitlements(), null, true);
         }
-
         consumerCurator.flush();
-
         log.info("All statuses recomputed.");
-
-        sendDeletedEvents(entsToRevoke);
-        return poolsToDelete;
     }
 
     private void sendDeletedEvents(List<Entitlement> entsToRevoke) {
@@ -2009,13 +2018,9 @@ public class CandlepinPoolManager implements PoolManager {
      * @return
      */
     private List<String> getEntIds(Collection<Entitlement> entitlements) {
-        List<String> ids = new ArrayList<>();
-
-        for (Entitlement e : entitlements) {
-            ids.add(e.getId());
-        }
-
-        return ids;
+        return entitlements.stream()
+            .map(Entitlement::getId)
+            .collect(Collectors.toList());
     }
 
     /**
@@ -2024,13 +2029,9 @@ public class CandlepinPoolManager implements PoolManager {
      * @return List pool ID list
      */
     private List<String> getPoolIds(Collection<Pool> pools) {
-        List<String> ids = new ArrayList<>();
-
-        for (Pool e : pools) {
-            ids.add(e.getId());
-        }
-
-        return ids;
+        return pools.stream()
+            .map(Pool::getId)
+            .collect(Collectors.toList());
     }
 
     /**
@@ -2038,49 +2039,37 @@ public class CandlepinPoolManager implements PoolManager {
      * the entitlements that are part of some stack. Then update them
      * accordingly
      *
-     * @param consumerSortedEntitlements Entitlements to be filtered
+     * @param entsToRevoke
      * @param alreadyDeletedPools pools to skip deletion as they have already been deleted
      * @return Entitlements that are stacked
      */
-    private void filterAndUpdateStackingEntitlements(
-        Map<Consumer, List<Entitlement>> consumerSortedEntitlements, Set<String> alreadyDeletedPools) {
-        Map<Consumer, List<Entitlement>> stackingEntitlements = new HashMap<>();
+    private void updateStackingEntitlements(List<Entitlement> entsToRevoke, Set<String> alreadyDeletedPools) {
+        Map<Consumer, List<Entitlement>> stackingEntsByConsumer = stackingEntitlementsOf(entsToRevoke);
+        log.debug("Found stacking entitlements for {} consumers", stackingEntsByConsumer.size());
+        Set<String> allStackingIds = stackIdsOf(stackingEntsByConsumer.values());
+        List<Pool> pools = poolCurator.getSubPoolForStackIds(null, allStackingIds);
+        poolRules.bulkUpdatePoolsFromStack(stackingEntsByConsumer.keySet(), pools, alreadyDeletedPools, true);
+    }
 
-        for (Consumer consumer : consumerSortedEntitlements.keySet()) {
-            List<Entitlement> ents = consumerSortedEntitlements.get(consumer);
-            if (CollectionUtils.isNotEmpty(ents)) {
-                for (Entitlement ent : ents) {
-                    Pool pool = ent.getPool();
+    private Map<Consumer, List<Entitlement>> stackingEntitlementsOf(List<Entitlement> entitlements) {
+        return entitlements.stream()
+            .filter(entitlement -> !entitlement.getPool().isDerived())
+            .filter(entitlement -> entitlement.getPool().isStacked())
+            .collect(Collectors.groupingBy(Entitlement::getConsumer));
+    }
 
-                    if (!"true".equals(pool.getAttributeValue(Pool.Attributes.DERIVED_POOL)) &&
-                        pool.getProduct().hasAttribute(Product.Attributes.STACKING_ID)) {
-                        List<Entitlement> entList = stackingEntitlements.get(consumer);
-                        if (entList == null) {
-                            entList = new ArrayList<>();
-                            stackingEntitlements.put(consumer, entList);
-                        }
-                        entList.add(ent);
-                    }
-                }
-            }
-        }
+    private Set<String> stackIdsOf(Collection<List<Entitlement>> entitlementsPerConsumer) {
+        return entitlementsPerConsumer.stream()
+            .map(this::stackIdsOf)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
+    }
 
-        for (Entry<Consumer, List<Entitlement>> entry : stackingEntitlements.entrySet()) {
-            if (log.isDebugEnabled()) {
-                log.debug("Found {} stacking entitlements to delete for consumer: {}",
-                    entry.getValue().size(), entry.getKey());
-            }
-
-            Set<String> stackIds = new HashSet<>();
-            for (Entitlement ent : entry.getValue()) {
-                stackIds.add(ent.getPool().getStackId());
-            }
-
-            List<Pool> subPools = poolCurator.getSubPoolForStackIds(entry.getKey(), stackIds);
-            if (CollectionUtils.isNotEmpty(subPools)) {
-                poolRules.updatePoolsFromStack(entry.getKey(), subPools, null, alreadyDeletedPools, true);
-            }
-        }
+    private Set<String> stackIdsOf(List<Entitlement> entitlements) {
+        return entitlements.stream()
+            .map(Entitlement::getPool)
+            .map(Pool::getStackId)
+            .collect(Collectors.toSet());
     }
 
     @Override
@@ -2284,7 +2273,7 @@ public class CandlepinPoolManager implements PoolManager {
                         consumerStackedEnts.put(consumer, stackedEntitlements);
                     }
 
-                    if (!"true".equals(pool.getAttributeValue(Pool.Attributes.DERIVED_POOL)) &&
+                    if (!pool.isDerived() &&
                         pool.hasProductAttribute(Product.Attributes.STACKING_ID)) {
 
                         stackedEntitlements.add(entitlement);

--- a/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -125,6 +125,7 @@ public class EntitlementCertificateGenerator {
         catch (CertificateSizeException cse) {
             throw cse;
         }
+        // Fixme throw custom exception instead of generic RuntimeException
         catch (Exception ex) {
             throw new RuntimeException(ex);
         }

--- a/server/src/main/java/org/candlepin/controller/Refresher.java
+++ b/server/src/main/java/org/candlepin/controller/Refresher.java
@@ -96,7 +96,7 @@ public class Refresher {
             Collection<? extends SubscriptionInfo> subs = subAdapter
                 .getSubscriptionsByProductId(product.getId());
 
-            log.debug("Will refresh {} subscriptions in all orgs using product: ",
+            log.debug("Will refresh {} subscriptions in all orgs using product: {}",
                 subs.size(), product.getId());
 
             if (log.isDebugEnabled()) {
@@ -144,8 +144,7 @@ public class Refresher {
              * dirty, they will never get regenerated
              */
             Pool masterPool = poolManager.convertToMasterPool(subscription);
-            poolManager.refreshPoolsForMasterPool(masterPool, true, lazy,
-                Collections.<String, Product>emptyMap());
+            poolManager.refreshPoolsForMasterPool(masterPool, true, lazy, Collections.emptyMap());
         }
 
         for (Owner owner : this.owners.values()) {

--- a/server/src/main/java/org/candlepin/model/EntitlementCertificateCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCertificateCurator.java
@@ -23,8 +23,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Singleton;
@@ -37,7 +39,7 @@ import javax.persistence.Query;
  */
 @Singleton
 public class EntitlementCertificateCurator extends AbstractHibernateCurator<EntitlementCertificate> {
-    private static Logger log = LoggerFactory.getLogger(EntitlementCertificateCurator.class);
+    private static final Logger log = LoggerFactory.getLogger(EntitlementCertificateCurator.class);
 
     @Inject
     public EntitlementCertificateCurator() {
@@ -97,56 +99,71 @@ public class EntitlementCertificateCurator extends AbstractHibernateCurator<Enti
      */
     @Transactional
     public int deleteByEntitlementIds(Iterable<String> entitlementIds) {
+        if (entitlementIds == null) {
+            return 0;
+        }
+
+        Map<String, Long> certIdToSerialMap = findCertIdsAndSerialsOf(entitlementIds);
+        Set<String> certIds = certIdToSerialMap.keySet();
+        Set<Long> serials = new HashSet<>(certIdToSerialMap.values());
+
+        int removed = deleteOldEntitlementCertificates(certIds);
+        log.debug("{} entitlement certificates removed", removed);
+
+        // Mark the serials as revoked so they get picked up and added to the CRL later
+        int revoked = revokeCertificateSerials(serials);
+        log.debug("{} certificate serials revoked", revoked);
+
+        return removed;
+    }
+
+    private Map<String, Long> findCertIdsAndSerialsOf(Iterable<String> entitlementIds) {
+        Map<String, Long> certIdToSerialMap = new HashMap<>();
+
+        String sjpql = "SELECT ec.id, ec.serial.id FROM EntitlementCertificate ec " +
+            "WHERE ec.entitlement.id IN :entids";
+        Query selector = this.getEntityManager().createQuery(sjpql);
+
+        // Impl note:
+        // If we don't set the flush mode here, we will trigger inserts on any pending new
+        // entitlement certificates, on top of potentially catching certs we don't intend
+        // to pick up.
+        selector.setFlushMode(javax.persistence.FlushModeType.COMMIT);
+
+        // Get certificate and serial IDs...
+        for (List<String> block : this.partition(entitlementIds)) {
+            selector.setParameter("entids", block);
+
+            for (Object[] ids : (List<Object[]>) selector.getResultList()) {
+                certIdToSerialMap.put((String) ids[0], (Long) ids[1]);
+            }
+        }
+        return certIdToSerialMap;
+    }
+
+    private int deleteOldEntitlementCertificates(Set<String> certIds) {
+        String rjpql = "DELETE FROM EntitlementCertificate ec WHERE ec.id IN :ecids";
+        Query remover = this.getEntityManager().createQuery(rjpql);
+
         int removed = 0;
-        int revoked = 0;
-
-        if (entitlementIds != null) {
-            Set<String> certIds = new HashSet<>();
-            Set<Long> serials = new HashSet<>();
-
-            String sjpql = "SELECT ec.id, ec.serial.id FROM EntitlementCertificate ec " +
-                "WHERE ec.entitlement.id IN :entids";
-            Query selector = this.getEntityManager().createQuery(sjpql);
-
-            // Impl note:
-            // If we don't set the flush mode here, we will trigger inserts on any pending new
-            // entitlement certificates, on top of potentially catching certs we don't intend
-            // to pick up.
-            selector.setFlushMode(javax.persistence.FlushModeType.COMMIT);
-
-            String rjpql = "DELETE FROM EntitlementCertificate ec WHERE ec.id IN :ecids";
-            Query remover = this.getEntityManager().createQuery(rjpql);
-
-            // Get certificate and serial IDs...
-            for (List<String> block : this.partition(entitlementIds)) {
-                selector.setParameter("entids", block);
-
-                for (Object[] ids : (List<Object[]>) selector.getResultList()) {
-                    certIds.add((String) ids[0]);
-                    serials.add((Long) ids[1]);
-                }
-            }
-
-            // Delete the old entitlement certificates
-            for (List<String> block : this.partition(certIds)) {
-                remover.setParameter("ecids", block);
-                removed += remover.executeUpdate();
-            }
-
-            log.debug("{} entitlement certificates removed", removed);
-
-            // Mark the serials as revoked so they get picked up and added to the CRL later
-            String ujpql = "UPDATE CertificateSerial cs SET cs.revoked = true WHERE cs.id IN :csids";
-            Query updater = this.getEntityManager().createQuery(ujpql);
-
-            for (List<Long> block : this.partition(serials)) {
-                updater.setParameter("csids", block);
-                revoked += updater.executeUpdate();
-            }
-
-            log.debug("{} certificate serials revoked", revoked);
+        for (List<String> block : this.partition(certIds)) {
+            remover.setParameter("ecids", block);
+            removed += remover.executeUpdate();
         }
 
         return removed;
+    }
+
+    private int revokeCertificateSerials(Set<Long> serials) {
+        String ujpql = "UPDATE CertificateSerial cs SET cs.revoked = true WHERE cs.id IN :csids";
+        Query updater = this.getEntityManager().createQuery(ujpql);
+
+        int revoked = 0;
+        for (List<Long> block : this.partition(serials)) {
+            updater.setParameter("csids", block);
+            revoked += updater.executeUpdate();
+        }
+
+        return revoked;
     }
 }

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -1212,7 +1212,7 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
             return Collections.unmodifiableMap(this.importedProductAttributes);
         }
 
-        return Collections.<String, String>emptyMap();
+        return Collections.emptyMap();
     }
 
     /**
@@ -1250,7 +1250,7 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
             return Collections.unmodifiableMap(this.importedDerivedProductAttributes);
         }
 
-        return Collections.<String, String>emptyMap();
+        return Collections.emptyMap();
     }
 
     /**
@@ -1357,8 +1357,8 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
     }
 
     public boolean isStacked() {
-        return (this.getProduct() != null ?
-            this.getProduct().hasAttribute(Product.Attributes.STACKING_ID) : false);
+        return this.getProduct() != null &&
+            this.getProduct().hasAttribute(Product.Attributes.STACKING_ID);
     }
 
     public String getStackId() {
@@ -1525,11 +1525,15 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
     }
 
     public boolean isLocked() {
-        return this.locked != null && locked.booleanValue();
+        return this.locked != null && locked;
     }
 
     public void setLocked(boolean locked) {
         this.locked = locked;
+    }
+
+    public boolean isDerived() {
+        return "true".equals(this.getAttributeValue(Pool.Attributes.DERIVED_POOL));
     }
 
 }

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -30,7 +30,6 @@ import org.candlepin.service.model.SubscriptionInfo;
 import com.google.inject.Inject;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +43,9 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-
+import java.util.stream.Collectors;
 
 
 /**
@@ -53,23 +53,23 @@ import java.util.Set;
  */
 public class PoolRules {
 
-    private static Logger log = LoggerFactory.getLogger(PoolRules.class);
+    private static final Logger log = LoggerFactory.getLogger(PoolRules.class);
 
-    private PoolManager poolManager;
-    private Configuration config;
-    private EntitlementCurator entCurator;
-    private OwnerProductCurator ownerProductCurator;
-    private ProductCurator productCurator;
+    private final PoolManager poolManager;
+    private final Configuration config;
+    private final EntitlementCurator entCurator;
+    private final OwnerProductCurator ownerProductCurator;
+    private final ProductCurator productCurator;
 
     @Inject
     public PoolRules(PoolManager poolManager, Configuration config, EntitlementCurator entCurator,
         OwnerProductCurator ownerProductCurator, ProductCurator productCurator) {
 
-        this.poolManager = poolManager;
-        this.config = config;
-        this.entCurator = entCurator;
-        this.ownerProductCurator = ownerProductCurator;
-        this.productCurator = productCurator;
+        this.poolManager = Objects.requireNonNull(poolManager);
+        this.config = Objects.requireNonNull(config);
+        this.entCurator = Objects.requireNonNull(entCurator);
+        this.ownerProductCurator = Objects.requireNonNull(ownerProductCurator);
+        this.productCurator = Objects.requireNonNull(productCurator);
     }
 
     private long calculateQuantity(long quantity, Product product, String upstreamPoolId) {
@@ -332,7 +332,7 @@ public class PoolRules {
 
             if (!existingPool.isMarkedForDelete()) {
                 boolean useDerived = masterPool.getDerivedProduct() != null &&
-                    BooleanUtils.toBoolean(existingPool.getAttributeValue(Pool.Attributes.DERIVED_POOL));
+                    existingPool.isDerived();
 
                 update.setProductsChanged(checkForChangedProducts(
                     useDerived ? masterPool.getDerivedProduct() : masterPool.getProduct(),
@@ -370,8 +370,7 @@ public class PoolRules {
      */
     public PoolUpdate updatePoolFromStack(Pool pool, Map<String, Product> changedProducts) {
         List<Entitlement> stackedEnts = this.entCurator
-            .findByStackId(pool.getSourceStack().getSourceConsumer(), pool.getSourceStackId())
-            .list();
+            .findByStackId(pool.getSourceStack().getSourceConsumer(), pool.getSourceStackId());
 
         return this.updatePoolFromStackedEntitlements(pool, stackedEnts, changedProducts);
     }
@@ -407,18 +406,14 @@ public class PoolRules {
             sourceStackIds.add(pool.getSourceStackId());
         }
 
-        List<Entitlement> allEntitlements = this.entCurator.findByStackIds(consumer, sourceStackIds).list();
+        List<Entitlement> allEntitlements = this.entCurator.findByStackIds(consumer, sourceStackIds);
         if (CollectionUtils.isNotEmpty(newEntitlements)) {
             allEntitlements.addAll(newEntitlements);
         }
 
         for (Entitlement entitlement : allEntitlements) {
-            List<Entitlement> ents = entitlementMap.get(entitlement.getPool().getStackId());
-            if (ents == null) {
-                ents = new ArrayList<>();
-                entitlementMap.put(entitlement.getPool().getStackId(), ents);
-            }
-
+            List<Entitlement> ents = entitlementMap
+                .computeIfAbsent(entitlement.getPool().getStackId(), k -> new ArrayList<>());
             ents.add(entitlement);
         }
 
@@ -427,7 +422,7 @@ public class PoolRules {
             List<Entitlement> entitlements = entitlementMap.get(pool.getSourceStackId());
             if (CollectionUtils.isNotEmpty(entitlements)) {
                 result.add(this.updatePoolFromStackedEntitlements(pool, entitlements,
-                    Collections.<String, Product>emptyMap()));
+                    Collections.emptyMap()));
             }
             else if (deleteIfNoStackedEnts) {
                 poolsToDelete.add(pool);
@@ -439,6 +434,87 @@ public class PoolRules {
         }
 
         return result;
+    }
+
+    public void bulkUpdatePoolsFromStack(Set<Consumer> consumers, List<Pool> pools,
+        Collection<String> alreadyDeletedPools, boolean deleteIfNoStackedEnts) {
+
+        log.debug("Bulk updating {} pools for {} consumers.", pools.size(), consumers.size());
+        List<Entitlement> stackingEntitlements = findStackingEntitlementsOf(pools);
+        log.debug("found {} stacking entitlements.", stackingEntitlements.size());
+        List<Entitlement> filteredEntitlements = filterByConsumers(consumers, stackingEntitlements);
+        Map<String, List<Entitlement>> entitlementsByStackingId = groupByStackingId(filteredEntitlements);
+
+        updatePoolsWithStackingEntitlements(pools, entitlementsByStackingId);
+
+        if (deleteIfNoStackedEnts) {
+            List<Pool> poolsToDelete = filterPoolsWithoutStackingEntitlements(pools,
+                entitlementsByStackingId);
+
+            if (!poolsToDelete.isEmpty()) {
+                this.poolManager.deletePools(poolsToDelete, alreadyDeletedPools);
+            }
+        }
+    }
+
+    private List<Entitlement> findStackingEntitlementsOf(List<Pool> pools) {
+        Set<String> sourceStackIds = stackIdsOf(pools);
+        log.debug("Found {} source stacks", sourceStackIds.size());
+        return this.entCurator.findByStackIds(null, sourceStackIds);
+    }
+
+    private Set<String> stackIdsOf(List<Pool> pools) {
+        return pools.stream()
+            .map(Pool::getSourceStackId)
+            .collect(Collectors.toSet());
+    }
+
+    private List<Pool> filterPoolsWithoutStackingEntitlements(
+        List<Pool> pools, Map<String, List<Entitlement>> entitlementsByStackingId) {
+        List<Pool> poolsToDelete = new ArrayList<>();
+        for (Pool pool : pools) {
+            List<Entitlement> entitlements = entitlementsByStackingId.get(pool.getSourceStackId());
+            if (CollectionUtils.isEmpty(entitlements)) {
+                poolsToDelete.add(pool);
+            }
+        }
+        return poolsToDelete;
+    }
+
+    private void updatePoolsWithStackingEntitlements(List<Pool> pools, Map<String,
+        List<Entitlement>> entitlementsByStackingId) {
+        for (Pool pool : pools) {
+            List<Entitlement> entitlements = entitlementsByStackingId.get(pool.getSourceStackId());
+            if (CollectionUtils.isNotEmpty(entitlements)) {
+                this.updatePoolFromStackedEntitlements(pool, entitlements,
+                    Collections.emptyMap());
+            }
+        }
+    }
+
+    private List<Entitlement> filterByConsumers(Set<Consumer> consumers, List<Entitlement> entitlements) {
+        Map<String, List<Entitlement>> entitlementsByConsumerUuid = groupByConsumerUuid(entitlements);
+        List<Entitlement> filteredEntitlements = new ArrayList<>(consumers.size());
+        for (Consumer consumer : consumers) {
+            if (entitlementsByConsumerUuid.containsKey(consumer.getUuid())) {
+                final List<Entitlement> foundEntitlements = entitlementsByConsumerUuid
+                    .get(consumer.getUuid());
+                log.debug("Found {} entitlements for consumer: {}", foundEntitlements.size(),
+                    consumer.getUuid());
+                filteredEntitlements.addAll(foundEntitlements);
+            }
+        }
+        return filteredEntitlements;
+    }
+
+    private Map<String, List<Entitlement>> groupByConsumerUuid(List<Entitlement> entitlements) {
+        return entitlements.stream()
+            .collect(Collectors.groupingBy(e -> e.getConsumer().getUuid()));
+    }
+
+    private Map<String, List<Entitlement>> groupByStackingId(List<Entitlement> entitlements) {
+        return entitlements.stream()
+            .collect(Collectors.groupingBy(entitlement -> entitlement.getPool().getStackId()));
     }
 
     public PoolUpdate updatePoolFromStackedEntitlements(Pool pool, Collection<Entitlement> stackedEnts,
@@ -596,7 +672,7 @@ public class PoolRules {
         Set<Product> currentProvided = productCurator.getPoolDerivedProvidedProductsCached(existingPool);
         Set<Product> incomingProvided = new HashSet<>();
 
-        /**
+        /*
          * Incoming pool is not in the database yet. It has the
          * derived products on the instance itself.
          */

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -44,7 +44,6 @@ import java.util.Set;
 import javax.inject.Inject;
 
 
-
 /**
  * EntitlementCuratorTest
  */
@@ -418,7 +417,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool);
         Entitlement created = bind(consumer, pool);
 
-        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId).list();
+        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId);
         assertEquals(1, results.size());
         assertTrue(results.contains(created));
     }
@@ -441,7 +440,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
             Entitlement created = bind(consumer, pool);
         }
 
-        List<Entitlement> results = entitlementCurator.findByStackIds(consumer, stackingIds).list();
+        List<Entitlement> results = entitlementCurator.findByStackIds(consumer, stackingIds);
         assertEquals(3, results.size());
     }
 
@@ -460,7 +459,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
             createdEntitlements.add(bind(consumer, pool));
         }
 
-        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId).list();
+        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId);
         assertEquals(ents, results.size());
         assertTrue(results.containsAll(createdEntitlements) && createdEntitlements.containsAll(results));
     }
@@ -491,7 +490,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
             createdEntitlements.add(bind(consumer, pool));
         }
 
-        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId).list();
+        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId);
         assertEquals(1, results.size());
         assertEquals(createdEntitlements.get(4), results.get(0));
     }

--- a/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -14,7 +14,14 @@
  */
 package org.candlepin.model;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.test.DatabaseTestFixture;
@@ -30,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 
 
 /**
@@ -217,7 +223,7 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         this.createOwnerProductMapping(owner, product1);
         this.createOwnerProductMapping(owner, product2);
 
-        Collection<String> ids = Collections.<String>emptyList();
+        Collection<String> ids = Collections.emptyList();
         Collection<Product> productsA = this.ownerProductCurator.getProductsByIds(owner, ids).list();
         Collection<Product> productsB = this.ownerProductCurator.getProductsByIds(owner.getId(), ids).list();
 
@@ -232,13 +238,13 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         Owner owner3 = this.createOwner();
         Product product = this.createProduct();
 
-        assertEquals(0L, (long) this.ownerProductCurator.getOwnerCount(product));
+        assertEquals(0L, this.ownerProductCurator.getOwnerCount(product));
 
         this.createOwnerProductMapping(owner1, product);
-        assertEquals(1L, (long) this.ownerProductCurator.getOwnerCount(product));
+        assertEquals(1L, this.ownerProductCurator.getOwnerCount(product));
 
         this.createOwnerProductMapping(owner2, product);
-        assertEquals(2L, (long) this.ownerProductCurator.getOwnerCount(product));
+        assertEquals(2L, this.ownerProductCurator.getOwnerCount(product));
     }
 
     @Test
@@ -605,9 +611,9 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         Product product4 = this.createProduct("p2", "p2", owner2);
 
         Map<String, List<Product>> productMap1 = this.ownerProductCurator.getProductsByVersions(owner1,
-            Collections.<String, Integer>singletonMap(product1.getId(), product1.getEntityVersion()));
+            Collections.singletonMap(product1.getId(), product1.getEntityVersion()));
         Map<String, List<Product>> productMap2 = this.ownerProductCurator.getProductsByVersions(owner2,
-            Collections.<String, Integer>singletonMap(product2.getId(), product2.getEntityVersion()));
+            Collections.singletonMap(product2.getId(), product2.getEntityVersion()));
 
         // productMap1 should contain only product2 and product3
         // productMap2 should contain only product1 and product3
@@ -645,9 +651,9 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         Product product4 = this.createProduct("p2", "p2", owner2);
 
         Map<String, List<Product>> productMap1 = this.ownerProductCurator.getProductsByVersions(null,
-            Collections.<String, Integer>singletonMap(product1.getId(), product1.getEntityVersion()));
+            Collections.singletonMap(product1.getId(), product1.getEntityVersion()));
         Map<String, List<Product>> productMap2 = this.ownerProductCurator.getProductsByVersions(null,
-            Collections.<String, Integer>singletonMap(product2.getId(), product2.getEntityVersion()));
+            Collections.singletonMap(product2.getId(), product2.getEntityVersion()));
 
         // Both maps should contain both products 1, 2 and 3
 
@@ -760,14 +766,14 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         assertEquals(0, productMap1.size());
 
         Map<String, List<Product>> productMap2 = this.ownerProductCurator
-            .getProductsByVersions(owner1, Collections.<String, Integer>emptyMap());
+            .getProductsByVersions(owner1, Collections.emptyMap());
         assertEquals(0, productMap2.size());
 
         Map<String, List<Product>> productMap3 = this.ownerProductCurator.getProductsByVersions(null, null);
         assertEquals(0, productMap3.size());
 
         Map<String, List<Product>> productMap4 = this.ownerProductCurator
-            .getProductsByVersions(null, Collections.<String, Integer>emptyMap());
+            .getProductsByVersions(null, Collections.emptyMap());
         assertEquals(0, productMap4.size());
     }
 

--- a/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.List;
 
 
-
 public class PoolCuratorFilterTest extends DatabaseTestFixture {
     private Owner owner;
     private PageRequest req = new PageRequest();
@@ -95,7 +94,7 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
         return searchPool;
     }
 
-    private void searchTest(PoolFilterBuilder filters, int expectedResults, String ... expectedIds) {
+    private void searchTest(PoolFilterBuilder filters, int expectedResults, String... expectedIds) {
         Page<List<Pool>> page = poolCurator.listAvailableEntitlementPools(
             null, owner.getId(), (Collection<String>) null, null, null, filters, req, false,
             false, false, null);
@@ -114,14 +113,14 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
         }
     }
 
-    private void searchTest(String searchFor, int expectedResults, String ... expectedIds) {
+    private void searchTest(String searchFor, int expectedResults, String... expectedIds) {
         PoolFilterBuilder filters = new PoolFilterBuilder();
         filters.addMatchesFilter(searchFor);
         searchTest(filters, expectedResults, expectedIds);
     }
 
     @Test
-    public void availablePoolsCanBeFilteredBySkuNameExactMatch() throws Exception {
+    public void availablePoolsCanBeFilteredBySkuNameExactMatch() {
         searchTest("Awesome OS Server Premium", 1, searchPool.getId());
     }
 
@@ -131,8 +130,8 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
         poolCurator.merge(searchPool);
         searchTest("got_con%tract_", 1, searchPool.getId());
         searchTest("got_con%tract_*", 1, searchPool.getId());
-        searchTest("got_c%ct_", 0, new String [] {});
-        searchTest("got_con%tra_t_", 0, new String [] {});
+        searchTest("got_c%ct_", 0);
+        searchTest("got_con%tra_t_", 0);
     }
 
     @Test
@@ -141,24 +140,24 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void availablePoolsCanBeFilteredBySkuName() throws Exception {
+    public void availablePoolsCanBeFilteredBySkuName() {
         searchTest("Awesome OS Server Premium", 1, searchPool.getId());
-        searchTest("Server", 0, new String [] {});
+        searchTest("Server", 0);
     }
 
     @Test
-    public void availablePoolsCanBeFilteredBySkuNameWildcard() throws Exception {
+    public void availablePoolsCanBeFilteredBySkuNameWildcard() {
         searchTest("*Ser*emium", 1, searchPool.getId());
         searchTest("*sER*emIum", 1, searchPool.getId()); // ignore case
-        searchTest("*Ser*emium?", 0, new String [] {});
+        searchTest("*Ser*emium?", 0);
         searchTest("*Ser*emiu?", 1, searchPool.getId());
-        searchTest("*Ser*emiumaroni", 0, new String [] {});
+        searchTest("*Ser*emiumaroni", 0);
         searchTest("*Ser*emium*", 1, searchPool.getId());
         searchTest("*Ser**emium", 1, searchPool.getId());
     }
 
     @Test
-    public void negationOfAKeyValueFilter() throws Exception {
+    public void negationOfAKeyValueFilter() {
         PoolFilterBuilder filter = new PoolFilterBuilder();
         filter.addAttributeFilter("hello", "true");
         searchTest(filter, 1, searchPool.getId());
@@ -169,18 +168,18 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void availablePoolsCanBeFilteredBySkuNameSingleCharWildcard() throws Exception {
+    public void availablePoolsCanBeFilteredBySkuNameSingleCharWildcard() {
         searchTest("Awesome OS Ser?er P?emium", 1, searchPool.getId());
         searchTest("*Ser??? P?emium", 1, searchPool.getId());
     }
 
     @Test
-    public void availablePoolsCanBeFilteredBySku() throws Exception {
+    public void availablePoolsCanBeFilteredBySku() {
         searchTest("*os-ser*", 1, searchPool.getId());
     }
 
     @Test
-    public void availablePoolsCanBeFilteredByProvidedProducts() throws Exception {
+    public void availablePoolsCanBeFilteredByProvidedProducts() {
         searchTest("Server Bits", 1, searchPool.getId());
         searchTest("*erv???Bi?s", 1, searchPool.getId());
         searchTest("202222", 1, searchPool.getId());
@@ -189,38 +188,38 @@ public class PoolCuratorFilterTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void availablePoolsCanBeFilteredByContractNumber() throws Exception {
+    public void availablePoolsCanBeFilteredByContractNumber() {
         searchTest("mycontract", 1, searchPool.getId());
         searchTest("my*cont??ct", 1, searchPool.getId());
     }
 
     @Test
-    public void availablePoolsCanBeFilteredByOrderNumber() throws Exception {
+    public void availablePoolsCanBeFilteredByOrderNumber() {
         searchTest("myorder", 1, searchPool.getId());
         searchTest("my*ord??", 1, searchPool.getId());
     }
 
     @Test
-    public void availablePoolsCanBeFilteredBySupportLevel() throws Exception {
+    public void availablePoolsCanBeFilteredBySupportLevel() {
         searchTest("CustomSupportLevel", 1, searchPool.getId());
         searchTest("*Cus*port*", 1, searchPool.getId());
         searchTest("*Cus???Su??ortLevel*", 1, searchPool.getId());
-        searchTest("*Self-Service*", 0, new String [] {});
+        searchTest("*Self-Service*", 0);
     }
 
     @Test
-    public void availablePoolsCanBeFilteredByContentName() throws Exception {
+    public void availablePoolsCanBeFilteredByContentName() {
         searchTest("Content One", 1, searchPool.getId());
         searchTest("*on*nt* one", 1, searchPool.getId());
         searchTest("*con???t??n*", 1, searchPool.getId());
-        searchTest("*New Content*", 0, new String [] {});
+        searchTest("*New Content*", 0);
     }
 
     @Test
-    public void availablePoolsCanBeFilteredByContentLabel() throws Exception {
+    public void availablePoolsCanBeFilteredByContentLabel() {
         searchTest("C-Label One", 1, searchPool.getId());
         searchTest("*-l*l*one", 1, searchPool.getId());
         searchTest("*c-l???l??n*", 1, searchPool.getId());
-        searchTest("*Content Label One*", 0, new String [] {});
+        searchTest("*Content Label One*", 0);
     }
 }

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -62,7 +62,6 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 
 
-
 /**
  * Test suite for the PoolCurator object
  */
@@ -162,7 +161,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testAvailablePoolsDoesNotIncludeUeberPool() throws Exception {
+    public void testAvailablePoolsDoesNotIncludeUeberPool() {
         Owner owner = this.createOwner();
         Product product = this.createProduct(owner);
 
@@ -183,7 +182,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void availablePoolsCanBeFilteredByProductPoolAttribute() throws Exception {
+    public void availablePoolsCanBeFilteredByProductPoolAttribute() {
         Date activeDate = TestUtil.createDate(2000, 3, 2);
 
         Pool pool1 = createPool(owner, product, 100L,
@@ -216,7 +215,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void availablePoolsCanBeFilteredByPoolAttribute() throws Exception {
+    public void availablePoolsCanBeFilteredByPoolAttribute() {
         Date activeDate = TestUtil.createDate(2000, 3, 2);
 
         Pool pool1 = createPool(owner, product, 100L,
@@ -246,7 +245,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void availablePoolsCanBeFilteredByPoolId() throws Exception {
+    public void availablePoolsCanBeFilteredByPoolId() {
         Date activeDate = TestUtil.createDate(2000, 3, 2);
 
         Pool pool1 = createPool(owner, product, 100L,
@@ -285,7 +284,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void availablePoolsCanNotBeFilteredByOverriddenAttribute() throws Exception {
+    public void availablePoolsCanNotBeFilteredByOverriddenAttribute() {
         Date activeDate = TestUtil.createDate(2000, 3, 2);
 
         Product product = TestUtil.createProduct();
@@ -318,8 +317,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void availablePoolsCanBeFilteredByBothPoolAndProductPoolAttribute()
-        throws Exception {
+    public void availablePoolsCanBeFilteredByBothPoolAndProductPoolAttribute() {
         Date activeDate = TestUtil.createDate(2000, 3, 2);
 
         Pool pool1 = createPool(owner, product, 100L,
@@ -354,7 +352,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void availablePoolsCanFilterByEmptyValueAttribute() throws Exception {
+    public void availablePoolsCanFilterByEmptyValueAttribute() {
         Date activeDate = TestUtil.createDate(2000, 3, 2);
 
         Pool pool1 = createPool(owner, product, 100L,
@@ -446,10 +444,10 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Consumer guestConsumer = createConsumer(owner);
         guestConsumer.setFact("virt.is_guest", "true");
         guestConsumer.setFact("virt.uuid", gid);
-        hostConsumer.addGuestId(new GuestId(gid , guestConsumer));
+        hostConsumer.addGuestId(new GuestId(gid, guestConsumer));
 
         guestConsumer = consumerCurator.merge(guestConsumer);
-        hostConsumer =  consumerCurator.merge(hostConsumer);
+        hostConsumer = consumerCurator.merge(hostConsumer);
 
         product1 = this.createProduct(product1, owner);
 
@@ -460,9 +458,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         pool.setAttribute(Pool.Attributes.REQUIRES_HOST, hostConsumer.getUuid().toUpperCase());
         poolCurator.create(pool);
 
-        /**
-         * This pool should not be found!
-         */
+        // This pool should not be found!
         Pool pool2 = createPool(owner, product1, 50L, activeDate, TestUtil.createDate(2005, 3, 2));
         pool2.setAttribute(Pool.Attributes.REQUIRES_HOST, "poolForSomeOtherHost");
         poolCurator.create(pool2);
@@ -481,6 +477,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         assertEquals(1, results.size());
         assertEquals(pool, results.get(0));
     }
+
     /**
      * When filtering pools by product/pool attributes, filters specified with
      * the same attribute name are ORed, and different attributes are ANDed.
@@ -543,7 +540,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         List<Pool> results = page.getPageData();
         assertEquals(2, results.size());
 
-        Pool[] expected = new Pool[]{ pool2, pool3 };
+        Pool[] expected = new Pool[] { pool2, pool3 };
         assertTrue(results.containsAll(Arrays.asList(expected)));
     }
 
@@ -820,7 +817,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     public void testBatchLookupOverconsumedBySubscriptionId() {
         Map<String, Entitlement> subIdMap = new HashMap<>();
         List<Pool> expectedPools = new ArrayList<>();
-        for (Integer i = 0; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
             Pool pool = createPool(owner, product, 1L, TestUtil.createDate(2050, 3, 2),
                 TestUtil.createDate(2055, 3, 2));
             poolCurator.create(pool);
@@ -1300,10 +1297,10 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void getSubPoolsForStackIds() {
-        Set stackIds = new HashSet<String>();
-        for (Integer i = 0; i < 5; i++) {
-            String stackId = "12345" + i.toString();
+    public void getSubPoolsForStackIdsByConsumer() {
+        Set<String> stackIds = new HashSet<>();
+        for (int i = 0; i < 5; i++) {
+            String stackId = "12345" + i;
             stackIds.add(stackId);
             Product product = TestUtil.createProduct();
             product.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
@@ -1320,6 +1317,33 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         }
 
         List<Pool> pools = poolCurator.getSubPoolForStackIds(consumer, stackIds);
+        assertEquals(5, pools.size());
+        for (Pool pool : pools) {
+            assertTrue(pool.getSourceStackId().startsWith("12345"));
+        }
+    }
+
+    @Test
+    void getSubPoolsForStackIds() {
+        Set<String> stackIds = new HashSet<>();
+        for (int i = 0; i < 5; i++) {
+            String stackId = "12345" + i;
+            stackIds.add(stackId);
+            Product product = TestUtil.createProduct();
+            product.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+            product.setAttribute(Product.Attributes.STACKING_ID, stackId);
+            product = this.createProduct(product, owner);
+
+            // Create derived pool referencing the entitlement just made:
+            Pool derivedPool = new Pool(owner, product, new HashSet<>(), 1L,
+                TestUtil.createDate(2011, 3, 2), TestUtil.createDate(2055, 3, 2), "", "", "");
+            derivedPool.setSourceStack(new SourceStack(consumer, stackId));
+            derivedPool.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer.getUuid());
+
+            poolCurator.create(derivedPool);
+        }
+
+        List<Pool> pools = poolCurator.getSubPoolForStackIds(null, stackIds);
         assertEquals(5, pools.size());
         for (Pool pool : pools) {
             assertTrue(pool.getSourceStackId().startsWith("12345"));
@@ -1346,13 +1370,13 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         pool2.setSourceSubscription(new SourceSubscription(sourcePool.getSubscriptionId(), "derived"));
         poolCurator.create(pool2);
 
-        assertTrue(poolCurator.getBySubscriptionId(owner, sub.getId()).size() == 2);
+        assertEquals(2, poolCurator.getBySubscriptionId(owner, sub.getId()).size());
         poolManager.deletePool(sourcePool);
 
         // because we check for null now, we want to verify the
         // subpool gets deleted when the original pool is deleted.
         Pool gone = poolCurator.get(pool2.getId());
-        assertEquals(gone, null);
+        assertNull(gone);
     }
 
     @Test
@@ -1474,7 +1498,6 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testGetPoolsOrderedByProductNameAscending() {
-
         Owner owner1 = this.createOwner();
         this.ownerCurator.create(owner1);
 
@@ -1508,7 +1531,6 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testGetPoolsOrderedByProductNameDescending() {
-
         //Checking for Descending
         Owner owner1 = this.createOwner();
         this.ownerCurator.create(owner1);
@@ -1528,7 +1550,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         Date activeOn1 = TestUtil.createDate(2019, 2, 2);
 
-        Page<List<Pool>> page1 = poolManager.listAvailableEntitlementPools(null, null,  owner1.getId(),
+        Page<List<Pool>> page1 = poolManager.listAvailableEntitlementPools(null, null, owner1.getId(),
             null, null, activeOn1, false, null, req1, false, false, null);
 
         List<Pool> pools1 = page1.getPageData();
@@ -1718,13 +1740,14 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     private Pool getMasterPoolBySubscriptionId(String subscriptionId) {
-        for (Pool pool: this.poolCurator.getPoolsBySubscriptionId(subscriptionId)) {
+        for (Pool pool : this.poolCurator.getPoolsBySubscriptionId(subscriptionId)) {
             if (pool.getType() == Pool.PoolType.NORMAL) {
                 return pool;
             }
         }
         return null;
     }
+
     @Test
     public void testGetMasterPoolBySubscriptionId() {
         List<Pool> pools = this.setupMasterPoolsTests();
@@ -1735,7 +1758,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         actual = getMasterPoolBySubscriptionId("sub2");
         assertEquals(pools.get(1), actual);
         actual = getMasterPoolBySubscriptionId("sub5");
-        assertEquals(null, actual);
+        assertNull(actual);
     }
 
     @Test
@@ -1782,8 +1805,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testHasAvailablePools()
-        throws Exception {
+    public void testHasAvailablePools() {
         Date activeDate = TestUtil.createDate(2000, 3, 2);
 
         Pool pool1 = createPool(owner, product, 100L,
@@ -1794,15 +1816,13 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testHasAvailablePoolsNoPools()
-        throws Exception {
+    public void testHasAvailablePoolsNoPools() {
         Date activeDate = TestUtil.createDate(2000, 3, 2);
         assertFalse(poolCurator.hasActiveEntitlementPools(owner.getId(), activeDate));
     }
 
     @Test
-    public void testHasAvailablePoolsNotCurrent()
-        throws Exception {
+    public void testHasAvailablePoolsNotCurrent() {
         Date activeDate = TestUtil.createDate(2000, 3, 2);
         Date startDate = TestUtil.createDate(2001, 3, 2);
 
@@ -1814,7 +1834,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testLookupDevPoolForConsumer() throws Exception {
+    public void testLookupDevPoolForConsumer() {
         // Make sure that multiple pools exist.
         createPool(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
             TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
@@ -1831,7 +1851,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testDevPoolForConsumerNotFoundReturnsNullWhenNoMatchOnConsumer() throws Exception {
+    public void testDevPoolForConsumerNotFoundReturnsNullWhenNoMatchOnConsumer() {
         // Make sure that multiple pools exist.
         createPool(owner, product, -1L, TestUtil.createDate(2010, 3, 2),
             TestUtil.createDate(Calendar.getInstance().get(Calendar.YEAR) + 1, 3, 2));
@@ -1856,15 +1876,15 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Entitlement e = new Entitlement(pool, consumer, owner, 5);
         e.setId(Util.generateDbUUID());
         entitlementCurator.create(e);
-        assertEquals(pool.getConsumed().longValue(), 0);
-        assertEquals(pool.getExported().longValue(), 0);
+        assertEquals(0, pool.getConsumed().longValue());
+        assertEquals(0, pool.getExported().longValue());
 
         poolCurator.calculateConsumedForOwnersPools(owner);
         poolCurator.calculateExportedForOwnersPools(owner);
         poolCurator.refresh(pool);
 
-        assertEquals(pool.getConsumed().longValue(), 5);
-        assertEquals(pool.getExported().longValue(), 5);
+        assertEquals(5, pool.getConsumed().longValue());
+        assertEquals(5, pool.getExported().longValue());
     }
 
     @Test
@@ -1878,15 +1898,15 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Entitlement e = new Entitlement(pool, consumer, owner, 5);
         e.setId(Util.generateDbUUID());
         entitlementCurator.create(e);
-        assertEquals(pool.getConsumed().longValue(), 0);
-        assertEquals(pool.getExported().longValue(), 0);
+        assertEquals(0, pool.getConsumed().longValue());
+        assertEquals(0, pool.getExported().longValue());
 
         poolCurator.calculateConsumedForOwnersPools(owner);
         poolCurator.calculateExportedForOwnersPools(owner);
         poolCurator.refresh(pool);
 
-        assertEquals(pool.getConsumed().longValue(), 5);
-        assertEquals(pool.getExported().longValue(), 0);
+        assertEquals(5, pool.getConsumed().longValue());
+        assertEquals(0, pool.getExported().longValue());
     }
 
     @Test
@@ -2034,7 +2054,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Map<String, Set<String>> expectedPoolProductMap = new HashMap<>();
 
         for (int i : Arrays.asList(0, 2, 4)) {
-            Set productIds = new HashSet<String>();
+            Set<String> productIds = new HashSet<>();
             Pool pool = pools.get(i);
 
             for (int j = productsPerPool * i; j < productsPerPool * i + productsToAttach; ++j) {
@@ -2081,7 +2101,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Map<String, Set<String>> expectedPoolProductMap = new HashMap<>();
 
         for (int i : Arrays.asList(0, 2, 4)) {
-            Set productIds = new HashSet<String>();
+            Set<String> productIds = new HashSet<>();
             Pool pool = pools.get(i);
 
             for (int j = productsPerPool * i; j < productsPerPool * i + productsToAttach; ++j) {
@@ -2129,7 +2149,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Map<String, Set<String>> expectedPoolProductMap = new HashMap<>();
 
         for (int i : Arrays.asList(0, 2, 4)) {
-            Set productIds = new HashSet<String>();
+            Set<String> productIds = new HashSet<>();
             Pool pool = pools.get(i);
 
             for (int j = productsPerPool * i; j < productsPerPool * i + productsToAttach; ++j) {
@@ -2177,7 +2197,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Map<String, Set<String>> expectedPoolProductMap = new HashMap<>();
 
         for (int i : Arrays.asList(0, 2, 4)) {
-            Set productIds = new HashSet<String>();
+            Set<String> productIds = new HashSet<>();
             Pool pool = pools.get(i);
 
             for (int j = productsPerPool * i; j < productsPerPool * i + productsToAttach; ++j) {
@@ -2224,7 +2244,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         Map<String, Set<String>> expectedPoolProductMap = new HashMap<>();
 
         for (int i : Arrays.asList(0, 2, 4)) {
-            Set productIds = new HashSet<String>();
+            Set<String> productIds = new HashSet<>();
             Pool pool = pools.get(i);
 
             for (int j = productsPerPool * i; j < productsPerPool * i + productsToAttach; ++j) {
@@ -2532,7 +2552,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         assertEquals(output.get(consumer1.getId()), Util.asSet(pool1.getId()));
         assertEquals(output.get(consumer2.getId()), Util.asSet(pool4.getId()));
 
-        output = this.poolCurator.getConsumerStackDerivedPoolIdMap(Collections.<String>emptyList());
+        output = this.poolCurator.getConsumerStackDerivedPoolIdMap(Collections.emptyList());
 
         assertNotNull(output);
         assertEquals(0, output.size());
@@ -2689,7 +2709,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         assertEquals(1, output.size());
         assertEquals(output, Util.asSet(pool7.getId()));
 
-        output = this.poolCurator.getUnentitledStackDerivedPoolIds(Collections.<String>emptyList());
+        output = this.poolCurator.getUnentitledStackDerivedPoolIds(Collections.emptyList());
 
         assertNotNull(output);
         assertEquals(1, output.size());

--- a/server/src/test/java/org/candlepin/model/PoolTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolTest.java
@@ -577,4 +577,20 @@ public class PoolTest extends DatabaseTestFixture {
         assertTrue(output.contains(expectedValue2));
         assertTrue(output.contains(expectedValue3));
     }
+
+    @Test
+    public void testIsDerivedPool() {
+        Pool derivedPool = TestUtil.createPool(owner, prod1, 1000);
+        derivedPool.setAttribute(Pool.Attributes.DERIVED_POOL, "true");
+
+        assertTrue(derivedPool.isDerived());
+    }
+
+    @Test
+    public void testIsNotDerivedPool() {
+        Pool derivedPool = TestUtil.createPool(owner, prod1, 1000);
+
+        assertFalse(derivedPool.isDerived());
+    }
+
 }

--- a/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -16,16 +16,19 @@ package org.candlepin.policy;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
-import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
@@ -66,7 +69,6 @@ import java.util.Map;
 import java.util.Set;
 
 
-
 /**
  * JsPoolRulesTest: Tests for the default rules.
  */
@@ -82,7 +84,7 @@ public class PoolRulesStackDerivedTest {
     @Mock private PoolManager poolManagerMock;
     @Mock private Configuration configMock;
     @Mock private EntitlementCurator entCurMock;
-    @Mock private ProductCurator  productCurator;
+    @Mock private ProductCurator productCurator;
 
     private UserPrincipal principal;
     private Owner owner;
@@ -186,9 +188,7 @@ public class PoolRulesStackDerivedTest {
         // Initial entitlement from one of the pools:
         stackedEnts.add(createEntFromPool(pool2));
 
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
-        when(cqmock.list()).thenReturn(stackedEnts);
-        when(entCurMock.findByStackId(consumer, STACK)).thenReturn(cqmock);
+        when(entCurMock.findByStackId(consumer, STACK)).thenReturn(stackedEnts);
 
         pool2.setAttribute(Product.Attributes.VIRT_LIMIT, "60");
         pool4.setAttribute(Product.Attributes.VIRT_LIMIT, "80");
@@ -215,6 +215,7 @@ public class PoolRulesStackDerivedTest {
     }
 
     private static int lastPoolId = 1;
+
     /**
      * Creates a Pool and caches stuff
      * @param sub
@@ -383,8 +384,6 @@ public class PoolRulesStackDerivedTest {
 
     @Test
     public void virtLimitFromFirstVirtLimitEntBatch() {
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
-
         stackedEnts.clear();
         Entitlement e1 = createEntFromPool(pool1);
         e1.setQuantity(4);
@@ -395,8 +394,7 @@ public class PoolRulesStackDerivedTest {
         Class<Set<String>> listClass = (Class<Set<String>>) (Class) HashSet.class;
         ArgumentCaptor<Set<String>> arg = ArgumentCaptor.forClass(listClass);
 
-        when(cqmock.list()).thenReturn(stackedEnts);
-        when(entCurMock.findByStackIds(eq(consumer), arg.capture())).thenReturn(cqmock);
+        when(entCurMock.findByStackIds(eq(consumer), arg.capture())).thenReturn(stackedEnts);
 
         List<PoolUpdate> updates = poolRules.updatePoolsFromStack(consumer,
             Arrays.asList(stackDerivedPool, stackDerivedPool2), null, false);
@@ -424,7 +422,7 @@ public class PoolRulesStackDerivedTest {
         update = poolRules.updatePoolFromStack(stackDerivedPool, null);
         assertTrue(update.changed());
         assertTrue(update.getQuantityChanged());
-        assertEquals(new Long("-1"), stackDerivedPool.getQuantity());
+        assertEquals(-1L, stackDerivedPool.getQuantity());
     }
 
     @Test
@@ -441,14 +439,14 @@ public class PoolRulesStackDerivedTest {
         stackedEnts.add(createEntFromPool(pool2));
 
         PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null);
-        assertEquals(new Long("-1"), stackDerivedPool.getQuantity());
+        assertEquals(-1L, stackDerivedPool.getQuantity());
 
         stackedEnts.remove(0);
         update = poolRules.updatePoolFromStack(stackDerivedPool, null);
         assertTrue(update.changed());
         assertTrue(update.getDatesChanged());
         assertFalse(update.getQuantityChanged());
-        assertEquals(new Long("-1"), stackDerivedPool.getQuantity());
+        assertEquals(-1L, stackDerivedPool.getQuantity());
     }
 
 }

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.nullable;
@@ -46,7 +47,6 @@ import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.GoneException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.config.CandlepinCommonTestConfig;
-import org.candlepin.controller.CandlepinPoolManager;
 import org.candlepin.controller.ContentAccessManager;
 import org.candlepin.controller.Entitler;
 import org.candlepin.controller.ManifestManager;
@@ -58,7 +58,6 @@ import org.candlepin.dto.api.v1.CertificateSerialDTO;
 import org.candlepin.dto.api.v1.ComplianceStatusDTO;
 import org.candlepin.dto.api.v1.ConsumerDTO;
 import org.candlepin.dto.api.v1.ContentAccessDTO;
-import org.candlepin.dto.api.v1.OwnerDTO;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Cdn;
 import org.candlepin.model.CdnCurator;
@@ -313,10 +312,6 @@ public class ConsumerResourceTest {
         return owner;
     }
 
-    protected OwnerDTO createOwnerDTO(String key) {
-        return translator.translate(createOwner(key), OwnerDTO.class);
-    }
-
     protected Consumer mockConsumer(Consumer consumer) {
         if (consumer != null) {
             consumer.ensureUUID();
@@ -381,6 +376,8 @@ public class ConsumerResourceTest {
         when(e.getPool()).thenReturn(p);
         when(p.getSubscriptionId()).thenReturn("4444");
 
+        doThrow(RuntimeException.class).when(mockPoolManager)
+            .regenerateCertificatesOf(any(Entitlement.class), anyBoolean());
         when(mockEntitlementCurator.get(eq("9999"))).thenReturn(e);
         when(mockSubscriptionServiceAdapter.getSubscription(eq("4444"))).thenReturn(s);
 
@@ -388,20 +385,15 @@ public class ConsumerResourceTest {
             any(Entitlement.class), any(Product.class)))
             .thenThrow(new IOException());
 
-        CandlepinPoolManager poolManager = new CandlepinPoolManager(
-            null, null, null, this.config, null, null, mockEntitlementCurator,
-            mockConsumerCurator, mockConsumerTypeCurator, null, null, null, null, null,
-            mockActivationKeyRules, null, null, null, null, null, null, null, null, null, null
-        );
-
         ConsumerResource consumerResource = new ConsumerResource(
             mockConsumerCurator, mockConsumerTypeCurator, null, null, mockEntitlementCurator, null,
             mockEntitlementCertServiceAdapter, null, null, null, null, null,
-            poolManager, null, null, null, null, null, null, null, null, null,
+            mockPoolManager, null, null, null, null, null, null, null, null, null,
             this.config, null, null, consumerBindUtil,
             null, null, this.factValidator, null, consumerEnricher, migrationProvider, translator,
             this.mockJobManager);
 
+        // Fixme throw custom exception from generator instead of generic RuntimeException
         assertThrows(RuntimeException.class, () ->
             consumerResource.regenerateEntitlementCertificates(consumer.getUuid(), "9999", false)
         );

--- a/server/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/server/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -182,8 +182,8 @@ public class ImporterTest {
 
     private Importer buildImporter() {
         return new Importer(this.mockConsumerTypeCurator, this.mockProductCurator, this.mockRulesImporter,
-            this.mockOwnerCurator, this.mockIdentityCertCurator, this.mockContentCurator,
-            this.mockPoolManager, this.mockPKIUtility, this.config, this.mockExporterMetadataCurator,
+            this.mockOwnerCurator, this.mockIdentityCertCurator,
+            this.mockPoolManager, this.mockPKIUtility, this.mockExporterMetadataCurator,
             this.mockCertSerialCurator, this.mockEventSink, this.i18n, this.mockDistributorVersionCurator,
             this.mockCdnCurator, this.syncUtils, this.mockImportRecordCurator,
             this.mockSubscriptionReconciler, this.mockEntitlementCurator, this.mockContentAccessManager,


### PR DESCRIPTION
 - Fix too many params issue in manifest import
 - Replace batch delete of entitlements with batch delete by ids
 - Refactor updatePoolsFromStack to avoid calling deletePools n times
 - Some cleanup as I went through the code (replace finally with try with resources, remove redundant type params, etc..)