### PR TITLE
[3.1]1929681: Candlepin will not install in FIPS mode

### DIFF
--- a/server/candlepin.spec.tmpl
+++ b/server/candlepin.spec.tmpl
@@ -1,5 +1,5 @@
-%global _binary_filedigest_algorithm 1
-%global _source_filedigest_algorithm 1
+%global _binary_filedigest_algorithm 8
+%global _source_filedigest_algorithm 8
 %global _binary_payload w9.gzdio
 %global _source_payload w9.gzdio
 


### PR DESCRIPTION
- Switch filedigest algorithm to sha-256