### PR TITLE
[3.2] 1944558: On SCA mode, stop throwing an error during auto-attach (ENT-3705)

### DIFF
--- a/server/spec/autobind_disabled_for_owner_spec.rb
+++ b/server/spec/autobind_disabled_for_owner_spec.rb
@@ -31,7 +31,7 @@ describe 'Autobind Disabled On Owner' do
     exception_thrown.should be true
   end
 
-  it 'autobind should fail when owner is in SCA mode' do
+  it 'autobind should not attach entitlements when owner is in SCA mode' do
     skip("candlepin running in standalone mode") if not is_hosted?
 
     exception_thrown = false
@@ -48,17 +48,10 @@ describe 'Autobind Disabled On Owner' do
       {'cpu.cpu_socket(s)' => '8'}, nil, owner['key'], [], [])
     consumer_cp = Candlepin.new(nil, nil, consumer.idCert.cert, consumer.idCert['key'])
 
-    begin
-      consumer_cp.consume_product()
-    rescue RestClient::BadRequest => e
-      exception_thrown = true
-      ex_message = "Ignoring request to auto-attach. " +
-        "It is disabled for org \"#{owner['key']}\" because of the content access mode setting."
-      data = JSON.parse(e.response)
-      expect(data['displayMessage']).to eq(ex_message)
-    end
+    consumer_cp.consume_product()
+    entitlements = consumer_cp.list_entitlements()
+    expect(entitlements.length).to eq(0)
 
-    expect(exception_thrown).to eq(true)
   end
 
   it 'autobind fails when hypervisor autobind disabled on owner' do

--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -546,9 +546,9 @@ describe 'Content Access' do
         facts= {'system.certificate_version' => '3.3'})
     consumer_cp.update_consumer({:installedProducts => installed})
 
-    lambda do
-      consumer_cp.consume_product()
-    end.should raise_exception(RestClient::BadRequest)
+    consumer_cp.consume_product()
+    entitlements = consumer_cp.list_entitlements()
+    expect(entitlements.length).to eq(0)
 
     # confirm that there is a content access cert
     #  and only a content access cert

--- a/server/spec/healing_spec.rb
+++ b/server/spec/healing_spec.rb
@@ -173,34 +173,4 @@ describe 'Healing' do
     exception_thrown.should be true
   end
 
-  it 'healing should fail when owner is in SCA mode' do
-    skip("candlepin running in standalone mode") if not is_hosted?
-
-    owner = create_owner(random_string("test_owner"), nil, {
-      'contentAccessModeList' => 'org_environment,entitlement',
-      'contentAccessMode' => "org_environment"
-    })
-    owner = @cp.get_owner(owner['key'])
-
-    expect(owner).to_not be_nil
-
-    cp_user = user_client(owner, random_string("testing-user"))
-    consumer = cp_user.register("foofy_test", :system, nil,
-      {'cpu.cpu_socket(s)' => '8'}, nil, owner['key'], [], [])
-    consumer_cp = Candlepin.new(nil, nil, consumer.idCert.cert, consumer.idCert['key'])
-    exception_thrown = false
-
-    begin
-      consumer_cp.consume_product()
-    rescue RestClient::BadRequest => e
-      exception_thrown = true
-      ex_message = "Ignoring request to auto-attach. " +
-        "It is disabled for org \"#{owner['key']}\" because of the content access mode setting."
-      data = JSON.parse(e.response)
-      expect(data['displayMessage']).to eq(ex_message)
-    end
-
-    expect(exception_thrown).to eq(true)
-  end
-
 end

--- a/server/src/main/java/org/candlepin/controller/Entitler.java
+++ b/server/src/main/java/org/candlepin/controller/Entitler.java
@@ -59,6 +59,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -225,10 +226,15 @@ public class Entitler {
                     "Auto-attach is disabled for owner \"{0}\"{1}.",
                     owner.getKey(), hypMessage));
             }
-            else {
+            else if (owner.isAutobindDisabled()) {
                 throw new AutobindDisabledForOwnerException(i18n.tr(
-                    "Auto-attach is disabled for owner \"{0}\"{1}.",
-                    owner.getKey(), caMessage));
+                    "Auto-attach is disabled for owner \"{0}\".",
+                    owner.getKey()));
+            }
+            else {
+                log.debug("Auto-attach is disabled for owner \"{0}\"{1}.",
+                    owner.getKey(), caMessage);
+                return Collections.EMPTY_LIST;
             }
         }
 

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2167,9 +2167,10 @@ public class ConsumerResource {
             }
             catch (AutobindDisabledForOwnerException e) {
                 if (owner.isContentAccessEnabled()) {
-                    throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
+                    log.debug("Ignoring request to auto-attach. " +
                         "It is disabled for org \"{0}\" because of the content access mode setting."
-                        , owner.getKey()));
+                        , owner.getKey());
+                    return Response.status(Response.Status.OK).build();
                 }
                 else {
                     throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
@@ -2229,15 +2230,14 @@ public class ConsumerResource {
             String message = "";
 
             if (owner.isContentAccessEnabled()) {
-                message = (i18n.tr("Organization \"{0}\" has auto-attach disabled because " +
-                    "of the content access mode setting.", owner.getKey()));
-
+                log.debug("Organization \"{0}\" has auto-attach disabled because " +
+                    "of the content access mode setting.", owner.getKey());
+                return Collections.EMPTY_LIST;
             }
             else {
                 message = (i18n.tr("Organization \"{0}\" has auto-attach disabled.", owner.getKey()));
+                throw new BadRequestException(message);
             }
-            throw new BadRequestException(message);
-
         }
 
         List<PoolQuantity> dryRunPools = new ArrayList<>();


### PR DESCRIPTION
 - No-op and return HTTP status 200 when auto-attaching on SCA mode

Additional changes
 - Returned Empty list in dryBind() of ConsumerResource, instead of
   throwing exception.
 - Used isContentAccessEnabled method, instead of
   isUsingSimpleContentAccess

(cherry picked from commit be654c64b388311cc9d5ec2970e8d3e92031ba3e)