### PR TITLE
ENT-3088: Fix container repo generation & add detached mode

### DIFF
--- a/docker/README.mkd
+++ b/docker/README.mkd
@@ -35,6 +35,9 @@ run the `switch-defaults` script.
 
 To run multiple candlepin containers simultaneously, give each invocation of `test` a unique name with the `-n` flag.
 
+You can also use the `-d` option which will containers in detached mode, which will keep them from being removed
+when the test script exits. This will also make them expose ports 8443, 8080 and 22 to the host.
+
 Some useful invocations of the `test` command:
 
 ```sh
@@ -47,6 +50,12 @@ Some useful invocations of the `test` command:
 # run mysql and postgres tests at the same time
 ./test -m -n "my_mysql_tests"
 ./test -p -n "my_postgres_tests"
+
+# run containers detached, expose ports 8443/8080/22 to the host, and don't remove
+# containers when ./test exits. The cp-test -R option will generate test data, content & rpms,
+# and the -s option will make sure the candlepin container will drop into the shell once the
+# data generation is done, to avoid the container shutting down.
+./test -d -c '/usr/bin/cp-test -R -s'
 ```
 
 See `test -h` for more options.

--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -39,6 +39,11 @@ PACKAGES=(
     tomcat
     vim-enhanced
     wget
+    createrepo_c
+    rpm-build
+    rpm-sign
+    python-requests
+    expect
 )
 
 yum install -y ${PACKAGES[@]}

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -12,6 +12,10 @@ services:
     environment:
       USING_MYSQL: "true"
       DBHOSTNAME: db
+    ports:
+      - "8443:8443"
+      - "8080:8080"
+      - "22:22"
     privileged: true
     volumes:
       - ../:/candlepin-dev

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -16,6 +16,10 @@ services:
       USING_POSTGRES: "true"
       DBHOSTNAME: db
       #DBPASSWORD: candlepin
+    ports:
+      - "8443:8443"
+      - "8080:8080"
+      - "22:22"
     privileged: true
     volumes:
       - ../:/candlepin-dev

--- a/docker/test
+++ b/docker/test
@@ -15,11 +15,14 @@ OPTIONS:
   -n NAME   Sets the project name for the docker-compose run
   -p        use postgres
   -l        skip docker pull and use local images
+  -d        run containers detached and expose https, http & ssh ports
+              this will also not automatically shut down & remove the
+              containers on the script's exit
 
 USAGE
 }
 
-while getopts ":bc:dmn:opl" opt; do
+while getopts ":c:mn:pld" opt; do
   case $opt in
     c) TEST_CMD="$OPTARG";;
     m) COMPOSE_ARGS="-f $DIR/docker-compose-mysql.yml";
@@ -27,6 +30,7 @@ while getopts ":bc:dmn:opl" opt; do
     n) PROJ_NAME="-p $OPTARG";;
     p) COMPOSE_ARGS="-f $DIR/docker-compose-postgres.yml";;
     l) USE_CACHE="1";;
+    d) DETACHED="1";;
     \?)
       echo "Invalid option: -$OPTARG" >&2
       usage
@@ -50,9 +54,15 @@ if [ "$USE_CACHE" != "1" ]; then
   docker-compose $COMPOSE_ARGS pull
 fi
 
-docker-compose $PROJ_NAME $COMPOSE_ARGS run --rm candlepin $TEST_CMD
-RETVAL=$?
-docker-compose $PROJ_NAME down
+if [ "$DETACHED" == "1" ]; then
+    # Run detached, and don't remove the containers
+    docker-compose $PROJ_NAME $COMPOSE_ARGS run -d --service-ports candlepin $TEST_CMD
+    RETVAL=$?
+else
+    docker-compose $PROJ_NAME $COMPOSE_ARGS run --rm candlepin $TEST_CMD
+    RETVAL=$?
+    docker-compose $PROJ_NAME down
+fi
 echo "return value: $RETVAL"
 cd -
 exit $RETVAL


### PR DESCRIPTION
- Add packages required for the generation of test content & rpms
- Add flag for detached mode to the test script, which will run
  containers detached from the docker/test script and will not
  stop/remove them once it exits. It will also expose ports 8443,
  8080 and 22 to the host machine