### PR TITLE
On SCA mode, stop throwing an error during dry-run auto-attach

### DIFF
--- a/server/spec/consumer_resource_spec.rb
+++ b/server/spec/consumer_resource_spec.rb
@@ -1438,6 +1438,12 @@ describe 'Consumer Resource' do
     expected_exceptions.each { |e| e.should be_an(RestClient::Gone) | be_an(RestClient::ResourceNotFound) }
   end
 
+  it "should not allow to content access certificate body when not SCA mode" do
+    expect {
+      @consumer1.get_content_access_body()
+    }.to raise_exception(RestClient::BadRequest)
+  end
+
 end
 
 describe 'Consumer Resource Consumer Fact Filter Tests' do

--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -883,4 +883,17 @@ describe 'Content Access' do
     end
   end
 
+  it 'should be disabled for owner in SCA mode' do
+    consumer = @user.register(random_string('testsystem'), :system, nil,
+               {'system.certificate_version' => '3.1'}, nil, nil, [], [], nil)
+
+    # System purpose status
+    status = @cp.get_purpose_compliance(consumer['uuid'])
+    expect(status['status']).to eq("disabled")
+
+    # compliance status
+    status = @cp.get_compliance(consumer['uuid'])
+    expect(status['status']).to eq("disabled")
+  end
+
 end

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2240,15 +2240,14 @@ public class ConsumerResource {
             String message = "";
 
             if (owner.isUsingSimpleContentAccess()) {
-                message = (i18n.tr("Organization \"{0}\" has auto-attach disabled because " +
-                    "of the content access mode setting.", owner.getKey()));
-
+                log.debug("Organization \"{0}\" has auto-attach disabled because " +
+                    "of the content access mode setting.", owner.getKey());
+                return Collections.EMPTY_LIST;
             }
             else {
                 message = (i18n.tr("Organization \"{0}\" has auto-attach disabled.", owner.getKey()));
+                throw new BadRequestException(message);
             }
-
-            throw new BadRequestException(message);
         }
 
         List<PoolQuantity> dryRunPools = new ArrayList<>();


### PR DESCRIPTION
- Added more spec tests around SCA mode.