### PR TITLE
[M] 1925546: Added additional checks for regenerating SCA certificates (ENT-3521)

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1137,7 +1137,6 @@ class Candlepin
 
   def create_pool(owner_key, product_id, params={})
     quantity = params[:quantity] || 1
-    provided_products = params[:provided_products] || []
 
     start_date = params[:start_date] || DateTime.now
     end_date = params[:end_date] || start_date + 365
@@ -1146,8 +1145,7 @@ class Candlepin
       'startDate' => start_date,
       'endDate'   => end_date,
       'quantity'  =>  quantity,
-      'productId' => product_id,
-      'providedProducts' => provided_products.collect { |pid| {'productId' => pid} }
+      'productId' => product_id
     }
 
     if params[:branding]
@@ -1166,8 +1164,8 @@ class Candlepin
       pool['orderNumber'] = params[:order_number]
     end
 
-    if params[:derived_product_id]
-      pool['derivedProductId'] = params[:derived_product_id]
+    if params[:upstream_pool_id]
+      pool['upstreamPoolId'] = params[:upstream_pool_id]
     end
 
     if params[:source_subscription]
@@ -1179,14 +1177,6 @@ class Candlepin
     elsif params[:subscriptionId] || params[:subscriptionSubKey]
       pool['subscriptionId'] = params[:subscriptionId] || "sub_id-#{rand(9)}#{rand(9)}#{rand(9)}"
       pool['subscriptionSubKey'] = params[:subscriptionSubKey] || 'master'
-    end
-
-    if params[:derived_provided_products]
-      pool['derivedProvidedProducts'] = params[:derived_provided_products].collect { |pid| {'productId' => pid} }
-    end
-
-    if params[:upstream_pool_id]
-      pool['upstreamPoolId'] = params[:upstream_pool_id]
     end
 
     return post("/owners/#{owner_key}/pools", {}, pool)

--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -36,11 +36,14 @@ describe 'Content Access' do
 
     @product = create_product('test-product', 'some product')
     @cp.add_content_to_product(@owner['key'], @product['id'], @content_id)
-    @cp.create_pool(@owner['key'], @product['id'], {:quantity => 10})
+    @pool = @cp.create_pool(@owner['key'], @product['id'], {:quantity => 10})
+
+    # We need to sleep here to ensure enough time passes from the last content update to whatever
+    # cert fetching we do at the start of most of these tests.
+    sleep 1
   end
 
   it "does allow addition of the content access level" do
-
     @cp.update_owner(@owner['key'], {'contentAccessMode' => "entitlement"})
     @owner = @cp.get_owner(@owner['key'])
 
@@ -287,8 +290,9 @@ describe 'Content Access' do
     certs = @consumer.list_certificates
     json_body = extract_payload(certs[0]['cert'])
     content = json_body['products'][0]['content'][0]
-    certs[0]['serial']['serial'].should == serial_id
-    content['name'].should == 'cname-extreme'
+
+    expect(certs[0]['serial']['serial']).to_not eq(serial_id)
+    expect(content['name']).to eq('cname-extreme')
   end
 
   it "does update second existing content access cert content when product data changes" do
@@ -296,18 +300,32 @@ describe 'Content Access' do
     @consumer2 = consumer_client(@user, @consumername2, type=:system, username=nil, facts= {'system.certificate_version' => '3.3'})
     certs1 = @consumer1.list_certificates
     certs2 = @consumer2.list_certificates
-    certs2.length.should == 1
-    serial_id2 = certs2[0]['serial']['serial']
+
+    expect(certs1.length).to eq(1)
+    expect(certs2.length).to eq(1)
+
+    cert_serial_1 = certs1[0]['serial']['serial']
+    cert_serial_2 = certs2[0]['serial']['serial']
+
     sleep 1
 
     @cp.update_content(@owner['key'], @content_id, {:name=>'cname-extreme'})
 
     certs1 = @consumer1.list_certificates
     certs2 = @consumer2.list_certificates
+
+    expect(certs1.length).to eq(1)
+    expect(certs2.length).to eq(1)
+
     json_body = extract_payload(certs2[0]['cert'])
     content = json_body['products'][0]['content'][0]
-    certs2[0]['serial']['serial'].should == serial_id2
-    content['name'].should == 'cname-extreme'
+
+    # The cert should have changed due to the content change, but both consumers should still have the
+    # same cert
+    expect(certs1[0]['serial']['serial']).to_not eq(cert_serial_1)
+    expect(certs2[0]['serial']['serial']).to_not eq(cert_serial_2)
+
+    expect(content['name']).to eq('cname-extreme')
   end
 
   it "does not update existing content access cert content when no data changes" do
@@ -315,11 +333,12 @@ describe 'Content Access' do
     certs = @consumer1.list_certificates
     serial_id = certs[0]['serial']['serial']
     updated = certs[0]['updated']
+
     sleep 1
 
     certs = @consumer1.list_certificates
-    certs[0]['serial']['serial'].should == serial_id
-    certs[0]['updated'].should == updated
+    expect(certs[0]['serial']['serial']).to eq(serial_id)
+    expect(certs[0]['updated']).to eq(updated)
   end
 
   it "does include the content access cert serial in serial list" do
@@ -826,6 +845,42 @@ describe 'Content Access' do
     expect(returned_uuids).to include(content_c2.id)
     expect(returned_uuids).to include(content_c3.id)
     expect(returned_uuids).to include(content_c4.id)
+  end
+
+  def regenerate_cert_test(&updater)
+    consumer = consumer_client(@user, @consumername, type=:system, username=nil, facts= {'system.certificate_version' => '3.3'})
+    certs = consumer.list_certificates()
+    expect(certs.length).to eq(1)
+    cert_serial = certs[0]['serial']
+    expect(cert_serial).to_not be_nil
+
+    updater.call()
+
+    updated_certs = consumer.list_certificates()
+    expect(updated_certs.length).to eq(1)
+    updated_cert_serial = updated_certs[0]['serial']
+    expect(updated_cert_serial).to_not be_nil
+
+    expect(updated_cert_serial['serial']).to_not eq(cert_serial['serial'])
+  end
+
+  it 'should regenerate SCA cert when content changes affect content view' do
+    regenerate_cert_test do
+      @cp.update_content(@owner['key'], @content['id'], { 'content_url' => '/updated/path' })
+    end
+  end
+
+  it 'should regenerate SCA cert when product changes affect content view' do
+    regenerate_cert_test do
+      @cp.remove_content_from_product(@owner['key'], @product['id'], @content['id'])
+    end
+  end
+
+  it 'should regenerate SCA cert when pool changes affect content view' do
+    regenerate_cert_test do
+      @pool['start_date'] = (DateTime.now + 1)
+      @cp.update_pool(@owner['key'], @pool)
+    end
   end
 
 end

--- a/server/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
@@ -88,8 +88,8 @@ public class HealEntireOrgJob implements AsyncJob {
                     i18n.tr("Healing attempted against non-existent org key \"{}\"", ownerKey), true);
             }
 
-            if (owner.isAutobindDisabled() || owner.isContentAccessEnabled()) {
-                String caMessage = owner.isContentAccessEnabled() ?
+            if (owner.isAutobindDisabled() || owner.isUsingSimpleContentAccess()) {
+                String caMessage = owner.isUsingSimpleContentAccess() ?
                     " because of the content access mode setting" : "";
                 throw new JobExecutionException(
                     i18n.tr("Auto-attach is disabled for owner {0}{1}.", owner.getKey(), caMessage), true);

--- a/server/src/main/java/org/candlepin/async/tasks/UndoImportsJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/UndoImportsJob.java
@@ -174,6 +174,7 @@ public class UndoImportsJob implements AsyncJob {
         // Clear out upstream ID so owner can import from other distributors:
         UpstreamConsumer uc = owner.getUpstreamConsumer();
         owner.setUpstreamConsumer(null);
+        owner.syncLastContentUpdate();
         owner = this.ownerCurator.merge(owner);
         this.ownerCurator.flush();
 

--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -49,16 +49,19 @@ import java.util.Objects;
 public class ContentManager {
     private static final Logger log = LoggerFactory.getLogger(ContentManager.class);
 
-    private ProductManager productManager;
+    private final ContentAccessManager contentAccessManager;
+    private final ProductManager productManager;
 
-    private ContentCurator contentCurator;
-    private OwnerContentCurator ownerContentCurator;
-    private OwnerProductCurator ownerProductCurator;
+    private final ContentCurator contentCurator;
+    private final OwnerContentCurator ownerContentCurator;
+    private final OwnerProductCurator ownerProductCurator;
 
     @Inject
-    public ContentManager(ProductManager productManager, ContentCurator contentCurator,
-        OwnerContentCurator ownerContentCurator, OwnerProductCurator ownerProductCurator) {
+    public ContentManager(ContentAccessManager contentAccessManager, ProductManager productManager,
+        ContentCurator contentCurator, OwnerContentCurator ownerContentCurator,
+        OwnerProductCurator ownerProductCurator) {
 
+        this.contentAccessManager = Objects.requireNonNull(contentAccessManager);
         this.productManager = Objects.requireNonNull(productManager);
 
         this.contentCurator = Objects.requireNonNull(contentCurator);
@@ -164,6 +167,9 @@ public class ContentManager {
         entity = this.contentCurator.create(entity);
         this.ownerContentCurator.mapContentToOwner(entity, owner);
 
+        log.debug("Synchronizing last content update for org: {}", owner);
+        this.contentAccessManager.syncOwnerLastContentUpdate(owner);
+
         return entity;
     }
 
@@ -268,6 +274,9 @@ public class ContentManager {
             }
         }
 
+        log.debug("Synchronizing last content update for org: {}", owner);
+        this.contentAccessManager.syncOwnerLastContentUpdate(owner);
+
         return updated;
     }
 
@@ -350,6 +359,9 @@ public class ContentManager {
                 this.productManager.updateProduct(owner, update, regenCerts);
             }
         }
+
+        log.debug("Synchronizing last content update for org: {}", owner);
+        this.contentAccessManager.syncOwnerLastContentUpdate(owner);
 
         return entity;
     }

--- a/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/server/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -326,7 +326,7 @@ public class EntitlementCertificateGenerator {
 
         // we need to clear the content access cert on regenerate
         Owner owner = ownerCurator.findOwnerById(consumer.getOwnerId());
-        if (owner.isContentAccessEnabled()) {
+        if (owner.isUsingSimpleContentAccess()) {
             this.contentAccessManager.removeContentAccessCert(consumer);
         }
 

--- a/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
@@ -113,7 +113,7 @@ public class SystemPurposeComplianceRules {
             return status;
         }
 
-        if (consumer.getOwner() != null && consumer.getOwner().isContentAccessEnabled()) {
+        if (consumer.getOwner() != null && consumer.getOwner().isUsingSimpleContentAccess()) {
             status.setDisabled(true);
             applyStatus(consumer, status, updateConsumer);
             return status;

--- a/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
@@ -178,7 +178,7 @@ public class ComplianceRules {
 
 
         // Status can only be 'disabled' when in golden ticket mode
-        if (consumer.getOwner() != null && consumer.getOwner().isContentAccessEnabled()) {
+        if (consumer.getOwner() != null && consumer.getOwner().isUsingSimpleContentAccess()) {
             ComplianceStatus cs = new ComplianceStatus(new Date());
             cs.setDisabled(true);
             applyStatus(consumer, cs, updateConsumer);

--- a/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/server/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -24,6 +24,7 @@ import org.candlepin.common.auth.SecurityHole;
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.ConflictException;
 import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.controller.ContentAccessManager;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.AsyncJobStatusDTO;
@@ -39,7 +40,6 @@ import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.EnvironmentContentCurator;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.OwnerContentCurator;
-import org.candlepin.model.OwnerEnvContentAccessCurator;
 import org.candlepin.util.RdbmsExceptionTranslator;
 
 import com.google.inject.Inject;
@@ -77,6 +77,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
+
+
 /**
  * REST API for managing Environments.
  */
@@ -92,18 +94,17 @@ public class EnvironmentResource {
     private PoolManager poolManager;
     private ConsumerCurator consumerCurator;
     private OwnerContentCurator ownerContentCurator;
-    private OwnerEnvContentAccessCurator ownerEnvContentAccessCurator;
     private RdbmsExceptionTranslator rdbmsExceptionTranslator;
     private ModelTranslator translator;
     private JobManager jobManager;
+    private ContentAccessManager contentAccessManager;
 
     @Inject
     public EnvironmentResource(EnvironmentCurator envCurator, I18n i18n,
         EnvironmentContentCurator envContentCurator, ConsumerResource consumerResource,
         PoolManager poolManager, ConsumerCurator consumerCurator, OwnerContentCurator ownerContentCurator,
-        RdbmsExceptionTranslator rdbmsExceptionTranslator,
-        OwnerEnvContentAccessCurator ownerEnvContentAccessCurator, ModelTranslator translator,
-        JobManager jobManager) {
+        RdbmsExceptionTranslator rdbmsExceptionTranslator, ModelTranslator translator, JobManager jobManager,
+        ContentAccessManager contentAccessManager) {
 
         this.envCurator = envCurator;
         this.i18n = i18n;
@@ -113,9 +114,30 @@ public class EnvironmentResource {
         this.consumerCurator = consumerCurator;
         this.ownerContentCurator = ownerContentCurator;
         this.rdbmsExceptionTranslator = rdbmsExceptionTranslator;
-        this.ownerEnvContentAccessCurator = ownerEnvContentAccessCurator;
         this.translator = translator;
         this.jobManager = jobManager;
+        this.contentAccessManager = contentAccessManager;
+    }
+
+    /**
+     * Attempts to lookup the environment from the given environment ID.
+     *
+     * @param environmentId
+     *  The ID of the environment to lookup
+     *
+     * @throws NotFoundException
+     *  if the given ID cannot be resolved to a valid Environment
+     *
+     * @return
+     *  the environment with the given ID
+     */
+    private Environment lookupEnvironment(String environmentId) {
+        Environment environment = this.envCurator.get(environmentId);
+        if (environment == null) {
+            throw new NotFoundException(i18n.tr("No such environment: {0}", environmentId));
+        }
+
+        return environment;
     }
 
     @ApiOperation(notes = "Retrieves a single Environment", value = "getEnv")
@@ -125,11 +147,8 @@ public class EnvironmentResource {
     @Produces(MediaType.APPLICATION_JSON)
     public EnvironmentDTO getEnv(
         @PathParam("env_id") @Verify(Environment.class) String envId) {
-        Environment e = envCurator.get(envId);
-        if (e == null) {
-            throw new NotFoundException(i18n.tr("No such environment: {0}", envId));
-        }
-        return translator.translate(e, EnvironmentDTO.class);
+        Environment environment = this.lookupEnvironment(envId);
+        return translator.translate(environment, EnvironmentDTO.class);
     }
 
     @ApiOperation(
@@ -141,26 +160,22 @@ public class EnvironmentResource {
     @Produces(MediaType.WILDCARD)
     @Path("/{env_id}")
     public void deleteEnv(@PathParam("env_id") @Verify(Environment.class) String envId) {
-        Environment e = envCurator.get(envId);
-        if (e == null) {
-            throw new NotFoundException(i18n.tr("No such environment: {0}", envId));
-        }
-
-        CandlepinQuery<Consumer> consumers = this.envCurator.getEnvironmentConsumers(e);
+        Environment environment = this.lookupEnvironment(envId);
+        CandlepinQuery<Consumer> consumers = this.envCurator.getEnvironmentConsumers(environment);
 
         // Cleanup all consumers and their entitlements:
-        log.info("Deleting consumers in environment {}", e);
+        log.info("Deleting consumers in environment {}", environment);
         for (Consumer c : consumers.list()) {
             log.info("Deleting consumer: {}", c);
 
             // We're about to delete these consumers; no need to regen/dirty their dependent
             // entitlements or recalculate status.
-            poolManager.revokeAllEntitlements(c, false);
-            consumerCurator.delete(c);
+            this.poolManager.revokeAllEntitlements(c, false);
+            this.consumerCurator.delete(c);
         }
 
-        log.info("Deleting environment: {}", e);
-        envCurator.delete(e);
+        log.info("Deleting environment: {}", environment);
+        this.envCurator.delete(environment);
     }
 
     @ApiOperation(notes = "Lists the Environments.  Only available to super admins.",
@@ -186,23 +201,17 @@ public class EnvironmentResource {
      */
     private Content resolveContent(Environment environment, String contentId) {
         if (environment == null || environment.getOwner() == null) {
-            throw new BadRequestException(
-                i18n.tr("No environment specified, or environment lacks owner information")
-            );
+            throw new BadRequestException(i18n.tr(
+                "No environment specified, or environment lacks owner information"));
         }
 
         if (contentId == null) {
-            throw new BadRequestException(
-                i18n.tr("No content ID specified")
-            );
+            throw new BadRequestException(i18n.tr("No content ID specified"));
         }
 
         Content resolved = this.ownerContentCurator.getContentById(environment.getOwner(), contentId);
-
         if (resolved == null) {
-            throw new NotFoundException(i18n.tr(
-                "Unable to find content with the ID \"{0}\".", contentId
-            ));
+            throw new NotFoundException(i18n.tr("Unable to find content with the ID \"{0}\".", contentId));
         }
 
         return resolved;
@@ -227,43 +236,43 @@ public class EnvironmentResource {
         List<org.candlepin.model.dto.EnvironmentContent> contentToPromote,
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) throws JobException {
 
-        Environment env = lookupEnvironment(envId);
+        Environment environment = this.lookupEnvironment(envId);
 
         // Make sure this content has not already been promoted within this environment
+
         // Impl note:
         // We have to do this in a separate loop or we'll end up with an undefined state, should
         // there be a problem with the request.
         for (org.candlepin.model.dto.EnvironmentContent promoteMe : contentToPromote) {
-            log.debug(
-                "EnvironmentContent to promote: {}:{}",
-                promoteMe.getEnvironmentId(), promoteMe.getContentId()
-            );
+            log.debug("EnvironmentContent to promote: {}:{}",
+                promoteMe.getEnvironmentId(), promoteMe.getContentId());
 
-            EnvironmentContent existing = this.envContentCurator.getByEnvironmentAndContent(
-                env, promoteMe.getContentId()
-            );
+            EnvironmentContent existing = this.envContentCurator
+                .getByEnvironmentAndContent(environment, promoteMe.getContentId());
 
             if (existing != null) {
                 throw new ConflictException(i18n.tr(
                     "The content with id {0} has already been promoted in this environment.",
-                    promoteMe.getContentId()
-                ));
+                    promoteMe.getContentId()));
             }
         }
 
         Set<String> contentIds = new HashSet<>();
 
         try {
-            contentIds = batchCreate(contentToPromote, env);
-            clearContentAccessCerts(env);
+            contentIds = this.batchCreate(contentToPromote, environment);
+
+            this.contentAccessManager.refreshEnvironmentContentAccessCerts(environment);
+            this.contentAccessManager.syncOwnerLastContentUpdate(environment.getOwner());
         }
         catch (PersistenceException pe) {
             if (rdbmsExceptionTranslator.isConstraintViolationDuplicateEntry(pe)) {
                 log.info("Concurrent content promotion will cause this request to fail.",
                     pe);
-                throw new ConflictException(
-                    i18n.tr("Some of the content is already associated with Environment: {0}",
-                        contentToPromote));
+
+                throw new ConflictException(i18n.tr(
+                    "Some of the content is already associated with Environment: {0}",
+                    contentToPromote));
             }
             else {
                 throw pe;
@@ -271,10 +280,10 @@ public class EnvironmentResource {
         }
 
         JobConfig config = RegenEnvEntitlementCertsJob.createJobConfig()
-            .setEnvironment(env)
+            .setEnvironment(environment)
             .setContent(contentIds)
             .setLazyRegeneration(lazyRegen)
-            .setOwner(env.getOwner());
+            .setOwner(environment.getOwner());
 
         AsyncJobStatus job = this.jobManager.queueJob(config);
         return this.translator.translate(job, AsyncJobStatusDTO.class);
@@ -297,12 +306,13 @@ public class EnvironmentResource {
         @QueryParam("content") String[] contentIds,
         @QueryParam("lazy_regen") @DefaultValue("true") Boolean lazyRegen) throws JobException {
 
-        Environment e = lookupEnvironment(envId);
+        Environment environment = this.lookupEnvironment(envId);
         Map<String, EnvironmentContent> demotedContent = new HashMap<>();
 
         // Step through and validate all given content IDs before deleting
         for (String contentId : contentIds) {
-            EnvironmentContent envContent = envContentCurator.getByEnvironmentAndContent(e, contentId);
+            EnvironmentContent envContent = this.envContentCurator
+                .getByEnvironmentAndContent(environment, contentId);
 
             if (envContent == null) {
                 throw new NotFoundException(i18n.tr("Content does not exist in environment: {0}", contentId));
@@ -312,8 +322,10 @@ public class EnvironmentResource {
         }
 
         try {
-            envContentCurator.bulkDelete(demotedContent.values());
-            clearContentAccessCerts(e);
+            this.envContentCurator.bulkDelete(demotedContent.values());
+
+            this.contentAccessManager.refreshEnvironmentContentAccessCerts(environment);
+            this.contentAccessManager.syncOwnerLastContentUpdate(environment.getOwner());
         }
         catch (RollbackException hibernateException) {
             if (rdbmsExceptionTranslator.isUpdateHadNoEffectException(hibernateException)) {
@@ -331,10 +343,10 @@ public class EnvironmentResource {
         // serializable. Attempting to use it causes exceptions.
         Set<String> demotedContentIds = new HashSet<>(demotedContent.keySet());
         JobConfig config = RegenEnvEntitlementCertsJob.createJobConfig()
-            .setEnvironment(e)
+            .setEnvironment(environment)
             .setContent(demotedContentIds)
             .setLazyRegeneration(lazyRegen)
-            .setOwner(e.getOwner());
+            .setOwner(environment.getOwner());
 
         AsyncJobStatus job = this.jobManager.queueJob(config);
         return this.translator.translate(job, AsyncJobStatusDTO.class);
@@ -347,7 +359,7 @@ public class EnvironmentResource {
      * @return contentIds Ids of the promoted content
      */
     @Transactional
-    public Set<String>  batchCreate(List<org.candlepin.model.dto.EnvironmentContent> contentToPromote,
+    public Set<String> batchCreate(List<org.candlepin.model.dto.EnvironmentContent> contentToPromote,
         Environment env) {
 
         Set<String> contentIds = new HashSet<>();
@@ -368,19 +380,6 @@ public class EnvironmentResource {
         return contentIds;
     }
 
-    @Transactional
-    private void clearContentAccessCerts(Environment env) {
-        ownerEnvContentAccessCurator.removeAllForEnvironment(env.getId());
-    }
-
-    private Environment lookupEnvironment(String envId) {
-        Environment e = envCurator.get(envId);
-        if (e == null) {
-            throw new NotFoundException(i18n.tr("No such environment: {0}", envId));
-        }
-        return e;
-    }
-
     @ApiOperation(notes = "Creates an Environment", value = "create")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -394,9 +393,10 @@ public class EnvironmentResource {
         @QueryParam("activation_keys") String activationKeys)
         throws BadRequestException {
 
-        Environment e = lookupEnvironment(envId);
-        consumer.setEnvironment(translator.translate(e, EnvironmentDTO.class));
-        return this.consumerResource.create(consumer, principal, userName, e.getOwner().getKey(),
+        Environment environment = this.lookupEnvironment(envId);
+        consumer.setEnvironment(translator.translate(environment, EnvironmentDTO.class));
+
+        return this.consumerResource.create(consumer, principal, userName, environment.getOwner().getKey(),
             activationKeys, true);
     }
 

--- a/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -256,6 +256,7 @@ public class OwnerContentResource {
         }
 
         this.contentAccessManager.refreshOwnerForContentAccess(owner);
+
         return result;
     }
 

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1651,6 +1651,11 @@ public class OwnerResource {
         }
 
         poolManager.createAndEnrichPools(subscription);
+
+        log.debug("Synchronizing last content update for org: {}", owner);
+        owner.syncLastContentUpdate();
+        this.ownerCurator.merge(owner);
+
         return subscription;
     }
 
@@ -1782,6 +1787,11 @@ public class OwnerResource {
         }
 
         pool = poolManager.createAndEnrichPools(pool);
+
+        log.debug("Synchronizing last content update for org: {}", owner);
+        owner.syncLastContentUpdate();
+        this.ownerCurator.merge(owner);
+
         return this.translator.translate(pool, PoolDTO.class);
     }
 
@@ -1867,6 +1877,11 @@ public class OwnerResource {
 
         // Apply changes to the pool and its derived pools
         this.poolManager.updateMasterPool(newPool);
+
+        Owner owner = newPool.getOwner();
+        log.debug("Synchronizing last content update for org: {}", owner);
+        owner.syncLastContentUpdate();
+        this.ownerCurator.merge(owner);
     }
 
     /**

--- a/server/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/server/src/main/java/org/candlepin/resource/PoolResource.java
@@ -262,6 +262,11 @@ public class PoolResource {
         }
 
         poolManager.deletePools(Collections.singleton(pool));
+
+        Owner owner = pool.getOwner();
+        log.debug("Synchronizing last content update for org: {}", owner);
+        owner.syncLastContentUpdate();
+        this.ownerCurator.merge(owner);
     }
 
     @ApiOperation(notes = "Retrieve a CDN for a Pool", value = "getPoolCdn")

--- a/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/server/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -89,7 +89,7 @@ public class ConsumerBindUtil {
 
         for (ActivationKey key : keys) {
             boolean keySuccess = true;
-            boolean scaEnabled = key.getOwner().isContentAccessEnabled();
+            boolean scaEnabled = key.getOwner().isUsingSimpleContentAccess();
             scaEnabledForAny |= scaEnabled;
 
             keySuccess &= handleActivationKeyServiceLevel(consumer, key.getServiceLevel(), key.getOwner());

--- a/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/server/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -354,7 +354,7 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
 
             Set<ProductContent> filteredContent = extensionUtil.filterProductContent(
                 prod, consumer, promotedContent, enableEnvironmentFiltering, entitledProductIds,
-                consumer.getOwner().isContentAccessEnabled());
+                consumer.getOwner().isUsingSimpleContentAccess());
 
             filteredContent = extensionUtil.filterContentByContentArch(filteredContent,
                 consumer, prod);

--- a/server/src/main/java/org/candlepin/util/Util.java
+++ b/server/src/main/java/org/candlepin/util/Util.java
@@ -52,6 +52,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.function.Predicate;
+
+
 
 /**
  * Genuinely random utilities.
@@ -539,15 +542,52 @@ public class Util {
     }
 
     /**
-     * Returns the first non-null non-empty value from the given array
-
-     * @param values values to be searched
-     * @return first non-null non-empty value or null
+     * Returns the first non-null value in the provided values. If all of the provided values are
+     * null, or no values are provided, this method returns null.
+     *
+     * @param values
+     *  the values to examine
+     *
+     * @return
+     *  the first non-null value of the values provided, or null if no such value is provided
      */
-    public static String firstOf(String... values) {
-        for (String value : values) {
-            if (value != null && !value.isEmpty()) {
-                return value;
+    public static <T> T firstOf(T... values) {
+        if (values != null) {
+            for (T value : values) {
+                if (value != null) {
+                    return value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the first value from the given values which is validated by the provided predicate.
+     * If none of the provided values are validated, or no values are provided, this method returns
+     * null.
+     *
+     * @param predicate
+     *  the predicate to use to find a value
+     *
+     * @param values
+     *  the values to examine
+     *
+     * @return
+     *  the first value which is validated by the provided predicate, or null if no such value is
+     *  provided
+     */
+    public static <T> T firstOf(Predicate<T> predicate, T... values) {
+        if (predicate == null) {
+            throw new IllegalArgumentException("predicate is null");
+        }
+
+        if (values != null) {
+            for (T value : values) {
+                if (predicate.test(value)) {
+                    return value;
+                }
             }
         }
 

--- a/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/server/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -321,7 +321,7 @@ public class X509V3ExtensionUtil extends X509Util {
         boolean enableEnvironmentFiltering = config.getBoolean(ConfigProperties.ENV_CONTENT_FILTERING);
         toReturn.setContent(createContent(
             filterProductContent(engProduct, consumer, promotedContent, enableEnvironmentFiltering,
-            entitledProductIds, consumer.getOwner().isContentAccessEnabled()), sku,
+            entitledProductIds, consumer.getOwner().isUsingSimpleContentAccess()), sku,
             contentPrefix, promotedContent, consumer, engProduct));
 
         return toReturn;

--- a/server/src/main/resources/db/changelog/20210211154615-add-owner-last-content-updated-column.xml
+++ b/server/src/main/resources/db/changelog/20210211154615-add-owner-last-content-updated-column.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20210211154615-1" author="crog">
+        <addColumn tableName="cp_owner">
+            <column name="last_content_update" type="${timestamp.type}"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1250,4 +1250,5 @@
     <include file="db/changelog/20201210043533-drop-cp-job-table.xml"/>
     <include file="db/changelog/20210118141207-create-consumer-activation-key-table.xml"/>
     <include file="db/changelog/20210127105630-migrate-product-hierarchy.xml"/>
+    <include file="db/changelog/20210211154615-add-owner-last-content-updated-column.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2342,4 +2342,5 @@
     <include file="db/changelog/20201210043533-drop-cp-job-table.xml"/>
     <include file="db/changelog/20210118141207-create-consumer-activation-key-table.xml"/>
     <include file="db/changelog/20210127105630-migrate-product-hierarchy.xml"/>
+    <include file="db/changelog/20210211154615-add-owner-last-content-updated-column.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -159,4 +159,5 @@
     <include file="db/changelog/20201210043533-drop-cp-job-table.xml"/>
     <include file="db/changelog/20210118141207-create-consumer-activation-key-table.xml"/>
     <include file="db/changelog/20210127105630-migrate-product-hierarchy.xml"/>
+    <include file="db/changelog/20210211154615-add-owner-last-content-updated-column.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -48,18 +48,20 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class ContentManagerTest extends DatabaseTestFixture {
 
     private ContentManager contentManager;
+    private ContentAccessManager mockContentAccessManager;
     private EntitlementCertificateGenerator mockEntCertGenerator;
     private ProductManager productManager;
 
     @BeforeEach
     public void setup() throws Exception {
+        this.mockContentAccessManager = mock(ContentAccessManager.class);
         this.mockEntCertGenerator = mock(EntitlementCertificateGenerator.class);
 
-        this.productManager = new ProductManager(
+        this.productManager = new ProductManager(this.mockContentAccessManager,
             this.mockEntCertGenerator, this.ownerContentCurator, this.ownerProductCurator,
             this.productCurator);
 
-        this.contentManager = new ContentManager(
+        this.contentManager = new ContentManager(this.mockContentAccessManager,
             this.productManager, this.contentCurator, this.ownerContentCurator,
             this.ownerProductCurator);
     }

--- a/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -54,14 +54,16 @@ import java.util.Date;
 public class ProductManagerTest extends DatabaseTestFixture {
 
     private EntitlementCertificateGenerator mockEntCertGenerator;
+    private ContentAccessManager mockContentAccessManager;
     private ProductManager productManager;
 
     @BeforeEach
     public void setup() throws Exception {
         this.mockEntCertGenerator = mock(EntitlementCertificateGenerator.class);
+        this.mockContentAccessManager = mock(ContentAccessManager.class);
 
-        this.productManager = new ProductManager(this.mockEntCertGenerator, this.ownerContentCurator,
-            this.ownerProductCurator, this.productCurator);
+        this.productManager = new ProductManager(this.mockContentAccessManager, this.mockEntCertGenerator,
+            this.ownerContentCurator, this.ownerProductCurator, this.productCurator);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 
 import org.candlepin.common.exceptions.BadRequestException;
 import org.candlepin.common.exceptions.NotFoundException;
+import org.candlepin.controller.ContentAccessManager;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
@@ -52,6 +53,7 @@ import javax.ws.rs.core.Response;
 public class SubscriptionResourceTest  {
     private SubscriptionResource subResource;
 
+    @Mock private ContentAccessManager mockContentAccessManager;
     @Mock private SubscriptionServiceAdapter subService;
     @Mock private ConsumerCurator consumerCurator;
     @Mock private PoolManager poolManager;
@@ -66,7 +68,8 @@ public class SubscriptionResourceTest  {
             I18nFactory.READ_PROPERTIES | I18nFactory.FALLBACK
         );
 
-        this.subResource = new SubscriptionResource(subService, consumerCurator, poolManager, i18n);
+        this.subResource = new SubscriptionResource(subService, consumerCurator, poolManager,
+            mockContentAccessManager, i18n);
     }
 
     @Test


### PR DESCRIPTION
- SCA certificates will now be regenerated on request if the org's
  content, products, or pools change after the last cert update
- Removed now-obsolete fields from the update_pool method in
  candlepin_api