### PR TITLE
[3.1]ENT-3286: Manifest delete takes 24 hours or more in large environment (60k consumers in owner)

### DIFF
--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -971,8 +971,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
      * @param stackId the ID of the stack
      * @return the list of entitlements for the consumer that are in the stack.
      */
-    @SuppressWarnings("unchecked")
-    public CandlepinQuery<Entitlement> findByStackId(Consumer consumer, String stackId) {
+    public List<Entitlement> findByStackId(Consumer consumer, String stackId) {
         return findByStackIds(consumer, Arrays.asList(stackId));
     }
 
@@ -984,20 +983,34 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
      * @param stackIds the IDs of the stacks
      * @return the list of entitlements for the consumer that are in the stack.
      */
+    public List<Entitlement> findByStackIds(Consumer consumer, Collection<String> stackIds) {
+        List<Entitlement> result = new ArrayList<>();
+        for (List<String> block: this.partition(stackIds)) {
+            result.addAll(findByStackIds(consumer, block));
+        }
+        return result;
+    }
+
     @SuppressWarnings("unchecked")
-    public CandlepinQuery<Entitlement> findByStackIds(Consumer consumer, Collection stackIds) {
-        DetachedCriteria criteria = DetachedCriteria.forClass(Entitlement.class)
-            .add(Restrictions.eq("consumer", consumer))
+    private List<Entitlement> findByStackIds(Consumer consumer, List<String> stackIds) {
+        if (stackIds == null || stackIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Criteria criteria = currentSession().createCriteria(Entitlement.class)
             .createAlias("pool", "ent_pool")
             .createAlias("ent_pool.product", "product")
             .createAlias("product.attributes", "attrs")
             .add(Restrictions.eq("attrs.indices", Product.Attributes.STACKING_ID))
-            .add(CPRestrictions.in("attrs.elements", stackIds))
+            .add(Restrictions.in("attrs.elements", stackIds))
             .add(Restrictions.isNull("ent_pool.sourceEntitlement"))
             .createAlias("ent_pool.sourceStack", "ss", org.hibernate.sql.JoinType.LEFT_OUTER_JOIN)
             .add(Restrictions.isNull("ss.id"));
 
-        return this.cpQueryFactory.<Entitlement>buildQuery(this.currentSession(), criteria);
+        if (consumer != null) {
+            criteria.add(Restrictions.eq("consumer", consumer));
+        }
+
+        return (List<Entitlement>) criteria.list();
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -40,7 +40,6 @@ import java.util.Set;
 import javax.inject.Singleton;
 
 
-
 /**
  * The OwnerProductCurator provides functionality for managing the mapping between owners and
  * products.
@@ -561,15 +560,21 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
             .list();
 
         if (ids != null && !ids.isEmpty()) {
-            criteria.clear();
-            criteria.put("product_uuid", productUuidMap.keySet());
-            criteria.put("pool_id", ids);
+            int providedProductsUpdated = 0;
+            int derivedProductsUpdated = 0;
+            for (List<String> poolIdBlock : this.partition(ids)) {
+                Map<String, Object> updateCriteria = new HashMap<>();
+                updateCriteria.put("product_uuid", productUuidMap.keySet());
+                updateCriteria.put("pool_id", poolIdBlock);
 
-            count = this.bulkSQLUpdate("cp2_pool_provided_products", "product_uuid", uuidMap, criteria);
-            log.debug("{} provided products updated", count);
+                providedProductsUpdated += this.bulkSQLUpdate("cp2_pool_provided_products",
+                    "product_uuid", uuidMap, updateCriteria);
 
-            count = this.bulkSQLUpdate("cp2_pool_derprov_products", "product_uuid", uuidMap, criteria);
-            log.debug("{} derived provided products updated", count);
+                derivedProductsUpdated += this.bulkSQLUpdate("cp2_pool_derprov_products",
+                    "product_uuid", uuidMap, updateCriteria);
+            }
+            log.debug("{} provided products updated", providedProductsUpdated);
+            log.debug("{} derived provided products updated", derivedProductsUpdated);
         }
         else {
             log.debug("0 provided products updated");

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -1525,11 +1525,15 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
     }
 
     public boolean isLocked() {
-        return this.locked != null && locked.booleanValue();
+        return this.locked != null && locked;
     }
 
     public void setLocked(boolean locked) {
         this.locked = locked;
+    }
+
+    public boolean isDerived() {
+        return "true".equals(this.getAttributeValue(Pool.Attributes.DERIVED_POOL));
     }
 
 }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -1132,15 +1132,29 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
      * @param stackIds
      * @return Derived pools which exist for the given consumer and stack ids
      */
-    @SuppressWarnings("checkstyle:indentation")
-    public List<Pool> getSubPoolForStackIds(Consumer consumer, Collection stackIds) {
+    public List<Pool> getSubPoolForStackIds(Consumer consumer, Collection<String> stackIds) {
+        List<Pool> result = new ArrayList<>();
+        for (List<String> block: this.partition(stackIds)) {
+            result.addAll(getSubPoolForStackIds(consumer, block));
+        }
+        return result;
+    }
+
+    @SuppressWarnings({"unchecked", "checkstyle:indentation"})
+    private List<Pool> getSubPoolForStackIds(Consumer consumer, List<String> stackIds) {
+        if (stackIds == null || stackIds.isEmpty()) {
+            return Collections.emptyList();
+        }
         Criteria getPools = createSecureCriteria()
             .createAlias("sourceStack", "ss")
-            .add(Restrictions.eq("ss.sourceConsumer", consumer))
             .add(Restrictions.and(
                 Restrictions.isNotNull("ss.sourceStackId"),
                 CPRestrictions.in("ss.sourceStackId", stackIds))
             );
+
+        if (consumer != null) {
+            getPools.add(Restrictions.eq("ss.sourceConsumer", consumer));
+        }
 
         return (List<Pool>) getPools.list();
     }

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -45,7 +45,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
+import java.util.stream.Collectors;
 
 
 /**
@@ -370,8 +370,7 @@ public class PoolRules {
      */
     public PoolUpdate updatePoolFromStack(Pool pool, Map<String, Product> changedProducts) {
         List<Entitlement> stackedEnts = this.entCurator
-            .findByStackId(pool.getSourceStack().getSourceConsumer(), pool.getSourceStackId())
-            .list();
+            .findByStackId(pool.getSourceStack().getSourceConsumer(), pool.getSourceStackId());
 
         return this.updatePoolFromStackedEntitlements(pool, stackedEnts, changedProducts);
     }
@@ -407,7 +406,7 @@ public class PoolRules {
             sourceStackIds.add(pool.getSourceStackId());
         }
 
-        List<Entitlement> allEntitlements = this.entCurator.findByStackIds(consumer, sourceStackIds).list();
+        List<Entitlement> allEntitlements = this.entCurator.findByStackIds(consumer, sourceStackIds);
         if (CollectionUtils.isNotEmpty(newEntitlements)) {
             allEntitlements.addAll(newEntitlements);
         }
@@ -439,6 +438,87 @@ public class PoolRules {
         }
 
         return result;
+    }
+
+    public void bulkUpdatePoolsFromStack(Set<Consumer> consumers, List<Pool> pools,
+        Collection<String> alreadyDeletedPools, boolean deleteIfNoStackedEnts) {
+
+        log.debug("Bulk updating {} pools for {} consumers.", pools.size(), consumers.size());
+        List<Entitlement> stackingEntitlements = findStackingEntitlementsOf(pools);
+        log.debug("found {} stacking entitlements.", stackingEntitlements.size());
+        List<Entitlement> filteredEntitlements = filterByConsumers(consumers, stackingEntitlements);
+        Map<String, List<Entitlement>> entitlementsByStackingId = groupByStackingId(filteredEntitlements);
+
+        updatePoolsWithStackingEntitlements(pools, entitlementsByStackingId);
+
+        if (deleteIfNoStackedEnts) {
+            List<Pool> poolsToDelete = filterPoolsWithoutStackingEntitlements(pools,
+                entitlementsByStackingId);
+
+            if (!poolsToDelete.isEmpty()) {
+                this.poolManager.deletePools(poolsToDelete, alreadyDeletedPools);
+            }
+        }
+    }
+
+    private List<Entitlement> findStackingEntitlementsOf(List<Pool> pools) {
+        Set<String> sourceStackIds = stackIdsOf(pools);
+        log.debug("Found {} source stacks", sourceStackIds.size());
+        return this.entCurator.findByStackIds(null, sourceStackIds);
+    }
+
+    private Set<String> stackIdsOf(List<Pool> pools) {
+        return pools.stream()
+            .map(Pool::getSourceStackId)
+            .collect(Collectors.toSet());
+    }
+
+    private List<Pool> filterPoolsWithoutStackingEntitlements(
+        List<Pool> pools, Map<String, List<Entitlement>> entitlementsByStackingId) {
+        List<Pool> poolsToDelete = new ArrayList<>();
+        for (Pool pool : pools) {
+            List<Entitlement> entitlements = entitlementsByStackingId.get(pool.getSourceStackId());
+            if (CollectionUtils.isEmpty(entitlements)) {
+                poolsToDelete.add(pool);
+            }
+        }
+        return poolsToDelete;
+    }
+
+    private void updatePoolsWithStackingEntitlements(List<Pool> pools, Map<String,
+        List<Entitlement>> entitlementsByStackingId) {
+        for (Pool pool : pools) {
+            List<Entitlement> entitlements = entitlementsByStackingId.get(pool.getSourceStackId());
+            if (CollectionUtils.isNotEmpty(entitlements)) {
+                this.updatePoolFromStackedEntitlements(pool, entitlements,
+                    Collections.emptyMap());
+            }
+        }
+    }
+
+    private List<Entitlement> filterByConsumers(Set<Consumer> consumers, List<Entitlement> entitlements) {
+        Map<String, List<Entitlement>> entitlementsByConsumerUuid = groupByConsumerUuid(entitlements);
+        List<Entitlement> filteredEntitlements = new ArrayList<>(consumers.size());
+        for (Consumer consumer : consumers) {
+            if (entitlementsByConsumerUuid.containsKey(consumer.getUuid())) {
+                final List<Entitlement> foundEntitlements = entitlementsByConsumerUuid
+                    .get(consumer.getUuid());
+                log.debug("Found {} entitlements for consumer: {}", foundEntitlements.size(),
+                    consumer.getUuid());
+                filteredEntitlements.addAll(foundEntitlements);
+            }
+        }
+        return filteredEntitlements;
+    }
+
+    private Map<String, List<Entitlement>> groupByConsumerUuid(List<Entitlement> entitlements) {
+        return entitlements.stream()
+            .collect(Collectors.groupingBy(e -> e.getConsumer().getUuid()));
+    }
+
+    private Map<String, List<Entitlement>> groupByStackingId(List<Entitlement> entitlements) {
+        return entitlements.stream()
+            .collect(Collectors.groupingBy(entitlement -> entitlement.getPool().getStackId()));
     }
 
     public PoolUpdate updatePoolFromStackedEntitlements(Pool pool, Collection<Entitlement> stackedEnts,

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -418,7 +418,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool);
         Entitlement created = bind(consumer, pool);
 
-        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId).list();
+        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId);
         assertEquals(1, results.size());
         assertTrue(results.contains(created));
     }
@@ -441,7 +441,29 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
             Entitlement created = bind(consumer, pool);
         }
 
-        List<Entitlement> results = entitlementCurator.findByStackIds(consumer, stackingIds).list();
+        List<Entitlement> results = entitlementCurator.findByStackIds(null, stackingIds);
+        assertEquals(3, results.size());
+    }
+
+    @Test
+    public void findByStackIdsByConsumerTest() {
+        Set<String> stackingIds = new HashSet<>();
+        for (int i = 0; i < 4; i++) {
+            String stackingId = "test_stack_id" + i;
+            if (i > 0) {
+                stackingIds.add(stackingId);
+            }
+
+            Product product = TestUtil.createProduct();
+            product.setAttribute(Product.Attributes.STACKING_ID, stackingId);
+            productCurator.create(product);
+
+            Pool pool = createPool(owner, product, 1L, dateSource.currentDate(), createFutureDate(1));
+            poolCurator.create(pool);
+            Entitlement created = bind(consumer, pool);
+        }
+
+        List<Entitlement> results = entitlementCurator.findByStackIds(consumer, stackingIds);
         assertEquals(3, results.size());
     }
 
@@ -460,7 +482,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
             createdEntitlements.add(bind(consumer, pool));
         }
 
-        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId).list();
+        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId);
         assertEquals(ents, results.size());
         assertTrue(results.containsAll(createdEntitlements) && createdEntitlements.containsAll(results));
     }
@@ -491,7 +513,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
             createdEntitlements.add(bind(consumer, pool));
         }
 
-        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId).list();
+        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId);
         assertEquals(1, results.size());
         assertEquals(createdEntitlements.get(4), results.get(0));
     }

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1295,6 +1295,35 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         poolCurator.create(derivedPool);
 
+        Pool pool = poolCurator.getSubPoolForStackIds(null, Arrays.asList(expectedStackId)).get(0);
+        assertNotNull(pool);
+    }
+
+    @Test
+    public void getSubPoolCountForStackByConsumer() {
+        String expectedStackId = "13245";
+        Product product = TestUtil.createProduct();
+        product.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        product.setAttribute(Product.Attributes.STACKING_ID, expectedStackId);
+        product = this.createProduct(product, owner);
+
+        // Create derived pool referencing the entitlement just made:
+        Pool derivedPool = new Pool(
+            owner,
+            product,
+            new HashSet<>(),
+            1L,
+            TestUtil.createDate(2011, 3, 2),
+            TestUtil.createDate(2055, 3, 2),
+            "",
+            "",
+            ""
+        );
+        derivedPool.setSourceStack(new SourceStack(consumer, expectedStackId));
+        derivedPool.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer.getUuid());
+
+        poolCurator.create(derivedPool);
+
         Pool pool = poolCurator.getSubPoolForStackIds(consumer, Arrays.asList(expectedStackId)).get(0);
         assertNotNull(pool);
     }

--- a/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -16,16 +16,19 @@ package org.candlepin.policy;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
-import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
@@ -186,9 +189,7 @@ public class PoolRulesStackDerivedTest {
         // Initial entitlement from one of the pools:
         stackedEnts.add(createEntFromPool(pool2));
 
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
-        when(cqmock.list()).thenReturn(stackedEnts);
-        when(entCurMock.findByStackId(consumer, STACK)).thenReturn(cqmock);
+        when(entCurMock.findByStackId(consumer, STACK)).thenReturn(stackedEnts);
 
         pool2.setAttribute(Product.Attributes.VIRT_LIMIT, "60");
         pool4.setAttribute(Product.Attributes.VIRT_LIMIT, "80");
@@ -383,8 +384,6 @@ public class PoolRulesStackDerivedTest {
 
     @Test
     public void virtLimitFromFirstVirtLimitEntBatch() {
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
-
         stackedEnts.clear();
         Entitlement e1 = createEntFromPool(pool1);
         e1.setQuantity(4);
@@ -395,8 +394,7 @@ public class PoolRulesStackDerivedTest {
         Class<Set<String>> listClass = (Class<Set<String>>) (Class) HashSet.class;
         ArgumentCaptor<Set<String>> arg = ArgumentCaptor.forClass(listClass);
 
-        when(cqmock.list()).thenReturn(stackedEnts);
-        when(entCurMock.findByStackIds(eq(consumer), arg.capture())).thenReturn(cqmock);
+        when(entCurMock.findByStackIds(eq(consumer), arg.capture())).thenReturn(stackedEnts);
 
         List<PoolUpdate> updates = poolRules.updatePoolsFromStack(consumer,
             Arrays.asList(stackDerivedPool, stackDerivedPool2), null, false);


### PR DESCRIPTION
 - Fix too many params issue in manifest import
 - Refactor updatePoolsFromStack to avoid calling deletePools n times