### PR TITLE
[M] Activation keys can no longer be created or updated with pools in SCA mode (ENT-3089)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/OwnerContentAccess.java
+++ b/server/src/main/java/org/candlepin/controller/OwnerContentAccess.java
@@ -12,10 +12,11 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller;
 
 import java.util.Objects;
+
+
 
 public class OwnerContentAccess {
 
@@ -55,9 +56,7 @@ public class OwnerContentAccess {
 
     @Override
     public String toString() {
-        return "OwnerContentAccess{" +
-            "contentAccessMode='" + contentAccessMode + '\'' +
-            ", contentAccessModeList='" + contentAccessModeList + '\'' +
-            '}';
+        return String.format("OwnerContentAccess [contentAccessMode: '%s', contentAccessModeList: '%s']",
+            this.getContentAccessMode(), this.getContentAccessModeList());
     }
 }

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -610,7 +610,7 @@ public class Owner extends AbstractHibernateObject<Owner>
      */
     @XmlTransient
     public boolean isContentAccessEnabled() {
-        return ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue().equals(this.getContentAccessMode());
+        return ContentAccessMode.ORG_ENVIRONMENT.matches(this.getContentAccessMode());
     }
 
 }

--- a/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/server/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -226,6 +226,15 @@ public class ActivationKeyResource {
         @QueryParam("quantity") Long quantity) {
 
         ActivationKey key = this.fetchActivationKey(activationKeyId);
+
+        // If we're running in SCA mode, don't allow adding (more) pools to the keys, as we want
+        // to signal how pointless this is.
+        Owner owner = key.getOwner();
+        if (owner != null && owner.isContentAccessEnabled()) {
+            throw new BadRequestException(i18n.tr("Pools cannot be added to activation keys while" +
+                "the org is operating in simple content access mode"));
+        }
+
         Pool pool = findPool(poolId);
 
         String message = activationKeyRules.validatePoolForActivationKey(key, pool, quantity);

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1035,8 +1035,8 @@ public class OwnerResource {
                         "directly in standalone mode."));
             }
 
-            // This kinda doubles up on some work here, but at least we nice, clear error messages
-            // rather than spooky ISEs.
+            // This kinda doubles up on some work here, but at least we output nice, clear error
+            // messages rather than spooky ISEs.
             this.validateContentAccessModeChanges(owner, contentAccessModeList, contentAccessMode);
             updateContentAccess = true;
         }
@@ -1314,6 +1314,16 @@ public class OwnerResource {
             throw new BadRequestException(
                 i18n.tr("The activation key name \"{0}\" is already in use for owner {1}",
                         dto.getName(), ownerKey));
+        }
+
+        // If we're running in SCA mode, don't allow creating keys with pools, as we want to signal
+        // how pointless this is.
+        if (owner.isContentAccessEnabled()) {
+            Set<ActivationKeyDTO.ActivationKeyPoolDTO> pools = dto.getPools();
+            if (pools != null && pools.size() > 0) {
+                throw new BadRequestException(i18n.tr("Activation keys cannot be created with pools while" +
+                    "the org is operating in simple content access mode"));
+            }
         }
 
         serviceLevelValidator.validate(owner.getId(), dto.getServiceLevel());

--- a/server/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
@@ -14,15 +14,19 @@
  */
 package org.candlepin.resource;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.common.exceptions.BadRequestException;
+import org.candlepin.controller.ContentAccessManager.ContentAccessMode;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.api.v1.ActivationKeyDTO;
 import org.candlepin.dto.api.v1.OwnerDTO;
@@ -30,7 +34,6 @@ import org.candlepin.jackson.ProductCachedSerializationModule;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
-import org.candlepin.model.ProductCurator;
 import org.candlepin.model.Release;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
@@ -44,7 +47,6 @@ import com.google.inject.Injector;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.xnap.commons.i18n.I18n;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -52,15 +54,18 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+
+
 /**
  * ActivationKeyResourceTest
  */
 public class ActivationKeyResourceTest extends DatabaseTestFixture {
-    @Inject private ProductCurator productCurator;
     @Inject private ActivationKeyCurator activationKeyCurator;
     @Inject private ServiceLevelValidator serviceLevelValidator;
-    @Inject private I18n i18n;
     @Inject private Injector injector;
+
+    private PoolManager mockPoolManager;
+    private ActivationKeyCurator mockActivationKeyCurator;
 
     protected ActivationKeyResource activationKeyResource;
     protected ActivationKeyRules activationKeyRules;
@@ -71,7 +76,17 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
     public void setUp() {
         activationKeyResource = injector.getInstance(ActivationKeyResource.class);
         activationKeyRules = injector.getInstance(ActivationKeyRules.class);
-        owner = createOwner();
+
+        this.mockPoolManager = mock(PoolManager.class);
+        this.mockActivationKeyCurator = mock(ActivationKeyCurator.class);
+
+        this.owner = createOwner();
+    }
+
+    private ActivationKeyResource buildResource() {
+        return new ActivationKeyResource(this.mockActivationKeyCurator, this.i18n, this.mockPoolManager,
+            this.serviceLevelValidator, this.activationKeyRules, null,
+            new ProductCachedSerializationModule(this.productCurator), this.modelTranslator);
     }
 
     @Test
@@ -139,17 +154,14 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
     @Test
     public void testActivationKeyWithNonMultiPool() {
         ActivationKey ak = genActivationKey();
-        ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
+
         Pool p = genPool();
         p.getProduct().setAttribute(Pool.Attributes.MULTI_ENTITLEMENT, "no");
-        PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
-        when(poolManager.get(eq("testPool"))).thenReturn(p);
+        when(this.mockActivationKeyCurator.secureGet(eq("testKey"))).thenReturn(ak);
+        when(this.mockPoolManager.get(eq("testPool"))).thenReturn(p);
 
-        ActivationKeyResource akr = new ActivationKeyResource(
-            akc, i18n, poolManager, serviceLevelValidator, activationKeyRules, null,
-            new ProductCachedSerializationModule(productCurator), this.modelTranslator);
+        ActivationKeyResource akr = this.buildResource();
         assertThrows(BadRequestException.class, () ->
             akr.addPoolToKey("testKey", "testPool", 2L)
         );
@@ -158,17 +170,13 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
     @Test
     public void testActivationKeyWithNegPoolQuantity() {
         ActivationKey ak = genActivationKey();
-        ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
         Pool p = genPool();
         p.setQuantity(10L);
-        PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
-        when(poolManager.get(eq("testPool"))).thenReturn(p);
+        when(this.mockActivationKeyCurator.secureGet(eq("testKey"))).thenReturn(ak);
+        when(this.mockPoolManager.get(eq("testPool"))).thenReturn(p);
 
-        ActivationKeyResource akr = new ActivationKeyResource(
-            akc, i18n, poolManager, serviceLevelValidator, activationKeyRules, null,
-            new ProductCachedSerializationModule(productCurator), this.modelTranslator);
+        ActivationKeyResource akr = this.buildResource();
         assertThrows(BadRequestException.class, () ->
             akr.addPoolToKey("testKey", "testPool", -3L)
         );
@@ -177,36 +185,28 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
     @Test
     public void testActivationKeyWithLargePoolQuantity() {
         ActivationKey ak = genActivationKey();
-        ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
         Pool p = genPool();
         p.getProduct().setAttribute(Pool.Attributes.MULTI_ENTITLEMENT, "yes");
         p.setQuantity(10L);
-        PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
-        when(poolManager.get(eq("testPool"))).thenReturn(p);
+        when(this.mockActivationKeyCurator.secureGet(eq("testKey"))).thenReturn(ak);
+        when(this.mockPoolManager.get(eq("testPool"))).thenReturn(p);
 
-        ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
-            serviceLevelValidator, activationKeyRules, null,
-            new ProductCachedSerializationModule(productCurator), this.modelTranslator);
+        ActivationKeyResource akr = this.buildResource();
         akr.addPoolToKey("testKey", "testPool", 15L);
     }
 
     @Test
     public void testActivationKeyWithUnlimitedPool() {
         ActivationKey ak = genActivationKey();
-        ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
         Pool p = genPool();
         p.getProduct().setAttribute(Pool.Attributes.MULTI_ENTITLEMENT, "yes");
         p.setQuantity(-1L);
-        PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
-        when(poolManager.get(eq("testPool"))).thenReturn(p);
+        when(this.mockActivationKeyCurator.secureGet(eq("testKey"))).thenReturn(ak);
+        when(this.mockPoolManager.get(eq("testPool"))).thenReturn(p);
 
-        ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
-            serviceLevelValidator, activationKeyRules, null,
-            new ProductCachedSerializationModule(productCurator), this.modelTranslator);
+        ActivationKeyResource akr = this.buildResource();
         akr.addPoolToKey("testKey", "testPool", 15L);
     }
 
@@ -214,18 +214,14 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
     @Test
     public void testActivationKeyWithPersonConsumerType() {
         ActivationKey ak = genActivationKey();
-        ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
         Pool p = genPool();
         p.getProduct().setAttribute(Pool.Attributes.REQUIRES_CONSUMER_TYPE, "person");
         p.setQuantity(1L);
-        PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
-        when(poolManager.get(eq("testPool"))).thenReturn(p);
+        when(this.mockActivationKeyCurator.secureGet(eq("testKey"))).thenReturn(ak);
+        when(this.mockPoolManager.get(eq("testPool"))).thenReturn(p);
 
-        ActivationKeyResource akr = new ActivationKeyResource(
-            akc, i18n, poolManager, serviceLevelValidator, activationKeyRules, null,
-            new ProductCachedSerializationModule(productCurator), this.modelTranslator);
+        ActivationKeyResource akr = this.buildResource();
         assertThrows(BadRequestException.class, () ->
             akr.addPoolToKey("testKey", "testPool", 1L)
         );
@@ -234,37 +230,29 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
     @Test
     public void testActivationKeyWithNonPersonConsumerType() {
         ActivationKey ak = genActivationKey();
-        ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
         Pool p = genPool();
         p.getProduct().setAttribute(Pool.Attributes.REQUIRES_CONSUMER_TYPE, "candlepin");
-        PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
-        when(poolManager.get(eq("testPool"))).thenReturn(p);
+        when(this.mockActivationKeyCurator.secureGet(eq("testKey"))).thenReturn(ak);
+        when(this.mockPoolManager.get(eq("testPool"))).thenReturn(p);
 
-        ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
-            serviceLevelValidator, activationKeyRules, null,
-            new ProductCachedSerializationModule(productCurator), this.modelTranslator);
+        ActivationKeyResource akr = this.buildResource();
         assertNotNull(akr.addPoolToKey("testKey", "testPool", 1L));
     }
 
     @Test
     public void testActivationKeyWithSameHostReqPools() {
         ActivationKey ak = genActivationKey();
-        ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
-        PoolManager poolManager = mock(PoolManager.class);
         Pool p1 = genPool();
         p1.setAttribute(Pool.Attributes.REQUIRES_HOST, "host1");
         Pool p2 = genPool();
         p2.setAttribute(Pool.Attributes.REQUIRES_HOST, "host1");
 
-        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
-        when(poolManager.get(eq("testPool1"))).thenReturn(p1);
-        when(poolManager.get(eq("testPool2"))).thenReturn(p2);
+        when(this.mockActivationKeyCurator.secureGet(eq("testKey"))).thenReturn(ak);
+        when(this.mockPoolManager.get(eq("testPool1"))).thenReturn(p1);
+        when(this.mockPoolManager.get(eq("testPool2"))).thenReturn(p2);
 
-        ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
-            serviceLevelValidator, activationKeyRules, null,
-            new ProductCachedSerializationModule(productCurator), this.modelTranslator);
+        ActivationKeyResource akr = this.buildResource();
 
         akr.addPoolToKey("testKey", "testPool1", 1L);
         assertEquals(1, ak.getPools().size());
@@ -278,40 +266,32 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
     @Test
     public void testActivationKeyWithDiffHostReqPools() {
         ActivationKey ak = genActivationKey();
-        ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
-        PoolManager poolManager = mock(PoolManager.class);
         Pool p1 = genPool();
         p1.setAttribute(Pool.Attributes.REQUIRES_HOST, "host1");
         Pool p2 = genPool();
         p2.setAttribute(Pool.Attributes.REQUIRES_HOST, "host2");
 
         ak.addPool(p2, 1L);
-        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
-        when(poolManager.get(eq("testPool1"))).thenReturn(p1);
+        when(this.mockActivationKeyCurator.secureGet(eq("testKey"))).thenReturn(ak);
+        when(this.mockPoolManager.get(eq("testPool1"))).thenReturn(p1);
 
-        ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
-            serviceLevelValidator, activationKeyRules, null,
-            new ProductCachedSerializationModule(productCurator), this.modelTranslator);
+        ActivationKeyResource akr = this.buildResource();
         akr.addPoolToKey("testKey", "testPool1", 1L);
     }
 
     @Test
     public void testActivationKeyHostReqPoolThenNonHostReq() {
         ActivationKey ak = genActivationKey();
-        ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
-        PoolManager poolManager = mock(PoolManager.class);
         Pool p1 = genPool();
         p1.setAttribute(Pool.Attributes.REQUIRES_HOST, "host1");
         Pool p2 = genPool();
         p2.setAttribute(Pool.Attributes.REQUIRES_HOST, "");
 
-        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
-        when(poolManager.get(eq("testPool1"))).thenReturn(p1);
-        when(poolManager.get(eq("testPool2"))).thenReturn(p2);
+        when(this.mockActivationKeyCurator.secureGet(eq("testKey"))).thenReturn(ak);
+        when(this.mockPoolManager.get(eq("testPool1"))).thenReturn(p1);
+        when(this.mockPoolManager.get(eq("testPool2"))).thenReturn(p2);
 
-        ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
-            serviceLevelValidator, activationKeyRules, null,
-            new ProductCachedSerializationModule(productCurator), this.modelTranslator);
+        ActivationKeyResource akr = this.buildResource();
         akr.addPoolToKey("testKey", "testPool1", 1L);
         assertEquals(1, ak.getPools().size());
         ak.addPool(p1, 1L);
@@ -322,17 +302,36 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
     @Test
     public void testActivationKeyWithNullQuantity() {
         ActivationKey ak = genActivationKey();
-        ActivationKeyCurator akc = mock(ActivationKeyCurator.class);
         Pool p = genPool();
-        PoolManager poolManager = mock(PoolManager.class);
 
-        when(akc.secureGet(eq("testKey"))).thenReturn(ak);
-        when(poolManager.get(eq("testPool"))).thenReturn(p);
+        when(this.mockActivationKeyCurator.secureGet(eq("testKey"))).thenReturn(ak);
+        when(this.mockPoolManager.get(eq("testPool"))).thenReturn(p);
 
-        ActivationKeyResource akr = new ActivationKeyResource(akc, i18n, poolManager,
-            serviceLevelValidator, activationKeyRules, null,
-            new ProductCachedSerializationModule(productCurator), this.modelTranslator);
+        ActivationKeyResource akr = this.buildResource();
         akr.addPoolToKey("testKey", "testPool", null);
+    }
+
+    @Test
+    public void testAddPoolToKeyFailsInSCAMode() {
+        Owner owner = new Owner()
+            .setKey("test-org")
+            .setContentAccessMode(ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
+
+        ActivationKey key = new ActivationKey("test-key", owner);
+        key.setId("test-key");
+
+        Pool pool = new Pool();
+        pool.setId("test-pool");
+
+        doReturn(pool).when(this.mockPoolManager).get(pool.getId());
+        doReturn(key).when(this.mockActivationKeyCurator).secureGet(key.getId());
+
+        ActivationKeyResource resource = this.buildResource();
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+            () -> resource.addPoolToKey(key.getId(), pool.getId(), 1L));
+
+        assertThat(exception.getMessage(), containsString("simple content access"));
     }
 
     @Test


### PR DESCRIPTION
- While SCA mode is enabled for a given organization, activation keys can
  no longer be created with pools, or have pools added to them