### PR TITLE
[3.1] Increased the Artemis disk usage limit (ENT-3337)

### DIFF
--- a/server/src/main/resources/broker.xml
+++ b/server/src/main/resources/broker.xml
@@ -117,6 +117,9 @@
         <large-messages-directory>/var/lib/candlepin/activemq-artemis/largemsgs</large-messages-directory>
         <paging-directory>/var/lib/candlepin/activemq-artemis/paging</paging-directory>
 
+        <!-- Only block message delivery once the disk is 99% used (1% remaining) -->
+        <max-disk-usage>99</max-disk-usage>
+
         <!-- Use default thread pool max sizes as defined by Artemis. -->
         <!-- Uncomment to customize.                                  -->
         <!-- <thread-pool-max-size>30</thread-pool-max-size> -->


### PR DESCRIPTION
- Increased the max-disk-usage Artemis setting from the default 90
  to 99, to help avoid erroneously hitting the limit before
  running out of disk space on larger, modern disks/drives