### PR TITLE
[3.2] 1949122: Changed how content access  mode is selected for new consumers (ENT-3755)

### DIFF
--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -23,7 +23,7 @@ module CandlepinMethods
     # Set the content access mode list for new owners. We do this here instead of doing it explicitly
     # in each test due to some test objects creating owners internally which need this list.
     if not params['contentAccessModeList']
-      params['contentAccessModeList']= 'org_environment,entitlement'
+      params['contentAccessModeList'] = 'org_environment,entitlement'
       params['contentAccessMode'] = 'entitlement'
     end
 

--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -396,18 +396,21 @@ describe 'Content Access' do
 
   RSpec.shared_examples "manifest import" do |async|
     it "will import a manifest when only the access mode changes" do
-
       cp = Candlepin.new('admin', 'admin')
       cp_export = async ? AsyncStandardExporter.new : StandardExporter.new
-      owner = cp_export.owner
 
+      owner = cp_export.owner
+      candlepin_client = cp_export.candlepin_client
+
+      # Ensure the consumer is using the standard content access mode initially
+      candlepin_client.update_consumer({'contentAccessMode' => "entitlement"})
       export1 = cp_export.create_candlepin_export()
       export1_file = cp_export.export_filename
 
       # Sleep long enough to ensure the timestamps would change
       sleep 1
 
-      candlepin_client = cp_export.candlepin_client
+      # Update the content access mode and create a new export
       candlepin_client.update_consumer({'contentAccessMode' => "org_environment"})
       export2 = cp_export.create_candlepin_export()
       export2_file = cp_export.export_filename

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -599,10 +599,22 @@ public class Owner extends AbstractHibernateObject<Owner>
         return this;
     }
 
-    @XmlTransient
     public boolean isAllowedContentAccessMode(String mode) {
         String[] list = contentAccessModeList.split(",");
         return ArrayUtils.contains(list, mode);
+    }
+
+    /**
+     * Checks whether or not this owner is able to use the specified content access mode
+     *
+     * @param mode
+     *  the mode to check
+     *
+     * @return
+     *  true if the specified content access mode is available to this owner; false otherwise
+     */
+    public boolean isAllowedContentAccessMode(ContentAccessMode mode) {
+        return mode != null && this.isAllowedContentAccessMode(mode.toDatabaseValue());
     }
 
     /**
@@ -610,7 +622,6 @@ public class Owner extends AbstractHibernateObject<Owner>
      *
      * @return Boolean
      */
-    @XmlTransient
     public boolean isContentAccessEnabled() {
         return ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue().equals(this.getContentAccessMode());
     }

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -47,6 +47,7 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.AutobindDisabledForOwnerException;
 import org.candlepin.controller.AutobindHypervisorDisabledException;
 import org.candlepin.controller.ContentAccessManager;
+import org.candlepin.controller.ContentAccessManager.ContentAccessMode;
 import org.candlepin.controller.Entitler;
 import org.candlepin.controller.ManifestManager;
 import org.candlepin.controller.PoolManager;
@@ -676,10 +677,6 @@ public class ConsumerResource {
             entity.setAutoheal(dto.getAutoheal());
         }
 
-        if (dto.getContentAccessMode() != null) {
-            entity.setContentAccessMode(dto.getContentAccessMode());
-        }
-
         if (dto.getAnnotations() != null) {
             entity.setAnnotations(dto.getAnnotations());
         }
@@ -849,9 +846,7 @@ public class ConsumerResource {
         updateCapabilities(consumerToCreate, null);
         logNewConsumerDebugInfo(consumerToCreate, keys, type);
 
-        validateContentAccessMode(consumerToCreate, owner);
-        // BZ 1618398 Remove validation check on consumer service level
-        // consumerBindUtil.validateServiceLevel(owner.getId(), consumerToCreate.getServiceLevel());
+        this.setContentAccessMode(consumer, type, owner, consumerToCreate);
 
         Set<ConsumerActivationKey> aks = new HashSet<>();
 
@@ -923,17 +918,57 @@ public class ConsumerResource {
         }
     }
 
-    private void validateContentAccessMode(Consumer consumer, Owner owner) throws BadRequestException {
-        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(consumer);
+    /**
+     * Validates the incoming content access mode value and sets it on the destination consumer if
+     * necessary.
+     *
+     * @param srcConsumer
+     *  the consumer DTO containing the requested content access mode
+     *
+     * @param ctype
+     *  the consumer's type
+     *
+     * @param owner
+     *  the owner of the consumer being updated
+     *
+     * @param dstConsumer
+     *  the destination consumer entity to update
+     *
+     * @throws BadRequestException
+     *  if the requested content access mode is invalid or otherwise cannot be set on the consumer
+     */
+    private void setContentAccessMode(ConsumerDTO srcConsumer, ConsumerType ctype, Owner owner,
+        Consumer dstConsumer) throws BadRequestException {
 
-        if (consumer.getContentAccessMode() != null) {
-            if (!ctype.isManifest()) {
+        String caMode = srcConsumer.getContentAccessMode();
+
+        if (ctype.isManifest()) {
+            if (caMode == null) {
+                // ENT-3755: Use the "best available" if nothing was provided
+                ContentAccessMode best = owner.isAllowedContentAccessMode(ContentAccessMode.ORG_ENVIRONMENT) ?
+                    ContentAccessMode.ORG_ENVIRONMENT :
+                    ContentAccessMode.ENTITLEMENT;
+
+                caMode = best.toDatabaseValue();
+            }
+            else if (caMode.isEmpty()) {
+                // Clear consumer's content access mode and defer to the org's instead
+                caMode = null;
+            }
+            else {
+                // Validate user's choice and use it if possible
+                if (!owner.isAllowedContentAccessMode(caMode)) {
+                    throw new BadRequestException(
+                        i18n.tr("The consumer cannot use the supplied content access mode."));
+                }
+            }
+
+            dstConsumer.setContentAccessMode(caMode);
+        }
+        else {
+            if (caMode != null && !caMode.isEmpty()) {
                 throw new BadRequestException(
                     i18n.tr("The consumer cannot be assigned a content access mode."));
-            }
-            if (!owner.isAllowedContentAccessMode(consumer.getContentAccessMode())) {
-                throw new BadRequestException(
-                    i18n.tr("The consumer cannot use the supplied content access mode."));
             }
         }
     }

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -80,6 +80,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -91,6 +94,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -275,6 +279,101 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         assertThrows(BadRequestException.class, () ->
             consumerResource.create(anotherToSubmit, principal, null, owner.getKey(), null, true)
         );
+    }
+
+    public static Stream<Arguments> manifestConsumerContentAccessModeInputSource() {
+        String entMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
+        String scaMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
+        String combined = String.join(",", entMode, scaMode);
+
+        return Stream.of(
+            Arguments.of(entMode, entMode, entMode, entMode, true),
+            Arguments.of(entMode, entMode, scaMode, entMode, false),
+            Arguments.of(entMode, entMode, "potato", entMode, false),
+            Arguments.of(entMode, entMode, "", null, true),
+            Arguments.of(entMode, entMode, null, entMode, true),
+
+            Arguments.of(scaMode, scaMode, entMode, scaMode, false),
+            Arguments.of(scaMode, scaMode, scaMode, scaMode, true),
+            Arguments.of(scaMode, scaMode, "potato", scaMode, false),
+            Arguments.of(scaMode, scaMode, "", null, true),
+            Arguments.of(scaMode, scaMode, null, scaMode, true),
+
+            Arguments.of(combined, entMode, entMode, entMode, true),
+            Arguments.of(combined, entMode, scaMode, scaMode, true),
+            Arguments.of(combined, entMode, "potato", scaMode, false),
+            Arguments.of(combined, entMode, "", null, true),
+            Arguments.of(combined, entMode, null, scaMode, true),
+
+            Arguments.of(combined, scaMode, entMode, entMode, true),
+            Arguments.of(combined, scaMode, scaMode, scaMode, true),
+            Arguments.of(combined, scaMode, "potato", null, false),
+            Arguments.of(combined, scaMode, "", null, true),
+            Arguments.of(combined, scaMode, null, scaMode, true)
+        );
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @MethodSource("manifestConsumerContentAccessModeInputSource")
+    public void testManifestConsumerCreationContentAccessMode(String ownerModeList, String ownerMode,
+        String providedContentAccessMode, String expectedConsumerMode, boolean validInputs) {
+
+        this.owner.setContentAccessModeList(ownerModeList);
+        this.owner.setContentAccessMode(ownerMode);
+
+        ConsumerType manifestType = new ConsumerType("manifest");
+        manifestType.setManifest(true);
+        manifestType = this.consumerTypeCurator.create(manifestType);
+        ConsumerTypeDTO manifestTypeDTO = modelTranslator.translate(manifestType, ConsumerTypeDTO.class);
+
+        ConsumerDTO dto = createConsumerDTO(CONSUMER_NAME, USER_NAME, null, manifestTypeDTO);
+        dto.setContentAccessMode(providedContentAccessMode);
+
+        if (validInputs) {
+            ConsumerDTO output = this.consumerResource
+                .create(dto, this.principal, null, this.owner.getKey(), null, false);
+
+            assertNotNull(output);
+            assertEquals(expectedConsumerMode, output.getContentAccessMode());
+        }
+        else {
+            assertThrows(BadRequestException.class, () ->
+                this.consumerResource.create(dto, this.principal, null, this.owner.getKey(), null, false));
+        }
+    }
+
+    public static Stream<Arguments> systemConsumerContentAccessModeInputSource() {
+        String entMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
+        String scaMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
+
+        return Stream.of(
+            Arguments.of(entMode, null, false),
+            Arguments.of(scaMode, null, false),
+            Arguments.of("potato", null, false),
+            Arguments.of("", null, true),
+            Arguments.of(null, null, true)
+        );
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @MethodSource("systemConsumerContentAccessModeInputSource")
+    public void testSystemConsumerCreationContentAccessMode(String providedConsumerMode,
+        String expectedConsumerMode, boolean validInputs) {
+
+        ConsumerDTO dto = createConsumerDTO(CONSUMER_NAME, USER_NAME, null, this.standardSystemTypeDTO);
+        dto.setContentAccessMode(providedConsumerMode);
+
+        if (validInputs) {
+            ConsumerDTO output = this.consumerResource
+                .create(dto, this.principal, null, this.owner.getKey(), null, false);
+
+            assertNotNull(output);
+            assertNull(output.getContentAccessMode());
+        }
+        else {
+            assertThrows(BadRequestException.class, () ->
+                this.consumerResource.create(dto, this.principal, null, this.owner.getKey(), null, false));
+        }
     }
 
     @Test


### PR DESCRIPTION
- During consumer creation, the content access mode is now ignored and
  the "best" mode will be selected based on modes available to the
  org in which the consumer is being created