### PR TITLE
[M] Fixed a bug with Content equality checks for fields with empty strings

### DIFF
--- a/server/src/main/java/org/candlepin/model/Content.java
+++ b/server/src/main/java/org/candlepin/model/Content.java
@@ -53,6 +53,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 
+
 /**
  * ProductContent
  */
@@ -338,7 +339,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
 
     @Override
     public String getContentUrl() {
-        return contentUrl;
+        return this.contentUrl == null || this.contentUrl.isEmpty() ? null : this.contentUrl;
     }
 
     public void setContentUrl(String contentUrl) {
@@ -351,7 +352,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
      */
     @Override
     public String getRequiredTags() {
-        return requiredTags;
+        return this.requiredTags == null || this.requiredTags.isEmpty() ? null : this.requiredTags;
     }
 
     /**
@@ -367,7 +368,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
      */
     @Override
     public String getReleaseVersion() {
-        return releaseVer;
+        return this.releaseVer == null || this.releaseVer.isEmpty() ? null : this.releaseVer;
     }
 
     /**
@@ -379,7 +380,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
 
     @Override
     public String getGpgUrl() {
-        return gpgUrl;
+        return this.gpgUrl == null || this.gpgUrl.isEmpty() ? null : this.gpgUrl;
     }
 
     public void setGpgUrl(String gpgUrl) {
@@ -484,7 +485,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
 
     @Override
     public String getArches() {
-        return arches;
+        return this.arches == null || this.arches.isEmpty() ? null : this.arches;
     }
 
     @XmlTransient
@@ -509,21 +510,25 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
             Content that = (Content) other;
 
             boolean equals = new EqualsBuilder()
-                .append(this.id, that.id)
-                .append(this.type, that.type)
-                .append(this.label, that.label)
-                .append(this.name, that.name)
-                .append(this.vendor, that.vendor)
-                .append(this.contentUrl, that.contentUrl)
-                .append(this.requiredTags, that.requiredTags)
-                .append(this.releaseVer, that.releaseVer)
-                .append(this.gpgUrl, that.gpgUrl)
-                .append(this.metadataExpire, that.metadataExpire)
-                .append(this.arches, that.arches)
+                .append(this.getId(), that.getId())
+                .append(this.getType(), that.getType())
+                .append(this.getLabel(), that.getLabel())
+                .append(this.getName(), that.getName())
+                .append(this.getVendor(), that.getVendor())
+                .append(this.getMetadataExpiration(), that.getMetadataExpiration())
+
+                // These fields require special consideration, as nulls and empty strings are
+                // considered identical for CP's purposes. The accessors should fix this for us,
+                // but if equality checks start failing in the future, this is something to check.
+                .append(this.getContentUrl(), that.getContentUrl())
+                .append(this.getRequiredTags(), that.getRequiredTags())
+                .append(this.getReleaseVersion(), that.getReleaseVersion())
+                .append(this.getGpgUrl(), that.getGpgUrl())
+                .append(this.getArches(), that.getArches())
                 .isEquals();
 
             if (equals) {
-                if (!Util.collectionsAreEqual(this.modifiedProductIds, that.modifiedProductIds)) {
+                if (!Util.collectionsAreEqual(this.getModifiedProductIds(), that.getModifiedProductIds())) {
                     return false;
                 }
             }
@@ -552,17 +557,17 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     public int getEntityVersion() {
         // This must always be a subset of equals
         HashCodeBuilder builder = new HashCodeBuilder(37, 7)
-            .append(this.id)
-            .append(this.type)
-            .append(this.label)
-            .append(this.name)
-            .append(this.vendor)
-            .append(this.contentUrl)
-            .append(this.requiredTags)
-            .append(this.releaseVer)
-            .append(this.gpgUrl)
-            .append(this.metadataExpire)
-            .append(this.arches);
+            .append(this.getId())
+            .append(this.getType())
+            .append(this.getLabel())
+            .append(this.getName())
+            .append(this.getVendor())
+            .append(this.getContentUrl())
+            .append(this.getRequiredTags())
+            .append(this.getReleaseVersion())
+            .append(this.getGpgUrl())
+            .append(this.getMetadataExpiration())
+            .append(this.getArches());
 
         // Impl note:
         // We need to be certain that the hash code is calculated in a way that's order
@@ -571,7 +576,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
         int accumulator = 0;
 
         if (!this.modifiedProductIds.isEmpty()) {
-            for (String pid : this.modifiedProductIds) {
+            for (String pid : this.getModifiedProductIds()) {
                 accumulator += (pid != null ? pid.hashCode() : 0);
             }
 


### PR DESCRIPTION
- Fixed a bug that could cause equality checks for two Content
  instances to fail if one had empty strings for certain fields
  and the other had nulls