### PR TITLE
[M] Bumped version of commons-io and ruby oauth

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     minitest (5.10.2)
-    oauth (0.5.3)
+    oauth (0.5.5)
     parallel (1.11.2)
     parallel_tests (2.14.1)
       parallel

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -329,7 +329,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>1.4</version>
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ ext.libraries = [
         "javax.transaction:jta",
         "javax.persistence:javax.persistence-api",
         "javax.xml.bind:jaxb-api",
-        "javax.annotation:javax.annotation-api", 
+        "javax.annotation:javax.annotation-api",
     ],
     commons: [
         "commons-codec:commons-codec",
@@ -178,7 +178,7 @@ allprojects {
             dependency group: 'org.hibernate', name: 'hibernate-jcache', version: '5.4.6.Final'
             dependency group: 'commons-codec', name: 'commons-codec', version: '1.11'
             dependency group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
-            dependency group: 'commons-io', name: 'commons-io', version: '1.4'
+            dependency group: 'commons-io', name: 'commons-io', version: '2.7'
             dependency group: 'commons-lang', name: 'commons-lang', version: '2.5'
             dependency group: 'org.apache.commons', name: 'commons-lang3', version: '3.2.1'
             dependency group: 'com.googlecode.gettext-commons', name: 'gettext-commons', version: '0.9.8'

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -556,7 +556,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>1.4</version>
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -683,7 +683,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>1.4</version>
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>


### PR DESCRIPTION
- Bumped commons-io to v2.7
- Bumped Ruby oauth to v0.5.5