### PR TITLE
[F] Removed Pool.providedProducts and Pool.derivedProvidedProducts (ENT-1832)

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -948,7 +948,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
      * @return a boolean
      */
     public boolean checkForCloudProfileFacts(Map<String, String> incomingFacts) {
-
         if (incomingFacts == null) {
             return false;
         }
@@ -958,9 +957,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         }
 
         for (CloudProfileFacts profileFact : CloudProfileFacts.values()) {
-
             if (incomingFacts.containsKey(profileFact.getFact())) {
-
                 if (this.facts == null ||
                     !this.facts.containsKey(profileFact.getFact()) ||
                     !this.facts.get(profileFact.getFact()).equals(incomingFacts.get(profileFact.getFact()))) {

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -823,7 +823,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
 
         Join<Entitlement, Pool> pool = entitlement.join(Entitlement_.pool);
         Join<Pool, Product> product = pool.join(Pool_.product);
-        Join<Pool, Product> providedProducts = pool.join(Pool_.providedProducts, JoinType.LEFT);
+        Join<Product, Product> providedProducts = product.join(Product_.providedProducts, JoinType.LEFT);
 
         return cb.and(
             cb.equal(entitlement.get(objectType), object),

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -45,8 +45,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
@@ -250,24 +248,6 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
     @NotNull
     private Product product;
 
-    // TODO: REMOVE THESE AND USE THE PROVIDED PRODUCTS ON THE PRODUCT
-    @ManyToMany
-    @JoinTable(
-        name = "cp2_pool_provided_products",
-        joinColumns = {@JoinColumn(name = "pool_id", insertable = false, updatable = false)},
-        inverseJoinColumns = {@JoinColumn(name = "product_uuid")})
-    @BatchSize(size = 1000)
-    private Set<Product> providedProducts;
-
-    @ManyToMany
-    @JoinTable(
-        name = "cp2_pool_derprov_products",
-        joinColumns = {@JoinColumn(name = "pool_id", insertable = false, updatable = false)},
-        inverseJoinColumns = {@JoinColumn(name = "product_uuid")})
-    @BatchSize(size = 1000)
-    private Set<Product> derivedProvidedProducts;
-    // TODO: REMOVE THE ABOVE
-
     @ElementCollection
     @BatchSize(size = 1000)
     @CollectionTable(name = "cp_pool_attribute", joinColumns = @JoinColumn(name = "pool_id"))
@@ -337,8 +317,6 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
 
     public Pool() {
         this.activeSubscription = Boolean.TRUE;
-        this.providedProducts = new HashSet<>();
-        this.derivedProvidedProducts = new HashSet<>();
         this.attributes = new HashMap<>();
         this.entitlements = new HashSet<>();
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -179,11 +179,9 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testGetCerts() throws JobException {
-        consumerResource.bind(consumer.getUuid(), pool.getId(),
-            null, 1, null, null, false, null, null);
-        List<CertificateDTO> serials = consumerResource
-            .getEntitlementCertificates(consumer.getUuid(), null);
+    public void testGetCerts() throws JobException, Exception {
+        consumerResource.bind(consumer.getUuid(), pool.getId(), null, 1, null, null, false, null, null);
+        List<CertificateDTO> serials = consumerResource.getEntitlementCertificates(consumer.getUuid(), null);
         assertEquals(1, serials.size());
     }
 


### PR DESCRIPTION
- Removed the providedProducts and derivedProvidedProduct pool
  attributes
- Fixed a sporadic unit test failure in the hypervisor update job
  test suite