### PR TITLE
[F] Updated queries to remove references to removed pool attributes (ENT-1837)

### DIFF
--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -948,7 +948,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
      * @return a boolean
      */
     public boolean checkForCloudProfileFacts(Map<String, String> incomingFacts) {
-
         if (incomingFacts == null) {
             return false;
         }
@@ -958,9 +957,7 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
         }
 
         for (CloudProfileFacts profileFact : CloudProfileFacts.values()) {
-
             if (incomingFacts.containsKey(profileFact.getFact())) {
-
                 if (this.facts == null ||
                     !this.facts.containsKey(profileFact.getFact()) ||
                     !this.facts.get(profileFact.getFact()).equals(incomingFacts.get(profileFact.getFact()))) {

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -823,7 +823,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
 
         Join<Entitlement, Pool> pool = entitlement.join(Entitlement_.pool);
         Join<Pool, Product> product = pool.join(Pool_.product);
-        Join<Pool, Product> providedProducts = pool.join(Pool_.providedProducts, JoinType.LEFT);
+        Join<Product, Product> providedProducts = product.join(Product_.providedProducts, JoinType.LEFT);
 
         return cb.and(
             cb.equal(entitlement.get(objectType), object),

--- a/server/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/server/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -1116,9 +1116,10 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         String queryStr = "SELECT DISTINCT e2.id " +
             // Required entitlement
             "FROM cp_entitlement e1 " +
-            "JOIN cp_pool pl1 on pl1.id = e1.pool_id " +
+            "JOIN cp_pool pl1 ON pl1.id = e1.pool_id " +
+            "JOIN cp2_products pp ON pp.uuid = pl1.product_uuid " +
             // Required entitlement => required pool => derived product => provided product
-            "JOIN cp2_product_provided_products ppp1 ON ppp1.product_uuid = pl1.derived_product_uuid " +
+            "JOIN cp2_product_provided_products ppp1 ON ppp1.product_uuid = pp.derived_product_uuid " +
             "JOIN cp2_products p ON p.uuid = ppp1.provided_product_uuid " +
             // Required product => conditional content
             "JOIN cp2_content_modified_products cmp ON cmp.element = p.product_id " +

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -45,8 +45,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
@@ -250,24 +248,6 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
     @NotNull
     private Product product;
 
-    // TODO: REMOVE THESE AND USE THE PROVIDED PRODUCTS ON THE PRODUCT
-    @ManyToMany
-    @JoinTable(
-        name = "cp2_pool_provided_products",
-        joinColumns = {@JoinColumn(name = "pool_id", insertable = false, updatable = false)},
-        inverseJoinColumns = {@JoinColumn(name = "product_uuid")})
-    @BatchSize(size = 1000)
-    private Set<Product> providedProducts;
-
-    @ManyToMany
-    @JoinTable(
-        name = "cp2_pool_derprov_products",
-        joinColumns = {@JoinColumn(name = "pool_id", insertable = false, updatable = false)},
-        inverseJoinColumns = {@JoinColumn(name = "product_uuid")})
-    @BatchSize(size = 1000)
-    private Set<Product> derivedProvidedProducts;
-    // TODO: REMOVE THE ABOVE
-
     @ElementCollection
     @BatchSize(size = 1000)
     @CollectionTable(name = "cp_pool_attribute", joinColumns = @JoinColumn(name = "pool_id"))
@@ -337,8 +317,6 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
 
     public Pool() {
         this.activeSubscription = Boolean.TRUE;
-        this.providedProducts = new HashSet<>();
-        this.derivedProvidedProducts = new HashSet<>();
         this.attributes = new HashMap<>();
         this.entitlements = new HashSet<>();
 

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -1843,11 +1843,8 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         String sql = "SELECT p.id FROM cp_pool p " +
             "LEFT JOIN cp2_owner_products op1 ON op1.owner_id = p.owner_id " +
             "  AND p.product_uuid = op1.product_uuid " +
-            "LEFT JOIN cp2_owner_products op2 ON op2.owner_id = p.owner_id " +
-            "  AND p.derived_product_uuid = op2.product_uuid " +
             "WHERE p.owner_id = :owner_id AND " +
-            "  ((p.product_uuid IS NOT NULL AND op1.product_uuid IS NULL) OR " +
-            "  (p.derived_product_uuid IS NOT NULL AND op2.product_uuid IS NULL))";
+            "  (p.product_uuid IS NOT NULL AND op1.product_uuid IS NULL)";
 
         return this.getEntityManager()
             .createNativeQuery(sql)

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -179,11 +179,9 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testGetCerts() throws JobException {
-        consumerResource.bind(consumer.getUuid(), pool.getId(),
-            null, 1, null, null, false, null, null);
-        List<CertificateDTO> serials = consumerResource
-            .getEntitlementCertificates(consumer.getUuid(), null);
+    public void testGetCerts() throws JobException, Exception {
+        consumerResource.bind(consumer.getUuid(), pool.getId(), null, 1, null, null, false, null, null);
+        List<CertificateDTO> serials = consumerResource.getEntitlementCertificates(consumer.getUuid(), null);
         assertEquals(1, serials.size());
     }
 


### PR DESCRIPTION
- Updated the entitlement curator and pool curator to no longer
  reference the cp_pool.provided_products column, or the
  cp2_pool_provided_products or cp2_pool_derprov_products tables