### PR TITLE
[2.9] 1937692: Fixed stacked entitlement recovation deleting unrelated pools (ENT-3632)

### DIFF
--- a/server/spec/one_sub_pool_per_stack_spec.rb
+++ b/server/spec/one_sub_pool_per_stack_spec.rb
@@ -352,6 +352,114 @@ describe 'One Sub Pool Per Stack' do
     @guest_client.list_entitlements.length.should == 0
   end
 
+  it 'ensures host unregistration does not affect other stacked pools' do
+    owner1 = create_owner(random_string('test_owner'))
+    owner2 = create_owner(random_string('test_owner'))
+
+    # Create target product/pool for owner1
+    owner1_content1 = @cp.create_content(owner1['key'], 'Provided Content 1', 'derived_provided_content_1', 'provided_content_label-1', 'yum', 'Red Hat')
+    owner1_content2 = @cp.create_content(owner1['key'], 'Provided Content 2', 'derived_provided_content_2', 'provided_content_label-2', 'yum', 'Red Hat')
+    owner1_derived_eng_product = @cp.create_product(owner1['key'], 'derived_eng_product', 'Red Hat Software Collection')
+    @cp.add_batch_content_to_product(owner1['key'], owner1_derived_eng_product['id'], [owner1_content1['id'], owner1_content2['id']])
+
+    owner1_derived_sku = @cp.create_product(owner1['key'], 'derived_sku', 'Stacking Derived Product', {
+      :multiplier => 1,
+      :attributes => {
+        'host_limited' => 'true'
+      }
+    })
+
+    owner1_sku = @cp.create_product(owner1['key'], 'test_sku', 'Stacking VDC Product', {
+      :multiplier => 1,
+      :attributes => {
+        'host_limited' => 'true',
+        'stacking_id' => 'shared_stacking_id',
+        'virt_limit' => 'unlimited'
+      }
+    })
+
+    owner1_pool = @cp.create_pool(owner1['key'], owner1_sku['id'], {
+      :quantity => 10,
+      :start_date => DateTime.now,
+      :end_date => DateTime.now + 365,
+      :attributes => {},
+      :stackId => 'shared_stacking_id',
+      :stacked => 'true',
+      :providedProducts => [],
+      :derivedProductId => owner1_derived_sku['id'],
+      :derivedProvidedProducts => [owner1_derived_eng_product]
+    })
+
+    # Create target product/pool for owner2
+    owner2_content1 = @cp.create_content(owner2['key'], 'Provided Content 1', 'derived_provided_content_1', 'provided_content_label-1', 'yum', 'Red Hat')
+    owner2_content2 = @cp.create_content(owner2['key'], 'Provided Content 2', 'derived_provided_content_2', 'provided_content_label-2', 'yum', 'Red Hat')
+    owner2_derived_eng_product = @cp.create_product(owner2['key'], 'derived_eng_product', 'Red Hat Software Collection')
+    @cp.add_batch_content_to_product(owner2['key'], owner2_derived_eng_product['id'], [owner2_content1['id'], owner2_content2['id']])
+
+    owner2_derived_sku = @cp.create_product(owner2['key'], 'derived_sku', 'Stacking Derived Product', {
+      :multiplier => 1,
+      :attributes => {
+        'host_limited' => 'true'
+      }
+    })
+
+    owner2_sku = @cp.create_product(owner2['key'], 'test_sku', 'Stacking VDC Product', {
+      :multiplier => 1,
+      :attributes => {
+        'host_limited' => 'true',
+        'stacking_id' => 'shared_stacking_id',
+        'virt_limit' => 'unlimited'
+      }
+    })
+
+    owner2_pool = @cp.create_pool(owner2['key'], owner2_sku['id'], {
+      :quantity => 10,
+      :start_date => DateTime.now,
+      :end_date => DateTime.now + 365,
+      :attributes => {},
+      :stackId => 'shared_stacking_id',
+      :stacked => 'true',
+      :providedProducts => [],
+      :derivedProductId => owner2_derived_sku['id'],
+      :derivedProvidedProducts => [owner2_derived_eng_product]
+    })
+
+
+    # Get initial pool count
+    owner1_pools_stage1 = @cp.list_owner_pools(owner1['key'])
+    owner2_pools_stage1 = @cp.list_owner_pools(owner2['key'])
+
+    # Create some consumers, and have them consume the pool
+    for i in 0..2 do
+      owner1_consumer_name = random_string('test_system')
+      owner1_consumer = @cp.register(owner1_consumer_name, :system, nil, {}, nil, owner1['key'], [], [], nil)
+
+      owner2_consumer_name = random_string('test_system')
+      owner2_consumer = @cp.register(owner2_consumer_name, :system, nil, {}, nil, owner2['key'], [], [], nil)
+
+      @cp.consume_pool(owner1_pool['id'], { :uuid => owner1_consumer['uuid'] })
+      @cp.consume_pool(owner2_pool['id'], { :uuid => owner2_consumer['uuid'] })
+    end
+
+    # Verify our updated pool count (attaching a VDC pool should trigger the creation of a new sub pool
+    # for each consumer)
+    owner1_pools_stage2 = @cp.list_owner_pools(owner1['key'])
+    owner2_pools_stage2 = @cp.list_owner_pools(owner2['key'])
+
+    expect(owner1_pools_stage2.length).to eq(owner1_pools_stage1.length + 3)
+    expect(owner2_pools_stage2.length).to eq(owner2_pools_stage1.length + 3)
+
+    # Unregister one of the hosts and verify that (a) only their pool was removed and (b) the other org's
+    # pools were not at all affected
+    @cp.unregister(owner2_consumer['uuid'])
+
+    owner1_pools_stage3 = @cp.list_owner_pools(owner1['key'])
+    owner2_pools_stage3 = @cp.list_owner_pools(owner2['key'])
+
+    expect(owner1_pools_stage3.length).to eq(owner1_pools_stage2.length)
+    expect(owner2_pools_stage3.length).to eq(owner2_pools_stage2.length - 1)
+  end
+
   it 'should remove guest entitlement when guest is migrated' do
     @host_client.consume_pool(@stacked_virt_pool1['id'], {:quantity => 1})[0]
     sub_pool = find_sub_pool(@guest_client, @guest['uuid'], @stack_id)

--- a/server/src/main/java/org/candlepin/bind/PostBindBonusPoolsOp.java
+++ b/server/src/main/java/org/candlepin/bind/PostBindBonusPoolsOp.java
@@ -51,6 +51,7 @@ public class PostBindBonusPoolsOp implements BindOperation {
     @Inject
     public PostBindBonusPoolsOp(PoolManager poolManager, ConsumerTypeCurator consumerTypeCurator,
         PoolCurator poolCurator, Enforcer enforcer) {
+
         this.poolManager = poolManager;
         this.consumerTypeCurator = consumerTypeCurator;
         this.poolCurator = poolCurator;
@@ -84,7 +85,7 @@ public class PostBindBonusPoolsOp implements BindOperation {
         // as these consumer types should not have created a stack derived pool in the first place.
         // Therefore, we do not need to check if any stack derived pools need updating
         if (!stackIds.isEmpty() && !ctype.isManifest()) {
-            subPoolsForStackIds = poolCurator.getSubPoolForStackIds(consumer, stackIds);
+            subPoolsForStackIds = poolCurator.getSubPoolsForStackIds(consumer, stackIds);
             if (CollectionUtils.isNotEmpty(subPoolsForStackIds)) {
                 poolManager.updatePoolsFromStackWithoutDeletingStack(consumer,
                     subPoolsForStackIds,

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -1289,20 +1289,31 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
     /**
      * Partitions the given collection using the value returned by the getInBlockSize() method as
-     * the partition size. This method is provided as a utility method to avoid referencing a very
-     * long constant name used in many curators. Callers which need this behavior with a custom
-     * size can simulate the behavior by using the <tt>Iterables.partition</tt> method directly:
-     * <pre>
-     *  Iterable<List<String>> blocks = ', 'entityIds, blockSize);
-     * </pre>
+     * the partition size.
      *
      * @param collection
      *  The collection to partition
      *
      * @return
-     *  An iterable collection of lists containing the partitioned data in the provided collection
+     *  An iterable collection of lists containing the partitioned data from the provided collection
      */
     protected <T> Iterable<List<T>> partition(Iterable<T> collection) {
-        return Iterables.partition(collection, this.getInBlockSize());
+        return this.partition(collection, this.getInBlockSize());
+    }
+
+    /**
+     * Partitions the given collection using the provided block size.
+     *
+     * @param collection
+     *  The collection to partition
+     *
+     * @param blockSize
+     *  The maximum size of the blocks to build when partitioning the collection
+     *
+     * @return
+     *  An iterable collection of lists containing the partitioned data from the provided collection
+     */
+    protected <T> Iterable<List<T>> partition(Iterable<T> collection, int blockSize) {
+        return Iterables.partition(collection, blockSize);
     }
 }

--- a/server/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/server/src/main/java/org/candlepin/model/PoolCurator.java
@@ -1129,35 +1129,70 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
     }
 
     /**
+     * Fetches the pools associated with the given consumer with the provided stack IDs. If no
+     * consumer is provided or no stack IDs are provided, this method returns an empty list.
+     *
      * @param consumer
+     *  the consumer for which to find stacked pools
+     *
      * @param stackIds
-     * @return Derived pools which exist for the given consumer and stack ids
+     *  a collection of stack IDs representing the stacks of pools to fetch
+     *
+     * @return
+     *  a list containing all of the stacked pools with the given stack IDs owned by the specified
+     *  consumer
      */
-    public List<Pool> getSubPoolForStackIds(Consumer consumer, Collection<String> stackIds) {
-        List<Pool> result = new ArrayList<>();
-        for (List<String> block: this.partition(stackIds)) {
-            result.addAll(getSubPoolForStackIds(consumer, block));
-        }
-        return result;
+    public List<Pool> getSubPoolsForStackIds(Consumer consumer, Collection<String> stackIds) {
+        return consumer != null ?
+            this.getSubPoolsForStackIds(Arrays.asList(consumer), stackIds) :
+            new ArrayList<>();
     }
 
-    @SuppressWarnings({"unchecked", "checkstyle:indentation"})
-    private List<Pool> getSubPoolForStackIds(Consumer consumer, List<String> stackIds) {
+    /**
+     * Fetches the pools associated with the given consumers with the provided stack IDs. If no
+     * consumers are provided or no stack IDs are provided, this method returns an empty list.
+     *
+     * @param consumers
+     *  a collection of consumers for which to find stacked pools
+     *
+     * @param stackIds
+     *  a collection of stack IDs representing the stacks of pools to fetch
+     *
+     * @return
+     *  a list containing all of the stacked pools with the given stack IDs owned by any of the
+     *  specified consumer
+     */
+    public List<Pool> getSubPoolsForStackIds(Collection<Consumer> consumers, Collection<String> stackIds) {
+        List<Pool> output = new ArrayList<>();
+
+        if (consumers == null || consumers.isEmpty()) {
+            return output;
+        }
+
         if (stackIds == null || stackIds.isEmpty()) {
-            return Collections.emptyList();
-        }
-        Criteria getPools = createSecureCriteria()
-            .createAlias("sourceStack", "ss")
-            .add(Restrictions.and(
-                Restrictions.isNotNull("ss.sourceStackId"),
-                CPRestrictions.in("ss.sourceStackId", stackIds))
-            );
-
-        if (consumer != null) {
-            getPools.add(Restrictions.eq("ss.sourceConsumer", consumer));
+            return output;
         }
 
-        return (List<Pool>) getPools.list();
+        // Impl note: There is some optimization that could be done here to determine the best way
+        // to chunk the two collections here to minimize the number of queries, but in the general
+        // case, this is likely sufficient. For now.
+        int blockSize = Math.min(this.getQueryParameterLimit() / 2, this.getInBlockSize());
+
+        String jpql = "SELECT pool FROM Pool pool JOIN pool.sourceStack stack " +
+            "WHERE stack.sourceStackId IN (:stackIds) AND stack.sourceConsumer IN (:consumers)";
+
+        TypedQuery<Pool> query = this.getEntityManager()
+            .createQuery(jpql, Pool.class);
+
+        for (List<Consumer> consumerBlock : this.partition(consumers, blockSize)) {
+            for (List<String> stackIdBlock : this.partition(stackIds, blockSize)) {
+                output.addAll(query.setParameter("stackIds", stackIdBlock)
+                    .setParameter("consumers", consumerBlock)
+                    .getResultList());
+            }
+        }
+
+        return output;
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -74,6 +74,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
     private Product derivedProvidedProduct;
     private Pool pool;
     private Consumer consumer;
+    private ConsumerType systemConsumerType;
 
     @BeforeEach
     public void setUp() {
@@ -81,7 +82,7 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         ownerCurator.create(owner);
 
         ConsumerType systemType = new ConsumerType(ConsumerTypeEnum.SYSTEM);
-        consumerTypeCurator.create(systemType);
+        this.systemConsumerType = this.consumerTypeCurator.create(systemType);
 
         product = this.createProduct(owner);
         providedProduct = this.createProduct(owner);
@@ -1264,89 +1265,257 @@ public class PoolCuratorTest extends DatabaseTestFixture {
         assertEquals(2, levels.size());
     }
 
-    @Test
-    public void getSubPoolCountForStack() {
-        String expectedStackId = "13245";
-        Product product = TestUtil.createProduct();
-        product.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
-        product.setAttribute(Product.Attributes.STACKING_ID, expectedStackId);
+
+    private Pool setupHostLimitedVirtPoolStack(Owner owner, Consumer consumer, String stackId) {
+        Product product = TestUtil.createProduct()
+            .setAttribute(Product.Attributes.VIRT_LIMIT, "unlimited")
+            .setAttribute(Product.Attributes.STACKING_ID, stackId);
+
         product = this.createProduct(product, owner);
 
-        // Create derived pool referencing the entitlement just made:
         Pool derivedPool = new Pool(
             owner,
             product,
             new HashSet<>(),
             1L,
-            TestUtil.createDate(2011, 3, 2),
-            TestUtil.createDate(2055, 3, 2),
+            TestUtil.createFutureDate(-2),
+            TestUtil.createFutureDate(2),
             "",
             "",
             ""
         );
-        derivedPool.setSourceStack(new SourceStack(consumer, expectedStackId));
+        derivedPool.setSourceStack(new SourceStack(consumer, stackId));
         derivedPool.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer.getUuid());
 
-        poolCurator.create(derivedPool);
-
-        Pool pool = poolCurator.getSubPoolForStackIds(null, Arrays.asList(expectedStackId)).get(0);
-        assertNotNull(pool);
+        return this.poolCurator.create(derivedPool);
     }
 
     @Test
-    public void getSubPoolCountForStackByConsumer() {
-        String expectedStackId = "13245";
-        Product product = TestUtil.createProduct();
-        product.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
-        product.setAttribute(Product.Attributes.STACKING_ID, expectedStackId);
-        product = this.createProduct(product, owner);
+    public void testGetSubPoolsForStackIdsSingleConsumerSingleStack() {
+        Owner owner = this.createOwner();
+        Consumer consumer1 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer2 = this.createConsumer(owner, this.systemConsumerType);
 
-        // Create derived pool referencing the entitlement just made:
-        Pool derivedPool = new Pool(
-            owner,
-            product,
-            new HashSet<>(),
-            1L,
-            TestUtil.createDate(2011, 3, 2),
-            TestUtil.createDate(2055, 3, 2),
-            "",
-            "",
-            ""
-        );
-        derivedPool.setSourceStack(new SourceStack(consumer, expectedStackId));
-        derivedPool.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer.getUuid());
+        String stackId1 = "test_stack_id-1";
+        String stackId2 = "test_stack_id-2";
+        String stackId3 = "test_stack_id-3";
+        String stackId4 = "test_stack_id-4";
 
-        poolCurator.create(derivedPool);
+        Pool dpool1 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId1);
+        Pool dpool2 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId2);
+        Pool dpool3 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId3);
+        Pool dpool4 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId1);
+        Pool dpool5 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId2);
+        Pool dpool6 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId3);
 
-        Pool pool = poolCurator.getSubPoolForStackIds(consumer, Arrays.asList(expectedStackId)).get(0);
-        assertNotNull(pool);
+        Collection<Pool> pools = this.poolCurator.getSubPoolsForStackIds(consumer1, Arrays.asList(stackId1));
+
+        assertNotNull(pools);
+        assertEquals(1, pools.size());
+        assertThat(pools, hasItems(dpool1));
     }
 
     @Test
-    public void getSubPoolsForStackIds() {
-        Set stackIds = new HashSet<String>();
-        for (Integer i = 0; i < 5; i++) {
-            String stackId = "12345" + i.toString();
-            stackIds.add(stackId);
-            Product product = TestUtil.createProduct();
-            product.setAttribute(Product.Attributes.VIRT_LIMIT, "3");
-            product.setAttribute(Product.Attributes.STACKING_ID, stackId);
-            product = this.createProduct(product, owner);
+    public void testGetSubPoolsForStackIdsSingleConsumerMultiStack() {
+        Owner owner = this.createOwner();
+        Consumer consumer1 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer2 = this.createConsumer(owner, this.systemConsumerType);
 
-            // Create derived pool referencing the entitlement just made:
-            Pool derivedPool = new Pool(owner, product, new HashSet<>(), 1L,
-                TestUtil.createDate(2011, 3, 2), TestUtil.createDate(2055, 3, 2), "", "", "");
-            derivedPool.setSourceStack(new SourceStack(consumer, stackId));
-            derivedPool.setAttribute(Pool.Attributes.REQUIRES_HOST, consumer.getUuid());
+        String stackId1 = "test_stack_id-1";
+        String stackId2 = "test_stack_id-2";
+        String stackId3 = "test_stack_id-3";
+        String stackId4 = "test_stack_id-4";
 
-            poolCurator.create(derivedPool);
-        }
+        Pool dpool1 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId1);
+        Pool dpool2 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId2);
+        Pool dpool3 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId3);
+        Pool dpool4 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId1);
+        Pool dpool5 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId2);
+        Pool dpool6 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId3);
 
-        List<Pool> pools = poolCurator.getSubPoolForStackIds(consumer, stackIds);
-        assertEquals(5, pools.size());
-        for (Pool pool : pools) {
-            assertTrue(pool.getSourceStackId().startsWith("12345"));
-        }
+        Collection<Pool> pools = this.poolCurator
+            .getSubPoolsForStackIds(consumer1, Arrays.asList(stackId1, stackId2, stackId4));
+
+        assertNotNull(pools);
+        assertEquals(2, pools.size());
+        assertThat(pools, hasItems(dpool1, dpool2));
+    }
+
+    @Test
+    public void testGetSubPoolsForStackIdsMultiConsumerSingleStack() {
+        Owner owner = this.createOwner();
+        Consumer consumer1 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer2 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer3 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer4 = this.createConsumer(owner, this.systemConsumerType);
+
+        String stackId1 = "test_stack_id-1";
+        String stackId2 = "test_stack_id-2";
+        String stackId3 = "test_stack_id-3";
+        String stackId4 = "test_stack_id-4";
+
+        Pool dpool1 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId1);
+        Pool dpool2 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId2);
+        Pool dpool3 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId3);
+        Pool dpool4 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId1);
+        Pool dpool5 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId2);
+        Pool dpool6 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId3);
+        Pool dpool7 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId1);
+        Pool dpool8 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId2);
+        Pool dpool9 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId3);
+
+        Collection<Pool> pools = this.poolCurator
+            .getSubPoolsForStackIds(Arrays.asList(consumer1, consumer2, consumer4), Arrays.asList(stackId1));
+
+        assertNotNull(pools);
+        assertEquals(2, pools.size());
+        assertThat(pools, hasItems(dpool1, dpool4));
+    }
+
+    @Test
+    public void testGetSubPoolsForStackIdsNullConsumer() {
+        Owner owner = this.createOwner();
+        Consumer consumer1 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer2 = this.createConsumer(owner, this.systemConsumerType);
+
+        String stackId1 = "test_stack_id-1";
+        String stackId2 = "test_stack_id-2";
+        String stackId3 = "test_stack_id-3";
+        String stackId4 = "test_stack_id-4";
+
+        Pool dpool1 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId1);
+        Pool dpool2 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId2);
+        Pool dpool3 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId3);
+        Pool dpool4 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId1);
+        Pool dpool5 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId2);
+        Pool dpool6 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId3);
+
+        Collection<Pool> pools = this.poolCurator
+            .getSubPoolsForStackIds((Consumer) null, Arrays.asList(stackId1, stackId2, stackId4));
+
+        assertNotNull(pools);
+        assertEquals(0, pools.size());
+    }
+
+    @Test
+    public void testGetSubPoolsForStackIdsNullConsumerCollection() {
+        Owner owner = this.createOwner();
+        Consumer consumer1 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer2 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer3 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer4 = this.createConsumer(owner, this.systemConsumerType);
+
+        String stackId1 = "test_stack_id-1";
+        String stackId2 = "test_stack_id-2";
+        String stackId3 = "test_stack_id-3";
+        String stackId4 = "test_stack_id-4";
+
+        Pool dpool1 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId1);
+        Pool dpool2 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId2);
+        Pool dpool3 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId3);
+        Pool dpool4 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId1);
+        Pool dpool5 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId2);
+        Pool dpool6 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId3);
+        Pool dpool7 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId1);
+        Pool dpool8 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId2);
+        Pool dpool9 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId3);
+
+        Collection<Pool> pools = this.poolCurator.getSubPoolsForStackIds((Collection<Consumer>) null,
+            Arrays.asList(stackId1, stackId2, stackId4));
+
+        assertNotNull(pools);
+        assertEquals(0, pools.size());
+    }
+
+    @Test
+    public void testGetSubPoolsForStackIdsEmptyConsumerCollection() {
+        Owner owner = this.createOwner();
+        Consumer consumer1 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer2 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer3 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer4 = this.createConsumer(owner, this.systemConsumerType);
+
+        String stackId1 = "test_stack_id-1";
+        String stackId2 = "test_stack_id-2";
+        String stackId3 = "test_stack_id-3";
+        String stackId4 = "test_stack_id-4";
+
+        Pool dpool1 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId1);
+        Pool dpool2 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId2);
+        Pool dpool3 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId3);
+        Pool dpool4 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId1);
+        Pool dpool5 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId2);
+        Pool dpool6 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId3);
+        Pool dpool7 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId1);
+        Pool dpool8 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId2);
+        Pool dpool9 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId3);
+
+        Collection<Pool> pools = this.poolCurator.getSubPoolsForStackIds(Collections.emptyList(),
+            Arrays.asList(stackId1, stackId2, stackId4));
+
+        assertNotNull(pools);
+        assertEquals(0, pools.size());
+    }
+
+    @Test
+    public void testGetSubPoolsForStackIdsIgnoresNullsInCollection() {
+        Owner owner = this.createOwner();
+        Consumer consumer1 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer2 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer3 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer4 = this.createConsumer(owner, this.systemConsumerType);
+
+        String stackId1 = "test_stack_id-1";
+        String stackId2 = "test_stack_id-2";
+        String stackId3 = "test_stack_id-3";
+        String stackId4 = "test_stack_id-4";
+
+        Pool dpool1 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId1);
+        Pool dpool2 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId2);
+        Pool dpool3 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId3);
+        Pool dpool4 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId1);
+        Pool dpool5 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId2);
+        Pool dpool6 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId3);
+        Pool dpool7 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId1);
+        Pool dpool8 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId2);
+        Pool dpool9 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId3);
+
+        Collection<Pool> pools = this.poolCurator.getSubPoolsForStackIds(Arrays.asList(consumer1, null),
+            Arrays.asList(stackId1, stackId2, stackId4));
+
+        assertNotNull(pools);
+        assertEquals(2, pools.size());
+        assertThat(pools, hasItems(dpool1, dpool2));
+    }
+
+    @Test
+    public void testGetSubPoolsForStackIdsWithConsumerCollectionOfNulls() {
+        Owner owner = this.createOwner();
+        Consumer consumer1 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer2 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer3 = this.createConsumer(owner, this.systemConsumerType);
+        Consumer consumer4 = this.createConsumer(owner, this.systemConsumerType);
+
+        String stackId1 = "test_stack_id-1";
+        String stackId2 = "test_stack_id-2";
+        String stackId3 = "test_stack_id-3";
+        String stackId4 = "test_stack_id-4";
+
+        Pool dpool1 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId1);
+        Pool dpool2 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId2);
+        Pool dpool3 = this.setupHostLimitedVirtPoolStack(owner, consumer1, stackId3);
+        Pool dpool4 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId1);
+        Pool dpool5 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId2);
+        Pool dpool6 = this.setupHostLimitedVirtPoolStack(owner, consumer2, stackId3);
+        Pool dpool7 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId1);
+        Pool dpool8 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId2);
+        Pool dpool9 = this.setupHostLimitedVirtPoolStack(owner, consumer3, stackId3);
+
+        Collection<Pool> pools = this.poolCurator.getSubPoolsForStackIds(Arrays.asList(null, null, null),
+            Arrays.asList(stackId1, stackId2, stackId4));
+
+        assertNotNull(pools);
+        assertEquals(0, pools.size());
     }
 
     @Test


### PR DESCRIPTION
- Fixed a severe issue that was causing all derived pools sharing
  a stacking ID to be removed when an entitlement for any of the pools
  was revoked
- Rewrote the PoolCurator.getSubPoolsByStackIds to no longer use
  deprecated Hibernate criteria queries