### PR TITLE
[M] Removed eager certificate regeneration during API-triggered refresh (ENT-3117)

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -6568,12 +6568,10 @@ paths:
 
     put:
       description: |
-        Tickle an owner to have all of their entitlement pools synced with their
-        subscriptions. This method (and the one below may not be entirely RESTful,
-        as the updated data is not supplied as an argument.
-        This API call is only relevant in a top level hosted deployment where
-        subscriptions and products are sourced from adapters. Calling this in
-        an on-site deployment is just a no-op.
+        Triggers an asynchronous "refresh" operation, updating the entitlement and subscription
+        information for the specified owner.
+        This endpoint is only functional in hosted mode, and no operation will be triggered
+        when called in a standalone, or on-site, deployment.
       tags:
         - Owner
       operationId: refreshPools
@@ -6587,16 +6585,10 @@ paths:
             type: string
         - name: auto_create_owner
           in: query
-          description: Specify Whether or not to create an owner automatically. Default is false.
+          description: Specify whether or not to create an owner automatically. Default is false.
           schema:
             type: boolean
             default: false
-        - name: lazy_regen
-          in: query
-          description: Regenerate certificates immediatelly or allow them to be regenerated on demand. Default is true.
-          schema:
-            type: boolean
-            default: true
       responses:
         200:
           description: A successful operation

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -578,13 +578,12 @@ class Candlepin
     return get(path, params)
   end
 
-  def refresh_pools(owner_key, immediate=false, create_owner=false, lazy_regen=true)
+  def refresh_pools(owner_key, immediate=false, create_owner=false)
     return async_call(immediate) do
       url = "/owners/#{owner_key}/subscriptions"
 
       params = {}
       params[:auto_create_owner] = true if create_owner
-      params[:lazy_regen] = false if !lazy_regen
 
       put(url, params)
     end

--- a/server/spec/refresh_pools_spec.rb
+++ b/server/spec/refresh_pools_spec.rb
@@ -1194,7 +1194,7 @@ describe 'Refresh Pools' do
     serial_concat = concat_serials(entitlement, bonus_entitlement)
 
     # verify serial does not change on simple refresh
-    @cp.refresh_pools(owner_key, false, false, false)
+    @cp.refresh_pools(owner_key, false, false)
     entitlement = @cp.get_entitlement(entitlement['id'])
     bonus_entitlement = @cp.get_entitlement(bonus_entitlement['id'])
 
@@ -1210,7 +1210,7 @@ describe 'Refresh Pools' do
     expect(concat_serials(entitlement, bonus_entitlement)).to eq(serial_concat)
 
     # this time when we refresh, serial should change
-    @cp.refresh_pools(owner_key, false, false, false)
+    @cp.refresh_pools(owner_key, false, false)
     entitlement = @cp.get_entitlement(entitlement['id'])
     bonus_entitlement = @cp.get_entitlement(bonus_entitlement['id'])
     expect(concat_serials(entitlement, bonus_entitlement)).to_not eq(serial_concat)

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1370,9 +1370,7 @@ public class OwnerResource implements OwnersApi {
     }
 
     @Override
-    public AsyncJobStatusDTO refreshPools(
-        String ownerKey, Boolean autoCreateOwner, Boolean lazyRegen) {
-
+    public AsyncJobStatusDTO refreshPools(String ownerKey, Boolean autoCreateOwner) {
         Owner owner = ownerCurator.getByKey(ownerKey);
         if (owner == null) {
             if (autoCreateOwner && ownerService.isOwnerKeyValidForCreation(ownerKey)) {
@@ -1390,7 +1388,7 @@ public class OwnerResource implements OwnersApi {
 
         JobConfig config = RefreshPoolsJob.createJobConfig()
             .setOwner(owner)
-            .setLazyRegeneration(lazyRegen);
+            .setLazyRegeneration(true);
 
         try {
             AsyncJobStatus job = this.jobManager.queueJob(config);


### PR DESCRIPTION
- Removed the ability to perform eager certificate regeneration
  during refresh when triggered from an API call. API-triggered
  refresh will now always mark certificates for later regeneration