### PR TITLE
ENT-3519: Fix to include auto-generated classes in WAR/RPM file

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -233,6 +233,45 @@ task pom {
                 build([:]) {
                     plugins {
                         plugin {
+                            groupId 'org.apache.maven.plugins'
+                            artifactId 'maven-dependency-plugin'
+                            version '3.1.2'
+                            executions {
+                                execution {
+                                    id 'unpack'
+                                    phase 'prepare-package'
+                                    goals {
+                                        goal 'unpack'
+                                    }
+                                    configuration {
+                                        artifactItems {
+                                            artifactItem {
+                                                groupId 'org.candlepin'
+                                                artifactId 'api'
+                                                type 'jar'
+                                                overWrite 'true'
+                                                outputDirectory '${project.basedir}/target/openapi_generated_classes'
+                                                includes '**/*.class'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        plugin {
+                            groupId 'org.apache.maven.plugins'
+                            artifactId 'maven-war-plugin'
+                            version '3.3.1'
+                            configuration {
+                                webResources {
+                                    resource {
+                                        directory '${project.basedir}/target/openapi_generated_classes'
+                                        targetPath 'WEB-INF/classes'
+                                    }
+                                }
+                            }
+                        }
+                        plugin {
                             artifactId "maven-surefire-plugin"
                         }
                         plugin {

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -464,6 +464,43 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.2</version>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.candlepin</groupId>
+                  <artifactId>api</artifactId>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.basedir}/target/openapi_generated_classes</outputDirectory>
+                  <includes>**/*.class</includes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.3.1</version>
+        <configuration>
+          <webResources>
+            <resource>
+              <directory>${project.basedir}/target/openapi_generated_classes</directory>
+              <targetPath>WEB-INF/classes</targetPath>
+            </resource>
+          </webResources>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
       <plugin>


### PR DESCRIPTION
Changes/Fix -
Used the ```unpack``` goal of maven dependency plugin to unpack the desired classes to a folder ```target/openapi_generated_classes``` and allowing maven war plugin to includes this folder during packaging.