### PR TITLE
[4.0] 1949980: Fix SCA cert regeneration for consumers in environments (ENT-3784)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -194,17 +194,16 @@ public class ContentAccessManager {
 
     private Configuration config;
     private PKIUtility pki;
+    private X509V3ExtensionUtil v3extensionUtil;
     private KeyPairCurator keyPairCurator;
     private CertificateSerialCurator serialCurator;
     private OwnerCurator ownerCurator;
     private OwnerContentCurator ownerContentCurator;
     private ContentAccessCertificateCurator contentAccessCertificateCurator;
-    private X509V3ExtensionUtil v3extensionUtil;
     private OwnerEnvContentAccessCurator ownerEnvContentAccessCurator;
     private ConsumerCurator consumerCurator;
     private ConsumerTypeCurator consumerTypeCurator;
     private EnvironmentCurator environmentCurator;
-    private ContentAccessCertificateCurator contentAccessCertCurator;
     private EventSink eventSink;
 
     private boolean standalone;
@@ -223,22 +222,20 @@ public class ContentAccessManager {
         ConsumerCurator consumerCurator,
         ConsumerTypeCurator consumerTypeCurator,
         EnvironmentCurator environmentCurator,
-        ContentAccessCertificateCurator contentAccessCertCurator,
         EventSink eventSink) {
 
         this.config = Objects.requireNonNull(config);
         this.pki = Objects.requireNonNull(pki);
+        this.v3extensionUtil = Objects.requireNonNull(v3extensionUtil);
         this.contentAccessCertificateCurator = Objects.requireNonNull(contentAccessCertificateCurator);
         this.keyPairCurator = Objects.requireNonNull(keyPairCurator);
         this.serialCurator = Objects.requireNonNull(serialCurator);
-        this.v3extensionUtil = Objects.requireNonNull(v3extensionUtil);
         this.ownerCurator = Objects.requireNonNull(ownerCurator);
         this.ownerContentCurator = Objects.requireNonNull(ownerContentCurator);
         this.ownerEnvContentAccessCurator = Objects.requireNonNull(ownerEnvContentAccessCurator);
         this.consumerCurator = Objects.requireNonNull(consumerCurator);
         this.consumerTypeCurator = Objects.requireNonNull(consumerTypeCurator);
         this.environmentCurator = Objects.requireNonNull(environmentCurator);
-        this.contentAccessCertCurator = Objects.requireNonNull(contentAccessCertCurator);
         this.eventSink = Objects.requireNonNull(eventSink);
         this.standalone = this.config.getBoolean(ConfigProperties.STANDALONE, true);
     }
@@ -287,6 +284,7 @@ public class ContentAccessManager {
 
                 consumer.setContentAccessCert(null);
                 this.contentAccessCertificateCurator.delete(existing);
+                this.ownerEnvContentAccessCurator.delete(oeca);
 
                 regenerate = true;
             }
@@ -334,7 +332,7 @@ public class ContentAccessManager {
 
             String contentJson = this.createPayloadAndSignature(owner, env);
             oeca = new OwnerEnvContentAccess(owner, env, contentJson);
-            oeca = this.ownerEnvContentAccessCurator.saveOrUpdate(oeca);
+            this.ownerEnvContentAccessCurator.create(oeca, false);
         }
 
         pem.append(oeca.getContentJson());
@@ -836,7 +834,7 @@ public class ContentAccessManager {
         this.ownerCurator.lock(owner);
 
         if (!owner.isUsingSimpleContentAccess()) {
-            this.contentAccessCertCurator.deleteForOwner(owner);
+            this.contentAccessCertificateCurator.deleteForOwner(owner);
         }
 
         // removed cached versions of content access cert data

--- a/server/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.candlepin.audit.EventSink;
+import org.candlepin.controller.ContentAccessManager.ContentAccessMode;
+import org.candlepin.model.CertificateSerial;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ContentAccessCertificate;
+import org.candlepin.model.ContentAccessCertificateCurator;
+import org.candlepin.model.Environment;
+import org.candlepin.model.KeyPairCurator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerEnvContentAccessCurator;
+import org.candlepin.pki.CertificateReader;
+import org.candlepin.pki.PKIUtility;
+import org.candlepin.pki.PrivateKeyReader;
+import org.candlepin.pki.SubjectKeyIdentifierWriter;
+import org.candlepin.pki.impl.DefaultSubjectKeyIdentifierWriter;
+import org.candlepin.pki.impl.JSSPKIUtility;
+import org.candlepin.pki.impl.JSSPrivateKeyReader;
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.util.Util;
+import org.candlepin.util.X509V3ExtensionUtil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import javax.inject.Inject;
+
+
+
+/**
+ * Test suite for the ContentAccessManager backed by the testing database infrastructure
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ContentAccessManagerDBTest extends DatabaseTestFixture {
+
+    private static final String ENTITLEMENT_MODE = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
+    private static final String ORG_ENVIRONMENT_MODE = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
+
+    @Inject private ContentAccessCertificateCurator caCertCurator;
+    @Inject private KeyPairCurator keyPairCurator;
+    @Inject private OwnerEnvContentAccessCurator ownerEnvContentAccessCurator;
+
+    private PKIUtility pkiUtility;
+    private ObjectMapper objMapper;
+    private X509V3ExtensionUtil x509V3ExtensionUtil;
+
+    private EventSink mockEventSink;
+
+
+    @BeforeEach
+    public void setup() throws Exception {
+        PrivateKeyReader keyReader = new JSSPrivateKeyReader();
+        CertificateReader certReader = new CertificateReader(this.config, keyReader);
+        SubjectKeyIdentifierWriter keyIdWriter = new DefaultSubjectKeyIdentifierWriter();
+        this.pkiUtility = spy(new JSSPKIUtility(certReader, keyIdWriter, this.config));
+
+        this.objMapper = new ObjectMapper();
+        this.x509V3ExtensionUtil = spy(new X509V3ExtensionUtil(this.config, this.entitlementCurator,
+            this.objMapper));
+
+        this.mockEventSink = mock(EventSink.class);
+    }
+
+    private ContentAccessManager createManager() {
+        return new ContentAccessManager(this.config, this.pkiUtility, this.x509V3ExtensionUtil,
+            this.caCertCurator, this.keyPairCurator, this.certSerialCurator, this.ownerCurator,
+            this.ownerContentCurator, this.ownerEnvContentAccessCurator, this.consumerCurator,
+            this.consumerTypeCurator, this.environmentCurator, this.mockEventSink);
+    }
+
+    private Owner createSCAOwner() {
+        Owner owner = this.createOwner();
+
+        owner.setContentAccessModeList(ENTITLEMENT_MODE + ", " + ORG_ENVIRONMENT_MODE);
+        owner.setContentAccessMode(ORG_ENVIRONMENT_MODE);
+
+        return this.ownerCurator.merge(owner);
+    }
+
+    private Consumer createV3Consumer(Owner owner, Environment environment) {
+        Consumer consumer = this.createConsumer(owner);
+
+        consumer.setFact("system.certificate_version", "3.0");
+        consumer.setEnvironment(environment);
+
+        return this.consumerCurator.merge(consumer);
+    }
+
+
+    private void scaCertGenerationTest(Consumer consumer) throws Exception {
+        ContentAccessManager manager = this.createManager();
+
+        ContentAccessCertificate cert = manager.getCertificate(consumer);
+
+        assertNotNull(cert);
+        assertNotNull(consumer.getContentAccessCert());
+    }
+
+    @Test
+    public void testGetCertificate() throws Exception {
+        Owner owner = this.createSCAOwner();
+        Consumer consumer = this.createV3Consumer(owner, null);
+
+        this.scaCertGenerationTest(consumer);
+    }
+
+    @Test
+    public void testGetCertificateWithEnvironment() throws Exception {
+        Owner owner = this.createSCAOwner();
+        Environment environment = this.createEnvironment(owner);
+        Consumer consumer = this.createV3Consumer(owner, environment);
+
+        this.scaCertGenerationTest(consumer);
+    }
+
+    private void regenerateExpiredSCACertTest(Consumer consumer) throws Exception {
+        ContentAccessManager manager = this.createManager();
+
+        ContentAccessCertificate cert = manager.getCertificate(consumer);
+
+        assertNotNull(cert);
+        assertNotNull(consumer.getContentAccessCert());
+
+        // Expire the cert, then run through the cycle again.
+        ContentAccessCertificate consumerCert = consumer.getContentAccessCert();
+        CertificateSerial serial = consumerCert.getSerial();
+
+        serial.setExpiration(Util.yesterday());
+        serial = this.certSerialCurator.merge(serial);
+
+        // This should trigger a new cert to be generated which should end up with
+        // a different serial than the one we have above.
+        cert = manager.getCertificate(consumer);
+
+        assertNotNull(cert);
+        assertNotNull(consumer.getContentAccessCert());
+
+        ContentAccessCertificate consumerCertUpdate = consumer.getContentAccessCert();
+        assertNotSame(consumerCertUpdate, consumerCert);
+        assertNotEquals(consumerCertUpdate.getId(), consumerCert.getId());
+    }
+
+    @Test
+    public void testGetCertificateRegeneratesExpiredCerts() throws Exception {
+        Owner owner = this.createSCAOwner();
+        Consumer consumer = this.createV3Consumer(owner, null);
+
+        this.regenerateExpiredSCACertTest(consumer);
+    }
+
+    @Test
+    public void testGetCertificateRegeneratesExpiredCertsWithEnvironment() throws Exception {
+        Owner owner = this.createSCAOwner();
+        Environment environment = this.createEnvironment(owner);
+        Consumer consumer = this.createV3Consumer(owner, environment);
+
+        this.regenerateExpiredSCACertTest(consumer);
+    }
+
+}

--- a/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -149,7 +149,7 @@ public class ContentAccessManagerTest {
         doAnswer(new PersistSimulator()).when(this.mockContentAccessCertCurator)
             .create(any(ContentAccessCertificate.class));
         doAnswer(new PersistSimulator()).when(this.mockOwnerEnvContentAccessCurator)
-            .saveOrUpdate(any(OwnerEnvContentAccess.class));
+            .create(any(OwnerEnvContentAccess.class), anyBoolean());
         doReturn(this.testingKeyPair).when(this.mockKeyPairCurator).getConsumerKeyPair(any(Consumer.class));
 
         doAnswer(iom -> {
@@ -186,8 +186,7 @@ public class ContentAccessManagerTest {
             this.config, this.pkiUtility, this.x509V3ExtensionUtil, this.mockContentAccessCertCurator,
             this.mockKeyPairCurator, this.mockCertSerialCurator, this.mockOwnerCurator,
             this.mockOwnerContentCurator, this.mockOwnerEnvContentAccessCurator, this.mockConsumerCurator,
-            this.mockConsumerTypeCurator, this.mockEnvironmentCurator, this.mockContentAccessCertCurator,
-            this.mockEventSink);
+            this.mockConsumerTypeCurator, this.mockEnvironmentCurator, this.mockEventSink);
     }
 
     private Owner mockOwner() {

--- a/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/server/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -503,9 +503,14 @@ public class DatabaseTestFixture {
         return entcert;
     }
 
+    protected Environment createEnvironment(Owner owner) {
+        String id = "test-env-" + TestUtil.randomInt();
+        return this.createEnvironment(owner, id, id, null, null, null);
+    }
+
     protected Environment createEnvironment(Owner owner, String id) {
         String name = "test-env-" + TestUtil.randomInt();
-        return this.createEnvironment(owner, name, name, null, null, null);
+        return this.createEnvironment(owner, id, name, null, null, null);
     }
 
     protected Environment createEnvironment(Owner owner, String id, String name) {


### PR DESCRIPTION
- Fixed a duplicate key error that could occur when regenerating
  SCA certs for a consumer that already had an expired or outdated
  certificate that was part of an environment