### PR TITLE
[M] Delete sub pool when virt_limit removed

### DIFF
--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -677,7 +677,7 @@ public class PoolRules {
          */
         if (existingPool.hasAttribute(Pool.Attributes.DERIVED_POOL) &&
             "true".equalsIgnoreCase(existingPool.getAttributeValue(Pool.Attributes.VIRT_ONLY)) &&
-            (attributes.containsKey(Product.Attributes.VIRT_LIMIT) ||
+            (existingPool.hasAttribute(Product.Attributes.VIRT_LIMIT) ||
             existingPool.getProduct().hasAttribute(Product.Attributes.VIRT_LIMIT))) {
 
             if (!attributes.containsKey(Product.Attributes.VIRT_LIMIT)) {

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -969,53 +969,6 @@ public class PoolManagerTest {
         verify(this.mockPoolCurator, times(1)).create(any(Pool.class));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Test
-    public void refreshPoolsCleanupPoolThatLostVirtLimit() {
-        List<Subscription> subscriptions = new ArrayList<>();
-        List<Pool> pools = new ArrayList<>();
-
-        Owner owner = getOwner();
-        Product product = TestUtil.createProduct();
-        product.setLocked(true);
-
-        Subscription s = TestUtil.createSubscription(owner, product);
-        s.setId("01923");
-        subscriptions.add(s);
-        Pool p = TestUtil.createPool(product);
-        p.setSourceSubscription(new SourceSubscription(s.getId(), "master"));
-        p.setMarkedForDelete(true);
-        p.setOwner(owner);
-        pools.add(p);
-
-        this.mockSubscriptions(owner, subscriptions);
-
-        mockPoolsList(pools);
-
-        List<PoolUpdate> updates = new LinkedList();
-        PoolUpdate u = new PoolUpdate(p);
-        u.setQuantityChanged(true);
-        u.setOrderChanged(true);
-        updates.add(u);
-        ArgumentCaptor<Pool> argPool = ArgumentCaptor.forClass(Pool.class);
-        when(poolRulesMock.updatePools(argPool.capture(), eq(pools), eq(s.getQuantity()), any(Map.class)))
-            .thenReturn(updates);
-
-        when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
-        this.mockProducts(owner, product);
-        this.mockProductImport(owner, product);
-        this.mockContentImport(owner, new Content[] {});
-
-        CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
-        when(cqmock.list()).thenReturn(pools);
-        when(cqmock.iterator()).thenReturn(pools.iterator());
-        when(mockPoolCurator.listByOwnerAndType(eq(owner), any(PoolType.class))).thenReturn(cqmock);
-
-        this.manager.getRefresher(mockSubAdapter).add(owner).run();
-        verify(poolRulesMock).createAndEnrichPools(argPool.capture(), any(List.class));
-        TestUtil.assertPoolsAreEqual(TestUtil.copyFromSub(s), argPool.getValue());
-    }
-
     /**
      * @return
      */

--- a/server/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
+++ b/server/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
@@ -14,10 +14,10 @@
  */
 package org.candlepin.policy.js.pool;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Mockito.anyListOf;
 import static org.mockito.Mockito.eq;
@@ -38,8 +38,8 @@ import org.candlepin.model.ProductCurator;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.test.TestUtil;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -61,7 +61,7 @@ public class PoolHelperTest {
     private Owner owner;
     private ProductCurator productCurator;
 
-    @Before
+    @BeforeEach
     public void init() {
         pm = mock(PoolManager.class);
         psa = mock(ProductServiceAdapter.class);


### PR DESCRIPTION
- Fix a refresh issue, where virt_limit is removed from a
  master pool, but the corresponding sub pool is not deleted