### PR TITLE
Pull internal centos/postgres images to avoid rate limits

### DIFF
--- a/docker/build-images
+++ b/docker/build-images
@@ -76,7 +76,7 @@ tag_images() {
 
 echo "Building images..."
 cd $SCRIPT_HOME
-docker-compose -f docker-compose-build.yml build $BUILD_ARGS $IMAGE && tag_images
+docker-compose -f docker-compose-build.yml build --build-arg INTERNAL_REGISTRY=$REGISTRY $BUILD_ARGS $IMAGE && tag_images
 evalrc $? "Build not successful."
 
 if [ $PUSH = true ]; then

--- a/docker/candlepin-base/Dockerfile
+++ b/docker/candlepin-base/Dockerfile
@@ -1,4 +1,5 @@
-FROM centos:7
+ARG INTERNAL_REGISTRY
+FROM $INTERNAL_REGISTRY/centos:7
 #MAINTAINER Devan Goodwin <dgoodwin@redhat.com>
 MAINTAINER Chris Rog <crog@redhat.com>
 

--- a/docker/gating-test-images/build.sh
+++ b/docker/gating-test-images/build.sh
@@ -6,6 +6,8 @@
 #   and loading/dumping of test data (temp-cp).
 # - All local images are removed after the push.
 
+REGISTRY=docker-registry.upshift.redhat.com/chainsaw
+
 retry() {
     local -r -i max_attempts="$1"; shift
     local -r name="$1"; shift
@@ -40,7 +42,7 @@ rm -f postgres/dump.sql
 
 echo "============ Building temporary base candlepin image ============ "
 # builds base centos image which installs candlepin dependencies & environment
-docker build --no-cache --tag=temp_base_candlepin temp-base-cp/
+docker build --build-arg INTERNAL_REGISTRY=$REGISTRY --no-cache --tag=temp_base_candlepin temp-base-cp/
 evalrc $? "temp_base_candlepin image build was not successful."
 
 echo "============ Building temporary candlepin image ============ "
@@ -74,7 +76,7 @@ docker swarm leave --force
 
 echo "============ Building postgres image which will automatically load the dump.sql we generated before ============ "
 mv /tmp/cp-docker/dump.sql postgres/
-docker build --tag=cp_postgres postgres/
+docker build --no-cache --build-arg INTERNAL_REGISTRY=$REGISTRY --tag=cp_postgres postgres/
 evalrc $? "postgres image build was not successful."
 rm postgres/dump.sql
 rm -rf /tmp/cp-docker/
@@ -84,8 +86,6 @@ docker build --no-cache --tag=cp_latest_stage cp-latest-stage/
 evalrc $? "cp_latest_stage image build was not successful."
 
 echo "============ Pushing images to registry... ============ "
-REGISTRY=docker-registry.upshift.redhat.com/chainsaw
-
 # Find out the candlepin version used in stage
 curl -k -u admin:admin https://subscription.rhsm.stage.redhat.com/subscription/status > stage_status.json
 CP_VERSION=$(python -c 'import json; fp = open("stage_status.json", "r"); obj = json.load(fp); fp.close(); print(obj["version"])');

--- a/docker/gating-test-images/postgres/Dockerfile
+++ b/docker/gating-test-images/postgres/Dockerfile
@@ -1,6 +1,7 @@
 # upgrade to 9.6 requires client version 9.4.1211
 # https://stackoverflow.com/questions/38427585/postgresql-error-column-am-amcanorder-doesnt-exist
-FROM postgres:9.5.9
+ARG INTERNAL_REGISTRY
+FROM $INTERNAL_REGISTRY/postgres:9.5.9
 
 MAINTAINER Nikos Moumoulidis <nmoumoul@redhat.com>
 

--- a/docker/gating-test-images/temp-base-cp/Dockerfile
+++ b/docker/gating-test-images/temp-base-cp/Dockerfile
@@ -1,4 +1,5 @@
-FROM centos:7
+ARG INTERNAL_REGISTRY
+FROM $INTERNAL_REGISTRY/centos:7
 MAINTAINER Nikos Moumoulidis <nmoumoul@redhat.com>
 
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
- Downloading images from the central docker registry may result in
  "You have reached your pull rate limit" errors. This avoids the
  issue by pulling our internal copies of centos/postgres