### PR TITLE
[M] 1949125: Changed how content access mode is validated for new consumers (ENT-3755)

### DIFF
--- a/server/spec/candlepin_scenarios.rb
+++ b/server/spec/candlepin_scenarios.rb
@@ -17,7 +17,7 @@ module CandlepinMethods
     # Set the content access mode list for new owners. We do this here instead of doing it explicitly
     # in each test due to some test objects creating owners internally which need this list.
     if not params['contentAccessModeList']
-      params['contentAccessModeList']= 'org_environment,entitlement'
+      params['contentAccessModeList'] = 'org_environment,entitlement'
       params['contentAccessMode'] = 'entitlement'
     end
 

--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -557,16 +557,18 @@ describe 'Content Access' do
 
   RSpec.shared_examples "manifest import" do |async|
     it "will import a manifest when only the access mode changes" do
-
       cp_export = async ? AsyncStandardExporter.new : StandardExporter.new
+      candlepin_client = cp_export.candlepin_client
 
+      # Ensure the consumer is using the standard content access mode initially
+      candlepin_client.update_consumer({'contentAccessMode' => "entitlement"})
       export1 = cp_export.create_candlepin_export()
       export1_file = cp_export.export_filename
 
       # Sleep long enough to ensure the timestamps would change
       sleep 1
 
-      candlepin_client = cp_export.candlepin_client
+      # Update the content access mode and create a new export
       candlepin_client.update_consumer({'contentAccessMode' => "org_environment"})
       export2 = cp_export.create_candlepin_export()
       export2_file = cp_export.export_filename

--- a/server/src/main/java/org/candlepin/model/Owner.java
+++ b/server/src/main/java/org/candlepin/model/Owner.java
@@ -597,13 +597,34 @@ public class Owner extends AbstractHibernateObject<Owner>
 
     public Owner setContentAccessModeList(String contentAccessModeList) {
         this.contentAccessModeList = contentAccessModeList;
-
         return this;
     }
 
+    /**
+     * Checks whether or not this owner is able to use the specified content access mode
+     *
+     * @param mode
+     *  the mode to check
+     *
+     * @return
+     *  true if the specified content access mode is available to this owner; false otherwise
+     */
     public boolean isAllowedContentAccessMode(String mode) {
-        String[] list = contentAccessModeList.split(",");
+        String[] list = this.contentAccessModeList.split(",");
         return ArrayUtils.contains(list, mode);
+    }
+
+    /**
+     * Checks whether or not this owner is able to use the specified content access mode
+     *
+     * @param mode
+     *  the mode to check
+     *
+     * @return
+     *  true if the specified content access mode is available to this owner; false otherwise
+     */
+    public boolean isAllowedContentAccessMode(ContentAccessMode mode) {
+        return mode != null && this.isAllowedContentAccessMode(mode.toDatabaseValue());
     }
 
     /**


### PR DESCRIPTION
- During the creation of a manifest consumer, if no content access mode
  is provided, a default value will be chosen by using the "best" mode
  from the org's available modes: SCA if available, entitlement mode
  otherwise