### PR TITLE
[M] Added missing query modifiers to the entity version lookup queries

### DIFF
--- a/server/src/main/java/org/candlepin/async/tasks/OrphanCleanupJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/OrphanCleanupJob.java
@@ -89,7 +89,7 @@ public class OrphanCleanupJob implements AsyncJob  {
         }
 
         this.productCurator.flush();
-        log.debug("{} orphaned product entities deleted", count);
+        log.debug("{} orphaned content entities deleted", count);
 
         return count;
     }
@@ -105,7 +105,7 @@ public class OrphanCleanupJob implements AsyncJob  {
         }
 
         this.contentCurator.flush();
-        log.debug("{} orphaned content entities deleted", count);
+        log.debug("{} orphaned product entities deleted", count);
 
         return count;
     }

--- a/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -384,14 +384,14 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
         Join<OwnerContent, Content> content = root.join(OwnerContent_.content);
 
         query.select(content.get(Content_.uuid))
-            .orderBy(builder.asc(content.get(Content_.id)), builder.desc(content.get(Content_.created)));
+            .distinct(true);
 
         // Impl note:
         // We have room to go higher with the block size here, but building this query is so slow that
         // as the block size goes up, it's actually slower than issuing smaller queries more often.
-        // Also, around a block size of around 5k, Hibernate's query builder starts hitting stack
+        // Also, around a block size of around 2.5k, Hibernate's query builder starts hitting stack
         // overflows.
-        int blockSize = 300;
+        int blockSize = 1000;
         for (List<Map.Entry<String, Integer>> block : this.partition(contentVersions.entrySet(), blockSize)) {
             Predicate[] predicates = new Predicate[block.size()];
             int index = 0;

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -493,14 +493,14 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
         Join<OwnerProduct, Product> product = root.join(OwnerProduct_.product);
 
         query.select(product.get(Product_.uuid))
-            .orderBy(builder.asc(product.get(Product_.id)), builder.desc(product.get(Product_.created)));
+            .distinct(true);
 
         // Impl note:
         // We have room to go higher with the block size here, but building this query is so slow that
         // as the block size goes up, it's actually slower than issuing smaller queries more often.
-        // Also, around a block size of around 5k, Hibernate's query builder starts hitting stack
+        // Also, around a block size of around 2.5k, Hibernate's query builder starts hitting stack
         // overflows.
-        int blockSize = 300;
+        int blockSize = 1000;
         for (List<Map.Entry<String, Integer>> block : this.partition(productVersions.entrySet(), blockSize)) {
             Predicate[] predicates = new Predicate[block.size()];
             int index = 0;


### PR DESCRIPTION
- Removed the unnecessary ordering and added the missing distinct
  keyword to the product and content lookup by version queries
- Fixed a bug that was causing the orphan cleanup job to output
  the product and content counts backward