### PR TITLE
ENT-2348: Show activation key name when consumer has been registered via activation key

### DIFF
--- a/server/src/main/java/org/candlepin/dto/api/v1/ConsumerActivationKeyDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ConsumerActivationKeyDTO.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+/**
+ * DTO representing the consumer activation keys used during registration.
+ */
+public class ConsumerActivationKeyDTO {
+    private String activationKeyName;
+    private String activationKeyId;
+
+    public ConsumerActivationKeyDTO(String activationKeyId, String activationKeyName) {
+        this.activationKeyId = activationKeyId;
+        this.activationKeyName = activationKeyName;
+    }
+
+    public String getActivationKeyName() {
+        return activationKeyName;
+    }
+
+    public ConsumerActivationKeyDTO activationKeyName(String activationKeyName) {
+        this.activationKeyName = activationKeyName;
+        return this;
+    }
+
+    public String getActivationKeyId() {
+        return activationKeyId;
+    }
+
+    public ConsumerActivationKeyDTO activationKeyId(String activationKeyId) {
+        this.activationKeyId = activationKeyId;
+        return this;
+    }
+}

--- a/server/src/main/java/org/candlepin/dto/api/v1/ConsumerDTO.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ConsumerDTO.java
@@ -87,6 +87,7 @@ public class ConsumerDTO extends TimestampedCandlepinDTO<ConsumerDTO> implements
     protected ConsumerTypeDTO type;
     protected CertificateDTO idCert;
     protected List<GuestIdDTO> guestIds;
+    protected Set<ConsumerActivationKeyDTO> activationKeys;
 
     /**
      * Serialization utility class for wrapping the 'releaseVer' field in a JSON object.
@@ -937,6 +938,27 @@ public class ConsumerDTO extends TimestampedCandlepinDTO<ConsumerDTO> implements
     }
 
     /**
+     * Retrieves the consumer activation keys field of this ConsumerDTO object.
+     *
+     * @return the consumer activation key of the consumer, or null if it has not yet been defined
+     */
+    public Set<ConsumerActivationKeyDTO> getActivationKeys() {
+        return this.activationKeys != null ? new SetView<>(activationKeys) : null;
+    }
+
+    /**
+     * Sets the consumer activation keys used during registration.
+     *
+     * @param activationKeys the activation key data to be set on this ConsumerDTO object.
+     *
+     * @return a reference to this DTO object.
+     */
+    public ConsumerDTO setActivationKeys(Set<ConsumerActivationKeyDTO> activationKeys) {
+        this.activationKeys = activationKeys;
+        return this;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -994,7 +1016,8 @@ public class ConsumerDTO extends TimestampedCandlepinDTO<ConsumerDTO> implements
                 .append(this.getContentAccessMode(), that.getContentAccessMode())
                 .append(this.getType(), that.getType())
                 .append(this.getIdCertificate(), that.getIdCertificate())
-                .append(this.getGuestIds(), that.getGuestIds());
+                .append(this.getGuestIds(), that.getGuestIds())
+                .append(this.getActivationKeys(), that.getActivationKeys());
 
             return builder.isEquals();
         }
@@ -1039,7 +1062,8 @@ public class ConsumerDTO extends TimestampedCandlepinDTO<ConsumerDTO> implements
             .append(this.getContentAccessMode())
             .append(this.getType())
             .append(this.getIdCertificate())
-            .append(this.getGuestIds());
+            .append(this.getGuestIds())
+            .append(this.getActivationKeys());
 
         return builder.toHashCode();
     }
@@ -1110,6 +1134,7 @@ public class ConsumerDTO extends TimestampedCandlepinDTO<ConsumerDTO> implements
         this.setContentAccessMode(source.getContentAccessMode());
         this.setType(source.getType());
         this.setIdCertificate(source.getIdCertificate());
+        this.setActivationKeys(source.getActivationKeys());
 
         return this;
     }

--- a/server/src/main/java/org/candlepin/dto/api/v1/ConsumerTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/ConsumerTranslator.java
@@ -18,6 +18,7 @@ import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.ObjectTranslator;
 import org.candlepin.dto.TimestampedEntityTranslator;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerActivationKey;
 import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
@@ -161,6 +162,19 @@ public class ConsumerTranslator extends TimestampedEntityTranslator<Consumer, Co
                     }
                 }
                 dest.setCapabilities(capabilitiesDTO);
+            }
+
+            Set<ConsumerActivationKey> keys = source.getActivationKeys();
+
+            if (keys != null) {
+                Set<ConsumerActivationKeyDTO> keysDTOSet = new HashSet<>();
+
+                for (ConsumerActivationKey key : keys) {
+                    keysDTOSet.add(new ConsumerActivationKeyDTO(key.getActivationKeyId(),
+                        key.getActivationKeyName()));
+                }
+
+                dest.setActivationKeys(keysDTOSet);
             }
 
             // Temporary measure to maintain API compatibility

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -264,6 +264,10 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @Column(name = "rh_cloud_profile_modified")
     private Date rhCloudProfileModified;
 
+    @Basic(fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "consumer", orphanRemoval = true, cascade = { CascadeType.ALL })
+    private Set<ConsumerActivationKey> activationKeys;
+
     public Consumer(String name, String userName, Owner owner, ConsumerType type) {
         this();
 
@@ -970,5 +974,13 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         }
 
         return false;
+    }
+
+    public void setActivationKeys(Set<ConsumerActivationKey> activationKeys) {
+        this.activationKeys = activationKeys;
+    }
+
+    public Set<ConsumerActivationKey> getActivationKeys() {
+        return this.activationKeys;
     }
 }

--- a/server/src/main/java/org/candlepin/model/ConsumerActivationKey.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerActivationKey.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Entity represents the consumer activation keys used during registration.
+ */
+@Entity
+@Table(name = ConsumerActivationKey.DB_TABLE)
+public class ConsumerActivationKey extends AbstractHibernateObject<ConsumerActivationKey> {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp2_consumer_activation_key";
+
+    @Id
+    @GeneratedValue(generator = "system-uuid")
+    @GenericGenerator(name = "system-uuid", strategy = "uuid")
+    @Column(length = 37)
+    @NotNull
+    private String id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consumer_id", nullable = false)
+    @NotNull
+    private Consumer consumer;
+
+    @Column(name = "activation_key_id")
+    private String activationKeyId;
+
+    @Column(name = "activation_key_name")
+    private String activationKeyName;
+
+    public ConsumerActivationKey() {
+        // Intentionally left empty
+    }
+
+    public ConsumerActivationKey(Consumer consumer, String activationKeyId, String activationKeyName) {
+        this.consumer = consumer;
+        this.activationKeyId = activationKeyId;
+        this.activationKeyName = activationKeyName;
+    }
+
+    public String getActivationKeyName() {
+        return activationKeyName;
+    }
+
+    public void setActivationKeyName(String activationKeyName) {
+        this.activationKeyName = activationKeyName;
+    }
+
+    public String getActivationKeyId() {
+        return activationKeyId;
+    }
+
+    public void setActivationKeyId(String activationKeyId) {
+        this.activationKeyId = activationKeyId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Consumer getConsumer() {
+        return consumer;
+    }
+
+    public void setConsumer(Consumer consumer) {
+        this.consumer = consumer;
+    }
+}

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -70,6 +70,7 @@ import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.CdnCurator;
 import org.candlepin.model.Certificate;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerActivationKey;
 import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerInstalledProduct;
@@ -851,6 +852,14 @@ public class ConsumerResource {
         validateContentAccessMode(consumerToCreate, owner);
         // BZ 1618398 Remove validation check on consumer service level
         // consumerBindUtil.validateServiceLevel(owner.getId(), consumerToCreate.getServiceLevel());
+
+        Set<ConsumerActivationKey> aks = new HashSet<>();
+
+        for (ActivationKey key : keys) {
+            aks.add(new ConsumerActivationKey(consumerToCreate, key.getId(), key.getName()));
+        }
+
+        consumerToCreate.setActivationKeys(aks);
 
         try {
             Date createdDate = consumerToCreate.getCreated();
@@ -2861,5 +2870,4 @@ public class ConsumerResource {
             calculatedAttributesUtil.buildCalculatedAttributes(ent.getPool(), null);
         ent.getPool().setCalculatedAttributes(calculatedAttributes);
     }
-
 }

--- a/server/src/main/resources/db/changelog/20210118141207-create-consumer-activation-key-table.xml
+++ b/server/src/main/resources/db/changelog/20210118141207-create-consumer-activation-key-table.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+
+    <changeSet id="20210118141207-1" author="prakgupt">
+        <comment>Create table for consumer activation key.</comment>
+
+        <createTable tableName="cp2_consumer_activation_key">
+            <column name="id" type="VARCHAR(32)">
+                <constraints nullable="false" primaryKey="true"
+                    primaryKeyName="cp2_consumer_activation_key_pkey"/>
+            </column>
+            <column name="created" type="${timestamp.type}"/>
+            <column name="updated" type="${timestamp.type}"/>
+
+            <column name="activation_key_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="activation_key_name" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="consumer_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+                baseTableName="cp2_consumer_activation_key"
+                baseColumnNames="consumer_id"
+                constraintName="cp2_consumer_activation_key_fk1"
+                deferrable="false"
+                initiallyDeferred="false"
+                onDelete="CASCADE"
+                onUpdate="NO ACTION"
+                referencedColumnNames="id"
+                referencedTableName="cp_consumer"
+                referencesUniqueColumn="false" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1246,4 +1246,5 @@
     <include file="db/changelog/20200910161135-purge-stale-quartz-data.xml"/>
     <include file="db/changelog/20201103112757-purge-current-sca-certs.xml"/>
     <include file="db/changelog/20201210043533-drop-cp-job-table.xml"/>
+    <include file="db/changelog/20210118141207-create-consumer-activation-key-table.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2338,4 +2338,5 @@
     <include file="db/changelog/20200910161135-purge-stale-quartz-data.xml"/>
     <include file="db/changelog/20201103112757-purge-current-sca-certs.xml"/>
     <include file="db/changelog/20201210043533-drop-cp-job-table.xml"/>
+    <include file="db/changelog/20210118141207-create-consumer-activation-key-table.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -155,4 +155,5 @@
     <include file="db/changelog/20200910161135-purge-stale-quartz-data.xml"/>
     <include file="db/changelog/20201103112757-purge-current-sca-certs.xml"/>
     <include file="db/changelog/20201210043533-drop-cp-job-table.xml"/>
+    <include file="db/changelog/20210118141207-create-consumer-activation-key-table.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/dto/api/v1/ConsumerDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ConsumerDTOTest.java
@@ -91,6 +91,11 @@ public class ConsumerDTOTest extends AbstractDTOTest<ConsumerDTO> {
             addOns.add("Add-On-" + i);
         }
 
+        Set<ConsumerActivationKeyDTO> keys = new HashSet<>();
+        for (int i = 0; i < 5; ++i) {
+            keys.add(new ConsumerActivationKeyDTO("keyId" + i, "keyName" + i));
+        }
+
         this.values = new HashMap<>();
         this.values.put("Id", "test-id");
         this.values.put("Uuid", "test-uuid");
@@ -121,6 +126,7 @@ public class ConsumerDTOTest extends AbstractDTOTest<ConsumerDTO> {
         this.values.put("GuestIds", guestIdDTOS);
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
+        this.values.put("ActivationKeys", keys);
 
         GuestIdDTO guestIdDTO = guestIdDTOTest.getPopulatedDTOInstance();
         guestIdDTO.setGuestId("guest-Id-x");

--- a/server/src/test/java/org/candlepin/dto/api/v1/ConsumerTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/api/v1/ConsumerTranslatorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerActivationKey;
 import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
@@ -173,6 +174,13 @@ public class ConsumerTranslatorTest extends
         }
         consumer.setGuestIds(guestIds);
 
+        Set<ConsumerActivationKey> keys = new HashSet<>();
+        for (int i = 0; i < 5; ++i) {
+            keys.add(new ConsumerActivationKey(consumer,
+                "keyId" + i, "keyName" + i));
+        }
+        consumer.setActivationKeys(keys);
+
         when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
@@ -261,6 +269,20 @@ public class ConsumerTranslatorTest extends
                     assertNull(dest.getCapabilities());
                 }
 
+                if (source.getActivationKeys() != null) {
+                    for (ConsumerActivationKey key : source.getActivationKeys()) {
+                        for (ConsumerActivationKeyDTO keyDTO : dest.getActivationKeys()) {
+
+                            if (key.getActivationKeyId().equals(keyDTO.getActivationKeyId())) {
+                                assertEquals(key.getActivationKeyName(), keyDTO.getActivationKeyName());
+                            }
+                        }
+                    }
+                }
+                else {
+                    assertNull(dest.getActivationKeys());
+                }
+
                 assertEquals(0, dest.getGuestIds().size());
             }
             else {
@@ -273,6 +295,7 @@ public class ConsumerTranslatorTest extends
                 assertNull(dest.getInstalledProducts());
                 assertNull(dest.getCapabilities());
                 assertNull(dest.getGuestIds());
+                assertNull(dest.getActivationKeys());
             }
         }
         else {


### PR DESCRIPTION
Changes made to show activation key name when consumer has been registered via activation key.