### PR TITLE
[3.1] 1949698: Fix SCA cert regeneration for consumers in environments (ENT-3784)

### DIFF
--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -43,8 +43,18 @@ describe 'Content Access' do
     sleep 1
   end
 
-  it "does allow addition of the content access level" do
+  def promote_content_to_environment(user, environment, content, enabled = true)
+    job = user.promote_content(environment['id'], [
+      {
+        :contentId => content['id'],
+        :enabled => enabled
+      }
+    ])
 
+    wait_for_job(job['id'], 15)
+  end
+
+  it "does allow addition of the content access level" do
     @cp.update_owner(@owner['key'], {'contentAccessMode' => "entitlement"})
     @owner = @cp.get_owner(@owner['key'])
 
@@ -123,12 +133,7 @@ describe 'Content Access' do
       @env = @user.create_environment(@owner['key'], random_string('testenv'),
         "My Test Env 1", "For test systems only.")
 
-      job = @user.promote_content(@env['id'],
-          [{
-            :contentId => @content['id'],
-            :enabled => false,
-          }])
-      wait_for_job(job['id'], 15)
+      promote_content_to_environment(@user, @env, @content, false)
 
       consumer = @user.register(random_string('consumer'), :system, nil,
           {'system.certificate_version' => '3.3'},nil, nil, [], [], @env['id'])
@@ -162,12 +167,8 @@ describe 'Content Access' do
     json_body = extract_payload(cert)
     expect(json_body['products'][0]['content'].length).to eq(0)
 
-    job = @user.promote_content(@env['id'], [{
-      :contentId => @content['id'],
-      :enabled => false,
-    }])
+    promote_content_to_environment(@user, @env, @content, false)
 
-    wait_for_job(job['id'], 15)
     @env = @user.get_environment(@env['id'])
     @env['environmentContent'].size.should == 1
 
@@ -636,12 +637,7 @@ describe 'Content Access' do
     @cp.add_content_to_product(@owner['key'], product['id'], content2['id'], true)
 
     # Promote content with enabled false
-    job = @org_admin.promote_content(@env['id'],
-    [{
-      :contentId => content['id'],
-      :enabled => false ,
-     }])
-    wait_for_job(job['id'], 15)
+    promote_content_to_environment(@org_admin, @env, content, false)
 
     pool = create_pool_and_subscription(@owner['key'], product['id'], 10)
     ent = consumer_cp.consume_pool(pool['id'], {:quantity => 1})[0]
@@ -708,16 +704,16 @@ describe 'Content Access' do
   end
 
 
-  def regenerate_cert_test(&updater)
-    consumer = consumer_client(@user, @consumername, type=:system, username=nil, facts= {'system.certificate_version' => '3.3'})
-    certs = consumer.list_certificates()
+  def regenerate_cert_test(consumer_client, &updater)
+    certs = consumer_client.list_certificates()
+    expect(certs).to_not be_nil
     expect(certs.length).to eq(1)
     cert_serial = certs[0]['serial']
     expect(cert_serial).to_not be_nil
 
     updater.call()
 
-    updated_certs = consumer.list_certificates()
+    updated_certs = consumer_client.list_certificates()
     expect(updated_certs.length).to eq(1)
     updated_cert_serial = updated_certs[0]['serial']
     expect(updated_cert_serial).to_not be_nil
@@ -726,23 +722,42 @@ describe 'Content Access' do
   end
 
   it 'should regenerate SCA cert when content changes affect content view' do
-    regenerate_cert_test do
+    client = consumer_client(@user, @consumername, type=:system, username=nil, facts= {'system.certificate_version' => '3.3'})
+
+    regenerate_cert_test(client) do
       @cp.update_content(@owner['key'], @content['id'], { 'content_url' => '/updated/path' })
     end
   end
 
   it 'should regenerate SCA cert when product changes affect content view' do
-    regenerate_cert_test do
+    client = consumer_client(@user, @consumername, type=:system, username=nil, facts= {'system.certificate_version' => '3.3'})
+
+    regenerate_cert_test(client) do
       @cp.remove_content_from_product(@owner['key'], @product['id'], @content['id'])
     end
   end
 
   it 'should regenerate SCA cert when pool changes affect content view' do
-    regenerate_cert_test do
+    client = consumer_client(@user, @consumername, type=:system, username=nil, facts= {'system.certificate_version' => '3.3'})
+
+    regenerate_cert_test(client) do
       @pool['start_date'] = (DateTime.now + 1)
       @cp.update_pool(@owner['key'], @pool)
     end
   end
 
+  it 'should regenerate SCA cert when environment content changes' do
+    environment = @user.create_environment(@owner['key'], random_string('testenv1'), "My Test Env 1", "For test systems only.")
+    promote_content_to_environment(@user, environment, @content, false)
+
+    consumer = @user.register(random_string('consumer'), :system, nil, {'system.certificate_version' => '3.3'}, nil, nil, [], [], environment['id'])
+    expect(consumer['environment']).to_not be_nil
+
+    client = Candlepin.new(nil, nil, consumer.idCert.cert, consumer.idCert['key'])
+
+    regenerate_cert_test(client) do
+      @cp.update_content(@owner['key'], @content['id'], { 'content_url' => '/updated/path' })
+    end
+  end
 
 end

--- a/server/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.audit.EventSink;
+import org.candlepin.controller.ContentAccessManager.ContentAccessMode;
+import org.candlepin.model.CertificateSerial;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ContentAccessCertificate;
+import org.candlepin.model.ContentAccessCertificateCurator;
+import org.candlepin.model.Environment;
+import org.candlepin.model.KeyPairCurator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerEnvContentAccessCurator;
+import org.candlepin.pki.CertificateReader;
+import org.candlepin.pki.PKIUtility;
+import org.candlepin.pki.PrivateKeyReader;
+import org.candlepin.pki.SubjectKeyIdentifierWriter;
+import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
+import org.candlepin.pki.impl.JSSPKIUtility;
+import org.candlepin.pki.impl.JSSPrivateKeyReader;
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.util.Util;
+import org.candlepin.util.X509V3ExtensionUtil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import javax.inject.Inject;
+
+
+
+/**
+ * Test suite for the ContentAccessManager backed by the testing database infrastructure
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ContentAccessManagerDBTest extends DatabaseTestFixture {
+
+    private static final String ENTITLEMENT_MODE = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
+    private static final String ORG_ENVIRONMENT_MODE = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
+
+    @Inject private ContentAccessCertificateCurator caCertCurator;
+    @Inject private KeyPairCurator keyPairCurator;
+    @Inject private OwnerEnvContentAccessCurator ownerEnvContentAccessCurator;
+
+    private PKIUtility pkiUtility;
+    private ObjectMapper objMapper;
+    private X509V3ExtensionUtil x509V3ExtensionUtil;
+
+    private EventSink mockEventSink;
+
+
+    @BeforeEach
+    public void setup() throws Exception {
+        PrivateKeyReader keyReader = new JSSPrivateKeyReader();
+        CertificateReader certReader = new CertificateReader(this.config, keyReader);
+        SubjectKeyIdentifierWriter keyIdWriter = new DefaultSubjectKeyIdentifierWriter();
+        this.pkiUtility = spy(new JSSPKIUtility(certReader, keyIdWriter, this.config));
+
+        this.objMapper = new ObjectMapper();
+        this.x509V3ExtensionUtil = spy(new X509V3ExtensionUtil(this.config, this.entitlementCurator,
+            this.objMapper));
+
+        this.mockEventSink = mock(EventSink.class);
+    }
+
+    private ContentAccessManager createManager() {
+        return new ContentAccessManager(this.config, this.pkiUtility, this.x509V3ExtensionUtil,
+            this.caCertCurator, this.keyPairCurator, this.certSerialCurator, this.ownerCurator,
+            this.ownerEnvContentAccessCurator, this.consumerCurator, this.consumerTypeCurator,
+            this.environmentCurator, this.ownerProductCurator, this.mockEventSink);
+    }
+
+    private Owner createSCAOwner() {
+        Owner owner = this.createOwner();
+
+        owner.setContentAccessModeList(ENTITLEMENT_MODE + ", " + ORG_ENVIRONMENT_MODE);
+        owner.setContentAccessMode(ORG_ENVIRONMENT_MODE);
+
+        return this.ownerCurator.merge(owner);
+    }
+
+    private Consumer createV3Consumer(Owner owner, Environment environment) {
+        Consumer consumer = this.createConsumer(owner);
+
+        consumer.setFact("system.certificate_version", "3.0");
+        consumer.setEnvironment(environment);
+
+        return this.consumerCurator.merge(consumer);
+    }
+
+
+    private void scaCertGenerationTest(Consumer consumer) throws Exception {
+        ContentAccessManager manager = this.createManager();
+
+        ContentAccessCertificate cert = manager.getCertificate(consumer);
+
+        assertNotNull(cert);
+        assertNotNull(consumer.getContentAccessCert());
+    }
+
+    @Test
+    public void testGetCertificate() throws Exception {
+        Owner owner = this.createSCAOwner();
+        Consumer consumer = this.createV3Consumer(owner, null);
+
+        this.scaCertGenerationTest(consumer);
+    }
+
+    @Test
+    public void testGetCertificateWithEnvironment() throws Exception {
+        Owner owner = this.createSCAOwner();
+        Environment environment = this.createEnvironment(owner);
+        Consumer consumer = this.createV3Consumer(owner, environment);
+
+        this.scaCertGenerationTest(consumer);
+    }
+
+    private void regenerateExpiredSCACertTest(Consumer consumer) throws Exception {
+        ContentAccessManager manager = this.createManager();
+
+        ContentAccessCertificate cert = manager.getCertificate(consumer);
+
+        assertNotNull(cert);
+        assertNotNull(consumer.getContentAccessCert());
+
+        // Expire the cert, then run through the cycle again.
+        ContentAccessCertificate consumerCert = consumer.getContentAccessCert();
+        CertificateSerial serial = consumerCert.getSerial();
+
+        serial.setExpiration(Util.yesterday());
+        serial = this.certSerialCurator.merge(serial);
+
+        // This should trigger a new cert to be generated which should end up with
+        // a different serial than the one we have above.
+        cert = manager.getCertificate(consumer);
+
+        assertNotNull(cert);
+        assertNotNull(consumer.getContentAccessCert());
+
+        ContentAccessCertificate consumerCertUpdate = consumer.getContentAccessCert();
+        assertNotSame(consumerCertUpdate, consumerCert);
+        assertNotEquals(consumerCertUpdate.getId(), consumerCert.getId());
+    }
+
+    @Test
+    public void testGetCertificateRegeneratesExpiredCerts() throws Exception {
+        Owner owner = this.createSCAOwner();
+        Consumer consumer = this.createV3Consumer(owner, null);
+
+        this.regenerateExpiredSCACertTest(consumer);
+    }
+
+    @Test
+    public void testGetCertificateRegeneratesExpiredCertsWithEnvironment() throws Exception {
+        Owner owner = this.createSCAOwner();
+        Environment environment = this.createEnvironment(owner);
+        Consumer consumer = this.createV3Consumer(owner, environment);
+
+        this.regenerateExpiredSCACertTest(consumer);
+    }
+
+}

--- a/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -149,7 +149,7 @@ public class ContentAccessManagerTest {
         doAnswer(new PersistSimulator()).when(this.mockContentAccessCertCurator)
             .create(any(ContentAccessCertificate.class));
         doAnswer(new PersistSimulator()).when(this.mockOwnerEnvContentAccessCurator)
-            .saveOrUpdate(any(OwnerEnvContentAccess.class));
+            .create(any(OwnerEnvContentAccess.class), anyBoolean());
         doReturn(this.testingKeyPair).when(this.mockKeyPairCurator).getConsumerKeyPair(any(Consumer.class));
 
         doAnswer(iom -> {
@@ -186,8 +186,8 @@ public class ContentAccessManagerTest {
             this.config, this.pkiUtility, this.x509V3ExtensionUtil, this.mockContentAccessCertCurator,
             this.mockKeyPairCurator, this.mockCertSerialCurator, this.mockOwnerCurator,
             this.mockOwnerEnvContentAccessCurator, this.mockConsumerCurator,
-            this.mockConsumerTypeCurator, this.mockEnvironmentCurator, this.mockContentAccessCertCurator,
-            this.mockOwnerProductCurator, this.mockEventSink);
+            this.mockConsumerTypeCurator, this.mockEnvironmentCurator, this.mockOwnerProductCurator,
+            this.mockEventSink);
     }
 
     private Owner mockOwner() {

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -504,9 +504,14 @@ public class DatabaseTestFixture {
         return entcert;
     }
 
+    protected Environment createEnvironment(Owner owner) {
+        String id = "test-env-" + TestUtil.randomInt();
+        return this.createEnvironment(owner, id, id, null, null, null);
+    }
+
     protected Environment createEnvironment(Owner owner, String id) {
         String name = "test-env-" + TestUtil.randomInt();
-        return this.createEnvironment(owner, name, name, null, null, null);
+        return this.createEnvironment(owner, id, name, null, null, null);
     }
 
     protected Environment createEnvironment(Owner owner, String id, String name) {


### PR DESCRIPTION
- Fixed a duplicate key error that could occur when regenerating
  SCA certs for a consumer that already had an expired or outdated
  certificate that was part of an environment