### PR TITLE
[3.1] Fixed some hard-coded end dates in unit tests (ENT-3621)

### DIFF
--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -144,7 +144,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         consumerCurator.create(c);
         Product product = TestUtil.createProduct();
         productCurator.create(product);
-        Pool p = createPool(owner, product, 2L, dateSource.currentDate(), createDate(2020, 1, 1));
+        Pool p = createPool(owner, product, 2L, dateSource.currentDate(), createFutureDate(3));
         poolCurator.create(p);
         EntitlementCertificate cert = createEntitlementCertificate("keyx", "certificatex");
         Entitlement entitlement = createEntitlement(owner, c, p, cert);
@@ -552,8 +552,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         product.setAttribute(Product.Attributes.STACKING_ID, stackingId);
         productCurator.create(product);
 
-        Pool futurePool = createPool(owner, product, 1L,
-            createFutureDate(1), createDate(2021, 1, 1));
+        Pool futurePool = createPool(owner, product, 1L, createFutureDate(1), createFutureDate(3));
         poolCurator.create(futurePool);
         bind(consumer, futurePool);
 

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -631,7 +631,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         sub.setId(Util.generateDbUUID());
         sub.setQuantity(16L);
         sub.setStartDate(TestUtil.createDate(2006, 10, 21));
-        sub.setEndDate(TestUtil.createDate(2020, 1, 1));
+        sub.setEndDate(TestUtil.createFutureDate(3));
         sub.setModified(new Date());
 
         Pool newPool = poolManager.createAndEnrichPools(sub).get(0);
@@ -871,7 +871,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     public void testLookupOverconsumedIgnoresOtherSourceEntitlementPools() {
 
         Pool pool = createPool(owner, product, 1L,
-            TestUtil.createDate(2011, 3, 2), TestUtil.createDate(2055, 3, 2));
+            TestUtil.createDate(2011, 3, 2), TestUtil.createFutureDate(3));
         poolCurator.create(pool);
 
         String subid = pool.getSubscriptionId();
@@ -889,7 +889,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
             new HashSet<>(),
             1L,
             TestUtil.createDate(2011, 3, 2),
-            TestUtil.createDate(2055, 3, 2),
+            TestUtil.createFutureDate(3),
             "",
             "",
             ""
@@ -1361,7 +1361,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         sub.setId(Util.generateDbUUID());
         sub.setQuantity(16L);
         sub.setStartDate(TestUtil.createDate(2006, 10, 21));
-        sub.setEndDate(TestUtil.createDate(2020, 1, 1));
+        sub.setEndDate(TestUtil.createFutureDate(3));
         sub.setModified(new Date());
 
         Pool sourcePool = poolManager.createAndEnrichPools(sub).get(0);

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -103,7 +103,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
             providedProducts,
             16L,
             TestUtil.createDate(2006, 10, 21),
-            TestUtil.createDate(2020, 1, 1),
+            TestUtil.createFutureDate(3),
             "1",
             "2",
             "3"

--- a/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/server/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -177,12 +177,12 @@ public class PoolRulesStackDerivedTest {
         pool2 = copyFromSub(sub2);
 
         sub3 = createStackedVirtSub(owner, prod2, TestUtil.createDate(2012, 1, 1),
-            TestUtil.createDate(2020, 1, 1));
+            TestUtil.createFutureDate(3));
         sub3.getProvidedProducts().add(provided3.toDTO());
         pool3 = copyFromSub(sub3);
 
         sub4 = createStackedVirtSub(owner, prod3, TestUtil.createDate(2012, 1, 1),
-            TestUtil.createDate(2020, 1, 1));
+            TestUtil.createFutureDate(3));
         sub4.getProvidedProducts().add(provided4.toDTO());
         pool4 = copyFromSub(sub4);
 

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceDisableStatusTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceDisableStatusTest.java
@@ -30,7 +30,6 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
 import org.candlepin.test.DatabaseTestFixture;
-import org.candlepin.test.TestDateUtil;
 import org.candlepin.test.TestUtil;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -61,8 +60,8 @@ public class ConsumerResourceDisableStatusTest extends DatabaseTestFixture {
 
         Product product = this.createProduct(owner);
 
-        Pool pool = createPool(owner, product, 10L, TestDateUtil.date(2010, 1, 1),
-            TestDateUtil.date(2020, 12, 31));
+        Pool pool = createPool(owner, product, 10L, TestUtil.createDate(2010, 1, 1),
+            TestUtil.createFutureDate(3));
         poolCurator.create(pool);
 
         consumer = TestUtil.createConsumer(standardSystemType, owner);

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -69,7 +69,6 @@ import org.candlepin.resource.util.ConsumerEnricher;
 import org.candlepin.resource.util.GuestMigration;
 import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.test.DatabaseTestFixture;
-import org.candlepin.test.TestDateUtil;
 import org.candlepin.test.TestUtil;
 
 import com.google.inject.AbstractModule;
@@ -170,7 +169,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         productCurator.create(product);
 
         pool = createPool(owner, product, 10L,
-            TestDateUtil.date(2010, 1, 1), TestUtil.createFutureDate(10));
+            TestUtil.createDate(2010, 1, 1), TestUtil.createFutureDate(3));
     }
 
     @AfterEach
@@ -190,16 +189,13 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
 
     @Test
     public void testGetSerialFiltering() throws JobException {
-        consumerResource.bind(consumer.getUuid(), pool.getId(),
-            null, 1, null, null, false, null, null);
-        consumerResource.bind(consumer.getUuid(), pool.getId(),
-            null, 1, null, null, false, null, null);
-        consumerResource.bind(consumer.getUuid(), pool.getId(),
-            null, 1, null, null, false, null, null);
-        consumerResource.bind(consumer.getUuid(), pool.getId(),
-            null, 1, null, null, false, null, null);
+        consumerResource.bind(consumer.getUuid(), pool.getId(), null, 1, null, null, false, null, null);
+        consumerResource.bind(consumer.getUuid(), pool.getId(), null, 1, null, null, false, null, null);
+        consumerResource.bind(consumer.getUuid(), pool.getId(), null, 1, null, null, false, null, null);
+        consumerResource.bind(consumer.getUuid(), pool.getId(), null, 1, null, null, false, null, null);
         List<CertificateDTO> certificates = consumerResource
             .getEntitlementCertificates(consumer.getUuid(), null);
+
         assertEquals(4, certificates.size());
 
         Long serial1 = certificates.get(0).getSerial().getId();


### PR DESCRIPTION
- Fixed several tests which had hard-coded end dates for pools
  which have since expired. The new dates are now dynamically
  generated such that they are always in the future.