### PR TITLE
[M] Fixed several Python2/3 compatibility issues in the org_migrator

### DIFF
--- a/server/bin/org_migrator/cp_connectors.py
+++ b/server/bin/org_migrator/cp_connectors.py
@@ -192,7 +192,7 @@ class PSQLConnector(DBConnector):
         return statement
 
     def is_closed(self):
-        if self.db is not None and self.db.closed == 0:
+        if hasattr(self, 'db') and self.db is not None and self.db.closed == 0:
             return False
 
         return True
@@ -270,7 +270,7 @@ class MySQLConnector(DBConnector):
         return statement
 
     def is_closed(self):
-        if self.db is not None and self.db.is_connected():
+        if hasattr(self, 'db') and self.db is not None and self.db.is_connected():
             return False
 
         return True

--- a/server/bin/org_migrator/org_migrator.py
+++ b/server/bin/org_migrator/org_migrator.py
@@ -3,13 +3,14 @@
 import binascii
 import datetime
 from functools import partial
+import getpass
 import json
 import logging
 from optparse import OptionParser
 import os
 import re
+import sys
 import zipfile
-import getpass
 
 import cp_connectors as cp
 
@@ -65,10 +66,18 @@ def list_orgs(db):
 
 def jsonify(data):
     def data_converter(obj):
-        if isinstance(obj, (bytearray, buffer, memoryview)):
-            return binascii.b2a_base64(obj)
         if isinstance(obj, datetime.datetime):
             return str(obj)
+
+        # In python2, our binary blobs will be "buffer" types. In python 3, it will be a bytearray, bytes
+        # or memoryview
+        if sys.version_info >= (3,0,0):
+            if isinstance(obj, (bytearray, bytes, memoryview)):
+                return binascii.b2a_base64(obj).decode()
+        else:
+            if isinstance(obj, buffer):
+                return binascii.b2a_base64(obj)
+
 
         raise TypeError("Unexpected type: %s" % (type(obj)))
 


### PR DESCRIPTION
- Fixed a bug that would trigger an extra exception if the DB
  connector fails to establish a connection early
- Fixed the NameError that could occur when running on python3
  when processing binary data