### PR TITLE
ENT-3446: Make Jenkins run cloud auth spec

### DIFF
--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -195,12 +195,13 @@ OPTIONS:
   -j <version>      use a specific Java version instead of the auto-detected default
   -v                enable verbose/debug output
   -i                internationalization - validate translation files
+  -k                run cloud registration rspec test suite (only for "hosted" mode)
   -a <arguments>    extra arguments to pass to the Candlepin deploy script (implies -d)
 HELP
 }
 
 ARGV=("$@")
-while getopts ":dtRqrHulsb:c:a:vj:i" opt; do
+while getopts ":dtRqrHulsb:c:a:vj:i:k" opt; do
     case $opt in
         d  ) DEPLOY="1";;
         t  )
@@ -246,6 +247,7 @@ while getopts ":dtRqrHulsb:c:a:vj:i" opt; do
         v  ) VERBOSE="1";;
         j  ) JAVA_VERSION="${OPTARG}";;
         i  ) TRANSLATE="1";;
+        k  ) CLOUD_AUTH_RSPEC="1";;
         ?  ) usage; exit;;
     esac
 done
@@ -416,6 +418,14 @@ if [ "$DEPLOY" == "1" ]; then
     fi
 
     DEPLOY_FLAGS="${DEPLOY_FLAGS}${EX_ARGS}"
+
+    # To run the cloud auth rspec test suite.
+    # We generate custom.yaml to enable the
+    # cloud auth property.
+    # This is valid only for hosted mode.
+    if [ "$CLOUD_AUTH_RSPEC" == "1" ] && [ "$HOSTED" == "1" ]; then
+      python $PROJECT_DIR/bin/generate_custom_yaml.py $PROJECT_DIR
+    fi
 
     # set up the database from setup-db.sh
     # only runs if function is defined

--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -44,6 +44,7 @@ PACKAGES=(
     rpm-sign
     python-requests
     expect
+    PyYAML
 )
 
 yum install -y ${PACKAGES[@]}

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
                     agent { label 'docker' }
                     environment {
                         CANDLEPIN_DATABASE = 'postgresql'
-                        CP_TEST_ARGS = '-H'
+                        CP_TEST_ARGS = '-H -k'
                     }
                     steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
@@ -86,7 +86,7 @@ pipeline {
                     agent { label 'docker' }
                     environment {
                         CANDLEPIN_DATABASE = 'mysql'
-                        CP_TEST_ARGS = '-H'
+                        CP_TEST_ARGS = '-H -k'
                     }
                     steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'

--- a/server/bin/generate_custom_yaml.py
+++ b/server/bin/generate_custom_yaml.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import yaml
+import sys
+
+data={
+    "candlepin.conf": {
+        "auth_cloud_enable": "true",
+    }
+}
+
+#accept the project directory file path
+project_dir=sys.argv[1]
+
+custom_file="".join((project_dir,'/custom.yaml'))
+f=open(custom_file,'w')
+f.write(yaml.dump(data))
+f.close()

--- a/server/conf/candlepin.conf.template
+++ b/server/conf/candlepin.conf.template
@@ -64,5 +64,6 @@ org.quartz.dataSource.myDS.maxConnections=5
 #overriding custom.yaml settings to ensure hostedtest resources are available
 candlepin.standalone=false
 module.config.hosted.configuration.module=org.candlepin.hostedtest.AdapterOverrideModule
+candlepin.auth.cloud.enable=<%= candlepin.auth_cloud_enable || false %>
 <% } %>\
 <%= candlepin.additional_properties %>


### PR DESCRIPTION
 - Added a `generate_custom_yaml.py` to generate a 
  custom YAML file to override the `candlepin.auth.cloud.enable` property
  in `candlepin.conf`.
   This is executed only on Jenkins for hosted mode.