### PR TITLE
1932662: Fixed candlepin test data for dev-sku (ENT-3600)

### DIFF
--- a/server/bin/test_data.json
+++ b/server/bin/test_data.json
@@ -2157,8 +2157,22 @@
             ]
         },
         {
-            "name": "Development SKU Product, no content",
+            "name": "Development SKU Product",
             "id": "dev-sku-product",
+            "type": "MKT",
+            "skip_pools": "true",
+            "provided_products": [
+                "100000000000011"
+            ],
+            "attributes": {
+                "support_level" : "Premium",
+                "support_type" : "Level 3",
+                "expires_after" : "75"
+            }
+        },
+        {
+            "name": "Development SKU Product, no content, no provided product",
+            "id": "dev-sku-no-provided-product",
             "type": "MKT",
             "skip_pools": "true",
             "attributes": {


### PR DESCRIPTION
Issue :
Incomplete test data for dev SKU product. Commit - https://github.com/candlepin/candlepin/pull/2918/commits/10eefcac2ca1c2aa3b9f306587cd7adfea74edc9 changed the working of dev pools which now consider provided products as well.

Changes : 
- Added provided product to ```dev-sku-product```
- Created another dev product with no provided product ```dev-sku-no-provided-product```