### PR TITLE
[3.1] 1928072: On SCA mode, stop throwing an error during auto-attach (ENT-3549)

### DIFF
--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -544,9 +544,9 @@ describe 'Content Access' do
     consumer_cp = consumer_client(@user, @consumername, type=:system, username=nil, facts= {'system.certificate_version' => '3.3'})
     consumer_cp.update_consumer({:installedProducts => installed})
 
-    lambda do
-      consumer_cp.consume_product()
-    end.should raise_exception(RestClient::BadRequest)
+    consumer_cp.consume_product()
+    entitlements = consumer_cp.list_entitlements()
+    expect(entitlements.length).to eq(0)
 
     # confirm that there is a content access cert
     #  and only a content access cert

--- a/server/spec/healing_spec.rb
+++ b/server/spec/healing_spec.rb
@@ -166,7 +166,7 @@ describe 'Healing' do
       consumer_cp.consume_product()
     rescue RestClient::BadRequest => e
       exception_thrown = true
-      ex_message = "Ignoring request to auto-attach. It is disabled for org \"#{owner['key']}\" because of the content access mode setting."
+      ex_message = "Ignoring request to auto-attach. It is disabled for org \"#{owner['key']}\"."
       data = JSON.parse(e.response)
       data['displayMessage'].should == ex_message
     end

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2136,9 +2136,16 @@ public class ConsumerResource {
                 entitlements = entitler.bindByProducts(autobindData);
             }
             catch (AutobindDisabledForOwnerException e) {
-                throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
-                    "It is disabled for org \"{0}\" because of the content access mode setting."
-                    , owner.getKey()));
+                if (owner.isContentAccessEnabled()) {
+                    throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
+                            "It is disabled for org \"{0}\" because of the content access mode setting."
+                        , owner.getKey()));
+                }
+                else {
+                    throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
+                            "It is disabled for org \"{0}\"."
+                        , owner.getKey()));
+                }
             }
             catch (AutobindHypervisorDisabledException e) {
                 throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +


### PR DESCRIPTION
 - No-op and return HTTP status 200 when auto-attaching on SCA mode