### PR TITLE
ENT-3406: Fix docked build - ARG not supported befor FROM

### DIFF
--- a/docker/build-images
+++ b/docker/build-images
@@ -76,7 +76,10 @@ tag_images() {
 
 echo "Building images..."
 cd $SCRIPT_HOME
-docker-compose -f docker-compose-build.yml build --build-arg INTERNAL_REGISTRY=$REGISTRY $BUILD_ARGS $IMAGE && tag_images
+# TODO Having ARG before FROM is not supported in docker 1.13.1.
+# TODO Revert this change once we update to higher version of docker or to podman
+sed 's,$INTERNAL_REGISTRY,'"${REGISTRY},g" candlepin-base/Dockerfile.template > candlepin-base/Dockerfile
+docker-compose -f docker-compose-build.yml build $BUILD_ARGS $IMAGE && tag_images
 evalrc $? "Build not successful."
 
 if [ $PUSH = true ]; then

--- a/docker/candlepin-base/Dockerfile.template
+++ b/docker/candlepin-base/Dockerfile.template
@@ -1,4 +1,3 @@
-ARG INTERNAL_REGISTRY
 FROM $INTERNAL_REGISTRY/centos:7
 #MAINTAINER Devan Goodwin <dgoodwin@redhat.com>
 MAINTAINER Chris Rog <crog@redhat.com>

--- a/docker/gating-test-images/build.sh
+++ b/docker/gating-test-images/build.sh
@@ -42,6 +42,9 @@ rm -f postgres/dump.sql
 
 echo "============ Building temporary base candlepin image ============ "
 # builds base centos image which installs candlepin dependencies & environment
+# TODO Having ARG before FROM is not supported in docker 1.13.1.
+# TODO Revert this change once we update to higher version of docker or to podman
+sed 's,$INTERNAL_REGISTRY,'"${REGISTRY},g" temp-base-cp/Dockerfile.template > temp-base-cp/Dockerfile
 docker build --build-arg INTERNAL_REGISTRY=$REGISTRY --no-cache --tag=temp_base_candlepin temp-base-cp/
 evalrc $? "temp_base_candlepin image build was not successful."
 
@@ -76,6 +79,9 @@ docker swarm leave --force
 
 echo "============ Building postgres image which will automatically load the dump.sql we generated before ============ "
 mv /tmp/cp-docker/dump.sql postgres/
+# TODO Having ARG before FROM is not supported in docker 1.13.1.
+# TODO Revert this change once we update to higher version of docker or to podman
+sed 's,$INTERNAL_REGISTRY,'"${REGISTRY},g" postgres/Dockerfile.template > postgres/Dockerfile
 docker build --no-cache --build-arg INTERNAL_REGISTRY=$REGISTRY --tag=cp_postgres postgres/
 evalrc $? "postgres image build was not successful."
 rm postgres/dump.sql

--- a/docker/gating-test-images/postgres/Dockerfile.template
+++ b/docker/gating-test-images/postgres/Dockerfile.template
@@ -1,6 +1,5 @@
 # upgrade to 9.6 requires client version 9.4.1211
 # https://stackoverflow.com/questions/38427585/postgresql-error-column-am-amcanorder-doesnt-exist
-ARG INTERNAL_REGISTRY
 FROM $INTERNAL_REGISTRY/postgres:9.5.9
 
 MAINTAINER Nikos Moumoulidis <nmoumoul@redhat.com>

--- a/docker/gating-test-images/temp-base-cp/Dockerfile.template
+++ b/docker/gating-test-images/temp-base-cp/Dockerfile.template
@@ -1,4 +1,3 @@
-ARG INTERNAL_REGISTRY
 FROM $INTERNAL_REGISTRY/centos:7
 MAINTAINER Nikos Moumoulidis <nmoumoul@redhat.com>
 


### PR DESCRIPTION
 - Added sed commands to replace variable with path to docked registry
 - These changes are temporary and should be reverted once we update docker or migrate to podman