### PR TITLE
1920158: ERROR: value too long for type character varying(32)

### DIFF
--- a/server/src/main/java/org/candlepin/model/ConsumerActivationKey.java
+++ b/server/src/main/java/org/candlepin/model/ConsumerActivationKey.java
@@ -34,7 +34,7 @@ import javax.validation.constraints.NotNull;
 public class ConsumerActivationKey extends AbstractHibernateObject<ConsumerActivationKey> {
 
     /** Name of the table backing this object in the database */
-    public static final String DB_TABLE = "cp2_consumer_activation_key";
+    public static final String DB_TABLE = "cp_consumer_activation_key";
 
     @Id
     @GeneratedValue(generator = "system-uuid")

--- a/server/src/main/resources/db/changelog/20210118141207-create-consumer-activation-key-table.xml
+++ b/server/src/main/resources/db/changelog/20210118141207-create-consumer-activation-key-table.xml
@@ -10,10 +10,10 @@
     <changeSet id="20210118141207-1" author="prakgupt">
         <comment>Create table for consumer activation key.</comment>
 
-        <createTable tableName="cp2_consumer_activation_key">
+        <createTable tableName="cp_consumer_activation_key">
             <column name="id" type="VARCHAR(32)">
                 <constraints nullable="false" primaryKey="true"
-                    primaryKeyName="cp2_consumer_activation_key_pkey"/>
+                    primaryKeyName="cp_consumer_activation_key_pkey"/>
             </column>
             <column name="created" type="${timestamp.type}"/>
             <column name="updated" type="${timestamp.type}"/>
@@ -22,7 +22,7 @@
                 <constraints nullable="false"/>
             </column>
 
-            <column name="activation_key_name" type="VARCHAR(32)">
+            <column name="activation_key_name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
 
@@ -32,9 +32,9 @@
         </createTable>
 
         <addForeignKeyConstraint
-                baseTableName="cp2_consumer_activation_key"
+                baseTableName="cp_consumer_activation_key"
                 baseColumnNames="consumer_id"
-                constraintName="cp2_consumer_activation_key_fk1"
+                constraintName="cp_consumer_activation_key_fk1"
                 deferrable="false"
                 initiallyDeferred="false"
                 onDelete="CASCADE"


### PR DESCRIPTION
 - Rename table cp2_consumer_activation_key to cp_consumer_activation_key
 - Update activation_key_name to VARCHAR(255)
 - Update foreign and primary key references