### PR TITLE
[2.9] 1894455: (second part of the fix): Manifest delete takes too long

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -635,7 +635,7 @@ public class CandlepinPoolManager implements PoolManager {
         return entitlementsToRegen;
     }
 
-    Set<Pool> revokeEntitlementsFromOverflowingPools(List<Pool> pools) {
+    private Set<Pool> revokeEntitlementsFromOverflowingPools(List<Pool> pools) {
         Collection<Pool> overflowing = pools.stream()
             .filter(Pool::isOverflowing)
             .collect(Collectors.toList());
@@ -650,10 +650,7 @@ public class CandlepinPoolManager implements PoolManager {
         overflowing = poolCurator.lock(overflowing);
 
         List<Entitlement> overFlowingEnts = this.poolCurator.retrieveOrderedEntitlementsOf(overflowing);
-        Map<String, List<Entitlement>> entMap = new HashMap<>();
-        for (Entitlement entitlement : overFlowingEnts) {
-            entMap.computeIfAbsent(entitlement.getPool().getId(), k -> new ArrayList<>()).add(entitlement);
-        }
+        Map<String, List<Entitlement>> entMap = groupByPoolId(overFlowingEnts);
 
         for (Pool pool : overflowing) {
             // we then start revoking the existing entitlements
@@ -676,6 +673,11 @@ public class CandlepinPoolManager implements PoolManager {
 
         // revoke the entitlements amassed above
         return revokeEntitlements(entitlementsToRevoke);
+    }
+
+    private Map<String, List<Entitlement>> groupByPoolId(Collection<Entitlement> entitlements) {
+        return entitlements.stream()
+            .collect(Collectors.groupingBy(entitlement -> entitlement.getPool().getId()));
     }
 
     /**
@@ -1921,6 +1923,7 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         log.debug("Adjusting consumed quantities on pools");
+        Set<Consumer> consumersToUpdate = new HashSet<>();
         List<Pool> poolsToSave = new ArrayList<>();
         Set<String> entIdsToRevoke = new HashSet<>();
         for (Entitlement ent : entsToRevoke) {
@@ -1947,10 +1950,11 @@ public class CandlepinPoolManager implements PoolManager {
             }
 
             consumer.setEntitlementCount(consumer.getEntitlementCount() - entQuantity);
-            consumerCurator.update(consumer);
+            consumersToUpdate.add(consumer);
             poolsToSave.add(pool);
         }
 
+        consumerCurator.bulkUpdate(consumersToUpdate, false);
         poolCurator.updateAll(poolsToSave, false, false);
 
         /*
@@ -1974,10 +1978,7 @@ public class CandlepinPoolManager implements PoolManager {
         entitlementCurator.flush();
         log.info("All deletes flushed successfully");
 
-        Map<Consumer, List<Entitlement>> consumerSortedEntitlements = entitlementCurator
-            .getDistinctConsumers(entsToRevoke);
-
-        filterAndUpdateStackingEntitlements(consumerSortedEntitlements, alreadyDeletedPools);
+        updateStackingEntitlements(entsToRevoke, alreadyDeletedPools);
 
         // post unbind actions
         for (Entitlement ent : entsToRevoke) {
@@ -1991,6 +1992,8 @@ public class CandlepinPoolManager implements PoolManager {
             return poolsToDelete;
         }
 
+        Map<Consumer, List<Entitlement>> consumerSortedEntitlements = entitlementCurator
+            .getDistinctConsumers(entsToRevoke);
         log.info("Recomputing status for {} consumers.", consumerSortedEntitlements.size());
         int i = 1;
         for (Consumer consumer : consumerSortedEntitlements.keySet()) {
@@ -2109,6 +2112,45 @@ public class CandlepinPoolManager implements PoolManager {
                 poolRules.updatePoolsFromStack(entry.getKey(), subPools, null, alreadyDeletedPools, true);
             }
         }
+    }
+
+
+    /**
+     * Filter the given entitlements so that this method returns only
+     * the entitlements that are part of some stack. Then update them
+     * accordingly
+     *
+     * @param entsToRevoke
+     * @param alreadyDeletedPools pools to skip deletion as they have already been deleted
+     * @return Entitlements that are stacked
+     */
+    private void updateStackingEntitlements(List<Entitlement> entsToRevoke, Set<String> alreadyDeletedPools) {
+        Map<Consumer, List<Entitlement>> stackingEntsByConsumer = stackingEntitlementsOf(entsToRevoke);
+        log.debug("Found stacking entitlements for {} consumers", stackingEntsByConsumer.size());
+        Set<String> allStackingIds = stackIdsOf(stackingEntsByConsumer.values());
+        List<Pool> pools = poolCurator.getSubPoolForStackIds(null, allStackingIds);
+        poolRules.bulkUpdatePoolsFromStack(stackingEntsByConsumer.keySet(), pools, alreadyDeletedPools, true);
+    }
+
+    private Map<Consumer, List<Entitlement>> stackingEntitlementsOf(List<Entitlement> entitlements) {
+        return entitlements.stream()
+            .filter(entitlement -> !entitlement.getPool().isDerived())
+            .filter(entitlement -> entitlement.getPool().isStacked())
+            .collect(Collectors.groupingBy(Entitlement::getConsumer));
+    }
+
+    private Set<String> stackIdsOf(Collection<List<Entitlement>> entitlementsPerConsumer) {
+        return entitlementsPerConsumer.stream()
+            .map(this::stackIdsOf)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
+    }
+
+    private Set<String> stackIdsOf(List<Entitlement> entitlements) {
+        return entitlements.stream()
+            .map(Entitlement::getPool)
+            .map(Pool::getStackId)
+            .collect(Collectors.toSet());
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -41,7 +41,6 @@ import java.util.Set;
 import javax.inject.Singleton;
 
 
-
 /**
  * The OwnerProductCurator provides functionality for managing the mapping between owners and
  * products.
@@ -562,15 +561,21 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
             .list();
 
         if (ids != null && !ids.isEmpty()) {
-            criteria.clear();
-            criteria.put("product_uuid", productUuidMap.keySet());
-            criteria.put("pool_id", ids);
+            int providedProductsUpdated = 0;
+            int derivedProductsUpdated = 0;
+            for (List<String> poolIdBlock : this.partition(ids)) {
+                Map<String, Object> updateCriteria = new HashMap<>();
+                updateCriteria.put("product_uuid", productUuidMap.keySet());
+                updateCriteria.put("pool_id", poolIdBlock);
 
-            count = this.bulkSQLUpdate("cp2_pool_provided_products", "product_uuid", uuidMap, criteria);
-            log.debug("{} provided products updated", count);
+                providedProductsUpdated += this.bulkSQLUpdate("cp2_pool_provided_products",
+                    "product_uuid", uuidMap, updateCriteria);
 
-            count = this.bulkSQLUpdate("cp2_pool_derprov_products", "product_uuid", uuidMap, criteria);
-            log.debug("{} derived provided products updated", count);
+                derivedProductsUpdated += this.bulkSQLUpdate("cp2_pool_derprov_products",
+                    "product_uuid", uuidMap, updateCriteria);
+            }
+            log.debug("{} provided products updated", providedProductsUpdated);
+            log.debug("{} derived provided products updated", derivedProductsUpdated);
         }
         else {
             log.debug("0 provided products updated");

--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -1499,11 +1499,15 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
     }
 
     public boolean isLocked() {
-        return this.locked != null && locked.booleanValue();
+        return this.locked != null && locked;
     }
 
     public void setLocked(boolean locked) {
         this.locked = locked;
+    }
+
+    public boolean isDerived() {
+        return "true".equals(this.getAttributeValue(Pool.Attributes.DERIVED_POOL));
     }
 
 }

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -519,7 +519,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         poolCurator.create(pool);
         Entitlement created = bind(consumer, pool);
 
-        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId).list();
+        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId);
         assertEquals(1, results.size());
         assertTrue(results.contains(created));
     }
@@ -542,7 +542,29 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
             Entitlement created = bind(consumer, pool);
         }
 
-        List<Entitlement> results = entitlementCurator.findByStackIds(consumer, stackingIds).list();
+        List<Entitlement> results = entitlementCurator.findByStackIds(null, stackingIds);
+        assertEquals(3, results.size());
+    }
+
+    @Test
+    public void findByStackIdsByConsumerTest() {
+        Set<String> stackingIds = new HashSet<>();
+        for (int i = 0; i < 4; i++) {
+            String stackingId = "test_stack_id" + i;
+            if (i > 0) {
+                stackingIds.add(stackingId);
+            }
+
+            Product product = TestUtil.createProduct();
+            product.setAttribute(Product.Attributes.STACKING_ID, stackingId);
+            productCurator.create(product);
+
+            Pool pool = createPool(owner, product, 1L, dateSource.currentDate(), createFutureDate(1));
+            poolCurator.create(pool);
+            Entitlement created = bind(consumer, pool);
+        }
+
+        List<Entitlement> results = entitlementCurator.findByStackIds(consumer, stackingIds);
         assertEquals(3, results.size());
     }
 
@@ -561,7 +583,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
             createdEntitlements.add(bind(consumer, pool));
         }
 
-        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId).list();
+        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId);
         assertEquals(ents, results.size());
         assertTrue(results.containsAll(createdEntitlements) && createdEntitlements.containsAll(results));
     }
@@ -592,7 +614,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
             createdEntitlements.add(bind(consumer, pool));
         }
 
-        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId).list();
+        List<Entitlement> results = entitlementCurator.findByStackId(consumer, stackingId);
         assertEquals(1, results.size());
         assertEquals(createdEntitlements.get(4), results.get(0));
     }

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1289,6 +1289,35 @@ public class PoolCuratorTest extends DatabaseTestFixture {
 
         poolCurator.create(derivedPool);
 
+        Pool pool = poolCurator.getSubPoolForStackIds(null, Arrays.asList(expectedStackId)).get(0);
+        assertNotNull(pool);
+    }
+
+    @Test
+    public void getSubPoolCountForStackByConsumer() {
+        String expectedStackId = "13245";
+        Product product = TestUtil.createProduct();
+        product.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
+        product.setAttribute(Product.Attributes.STACKING_ID, expectedStackId);
+        product = this.createProduct(product, owner);
+
+        // Create derived pool referencing the entitlement just made:
+        Pool derivedPool = new Pool(
+            owner,
+            product,
+            new HashSet<>(),
+            1L,
+            TestUtil.createDate(2011, 3, 2),
+            TestUtil.createDate(2055, 3, 2),
+            "",
+            "",
+            ""
+        );
+        derivedPool.setSourceStack(new SourceStack(consumer, expectedStackId));
+        derivedPool.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer.getUuid());
+
+        poolCurator.create(derivedPool);
+
         Pool pool = poolCurator.getSubPoolForStackIds(consumer, Arrays.asList(expectedStackId)).get(0);
         assertNotNull(pool);
     }

--- a/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -14,20 +14,21 @@
  */
 package org.candlepin.policy;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.auth.UserPrincipal;
 import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
-import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
@@ -185,9 +186,7 @@ public class PoolRulesStackDerivedTest {
         // Initial entitlement from one of the pools:
         stackedEnts.add(createEntFromPool(pool2));
 
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
-        when(cqmock.list()).thenReturn(stackedEnts);
-        when(entCurMock.findByStackId(consumer, STACK)).thenReturn(cqmock);
+        when(entCurMock.findByStackId(consumer, STACK)).thenReturn(stackedEnts);
 
         pool2.setAttribute(Product.Attributes.VIRT_LIMIT, "60");
         pool4.setAttribute(Product.Attributes.VIRT_LIMIT, "80");
@@ -382,8 +381,6 @@ public class PoolRulesStackDerivedTest {
 
     @Test
     public void virtLimitFromFirstVirtLimitEntBatch() {
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
-
         stackedEnts.clear();
         Entitlement e1 = createEntFromPool(pool1);
         e1.setQuantity(4);
@@ -394,8 +391,7 @@ public class PoolRulesStackDerivedTest {
         Class<Set<String>> listClass = (Class<Set<String>>) (Class) HashSet.class;
         ArgumentCaptor<Set<String>> arg = ArgumentCaptor.forClass(listClass);
 
-        when(cqmock.list()).thenReturn(stackedEnts);
-        when(entCurMock.findByStackIds(eq(consumer), arg.capture())).thenReturn(cqmock);
+        when(entCurMock.findByStackIds(eq(consumer), arg.capture())).thenReturn(stackedEnts);
 
         List<PoolUpdate> updates = poolRules.updatePoolsFromStack(consumer,
             Arrays.asList(stackDerivedPool, stackDerivedPool2), null, false);


### PR DESCRIPTION
(This fixes both satellite bzs, related to manifest import/delete: 1840803 & 1840805)
 - Fix too many params issue in manifest import
 - Refactor updatePoolsFromStack to avoid calling deletePools n times