### PR TITLE
ENT-3491: Addressing sporadic spec test failure in import_update_spec.rb

### DIFF
--- a/server/spec/import_update_spec.rb
+++ b/server/spec/import_update_spec.rb
@@ -72,6 +72,15 @@ describe 'Import Update', :serial => true do
   end
 
   it 'should remove all imported subscriptions if import has no entitlements' do
+
+    # The manifest metadata can end up
+    #  with a created date that is a fraction of a second ahead of
+    #  the created date in the cp_export_metadata table.
+    #  This results into the manifest metadata conflict with error
+    #  "Import is the same as existing data". Hence to avoid this,
+    #  adding a sleep before creating another export.
+    sleep 2
+
     no_ent_export = @exporter.create_candlepin_export_update_no_ent()
 
     @cp.import(@import_owner['key'], no_ent_export.export_filename)


### PR DESCRIPTION
 - The issue is in MySQL which does not store partial seconds.
   This was already addressed in commit 82a4051. To resolve,
   added `sleep 2` before the next export operation executes. 
   This ensures there is a time difference between the exports.