### PR TITLE
[F] Updated the OrphanCleanupJob to be aware of product to product references (ENT-2011)

### DIFF
--- a/server/src/main/java/org/candlepin/async/tasks/OrphanCleanupJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/OrphanCleanupJob.java
@@ -101,13 +101,26 @@ public class OrphanCleanupJob implements AsyncJob  {
         List<String> orphanedProductUuids = this.ownerProductCurator.getOrphanedProductUuids();
 
         Set<Pair<String, String>> activePoolProducts = this.productCurator
-            .getProductsWithPools(orphanedProductUuids);
+            .getPoolsReferencingProducts(orphanedProductUuids);
 
         if (activePoolProducts != null && !activePoolProducts.isEmpty()) {
             log.warn("Found {} pools referencing orphaned products:", activePoolProducts.size());
 
             for (Pair<String, String> pair : activePoolProducts) {
-                log.warn("  Pool: {}, Product UUID: {}", pair.getValue(), pair.getKey());
+                log.warn("  Pool: {}, Orphan product UUID: {}", pair.getValue(), pair.getKey());
+                orphanedProductUuids.remove(pair.getKey());
+            }
+        }
+
+        Set<Pair<String, String>> activeProductProducts = this.productCurator
+            .getProductsReferencingProducts(orphanedProductUuids);
+
+        if (activeProductProducts != null && !activeProductProducts.isEmpty()) {
+            log.warn("Found {} products referencing orphaned provided products:",
+                activeProductProducts.size());
+
+            for (Pair<String, String> pair : activeProductProducts) {
+                log.warn("  Product: {}, Orphan product UUID: {}", pair.getValue(), pair.getKey());
                 orphanedProductUuids.remove(pair.getKey());
             }
         }

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -358,9 +358,11 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
     public int mapProductToOwners(Product product, Owner... owners) {
         int count = 0;
 
-        for (Owner owner : owners) {
-            if (this.mapProductToOwner(product, owner)) {
-                ++count;
+        if (owners != null) {
+            for (Owner owner : owners) {
+                if (this.mapProductToOwner(product, owner)) {
+                    ++count;
+                }
             }
         }
 
@@ -371,9 +373,11 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
     public int mapOwnerToProducts(Owner owner, Product... products) {
         int count = 0;
 
-        for (Product product : products) {
-            if (this.mapProductToOwner(product, owner)) {
-                ++count;
+        if (products != null) {
+            for (Product product : products) {
+                if (this.mapProductToOwner(product, owner)) {
+                    ++count;
+                }
             }
         }
 


### PR DESCRIPTION
- OrphanCleanupJob will now avoid removing orphaned products which are
  still referenced by other products
- Fixed a null pointer exception that could occur in OwnerProductCurator
  if creating owner-product links with a null owner or product collection