### PR TITLE
ENT-3406: Failing docker build: --build-arg is not supported

### DIFF
--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -1,6 +1,6 @@
 ## this is just for building the containers, meant to be used with the build-images script
 ---
-version: '2'
+version: '3'
 services:
   candlepin-base:
     build: candlepin-base/

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   db:
     image: ${REGISTRY}/mariadb:10.2

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   db:
     # upgrade to 9.6 requires client version 9.4.1211


### PR DESCRIPTION
 - Updated version of docker-compose files