### PR TITLE
1919458: invalid Content-Type yields 500 (ENT-3439)

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1721,6 +1721,21 @@ class Candlepin
     return JSON.parse(response.body) unless response.body.empty?
   end
 
+  def get_response(uri, content_type='application/json')
+    # escape and build uri
+    euri = URI.escape(uri)
+
+    # execute
+    puts ("GET #{euri}") if @verbose
+    if content_type.nil?
+      response = get_client(euri, Net::HTTP::Get, :get)[euri].get :content_type => 'application/json'
+    else
+      response = get_client(euri, Net::HTTP::Get, :get)[euri].get :content_type => content_type
+    end
+
+    return (response.body)
+  end
+
 
 
   protected

--- a/server/spec/filter_response_spec.rb
+++ b/server/spec/filter_response_spec.rb
@@ -78,4 +78,17 @@ describe 'Response JSON Filtering' do
       consumer["owner"]["id"].should_not == nil
     end
   end
+
+  it 'should get valid response on invalid content types' do
+    lambda {
+      @cp.get_response("/consumers/#{@consumer1.uuid}", 'application|json')
+    }.should raise_exception(RestClient::BadRequest)
+
+    response = @cp.get_response("/consumers/#{@consumer1.uuid}",'application/json')
+    expect(response.code).to eq(200)
+
+    lambda {
+      @cp.get_response("/consumers/#{@consumer1.uuid}", 'application-json')
+    }.should raise_exception(RestClient::BadRequest)
+  end
 end

--- a/server/src/main/java/org/candlepin/guice/CandlepinFilterModule.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinFilterModule.java
@@ -17,6 +17,7 @@ package org.candlepin.guice;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.common.filter.LoggingFilter;
 import org.candlepin.config.ConfigProperties;
+import org.candlepin.servlet.filter.CandlepinContentTypeFilter;
 import org.candlepin.servlet.filter.CandlepinPersistFilter;
 import org.candlepin.servlet.filter.CandlepinScopeFilter;
 import org.candlepin.servlet.filter.EventFilter;
@@ -62,6 +63,7 @@ public class CandlepinFilterModule extends ServletModule {
             // don't filter token
             regex = "^(?!/token).*";
         }
+        filterRegex(regex).through(CandlepinContentTypeFilter.class);
         filterRegex(regex).through(CandlepinScopeFilter.class);
         filterRegex(regex).through(CandlepinPersistFilter.class);
         filterRegex(regex).through(LoggingFilter.class, loggingFilterConfig);

--- a/server/src/main/java/org/candlepin/servlet/filter/CandlepinContentTypeFilter.java
+++ b/server/src/main/java/org/candlepin/servlet/filter/CandlepinContentTypeFilter.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.servlet.filter;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Singleton;
+
+import org.xnap.commons.i18n.I18n;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * CandlepinContentTypeFilter
+ *
+ * A servlet filter used to filter out the invalid content type from a
+ * request.
+ */
+
+@Singleton
+public class CandlepinContentTypeFilter implements Filter {
+
+    private Injector injector;
+
+    @Inject
+    public CandlepinContentTypeFilter(Injector injector) {
+        this.injector = injector;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+        FilterChain chain) throws IOException, ServletException {
+
+        I18n i18n = injector.getInstance(I18n.class);
+        // Validate media type contains a slash, to avoid RESTEasy's inability to handle this
+        String contentType = request.getContentType();
+
+        if (contentType != null && !contentType.contains("/")) {
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+            httpResponse.setContentType("text/plain");
+            httpResponse.setCharacterEncoding("UTF-8");
+            httpResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            httpResponse.getWriter().write(i18n.tr("Invalid Content-Type {0}", contentType));
+            return;
+        }
+        else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public void init(FilterConfig config) throws ServletException {
+    }
+
+}


### PR DESCRIPTION
 - Added a CandlepinContentTypeFilter. It will execute before
   each request to validate the content-type.
 - Added the RSpec test.