### PR TITLE
[M] Removed foreign key constraints from obsolete pool tables (ENT-3668)

### DIFF
--- a/server/src/main/resources/db/changelog/20210317160453-drop_pool_provided_product_fks.xml
+++ b/server/src/main/resources/db/changelog/20210317160453-drop_pool_provided_product_fks.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20210317160453-1" author="crog">
+        <dropAllForeignKeyConstraints baseTableName="cp2_pool_provided_products"/>
+    </changeSet>
+
+    <changeSet id="20210317160453-2" author="crog">
+        <dropAllForeignKeyConstraints baseTableName="cp2_pool_derprov_products"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1251,4 +1251,5 @@
     <include file="db/changelog/20210118141207-create-consumer-activation-key-table.xml"/>
     <include file="db/changelog/20210127105630-migrate-product-hierarchy.xml"/>
     <include file="db/changelog/20210211154615-add-owner-last-content-updated-column.xml"/>
+    <include file="db/changelog/20210317160453-drop_pool_provided_product_fks.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2343,4 +2343,5 @@
     <include file="db/changelog/20210118141207-create-consumer-activation-key-table.xml"/>
     <include file="db/changelog/20210127105630-migrate-product-hierarchy.xml"/>
     <include file="db/changelog/20210211154615-add-owner-last-content-updated-column.xml"/>
+    <include file="db/changelog/20210317160453-drop_pool_provided_product_fks.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -160,4 +160,5 @@
     <include file="db/changelog/20210118141207-create-consumer-activation-key-table.xml"/>
     <include file="db/changelog/20210127105630-migrate-product-hierarchy.xml"/>
     <include file="db/changelog/20210211154615-add-owner-last-content-updated-column.xml"/>
+    <include file="db/changelog/20210317160453-drop_pool_provided_product_fks.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- Removed the foreign key constraints from cp2_pool_provided_products
  and cp2_pool_derprov_products, as these tables have been obsoleted
  and existing data in them could prevent pools or products from
  being deleted properly.