### PR TITLE
[M] Added pagination to consumer fetching endpoints (ENT-3793)

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -608,6 +608,9 @@ paths:
       tags:
         - Consumer
       operationId: searchConsumers
+      x-java-response:
+        type: java.util.stream.Stream
+        isContainer: true
       security: []
       parameters:
         - name: username
@@ -649,9 +652,6 @@ paths:
             type: array
             items:
               $ref: '#/components/schemas/KeyValueParamDTO'
-      x-java-response:
-        type: Iterable
-        isContainer: true
       responses:
         200:
           description: List of consumers
@@ -4748,7 +4748,7 @@ paths:
         - Owner
       operationId: listConsumers
       x-java-response:
-        type: Iterable
+        type: java.util.stream.Stream
         isContainer: true
       parameters:
         - name: owner_key
@@ -4791,27 +4791,6 @@ paths:
             type: array
             items:
               $ref: '#/components/schemas/KeyValueParamDTO'
-        - name: sku
-          in: query
-          description: The list of skus
-          schema:
-            type: array
-            items:
-              type: string
-        - name: subscription_id
-          in: query
-          description: The list of subscription IDs
-          schema:
-            type: array
-            items:
-              type: string
-        - name: contract
-          in: query
-          description: The list of contract numbers
-          schema:
-            type: array
-            items:
-              type: string
       security: []
       responses:
         200:
@@ -4856,31 +4835,29 @@ paths:
           required: true
           schema:
             type: string
+        - name: username
+          in: query
+          description: The username of the consumer
+          schema:
+            type: string
         - name: type
           in: query
-          description: The type of the consumer
+          description: The consumer type
           schema:
             type: array
             uniqueItems: true
             items:
               type: string
-        - name: sku
+        - name: uuid
           in: query
-          description: The list product ids
+          description: The UUID of consumers
           schema:
             type: array
             items:
               type: string
-        - name: subscription_id
+        - name: hypervisor_id
           in: query
-          description: The list of subscription ids
-          schema:
-            type: array
-            items:
-              type: string
-        - name: contract
-          in: query
-          description: The list of contract numbers
+          description: The hypervisor IDs
           schema:
             type: array
             items:
@@ -5588,7 +5565,7 @@ paths:
         - Owner
       operationId: listPools
       x-java-response:
-        type: Iterable
+        type: java.util.stream.Stream
         isContainer: true
       parameters:
         - name: owner_key

--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1007,14 +1007,11 @@ class Candlepin
     return get(path, params)
   end
 
-  def count_owner_consumers(owner_key, consumer_types=[], skus=[], subscription_ids=[], contracts=[])
+  def count_owner_consumers(owner_key, consumer_types=[])
     path = "/owners/#{owner_key}/consumers/count"
 
     params = {}
     params[:type] = consumer_types if !consumer_types.empty?
-    params[:sku] = skus if !skus.empty?
-    params[:subscription_id] = subscription_ids if !subscription_ids.empty?
-    params[:contract] = contracts if !contracts.empty?
 
     return get(path, params, accept_header=:json, dont_parse=true)
   end

--- a/server/spec/owner_resource_spec.rb
+++ b/server/spec/owner_resource_spec.rb
@@ -894,7 +894,7 @@ describe 'Owner Resource Consumer Fact Filter Tests' do
     consumers.length.should == 2
   end
 
-  it 'lets owners filterconsumers by facts with wildcards' do
+  it 'lets owners filter consumers by facts with wildcards' do
     consumers = @cp.list_owner_consumers(@owner['key'], [], ['*key*:*val*'])
     consumers.length.should == 3
 
@@ -1137,69 +1137,6 @@ describe 'Owner Resource counting feature' do
     expect(Integer(json_count)).to be == 1
 
     json_count = @owner_cp.count_owner_consumers(@owner['key'], type=[:system, :hypervisor])
-    expect(Integer(json_count)).to be == 2
-  end
-
-  it 'should count consumers only with specific skus' do
-    c = @owner_cp.register('consumer_name')
-    sku1 = create_product_and_bint_it_to_consumer_return_sku(c)
-    sku2 = create_product_and_bint_it_to_consumer_return_sku(c)
-    sku3 = create_consumer_with_binding_to_new_product_return_sku
-    expect(sku1).not_to be(sku2)
-    expect(sku2).not_to be(sku3)
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], ["not-existing-sku"])
-    expect(Integer(json_count)).to be == 0
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [sku1])
-    expect(Integer(json_count)).to be == 1
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [sku1, sku2])
-    expect(Integer(json_count)).to be == 1
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [sku1, sku2, sku3])
-    expect(Integer(json_count)).to be == 2
-  end
-
-  it 'should count consumers only with specific subscriptionIds' do
-    c = @owner_cp.register('consumer_name')
-    subId1 = create_product_and_bint_it_to_consumer_return_subId(c)
-    subId2 = create_product_and_bint_it_to_consumer_return_subId(c)
-    subId3 = create_consumer_with_binding_to_new_product_return_subId
-    expect(subId1).not_to be(subId2)
-    expect(subId2).not_to be(subId3)
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], ["not-existing-subId"])
-    expect(Integer(json_count)).to be == 0
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [subId1])
-    expect(Integer(json_count)).to be == 1
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [subId1, subId2])
-    expect(Integer(json_count)).to be == 1
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [subId1, subId2, subId3])
-    expect(Integer(json_count)).to be == 2
-  end
-
-  it 'should count consumer only with specific contract numbers' do
-    c = @owner_cp.register('consumer_name')
-    cn1 = create_product_and_bint_it_to_consumer_return_contractNr(c)
-    cn2 = create_product_and_bint_it_to_consumer_return_contractNr(c)
-    cn3 = create_consumer_with_binding_to_new_product_return_contractNr
-    expect(cn1).not_to be(cn2)
-    expect(cn2).not_to be(cn3)
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [], ["not-exisitng-cn"])
-    expect(Integer(json_count)).to be == 0
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [], [cn1])
-    expect(Integer(json_count)).to be == 1
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [], [cn1, cn2])
-    expect(Integer(json_count)).to be == 1
-
-    json_count = @owner_cp.count_owner_consumers(@owner['key'], [], [], [], [cn1, cn2, cn3])
     expect(Integer(json_count)).to be == 2
   end
 

--- a/server/src/main/java/org/candlepin/async/tasks/JobCleaner.java
+++ b/server/src/main/java/org/candlepin/async/tasks/JobCleaner.java
@@ -22,7 +22,7 @@ import org.candlepin.async.JobManager;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.AsyncJobStatus.JobState;
-import org.candlepin.model.AsyncJobStatusCurator.AsyncJobStatusQueryBuilder;
+import org.candlepin.model.AsyncJobStatusCurator.AsyncJobStatusQueryArguments;
 import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
@@ -128,11 +128,11 @@ public class JobCleaner implements AsyncJob {
             .collect(Collectors.toSet());
 
         // Build the query builder with our config
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(jobStates)
             .setEndDate(cutoff);
 
-        int removed = this.jobManager.cleanupJobs(queryBuilder);
+        int removed = this.jobManager.cleanupJobs(queryArgs);
         log.info("Removed {} terminal jobs older than {}", removed, cutoff);
 
         return removed;
@@ -145,11 +145,11 @@ public class JobCleaner implements AsyncJob {
             .collect(Collectors.toSet());
 
         // Build the query builder with our config
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(jobStates)
             .setEndDate(cutoff);
 
-        int aborted = this.jobManager.abortNonTerminalJobs(queryBuilder);
+        int aborted = this.jobManager.abortNonTerminalJobs(queryArgs);
         log.info("Aborted {} non-running jobs older than {}", aborted, cutoff);
 
         return aborted;
@@ -160,11 +160,11 @@ public class JobCleaner implements AsyncJob {
         Set<JobState> jobStates = Util.asSet(JobState.RUNNING);
 
         // Build the query builder with our config
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(jobStates)
             .setEndDate(cutoff);
 
-        int aborted = this.jobManager.abortNonTerminalJobs(queryBuilder);
+        int aborted = this.jobManager.abortNonTerminalJobs(queryArgs);
         log.info("Aborted {} running jobs older than {}", aborted, cutoff);
 
         return aborted;

--- a/server/src/main/java/org/candlepin/auth/permissions/AsyncJobStatusPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/AsyncJobStatusPermission.java
@@ -27,6 +27,10 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
+
 
 
 /**
@@ -66,6 +70,15 @@ public class AsyncJobStatusPermission extends TypedPermission<AsyncJobStatus> {
 
     @Override
     public Criterion getCriteriaRestrictions(Class entityClass) {
+        // This behavior is deprecated. Always return null.
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
         // This behavior is deprecated. Always return null.
         return null;
     }

--- a/server/src/main/java/org/candlepin/auth/permissions/AttachPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/AttachPermission.java
@@ -18,9 +18,14 @@ import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
+import org.candlepin.model.Pool_;
 
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
 
 
 
@@ -60,6 +65,18 @@ public class AttachPermission extends TypedPermission<Pool> {
     public Criterion getCriteriaRestrictions(Class entityClass) {
         if (entityClass.equals(Pool.class)) {
             return Restrictions.eq("owner", owner);
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
+        if (Pool.class.equals(entityClass)) {
+            return builder.equal(((From<?, Pool>) path).get(Pool_.owner), this.getOwner());
         }
 
         return null;

--- a/server/src/main/java/org/candlepin/auth/permissions/ConsumerEntitlementPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/ConsumerEntitlementPermission.java
@@ -22,6 +22,12 @@ import org.candlepin.model.Owner;
 
 import org.hibernate.criterion.Criterion;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
+
+
+
 /**
  *
  */
@@ -47,6 +53,14 @@ public class ConsumerEntitlementPermission extends TypedPermission<Entitlement> 
 
     @Override
     public Criterion getCriteriaRestrictions(Class entityClass) {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
         return null;
     }
 

--- a/server/src/main/java/org/candlepin/auth/permissions/ConsumerOrgHypervisorPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/ConsumerOrgHypervisorPermission.java
@@ -17,9 +17,14 @@ package org.candlepin.auth.permissions;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Owner;
+import org.candlepin.model.Owner_;
 
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
 
 
 
@@ -54,6 +59,18 @@ public class ConsumerOrgHypervisorPermission extends TypedPermission<Owner> {
     public Criterion getCriteriaRestrictions(Class entityClass) {
         if (entityClass.equals(Owner.class)) {
             return Restrictions.eq("key", owner.getKey());
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
+        if (Owner.class.equals(entityClass)) {
+            return builder.equal(((From<?, Owner>) path).get(Owner_.key), this.getOwner().getKey());
         }
 
         return null;

--- a/server/src/main/java/org/candlepin/auth/permissions/ConsumerPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/ConsumerPermission.java
@@ -17,10 +17,17 @@ package org.candlepin.auth.permissions;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.Consumer_;
 import org.candlepin.model.Owner;
 
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
+
+
 
 /**
  *
@@ -51,6 +58,18 @@ public class ConsumerPermission extends TypedPermission<Consumer> {
         if (entityClass.equals(Consumer.class)) {
             return Restrictions.idEq(consumer.getId());
         }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
+        if (Consumer.class.equals(entityClass)) {
+            return builder.equal(((From<?, Consumer>) path).get(Consumer_.id), this.getConsumer().getId());
+        }
+
         return null;
     }
 

--- a/server/src/main/java/org/candlepin/auth/permissions/ConsumerServiceLevelsPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/ConsumerServiceLevelsPermission.java
@@ -18,9 +18,16 @@ import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
+import org.candlepin.model.Owner_;
 
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
+
+
 
 /**
  * Permission allowing consumers to view their owner's service levels.
@@ -54,6 +61,18 @@ public class ConsumerServiceLevelsPermission extends TypedPermission<Owner> {
         if (entityClass.equals(Owner.class)) {
             return Restrictions.eq("key", owner.getKey());
         }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
+        if (Owner.class.equals(entityClass)) {
+            return builder.equal(((From<?, Owner>) path).get(Owner_.key), this.getOwner().getKey());
+        }
+
         return null;
     }
 

--- a/server/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
@@ -17,19 +17,30 @@ package org.candlepin.auth.permissions;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.Consumer_;
 import org.candlepin.model.Environment;
+import org.candlepin.model.Environment_;
 import org.candlepin.model.Owned;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerContent;
+import org.candlepin.model.OwnerContent_;
 import org.candlepin.model.OwnerProduct;
+import org.candlepin.model.OwnerProduct_;
+import org.candlepin.model.Owner_;
 import org.candlepin.model.Pool;
+import org.candlepin.model.Pool_;
 import org.candlepin.model.activationkeys.ActivationKey;
+import org.candlepin.model.activationkeys.ActivationKey_;
 
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 
 import java.io.Serializable;
 import java.util.Objects;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
 
 
 
@@ -87,6 +98,36 @@ public class OwnerPermission implements Permission, Serializable {
         }
         else if (OwnerContent.class.equals(entityClass)) {
             return Restrictions.eq("owner", owner);
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
+        if (Owner.class.equals(entityClass)) {
+            return builder.equal(((From<?, Owner>) path).get(Owner_.key), this.getOwner().getKey());
+        }
+        else if (Consumer.class.equals(entityClass)) {
+            return builder.equal(((From<?, Consumer>) path).get(Consumer_.ownerId), this.getOwner().getId());
+        }
+        else if (Pool.class.equals(entityClass)) {
+            return builder.equal(((From<?, Pool>) path).get(Pool_.owner), this.getOwner());
+        }
+        else if (ActivationKey.class.equals(entityClass)) {
+            return builder.equal(((From<?, ActivationKey>) path).get(ActivationKey_.owner), this.getOwner());
+        }
+        else if (Environment.class.equals(entityClass)) {
+            return builder.equal(((From<?, Environment>) path).get(Environment_.owner), this.getOwner());
+        }
+        else if (OwnerProduct.class.equals(entityClass)) {
+            return builder.equal(((From<?, OwnerProduct>) path).get(OwnerProduct_.owner), this.getOwner());
+        }
+        else if (OwnerContent.class.equals(entityClass)) {
+            return builder.equal(((From<?, OwnerContent>) path).get(OwnerContent_.owner), this.getOwner());
         }
 
         return null;

--- a/server/src/main/java/org/candlepin/auth/permissions/OwnerPoolsPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/OwnerPoolsPermission.java
@@ -20,6 +20,12 @@ import org.candlepin.model.Owner;
 
 import org.hibernate.criterion.Criterion;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
+
+
+
 /**
  * Grants access to view an owner's pools, as well as their backing subscriptions.
  */
@@ -47,6 +53,14 @@ public class OwnerPoolsPermission extends TypedPermission<Owner> {
 
     @Override
     public Criterion getCriteriaRestrictions(Class entityClass) {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
         return null;
     }
 

--- a/server/src/main/java/org/candlepin/auth/permissions/Permission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/Permission.java
@@ -20,6 +20,10 @@ import org.candlepin.model.Owner;
 
 import org.hibernate.criterion.Criterion;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
+
 
 
 /**
@@ -47,6 +51,23 @@ public interface Permission {
      * @return The modified Criteria query to be run.
      */
     Criterion getCriteriaRestrictions(Class entityClass);
+
+    /**
+     * Fetches a predicate to add to a JPA query to limit the results.
+     *
+     * @param entityClass
+     *  the class of the entity being queried
+     *
+     * @param builder
+     *  a CriteriaBuilder instance to use to build predicates
+     *
+     * @param path
+     *  the path of the query from which to apply the predicates
+     *
+     * @return
+     *  a predicate to apply to a query to further limit the results based on this permission
+     */
+    <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path);
 
     /**
      * @return an owner if this permission is specific to one, otherwise null

--- a/server/src/main/java/org/candlepin/auth/permissions/UserUserPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/UserUserPermission.java
@@ -18,9 +18,16 @@ import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Owner;
 import org.candlepin.model.User;
+import org.candlepin.model.User_;
 
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
+
+
 
 /**
  * A permission granting an authenticated user permission to view itself.
@@ -49,6 +56,18 @@ public class UserUserPermission extends TypedPermission<User> {
         if (entityClass.equals(User.class)) {
             return Restrictions.eq("username", username);
         }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
+        if (User.class.equals(entityClass)) {
+            return builder.equal(((From<?, User>) path).get(User_.username), this.getUsername());
+        }
+
         return null;
     }
 

--- a/server/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
+++ b/server/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
@@ -17,6 +17,7 @@ package org.candlepin.auth.permissions;
 import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.Consumer_;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
 import org.candlepin.service.model.UserInfo;
@@ -25,6 +26,12 @@ import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 
 import java.io.Serializable;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
+
+
 
 /**
  * A permission allowing a user access to consumers in their org only if they were the ones
@@ -82,6 +89,18 @@ public class UsernameConsumersPermission implements Permission, Serializable {
     public Criterion getCriteriaRestrictions(Class entityClass) {
         if (entityClass.equals(Consumer.class)) {
             return Restrictions.eq("username", user.getUsername());
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
+        if (Consumer.class.equals(entityClass)) {
+            return builder.equal(((From<?, Consumer>) path).get(Consumer_.username), this.getUsername());
         }
 
         return null;

--- a/server/src/main/java/org/candlepin/model/AsyncJobStatusCurator.java
+++ b/server/src/main/java/org/candlepin/model/AsyncJobStatusCurator.java
@@ -53,29 +53,7 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
     /**
      * Container object for providing various arguments to the job status lookup method(s).
      */
-    public static class AsyncJobStatusQueryBuilder {
-
-        public static final class Order {
-            private final String column;
-            private final boolean reverse;
-
-            public Order(String column, boolean reverse) {
-                if (column == null || column.isEmpty()) {
-                    throw new IllegalArgumentException("column is null or empty");
-                }
-
-                this.column = column;
-                this.reverse = reverse;
-            }
-
-            public String column() {
-                return this.column;
-            }
-
-            public boolean reverse() {
-                return this.reverse;
-            }
-        }
+    public static class AsyncJobStatusQueryArguments extends QueryArguments<AsyncJobStatusQueryArguments> {
 
         private Collection<String> jobIds;
         private Collection<String> jobKeys;
@@ -88,16 +66,12 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
         private Date startDate;
         private Date endDate;
 
-        private Integer offset;
-        private Integer limit;
-        private Collection<Order> order;
-
-        public AsyncJobStatusQueryBuilder setJobIds(Collection<String> jobIds) {
+        public AsyncJobStatusQueryArguments setJobIds(Collection<String> jobIds) {
             this.jobIds = jobIds;
             return this;
         }
 
-        public AsyncJobStatusQueryBuilder setJobIds(String... jobIds) {
+        public AsyncJobStatusQueryArguments setJobIds(String... jobIds) {
             return this.setJobIds(jobIds != null ? Arrays.asList(jobIds) : null);
         }
 
@@ -105,12 +79,12 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             return this.jobIds;
         }
 
-        public AsyncJobStatusQueryBuilder setJobKeys(Collection<String> jobKeys) {
+        public AsyncJobStatusQueryArguments setJobKeys(Collection<String> jobKeys) {
             this.jobKeys = jobKeys;
             return this;
         }
 
-        public AsyncJobStatusQueryBuilder setJobKeys(String... jobKeys) {
+        public AsyncJobStatusQueryArguments setJobKeys(String... jobKeys) {
             return this.setJobKeys(jobKeys != null ? Arrays.asList(jobKeys) : null);
         }
 
@@ -118,12 +92,12 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             return this.jobKeys;
         }
 
-        public AsyncJobStatusQueryBuilder setJobStates(Collection<JobState> jobStates) {
+        public AsyncJobStatusQueryArguments setJobStates(Collection<JobState> jobStates) {
             this.jobStates = jobStates;
             return this;
         }
 
-        public AsyncJobStatusQueryBuilder setJobStates(JobState... jobStates) {
+        public AsyncJobStatusQueryArguments setJobStates(JobState... jobStates) {
             return this.setJobStates(jobStates != null ? Arrays.asList(jobStates) : null);
         }
 
@@ -131,12 +105,12 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             return this.jobStates;
         }
 
-        public AsyncJobStatusQueryBuilder setOwnerIds(Collection<String> ownerIds) {
+        public AsyncJobStatusQueryArguments setOwnerIds(Collection<String> ownerIds) {
             this.ownerIds = ownerIds;
             return this;
         }
 
-        public AsyncJobStatusQueryBuilder setOwnerIds(String... ownerIds) {
+        public AsyncJobStatusQueryArguments setOwnerIds(String... ownerIds) {
             return this.setOwnerIds(ownerIds != null ? Arrays.asList(ownerIds) : null);
         }
 
@@ -144,12 +118,12 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             return this.ownerIds;
         }
 
-        public AsyncJobStatusQueryBuilder setPrincipalNames(Collection<String> principals) {
+        public AsyncJobStatusQueryArguments setPrincipalNames(Collection<String> principals) {
             this.principals = principals;
             return this;
         }
 
-        public AsyncJobStatusQueryBuilder setPrincipalNames(String... principals) {
+        public AsyncJobStatusQueryArguments setPrincipalNames(String... principals) {
             return this.setPrincipalNames(principals != null ? Arrays.asList(principals) : null);
         }
 
@@ -157,12 +131,12 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             return this.principals;
         }
 
-        public AsyncJobStatusQueryBuilder setOrigins(Collection<String> origins) {
+        public AsyncJobStatusQueryArguments setOrigins(Collection<String> origins) {
             this.origins = origins;
             return this;
         }
 
-        public AsyncJobStatusQueryBuilder setOrigins(String... origins) {
+        public AsyncJobStatusQueryArguments setOrigins(String... origins) {
             return this.setOrigins(origins != null ? Arrays.asList(origins) : null);
         }
 
@@ -170,12 +144,12 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             return this.origins;
         }
 
-        public AsyncJobStatusQueryBuilder setExecutors(Collection<String> executors) {
+        public AsyncJobStatusQueryArguments setExecutors(Collection<String> executors) {
             this.executors = executors;
             return this;
         }
 
-        public AsyncJobStatusQueryBuilder setExecutors(String... executors) {
+        public AsyncJobStatusQueryArguments setExecutors(String... executors) {
             return this.setExecutors(executors != null ? Arrays.asList(executors) : null);
         }
 
@@ -183,7 +157,7 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             return this.executors;
         }
 
-        public AsyncJobStatusQueryBuilder setStartDate(Date startDate) {
+        public AsyncJobStatusQueryArguments setStartDate(Date startDate) {
             this.startDate = startDate;
             return this;
         }
@@ -192,7 +166,7 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             return this.startDate;
         }
 
-        public AsyncJobStatusQueryBuilder setEndDate(Date endDate) {
+        public AsyncJobStatusQueryArguments setEndDate(Date endDate) {
             this.endDate = endDate;
             return this;
         }
@@ -201,43 +175,16 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             return this.endDate;
         }
 
-        public AsyncJobStatusQueryBuilder setOffset(Integer offset) {
-            this.offset = offset;
-            return this;
-        }
-
-        public Integer getOffset() {
-            return this.offset;
-        }
-
-        public AsyncJobStatusQueryBuilder setLimit(Integer limit) {
-            this.limit = limit;
-            return this;
-        }
-
-        public Integer getLimit() {
-            return this.limit;
-        }
-
-        public AsyncJobStatusQueryBuilder setOrder(Collection<Order> order) {
-            this.order = order;
-            return this;
-        }
-
-        public Collection<Order> getOrder() {
-            return this.order;
-        }
-
         @Override
         public boolean equals(Object obj) {
             if (obj == this) {
                 return true;
             }
 
-            if (obj instanceof AsyncJobStatusQueryBuilder) {
-                AsyncJobStatusQueryBuilder that = (AsyncJobStatusQueryBuilder) obj;
+            if (obj instanceof AsyncJobStatusQueryArguments && super.equals(obj)) {
+                AsyncJobStatusQueryArguments that = (AsyncJobStatusQueryArguments) obj;
 
-                EqualsBuilder builder = new EqualsBuilder()
+                return new EqualsBuilder()
                     .append(this.getJobIds(), that.getJobIds())
                     .append(this.getJobKeys(), that.getJobKeys())
                     .append(this.getJobStates(), that.getJobStates())
@@ -247,11 +194,7 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
                     .append(this.getExecutors(), that.getExecutors())
                     .append(this.getStartDate(), that.getStartDate())
                     .append(this.getEndDate(), that.getEndDate())
-                    .append(this.getOffset(), that.getOffset())
-                    .append(this.getLimit(), that.getLimit())
-                    .append(this.getOrder(), that.getOrder());
-
-                return builder.isEquals();
+                    .isEquals();
             }
 
             return false;
@@ -259,7 +202,8 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
 
         @Override
         public int hashCode() {
-            HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            return new HashCodeBuilder(37, 7)
+                .append(super.hashCode())
                 .append(this.getJobIds())
                 .append(this.getJobKeys())
                 .append(this.getJobStates())
@@ -269,11 +213,7 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
                 .append(this.getExecutors())
                 .append(this.getStartDate())
                 .append(this.getEndDate())
-                .append(this.getOffset())
-                .append(this.getLimit())
-                .append(this.getOrder());
-
-            return builder.toHashCode();
+                .toHashCode();
         }
     }
 
@@ -339,41 +279,41 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
      * Fetches a collection of jobs based on the provided filter data in the query builder. If the
      * query builder is null or contains no arguments, this method will return all known async jobs.
      *
-     * @param queryBuilder
-     *  an AsyncJobStatusQueryBuilder instance containing the various arguments or filters to use
+     * @param queryArgs
+     *  an AsyncJobStatusQueryArguments instance containing the various arguments or filters to use
      *  to select jobs
      *
      * @return
      *  a list of jobs matching the provided query arguments/filters
      */
-    public List<AsyncJobStatus> findJobs(AsyncJobStatusQueryBuilder queryBuilder) {
+    public List<AsyncJobStatus> findJobs(AsyncJobStatusQueryArguments queryArgs) {
         CriteriaBuilder criteriaBuilder = this.getEntityManager().getCriteriaBuilder();
         CriteriaQuery<AsyncJobStatus> criteriaQuery = criteriaBuilder.createQuery(AsyncJobStatus.class);
 
         Root<AsyncJobStatus> job = criteriaQuery.from(AsyncJobStatus.class);
         criteriaQuery.select(job);
 
-        List<Predicate> predicates = this.buildJobQueryPredicates(criteriaBuilder, job, queryBuilder);
+        List<Predicate> predicates = this.buildJobQueryPredicates(criteriaBuilder, job, queryArgs);
         if (predicates.size() > 0) {
             Predicate[] predicateArray = new Predicate[predicates.size()];
             criteriaQuery.where(predicates.toArray(predicateArray));
         }
 
-        List<Order> order = this.buildJobQueryOrder(criteriaBuilder, job, queryBuilder);
-        if (order.size() > 0) {
+        List<Order> order = this.buildJPAQueryOrder(criteriaBuilder, job, queryArgs);
+        if (order != null && order.size() > 0) {
             criteriaQuery.orderBy(order);
         }
 
         TypedQuery<AsyncJobStatus> query = this.getEntityManager()
             .createQuery(criteriaQuery);
 
-        if (queryBuilder != null) {
-            Integer offset = queryBuilder.getOffset();
+        if (queryArgs != null) {
+            Integer offset = queryArgs.getOffset();
             if (offset != null && offset > 0) {
                 query.setFirstResult(offset);
             }
 
-            Integer limit = queryBuilder.getLimit();
+            Integer limit = queryArgs.getLimit();
             if (limit != null && limit > 0) {
                 query.setMaxResults(limit);
             }
@@ -387,21 +327,21 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
      * query builder is null or contains no arguments, this method will return the count of all
      * known jobs.
      *
-     * @param queryBuilder
-     *  an AsyncJobStatusQueryBuilder instance containing the various arguments or filters to use
+     * @param queryArgs
+     *  an AsyncJobStatusQueryArguments instance containing the various arguments or filters to use
      *  to count jobs
      *
      * @return
-     *  a list of jobs matching the provided query arguments/filters
+     *  the number of jobs matching the provided query arguments/filters
      */
-    public long getJobCount(AsyncJobStatusQueryBuilder queryBuilder) {
+    public long getJobCount(AsyncJobStatusQueryArguments queryArgs) {
         CriteriaBuilder criteriaBuilder = this.getEntityManager().getCriteriaBuilder();
         CriteriaQuery<Long> query = criteriaBuilder.createQuery(Long.class);
 
         Root<AsyncJobStatus> job = query.from(AsyncJobStatus.class);
         query.select(criteriaBuilder.count(job));
 
-        List<Predicate> predicates = this.buildJobQueryPredicates(criteriaBuilder, job, queryBuilder);
+        List<Predicate> predicates = this.buildJobQueryPredicates(criteriaBuilder, job, queryArgs);
         if (predicates.size() > 0) {
             Predicate[] predicateArray = new Predicate[predicates.size()];
             query.where(predicates.toArray(predicateArray));
@@ -416,14 +356,14 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
      * Deletes a number of jobs based on the provided filter data in the query builder. If the
      * query builder is null or contains no arguments, this method does nothing.
      *
-     * @param queryBuilder
-     *  an AsyncJobStatusQueryBuilder instance containing the various arguments or filters to use
+     * @param queryArgs
+     *  an AsyncJobStatusQueryArguments instance containing the various arguments or filters to use
      *  to select jobs
      *
      * @return
      *  the number of jobs deleted as a result of a call to this method
      */
-    public int deleteJobs(AsyncJobStatusQueryBuilder queryBuilder) {
+    public int deleteJobs(AsyncJobStatusQueryArguments queryArgs) {
         EntityManager entityManager = this.getEntityManager();
         CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
         CriteriaDelete<AsyncJobStatus> query = criteriaBuilder.createCriteriaDelete(AsyncJobStatus.class);
@@ -431,7 +371,7 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
         Root<AsyncJobStatus> job = query.from(AsyncJobStatus.class);
 
         // Sanity check: Don't execute a deletion if we haven't provided at least *some* restrictions.
-        List<Predicate> predicates = this.buildJobQueryPredicates(criteriaBuilder, job, queryBuilder);
+        List<Predicate> predicates = this.buildJobQueryPredicates(criteriaBuilder, job, queryArgs);
         if (predicates.size() > 0) {
             Predicate[] predicateArray = new Predicate[predicates.size()];
             query.where(predicates.toArray(predicateArray));
@@ -450,8 +390,8 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
      * <strong>Warning:</strong> This method provides no state transition validation, and could put
      * jobs into invalid or desynced states.
      *
-     * @param queryBuilder
-     *  an AsyncJobStatusQueryBuilder instance containing the various arguments or filters to use
+     * @param queryArgs
+     *  an AsyncJobStatusQueryArguments instance containing the various arguments or filters to use
      *  to select jobs
      *
      * @param state
@@ -460,18 +400,18 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
      * @return
      *  the number of jobs updated as a result of a call to this method
      */
-    public int updateJobState(AsyncJobStatusQueryBuilder queryBuilder, JobState state) {
+    public int updateJobState(AsyncJobStatusQueryArguments queryArgs, JobState state) {
         EntityManager entityManager = this.getEntityManager();
         CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
         CriteriaUpdate<AsyncJobStatus> update = criteriaBuilder.createCriteriaUpdate(AsyncJobStatus.class);
         Root<AsyncJobStatus> job = update.from(AsyncJobStatus.class);
 
         // Impl note: order of the assignments is important here.
-        update.<Integer>set(job.get("previousState"), job.get("state"))
-            .set(job.get("state"), state);
+        update.set(job.get(AsyncJobStatus_.previousState), job.get(AsyncJobStatus_.state))
+            .set(job.get(AsyncJobStatus_.state), state);
 
         // Sanity check: Don't execute a state change if we haven't provided at least *some* restrictions.
-        List<Predicate> predicates = this.buildJobQueryPredicates(criteriaBuilder, job, queryBuilder);
+        List<Predicate> predicates = this.buildJobQueryPredicates(criteriaBuilder, job, queryArgs);
         if (predicates.size() > 0) {
             Predicate[] predicateArray = new Predicate[predicates.size()];
             update.where(predicates.toArray(predicateArray));
@@ -484,50 +424,6 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
     }
 
     /**
-     * Builds a collection of order instances to be used for querying jobs using the JPA criteria
-     * query API.
-     *
-     * @param critBuilder
-     *  the CriteriaBuilder instance to use to create order
-
-     * @param root
-     *  the root of the query, should be a reference to the AsyncJobStatus root
-     *
-     * @param queryBuilder
-     *  an AsyncJobStatusQueryBuilder instance containing the order specification
-     *  to select jobs
-     *
-     * @throws InvalidOrderKeyException
-     *  if an order is provided referencing an attribute name (key) that does not exist
-     *
-     * @return
-     *  a list of order instances to sort jobs based on the query ordering provided
-     */
-    private List<Order> buildJobQueryOrder(CriteriaBuilder criteriaBuilder, Root<AsyncJobStatus> root,
-        AsyncJobStatusQueryBuilder queryBuilder) {
-
-        List<Order> orderList = new ArrayList<>();
-
-        if (queryBuilder != null) {
-            if (queryBuilder.getOrder() != null) {
-                for (AsyncJobStatusQueryBuilder.Order order : queryBuilder.getOrder()) {
-                    try {
-                        orderList.add(order.reverse() ?
-                            criteriaBuilder.desc(root.get(order.column())) :
-                            criteriaBuilder.asc(root.get(order.column())));
-                    }
-                    catch (IllegalArgumentException e) {
-                        String errmsg = String.format("Invalid attribute key: %s", order.column());
-                        throw new InvalidOrderKeyException(errmsg, e);
-                    }
-                }
-            }
-        }
-
-        return orderList;
-    }
-
-    /**
      * Builds a collection of predicates to be used for querying jobs using the JPA criteria query
      * API.
      *
@@ -537,67 +433,68 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
      * @param root
      *  the root of the query, should be a reference to the AsyncJobStatus root
      *
-     * @param queryBuilder
-     *  an AsyncJobStatusQueryBuilder instance containing the various arguments or filters to use
+     * @param queryArgs
+     *  an AsyncJobStatusQueryArguments instance containing the various arguments or filters to use
      *  to select jobs
      *
      * @return
      *  a list of predicates to select jobs based on the query parameters provided
      */
     private List<Predicate> buildJobQueryPredicates(CriteriaBuilder criteriaBuilder,
-        Root<AsyncJobStatus> root, AsyncJobStatusQueryBuilder queryBuilder) {
+        Root<AsyncJobStatus> root, AsyncJobStatusQueryArguments queryArgs) {
 
         List<Predicate> predicates = new ArrayList<>();
 
-        if (queryBuilder != null) {
-            if (queryBuilder.getJobIds() != null && !queryBuilder.getJobIds().isEmpty()) {
-                predicates.add(root.get("id").in(queryBuilder.getJobIds()));
+        if (queryArgs != null) {
+            if (this.checkQueryArgumentCollection(queryArgs.getJobIds())) {
+                predicates.add(root.get(AsyncJobStatus_.id).in(queryArgs.getJobIds()));
             }
 
-            if (queryBuilder.getJobKeys() != null && !queryBuilder.getJobKeys().isEmpty()) {
-                predicates.add(root.get("jobKey").in(queryBuilder.getJobKeys()));
+            if (this.checkQueryArgumentCollection(queryArgs.getJobKeys())) {
+                predicates.add(root.get(AsyncJobStatus_.jobKey).in(queryArgs.getJobKeys()));
             }
 
-            if (queryBuilder.getJobStates() != null && !queryBuilder.getJobStates().isEmpty()) {
-                predicates.add(root.get("state").in(queryBuilder.getJobStates()));
+            if (this.checkQueryArgumentCollection(queryArgs.getJobStates())) {
+                predicates.add(root.get(AsyncJobStatus_.state).in(queryArgs.getJobStates()));
             }
 
-            Collection<String> ownerIds = queryBuilder.getOwnerIds();
-            if (ownerIds != null && !ownerIds.isEmpty()) {
-                Predicate ownerPredicate = root.get("ownerId").in(queryBuilder.getOwnerIds());
+            Collection<String> ownerIds = queryArgs.getOwnerIds();
+            if (this.checkQueryArgumentCollection(ownerIds)) {
+                Predicate ownerPredicate = root.get(AsyncJobStatus_.ownerId).in(ownerIds);
 
                 if (ownerIds.contains(null)) {
                     // While it'd be nice to remove nulls here, we can't guarantee every collection
                     // provided will support the remove operation, so we'll just leave it.
+                    Predicate nullPredicate = root.get(AsyncJobStatus_.ownerId).isNull();
 
                     ownerPredicate = ownerIds.size() > 1 ?
-                        criteriaBuilder.or(ownerPredicate, root.get("ownerId").isNull()) :
-                        root.get("ownerId").isNull();
+                        criteriaBuilder.or(ownerPredicate, nullPredicate) :
+                        nullPredicate;
                 }
 
                 predicates.add(ownerPredicate);
             }
 
-            if (queryBuilder.getPrincipalNames() != null && !queryBuilder.getPrincipalNames().isEmpty()) {
-                predicates.add(root.get("principal").in(queryBuilder.getPrincipalNames()));
+            if (this.checkQueryArgumentCollection(queryArgs.getPrincipalNames())) {
+                predicates.add(root.get(AsyncJobStatus_.principal).in(queryArgs.getPrincipalNames()));
             }
 
-            if (queryBuilder.getOrigins() != null && !queryBuilder.getOrigins().isEmpty()) {
-                predicates.add(root.get("origin").in(queryBuilder.getOrigins()));
+            if (this.checkQueryArgumentCollection(queryArgs.getOrigins())) {
+                predicates.add(root.get(AsyncJobStatus_.origin).in(queryArgs.getOrigins()));
             }
 
-            if (queryBuilder.getExecutors() != null && !queryBuilder.getExecutors().isEmpty()) {
-                predicates.add(root.get("executor").in(queryBuilder.getExecutors()));
+            if (this.checkQueryArgumentCollection(queryArgs.getExecutors())) {
+                predicates.add(root.get(AsyncJobStatus_.executor).in(queryArgs.getExecutors()));
             }
 
-            if (queryBuilder.getStartDate() != null) {
-                predicates.add(
-                    criteriaBuilder.greaterThanOrEqualTo(root.get("updated"), queryBuilder.getStartDate()));
+            if (queryArgs.getStartDate() != null) {
+                predicates.add(criteriaBuilder
+                    .greaterThanOrEqualTo(root.get(AsyncJobStatus_.updated), queryArgs.getStartDate()));
             }
 
-            if (queryBuilder.getEndDate() != null) {
-                predicates.add(
-                    criteriaBuilder.lessThanOrEqualTo(root.get("updated"), queryBuilder.getEndDate()));
+            if (queryArgs.getEndDate() != null) {
+                predicates.add(criteriaBuilder
+                    .lessThanOrEqualTo(root.get(AsyncJobStatus_.updated), queryArgs.getEndDate()));
             }
         }
 
@@ -637,14 +534,14 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
         List<Predicate> predicates = new ArrayList<>();
 
         // Add the job key restriction
-        predicates.add(criteriaBuilder.equal(job.get("jobKey"), jobKey));
+        predicates.add(criteriaBuilder.equal(job.get(AsyncJobStatus_.jobKey), jobKey));
 
         // Add the non-terminal state restriction
         Collection<JobState> states = Arrays.stream(JobState.values())
             .filter(s -> !s.isTerminal())
             .collect(Collectors.toSet());
 
-        predicates.add(job.get("state").in(states));
+        predicates.add(job.get(AsyncJobStatus_.state).in(states));
 
         // Add the argument restrictions if necessary
         if (arguments != null) {
@@ -656,7 +553,7 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             }
 
             for (Map.Entry<String, String> entry : arguments.entrySet()) {
-                MapJoin<AsyncJobStatus, String, String> jobArguments = job.joinMap("arguments");
+                MapJoin<AsyncJobStatus, String, String> jobArguments = job.join(AsyncJobStatus_.arguments);
 
                 predicates.add(criteriaBuilder.and(
                     criteriaBuilder.equal(jobArguments.key(), entry.getKey()),
@@ -665,7 +562,7 @@ public class AsyncJobStatusCurator extends AbstractHibernateCurator<AsyncJobStat
             }
         }
 
-        query.select(job.get("id"));
+        query.select(job.get(AsyncJobStatus_.id));
 
         Predicate[] predicateArray = new Predicate[predicates.size()];
         query.where(predicates.toArray(predicateArray));

--- a/server/src/main/java/org/candlepin/model/Consumer.java
+++ b/server/src/main/java/org/candlepin/model/Consumer.java
@@ -198,6 +198,10 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "consumer", fetch = FetchType.LAZY)
     private Set<Entitlement> entitlements;
 
+    // TODO: FIXME:
+    // Hibernate has a known issue with map-backed element collections that contain entries with
+    // null values. Upon persist, and entries with null values will be silently discarded rather
+    // than persisted, even if the configuration explicitly allows such a thing.
     @ElementCollection
     @CollectionTable(name = "cp_consumer_facts", joinColumns = @JoinColumn(name = "cp_consumer_id"))
     @MapKeyColumn(name = "mapkey")
@@ -363,9 +367,13 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     /**
      * @param name the name of this consumer.
+     *
+     * @return
+     *  a reference to this consumer instance
      */
-    public void setName(String name) {
+    public Consumer setName(String name) {
         this.name = name;
+        return this;
     }
 
     /**
@@ -377,9 +385,13 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     /**
      * @param userName the userName to set
+     *
+     * @return
+     *  a reference to this consumer instance
      */
-    public void setUsername(String userName) {
+    public Consumer setUsername(String userName) {
         this.username = userName;
+        return this;
     }
 
     /**
@@ -394,10 +406,15 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
      *
      * @param typeId
      *  The ID of the consumer type to use for this consumer
+     *
+     * @return
+     *  a reference to this consumer instance
      */
-    public void setTypeId(String typeId) {
+    public Consumer setTypeId(String typeId) {
         this.typeId = typeId;
         this.updateRHCloudProfileModified();
+
+        return this;
     }
 
     /**
@@ -405,13 +422,16 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
      *
      * @param type
      *  The ConsumerType instance to use as the type for this consumer
+     *
+     * @return
+     *  a reference to this consumer instance
      */
-    public void setType(ConsumerType type) {
+    public Consumer setType(ConsumerType type) {
         if (type == null || type.getId() == null) {
             throw new IllegalArgumentException("type is null or has not been persisted");
         }
-        this.typeId = type.getId();
-        this.updateRHCloudProfileModified();
+
+        return this.setTypeId(type.getId());
     }
 
     /**
@@ -479,12 +499,16 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     /**
      * @param factsIn facts about this consumer.
+     *
+     * @return
+     *  a reference to this consumer instance
      */
-    public void setFacts(Map<String, String> factsIn) {
+    public Consumer setFacts(Map<String, String> factsIn) {
         if (this.checkForCloudProfileFacts(factsIn)) {
             this.updateRHCloudProfileModified();
         }
         facts = factsIn;
+        return this;
     }
 
     /**
@@ -856,13 +880,19 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
 
     /**
      * @param hypervisorId the hypervisorId to set
+     *
+     * @return
+     *  a reference to this consumer instance
      */
-    public void setHypervisorId(HypervisorId hypervisorId) {
+    public Consumer setHypervisorId(HypervisorId hypervisorId) {
         if (hypervisorId != null) {
             hypervisorId.setConsumer(this);
         }
+
         this.hypervisorId = hypervisorId;
         this.updateRHCloudProfileModified();
+
+        return this;
     }
 
     @XmlTransient

--- a/server/src/main/java/org/candlepin/model/HypervisorId.java
+++ b/server/src/main/java/org/candlepin/model/HypervisorId.java
@@ -30,10 +30,8 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
+
+
 
 /**
  * HypervisorId represents a hypervisor host, unique per organization
@@ -46,8 +44,6 @@ import javax.xml.bind.annotation.XmlTransient;
  * with a hypervisorId so that hypervisorCheckIn can update its guest list
  * without additional info or lookups.
  */
-@XmlRootElement
-@XmlAccessorType(XmlAccessType.PROPERTY)
 @Entity
 @Table(name = HypervisorId.DB_TABLE, uniqueConstraints =
     @UniqueConstraint(name = "cp_consumer_hypervisor_ukey", columnNames = {"owner_id", "hypervisor_id"}))
@@ -74,32 +70,16 @@ public class HypervisorId extends AbstractHibernateObject {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, unique = true)
-    @XmlTransient
     @NotNull
     private Consumer consumer;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
-    @XmlTransient
     @NotNull
     private Owner owner;
 
     public HypervisorId() {
-    }
-
-    public HypervisorId(String hypervisorId) {
-        this.setHypervisorId(hypervisorId);
-    }
-
-    public HypervisorId(Consumer consumer, Owner owner, String hypervisorId) {
-        this(hypervisorId);
-        this.setConsumer(consumer);
-        this.setOwner(owner);
-    }
-
-    public HypervisorId(Consumer consumer, Owner owner, String hypervisorId, String reporterId) {
-        this(consumer, owner, hypervisorId);
-        this.setReporterId(reporterId);
+        // Intentionally left empty
     }
 
     @Override
@@ -109,9 +89,13 @@ public class HypervisorId extends AbstractHibernateObject {
 
     /**
      * @param id the id to set
+     *
+     * @return
+     *  a reference to this HypervisorId
      */
-    public void setId(String id) {
+    public HypervisorId setId(String id) {
         this.id = id;
+        return this;
     }
 
     /**
@@ -123,17 +107,18 @@ public class HypervisorId extends AbstractHibernateObject {
 
     /**
      * @param hypervisorId the hypervisorId to set
+     *
+     * @return
+     *  a reference to this HypervisorId
      */
-    public void setHypervisorId(String hypervisorId) {
+    public HypervisorId setHypervisorId(String hypervisorId) {
         // Hypervisor uuid is case insensitive, we need to force it to lower
         // case in order to enforce the unique hypervisorId per org constraint
         //
         // Queries in Candlepin are dependent on the fact this attribute is
         // being stored in lower case.
-        if (hypervisorId != null) {
-            hypervisorId = hypervisorId.toLowerCase();
-        }
-        this.hypervisorId = hypervisorId;
+        this.hypervisorId = hypervisorId != null ? hypervisorId.toLowerCase() : null;
+        return this;
     }
 
     /**
@@ -145,38 +130,48 @@ public class HypervisorId extends AbstractHibernateObject {
 
     /**
      * @param reporterId the reporterId to set
+     *
+     * @return
+     *  a reference to this HypervisorId
      */
-    public void setReporterId(String reporterId) {
+    public HypervisorId setReporterId(String reporterId) {
         this.reporterId = reporterId;
+        return this;
     }
 
     /**
      * @return the consumer
      */
-    @XmlTransient
     public Consumer getConsumer() {
         return consumer;
     }
 
     /**
      * @param consumer the consumer to set
+     *
+     * @return
+     *  a reference to this HypervisorId
      */
-    public void setConsumer(Consumer consumer) {
+    public HypervisorId setConsumer(Consumer consumer) {
         this.consumer = consumer;
+        return this;
     }
 
     /**
      * @return the owner
      */
-    @XmlTransient
     public Owner getOwner() {
         return owner;
     }
 
     /**
      * @param owner the owner to set
+     *
+     * @return
+     *  a reference to this HypervisorId
      */
-    public void setOwner(Owner owner) {
+    public HypervisorId setOwner(Owner owner) {
         this.owner = owner;
+        return this;
     }
 }

--- a/server/src/main/java/org/candlepin/model/OwnerInfoCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerInfoCurator.java
@@ -82,7 +82,7 @@ public class OwnerInfoCurator {
             typeHash.put(type.getLabel(), type);
 
             // Do the real work
-            int consumers = consumerCurator.getConsumerCount(owner, type);
+            int consumers = (int) consumerCurator.getConsumerCount(owner, type);
             int entCount = consumerCurator.getConsumerEntitlementCount(owner, type);
             info.addTypeTotal(type, consumers, entCount);
 

--- a/server/src/main/java/org/candlepin/model/QueryArguments.java
+++ b/server/src/main/java/org/candlepin/model/QueryArguments.java
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+
+
+/**
+ * Container object for providing various arguments to the consumerlookup method(s).
+ *
+ * @param <T>
+ *  The type of the QueryArguments subclass; used for method chaining
+ */
+public class QueryArguments<T extends QueryArguments> {
+
+    /** The number of elements a given collection in the query builder may have */
+    public static final int COLLECTION_SIZE_LIMIT = 512;
+
+    /** Generic container class for storing result ordering information */
+    public static final class Order {
+        private final String column;
+        private final boolean reverse;
+
+        /**
+         * Creates a new Order instance on the specified column.
+         *
+         * @param column
+         *  the name of a column by which to order the query results; cannot be null or empty
+         *
+         * @param reverse
+         *  whether or not to fetch the results in reverse (descending) order
+         *
+         * @throws IllegalArgumentException
+         *  if column is null or empty
+         */
+        public Order(String column, boolean reverse) {
+            if (column == null || column.isEmpty()) {
+                throw new IllegalArgumentException("column is null or empty");
+            }
+
+            this.column = column;
+            this.reverse = reverse;
+        }
+
+        /**
+         * Fetches the name of a column by which to order the query results
+         *
+         * @return
+         *  the name of a column by which to order query results
+         */
+        public String column() {
+            return this.column;
+        }
+
+        /**
+         * Whether or not the ordering of results should be in reverse (descending) order.
+         *
+         * @return
+         *  true if the results should be ordered in descending order; false otherwise
+         */
+        public boolean reverse() {
+            return this.reverse;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj instanceof Order) {
+                Order that = (Order) obj;
+
+                return new EqualsBuilder()
+                    .append(this.column(), that.column())
+                    .append(this.reverse(), that.reverse())
+                    .isEquals();
+            }
+
+            return false;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int hashCode() {
+            return new HashCodeBuilder(37, 7)
+                .append(this.column())
+                .append(this.reverse())
+                .toHashCode();
+        }
+    }
+
+    protected Integer offset;
+    protected Integer limit;
+    protected Collection<Order> order;
+
+
+    /**
+     * Sets or clears the offset at which to begin fetching results. If null, any previously set
+     * offset will be cleared.
+     *
+     * @param offset
+     *  the row offset at which to begin fetching results, or null to clear the offset
+     *
+     * @return
+     *  a reference to this QueryArguments
+     */
+    public T setOffset(Integer offset) {
+        this.offset = offset;
+        return (T) this;
+    }
+
+    /**
+     * Gets the offset at which to begin fetching results. If an offset has not yet been defined,
+     * this method returns null.that
+     *
+     * @return
+     *  the offset at which to begin fetching results, or null if the offset has not been defined
+     */
+    public Integer getOffset() {
+        return this.offset;
+    }
+
+    /**
+     * Sets or clears the limit defining the number of results to fetch. If null, any previously set
+     * limit will be cleared.
+     *
+     * @param limit
+     *  the maximum number of results to fetch, or null to clear the limit
+     *
+     * @return
+     *  a reference to this QueryArguments
+     */
+    public T setLimit(Integer limit) {
+        this.limit = limit;
+        return (T) this;
+    }
+
+    /**
+     * Gets the maximum number of results to fetch. If a limit has not yet been defined, this method
+     * returns null.
+     *
+     * @return
+     *  the maximum number of results to fetch, or null if limit has not been defined
+     */
+    public Integer getLimit() {
+        return this.limit;
+    }
+
+    /**
+     * Sets or clears the collection of result ordering to apply to the query. If null, any
+     * previously set order is cleared.
+     *
+     * @param order
+     *  a collection of Order objects defining the result ordering to apply to the query, or null
+     *  to clear the result order
+     *
+     * @return
+     *  a reference to this QueryArguments
+     */
+    public T setOrder(Collection<Order> order) {
+        this.order = order;
+        return (T) this;
+    }
+
+    /**
+     * Adds the specified result ordering to this query builder.
+     *
+     * @param column
+     *  the name of a column by which to order the query results; cannot be null or empty
+     *
+     * @param reverse
+     *  whether or not to fetch the results in reverse (descending) order
+     *
+     * @throws IllegalArgumentException
+     *  if column is null or empty
+     *
+     * @return
+     *  a reference to this QueryArguments
+     */
+    public T addOrder(String column, boolean reverse) {
+        if (this.order == null) {
+            this.order = new LinkedList<>();
+        }
+
+        this.order.add(new Order(column, reverse));
+        return (T) this;
+    }
+
+    /**
+     * Gets the result ordering to apply to the query. If no ordering has been set, this method
+     * returns null.
+     *
+     * @return
+     *  a collection containing all of the result ordering to apply to the query, or null if no
+     *  ordering has been defined
+     */
+    public Collection<Order> getOrder() {
+        return this.order;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        if (obj instanceof QueryArguments) {
+            QueryArguments that = (QueryArguments) obj;
+
+            return new EqualsBuilder()
+                .append(this.getOffset(), that.getOffset())
+                .append(this.getLimit(), that.getLimit())
+                .append(this.getOrder(), that.getOrder())
+                .isEquals();
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(37, 7)
+            .append(this.getOffset())
+            .append(this.getLimit())
+            .append(this.getOrder())
+            .toHashCode();
+    }
+
+}

--- a/server/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/server/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -345,9 +345,12 @@ public class HypervisorResource implements HypervisorsApi {
         consumer.setOwner(owner);
 
         // Create HypervisorId
-        HypervisorId hypervisorId = new HypervisorId(consumer, owner, incHypervisorId);
-        hypervisorId.setOwner(owner);
-        consumer.setHypervisorId(hypervisorId);
+        HypervisorId hid = new HypervisorId()
+            .setOwner(owner)
+            .setConsumer(consumer)
+            .setHypervisorId(incHypervisorId);
+
+        consumer.setHypervisorId(hid);
 
         // Create Consumer
         return consumerResource.createConsumerFromDTO(

--- a/server/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
+++ b/server/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
@@ -252,8 +252,14 @@ public class HypervisorUpdateAction {
 
         if (consumer.getHypervisorId() == null) {
             log.debug("Existing hypervisor id is null, changing hypervisor id to [" + hypervisorId + "]");
-            consumer.setHypervisorId(new HypervisorId(consumer, owner, hypervisorId,
-                reporterId));
+
+            HypervisorId hid = new HypervisorId()
+                .setOwner(owner)
+                .setConsumer(consumer)
+                .setHypervisorId(hypervisorId)
+                .setReporterId(reporterId);
+
+            consumer.setHypervisorId(hid);
         }
         else if (!hypervisorId.equalsIgnoreCase(consumer.getHypervisorId().getHypervisorId())) {
             log.debug("New hypervisor id is different, Changing hypervisor id to [" + hypervisorId + "]");
@@ -342,12 +348,10 @@ public class HypervisorUpdateAction {
         consumer.setOwner(owner);
         consumer.setAutoheal(true);
         consumer.setCanActivate(subAdapter.canActivateSubscription(consumer));
-        if (owner.getDefaultServiceLevel() != null) {
-            consumer.setServiceLevel(owner.getDefaultServiceLevel());
-        }
-        else {
-            consumer.setServiceLevel("");
-        }
+        consumer.setServiceLevel(owner.getDefaultServiceLevel() != null ?
+            owner.getDefaultServiceLevel() :
+            "");
+
         if (principal != null) {
             consumer.setUsername(principal);
         }
@@ -357,8 +361,12 @@ public class HypervisorUpdateAction {
 
 
         // Create HypervisorId
-        HypervisorId hypervisorId = new HypervisorId(consumer, owner, incHypervisorId);
-        hypervisorId.setReporterId(reporterId);
+        HypervisorId hypervisorId = new HypervisorId()
+            .setOwner(owner)
+            .setConsumer(consumer)
+            .setHypervisorId(incHypervisorId)
+            .setReporterId(reporterId);
+
         consumer.setHypervisorId(hypervisorId);
 
         // TODO: Refactor this to not call resource methods directly

--- a/server/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/server/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -52,7 +52,7 @@ import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.AsyncJobStatus;
 import org.candlepin.model.AsyncJobStatus.JobState;
 import org.candlepin.model.AsyncJobStatusCurator;
-import org.candlepin.model.AsyncJobStatusCurator.AsyncJobStatusQueryBuilder;
+import org.candlepin.model.AsyncJobStatusCurator.AsyncJobStatusQueryArguments;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.util.Util;
@@ -1260,7 +1260,7 @@ public class JobManagerTest {
             .setJobKey(TestJob.JOB_KEY)
             .setState(JobState.RUNNING));
 
-        AsyncJobStatusQueryBuilder input = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments input = new AsyncJobStatusQueryArguments()
             .setJobStates(Collections.singleton(JobState.RUNNING))
             .setExecutors(Collections.singleton(Util.getHostname()));
 
@@ -1387,15 +1387,15 @@ public class JobManagerTest {
         Date start = Util.yesterday();
         Date end = Util.tomorrow();
 
-        AsyncJobStatusQueryBuilder input = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments input = new AsyncJobStatusQueryArguments()
             .setJobKeys(jobKeys)
             .setJobStates(jobStates)
             .setOwnerIds(ownerIds)
             .setStartDate(start)
             .setEndDate(end);
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         doReturn(expected).when(this.jobCurator).findJobs(eq(input));
 
@@ -1409,7 +1409,7 @@ public class JobManagerTest {
         // Verify input is passed through, unmodified
         verify(this.jobCurator, times(1)).findJobs(captor.capture());
 
-        AsyncJobStatusQueryBuilder captured = captor.getValue();
+        AsyncJobStatusQueryArguments captured = captor.getValue();
 
         assertNotNull(captured);
         assertEquals(input, captured);
@@ -1422,8 +1422,8 @@ public class JobManagerTest {
         AsyncJobStatus status3 = this.createJobStatus("test_job-3");
         List<AsyncJobStatus> expected = Arrays.asList(status1, status2, status3);
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         doReturn(expected).when(this.jobCurator).findJobs(eq(null));
 
@@ -1437,12 +1437,12 @@ public class JobManagerTest {
         // Verify input is passed through, unmodified
         verify(this.jobCurator, times(1)).findJobs(captor.capture());
 
-        AsyncJobStatusQueryBuilder captured = captor.getValue();
+        AsyncJobStatusQueryArguments captured = captor.getValue();
         assertNull(captured);
     }
 
-    private AsyncJobStatusQueryBuilder generateQueryBuilder() {
-        return new AsyncJobStatusQueryBuilder()
+    private AsyncJobStatusQueryArguments generateQueryArguments() {
+        return new AsyncJobStatusQueryArguments()
             .setJobIds(Util.asSet("job_id-1", "job_id-2", "job_id-3"))
             .setJobKeys(Util.asSet("job_key-1", "job_key-2", "job_key-3"))
             .setJobStates(Util.asSet(JobState.CREATED, JobState.QUEUED, JobState.RUNNING, JobState.FINISHED))
@@ -1460,13 +1460,13 @@ public class JobManagerTest {
             .filter(JobState::isTerminal)
             .collect(Collectors.toSet());
 
-        AsyncJobStatusQueryBuilder input = this.generateQueryBuilder()
+        AsyncJobStatusQueryArguments input = this.generateQueryArguments()
             .setJobStates(jobStates);
 
         int expected = new Random().nextInt();
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         doReturn(expected).when(this.jobCurator).deleteJobs(eq(input));
 
@@ -1479,7 +1479,7 @@ public class JobManagerTest {
         // Verify input is passed through, unmodified
         verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
 
-        AsyncJobStatusQueryBuilder captured = captor.getValue();
+        AsyncJobStatusQueryArguments captured = captor.getValue();
 
         assertNotNull(captured);
         assertEquals(input, captured);
@@ -1489,13 +1489,13 @@ public class JobManagerTest {
     public void testCleanupJobsLimitsJobStatesToTerminalStates() {
         Set<JobState> jobStates = Util.asSet(JobState.values());
 
-        AsyncJobStatusQueryBuilder input = this.generateQueryBuilder()
+        AsyncJobStatusQueryArguments input = this.generateQueryArguments()
             .setJobStates(jobStates);
 
         int expected = new Random().nextInt();
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         doReturn(expected).when(this.jobCurator).deleteJobs(eq(input));
 
@@ -1504,7 +1504,7 @@ public class JobManagerTest {
 
         verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
 
-        AsyncJobStatusQueryBuilder captured = captor.getValue();
+        AsyncJobStatusQueryArguments captured = captor.getValue();
 
         assertNotNull(captured);
         Collection<JobState> actual = captured.getJobStates();
@@ -1525,34 +1525,34 @@ public class JobManagerTest {
             .filter(state -> !state.isTerminal())
             .collect(Collectors.toSet());
 
-        AsyncJobStatusQueryBuilder input = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments input = new AsyncJobStatusQueryArguments()
             .setJobStates(jobStates);
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         doThrow(new RuntimeException("this should not happen"))
             .when(this.jobCurator)
-            .deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            .deleteJobs(any(AsyncJobStatusQueryArguments.class));
 
         JobManager manager = this.createJobManager();
         int output = manager.cleanupJobs(input);
 
-        verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+        verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         assertEquals(0, output);
     }
 
     @Test
     public void testCleanupJobsDefaultsToTerminalStates() {
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobManager manager = this.createJobManager();
         int output = manager.cleanupJobs(null);
 
         verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
 
-        AsyncJobStatusQueryBuilder captured = captor.getValue();
+        AsyncJobStatusQueryArguments captured = captor.getValue();
 
         assertNotNull(captured);
         Collection<JobState> actual = captured.getJobStates();
@@ -1576,13 +1576,13 @@ public class JobManagerTest {
             .filter(state -> !state.isTerminal())
             .collect(Collectors.toSet());
 
-        AsyncJobStatusQueryBuilder input = this.generateQueryBuilder()
+        AsyncJobStatusQueryArguments input = this.generateQueryArguments()
             .setJobStates(states);
 
         int expected = new Random().nextInt();
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         doReturn(expected).when(this.jobCurator).updateJobState(eq(input), eq(JobState.ABORTED));
 
@@ -1595,7 +1595,7 @@ public class JobManagerTest {
         // Verify input is passed through, unmodified
         verify(this.jobCurator, times(1)).updateJobState(captor.capture(), eq(JobState.ABORTED));
 
-        AsyncJobStatusQueryBuilder captured = captor.getValue();
+        AsyncJobStatusQueryArguments captured = captor.getValue();
 
         assertNotNull(captured);
         assertEquals(input, captured);
@@ -1605,13 +1605,13 @@ public class JobManagerTest {
     public void testAbortNonTerminalJobsLimitsJobStatesToNonTerminalStates() {
         Set<JobState> jobStates = Util.asSet(JobState.values());
 
-        AsyncJobStatusQueryBuilder input = this.generateQueryBuilder()
+        AsyncJobStatusQueryArguments input = this.generateQueryArguments()
             .setJobStates(jobStates);
 
         int expected = new Random().nextInt();
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         doReturn(expected).when(this.jobCurator).updateJobState(eq(input), eq(JobState.ABORTED));
 
@@ -1622,7 +1622,7 @@ public class JobManagerTest {
 
         verify(this.jobCurator, times(1)).updateJobState(captor.capture(), eq(JobState.ABORTED));
 
-        AsyncJobStatusQueryBuilder captured = captor.getValue();
+        AsyncJobStatusQueryArguments captured = captor.getValue();
 
         assertNotNull(captured);
         Collection<JobState> actual = captured.getJobStates();
@@ -1639,15 +1639,15 @@ public class JobManagerTest {
 
     @Test
     public void testAbortNonTerminalJobsDefaultsToNoneTerminalStates() {
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobManager manager = this.createJobManager();
         int output = manager.abortNonTerminalJobs(null);
 
         verify(this.jobCurator, times(1)).updateJobState(captor.capture(), eq(JobState.ABORTED));
 
-        AsyncJobStatusQueryBuilder captured = captor.getValue();
+        AsyncJobStatusQueryArguments captured = captor.getValue();
 
         assertNotNull(captured);
         Collection<JobState> actual = captured.getJobStates();

--- a/server/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
@@ -223,7 +223,7 @@ public class HypervisorUpdateJobTest {
         hypervisor.setName("hypervisor_name");
         hypervisor.setOwner(owner);
         String hypervisorId = "uuid_999";
-        hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
+        hypervisor.setHypervisorId(new HypervisorId().setHypervisorId(hypervisorId));
         when(consumerCurator.getExistingConsumerByHypervisorIdOrUuid(any(String.class), any(String.class),
             nullable(String.class))).thenReturn(hypervisor);
 
@@ -247,7 +247,7 @@ public class HypervisorUpdateJobTest {
         hypervisor.setName("hypervisor_name");
         hypervisor.setOwner(owner);
         String hypervisorId = "uuid_999";
-        hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
+        hypervisor.setHypervisorId(new HypervisorId().setHypervisorId(hypervisorId));
         when(consumerCurator.getExistingConsumerByHypervisorIdOrUuid(any(String.class), any(String.class),
             nullable(String.class))).thenReturn(hypervisor);
 
@@ -272,7 +272,7 @@ public class HypervisorUpdateJobTest {
         hypervisor.setFact(Consumer.Facts.SYSTEM_UUID, "myUuid");
         hypervisor.setId("the-id");
         String hypervisorId = "existing_hypervisor_id";
-        hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
+        hypervisor.setHypervisorId(new HypervisorId().setHypervisorId(hypervisorId));
         when(consumerCurator.getExistingConsumerByHypervisorIdOrUuid(any(String.class), any(String.class),
             any(String.class))).thenReturn(hypervisor);
         when(config.getBoolean(eq(ConfigProperties.USE_SYSTEM_UUID_FOR_MATCHING))).thenReturn(true);
@@ -311,7 +311,7 @@ public class HypervisorUpdateJobTest {
         hypervisor.setOwner(owner);
         hypervisor.setFact(Consumer.Facts.SYSTEM_UUID, "myUuid");
         String hypervisorId = "existing_hypervisor_id";
-        hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
+        hypervisor.setHypervisorId(new HypervisorId().setHypervisorId(hypervisorId));
         when(consumerCurator.getExistingConsumerByHypervisorIdOrUuid(any(String.class), any(String.class),
             isNull())).thenReturn(null);
         // if it uses the uuid then it will return the hypervisor and update it. That will fail the test.
@@ -427,7 +427,7 @@ public class HypervisorUpdateJobTest {
         hypervisor.setFact(Consumer.Facts.SYSTEM_UUID, "myUuid");
         hypervisor.setId("the-id");
         String hypervisorId = "existing_hypervisor_id";
-        hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
+        hypervisor.setHypervisorId(new HypervisorId().setHypervisorId(hypervisorId));
         when(consumerCurator.getExistingConsumerByHypervisorIdOrUuid(any(String.class), any(String.class),
             any(String.class))).thenReturn(hypervisor);
         when(config.getBoolean(eq(ConfigProperties.USE_SYSTEM_UUID_FOR_MATCHING))).thenReturn(true);
@@ -498,7 +498,7 @@ public class HypervisorUpdateJobTest {
         hypervisor.setName("hypervisor_name");
         hypervisor.setOwner(owner);
         String hypervisorId = "uuid_999";
-        hypervisor.setHypervisorId(new HypervisorId(hypervisorId));
+        hypervisor.setHypervisorId(new HypervisorId().setHypervisorId(hypervisorId));
         hypervisor.setType(consumerTypeCurator.getByLabel(ConsumerTypeEnum.HYPERVISOR.getLabel(), true));
 
         // This must be the last operation in the sequence, or we could run into minor amounts of drift

--- a/server/src/test/java/org/candlepin/model/AsyncJobStatusCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/AsyncJobStatusCuratorTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.candlepin.model.AsyncJobStatus.JobState;
-import org.candlepin.model.AsyncJobStatusCurator.AsyncJobStatusQueryBuilder;
+import org.candlepin.model.AsyncJobStatusCurator.AsyncJobStatusQueryArguments;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.util.Util;
 
@@ -321,10 +321,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobIds(jobIds);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -355,10 +355,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         jobIds.addAll(expectedJobIds);
         jobIds.addAll(extraneousJobIds);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobIds(jobIds);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -385,10 +385,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(jobKeys);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -414,10 +414,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(jobKeys);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -448,10 +448,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         jobKeys.addAll(expectedKeys);
         jobKeys.addAll(extraneousKeys);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(jobKeys);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -478,10 +478,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(jobStates);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -507,10 +507,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(jobStates);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -541,10 +541,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         jobStates.addAll(expectedStates);
         jobStates.addAll(extraneousStates);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(jobStates);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -575,10 +575,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(ownerIds);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -609,10 +609,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(ownerIds);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -648,10 +648,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         ownerIds.addAll(expectedKeys);
         ownerIds.addAll(extraneousKeys);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(ownerIds);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -685,10 +685,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(ownerIds);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -720,10 +720,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(ownerIds);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -749,10 +749,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setEndDate(now);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -778,10 +778,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setStartDate(now);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -808,11 +808,11 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setStartDate(start)
             .setEndDate(end);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -839,10 +839,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .filter(job -> expected.contains(job.getPrincipalName()))
             .count();
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setPrincipalNames(query);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expectedCount, fetched.size());
@@ -868,10 +868,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .filter(job -> expected.contains(job.getOrigin()))
             .count();
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOrigins(query);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expectedCount, fetched.size());
@@ -897,10 +897,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .filter(job -> expected.contains(job.getExecutor()))
             .count();
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setExecutors(query);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expectedCount, fetched.size());
@@ -924,10 +924,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         assertTrue(offset > 0);
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOffset(offset);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
         List<AsyncJobStatus> allJobs = this.asyncJobCurator.findJobs(null);
 
         assertNotNull(fetched);
@@ -954,10 +954,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         assertTrue(limit > 0);
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setLimit(limit);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
         List<AsyncJobStatus> allJobs = this.asyncJobCurator.findJobs(null);
 
         assertNotNull(fetched);
@@ -978,10 +978,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         List<AsyncJobStatus> created = this.createJobsForQueryTests(keys, states, owners, null, null, null);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
-            .setOrder(Arrays.asList(new AsyncJobStatusQueryBuilder.Order("id", false)));
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
+            .setOrder(Arrays.asList(new AsyncJobStatusQueryArguments.Order("id", false)));
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
 
@@ -1004,10 +1004,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         List<AsyncJobStatus> created = this.createJobsForQueryTests(keys, states, owners, null, null, null);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
-            .setOrder(Arrays.asList(new AsyncJobStatusQueryBuilder.Order("id", true)));
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
+            .setOrder(Arrays.asList(new AsyncJobStatusQueryArguments.Order("id", true)));
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
 
@@ -1030,14 +1030,14 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         List<AsyncJobStatus> created = this.createJobsForQueryTests(keys, states, owners, null, null, null);
 
-        List<AsyncJobStatusQueryBuilder.Order> order = Arrays.asList(
-            new AsyncJobStatusQueryBuilder.Order("jobKey", false),
-            new AsyncJobStatusQueryBuilder.Order("id", true));
+        List<AsyncJobStatusQueryArguments.Order> order = Arrays.asList(
+            new AsyncJobStatusQueryArguments.Order("jobKey", false),
+            new AsyncJobStatusQueryArguments.Order("id", true));
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOrder(order);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
 
@@ -1061,10 +1061,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testFindJobsWithInvalidOrderKey() {
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
-            .setOrder(Arrays.asList(new AsyncJobStatusQueryBuilder.Order("bad_key", true)));
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
+            .setOrder(Arrays.asList(new AsyncJobStatusQueryArguments.Order("bad_key", true)));
 
-        assertThrows(InvalidOrderKeyException.class, () -> this.asyncJobCurator.findJobs(queryBuilder));
+        assertThrows(InvalidOrderKeyException.class, () -> this.asyncJobCurator.findJobs(queryArgs));
     }
 
     @Test
@@ -1104,7 +1104,7 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(jobKeys)
             .setJobStates(jobStates)
             .setOwnerIds(ownerIds)
@@ -1114,7 +1114,7 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .setStartDate(start)
             .setEndDate(end);
 
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(expected, fetched.size());
@@ -1138,8 +1138,8 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         List<AsyncJobStatus> created = this.createJobsForQueryTests(keys, states, owners, null, null, null);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder();
-        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryBuilder);
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments();
+        List<AsyncJobStatus> fetched = this.asyncJobCurator.findJobs(queryArgs);
 
         assertNotNull(fetched);
         assertEquals(created.size(), fetched.size());
@@ -1184,10 +1184,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .map(job -> job.getId())
             .collect(Collectors.toList());
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobIds(jobIds);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(expected.size(), deleted);
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1221,10 +1221,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         jobIds.addAll(expectedJobIds);
         jobIds.addAll(extraneousJobIds);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobIds(jobIds);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(expected.size(), deleted);
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1252,10 +1252,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(jobKeys);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1283,10 +1283,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(jobKeys);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1319,10 +1319,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         jobKeys.addAll(expectedKeys);
         jobKeys.addAll(extraneousKeys);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(jobKeys);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1350,10 +1350,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(jobStates);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1381,10 +1381,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(jobStates);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1417,10 +1417,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         jobStates.addAll(expectedStates);
         jobStates.addAll(extraneousStates);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(jobStates);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1452,10 +1452,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(ownerIds);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1487,10 +1487,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(ownerIds);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1527,10 +1527,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         ownerIds.addAll(expectedKeys);
         ownerIds.addAll(extraneousKeys);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(ownerIds);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1563,10 +1563,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(ownerIds);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1600,10 +1600,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(ownerIds);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1631,10 +1631,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setEndDate(now);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1662,10 +1662,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setStartDate(now);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1694,11 +1694,11 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setStartDate(start)
             .setEndDate(end);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1726,10 +1726,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .filter(job -> expected.contains(job.getPrincipalName()))
             .collect(Collectors.toList());
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setPrincipalNames(query);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(toDelete.size(), deleted);
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1757,10 +1757,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .filter(job -> expected.contains(job.getOrigin()))
             .collect(Collectors.toList());
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOrigins(query);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(toDelete.size(), deleted);
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1788,10 +1788,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .filter(job -> expected.contains(job.getExecutor()))
             .collect(Collectors.toList());
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setExecutors(query);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(toDelete.size(), deleted);
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1840,7 +1840,7 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expected.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(jobKeys)
             .setJobStates(jobStates)
             .setOwnerIds(ownerIds)
@@ -1850,7 +1850,7 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .setStartDate(start)
             .setEndDate(end);
 
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
         assertEquals(deleted, expected.size());
 
         List<AsyncJobStatus> remaining = this.asyncJobCurator.listAll().list();
@@ -1870,8 +1870,8 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         List<AsyncJobStatus> created = this.createJobsForQueryTests(keys, states, owners, null, null, null);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder();
-        int deleted = this.asyncJobCurator.deleteJobs(queryBuilder);
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments();
+        int deleted = this.asyncJobCurator.deleteJobs(queryArgs);
 
         // The sanity check should cause this to delete nothing.
         assertEquals(0, deleted);
@@ -1904,11 +1904,6 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             assertTrue(created.contains(job));
         }
     }
-
-
-
-
-
 
     /**
      * Validates the job states by checking that the jobs in the provided map have been updated to the
@@ -1963,10 +1958,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .map(job -> job.getId())
             .collect(Collectors.toList());
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobIds(expectedJobIds);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -1995,10 +1990,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
         jobIds.addAll(expectedJobIds);
         jobIds.addAll(extraneousJobIds);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobIds(jobIds);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(extraneousJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2029,10 +2024,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(combined);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2063,10 +2058,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(combined);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2097,10 +2092,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(combined);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2131,10 +2126,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(combined);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2165,10 +2160,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(combined);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2199,10 +2194,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobStates(combined);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2233,10 +2228,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(combined);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2267,10 +2262,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(combined);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2301,10 +2296,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(combined);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2331,10 +2326,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(expected);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2365,10 +2360,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOwnerIds(combined);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2395,10 +2390,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setEndDate(now);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2425,10 +2420,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setStartDate(now);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2456,11 +2451,11 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setStartDate(start)
             .setEndDate(end);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2487,10 +2482,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .map(job -> job.getId())
             .collect(Collectors.toList());
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setPrincipalNames(query);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2517,10 +2512,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .map(job -> job.getId())
             .collect(Collectors.toList());
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setOrigins(query);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2547,10 +2542,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .map(job -> job.getId())
             .collect(Collectors.toList());
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setExecutors(query);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2600,7 +2595,7 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
 
         assertTrue(expectedJobIds.size() > 0);
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder()
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments()
             .setJobKeys(jobKeys)
             .setJobStates(jobStates)
             .setOwnerIds(ownerIds)
@@ -2610,7 +2605,7 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             .setStartDate(start)
             .setEndDate(end);
 
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(expectedJobIds.size(), updated);
 
         this.validateJobStates(jobMap, expectedJobIds, JobState.ABORTED);
@@ -2628,10 +2623,10 @@ public class AsyncJobStatusCuratorTest extends DatabaseTestFixture {
             jobMap.put(job.getId(), job);
         }
 
-        AsyncJobStatusQueryBuilder queryBuilder = new AsyncJobStatusQueryBuilder();
+        AsyncJobStatusQueryArguments queryArgs = new AsyncJobStatusQueryArguments();
 
         // The sanity check should cause this to update nothing.
-        int updated = this.asyncJobCurator.updateJobState(queryBuilder, JobState.ABORTED);
+        int updated = this.asyncJobCurator.updateJobState(queryArgs, JobState.ABORTED);
         assertEquals(0, updated);
 
         this.validateJobStates(jobMap, Arrays.asList(), JobState.ABORTED);

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -17,7 +17,6 @@ package org.candlepin.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -44,7 +43,6 @@ import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -1344,8 +1342,10 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void testGetHypervisor() {
         String hypervisorid = "hypervisor";
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        HypervisorId hypervisorId = new HypervisorId(hypervisorid);
-        hypervisorId.setOwner(owner);
+        HypervisorId hypervisorId = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorid);
+
         consumer.setHypervisorId(hypervisorId);
         consumer = consumerCurator.create(consumer);
         Consumer result = consumerCurator.getHypervisor(hypervisorid, owner);
@@ -1356,8 +1356,10 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void testGetHypervisorCaseInsensitive() {
         String hypervisorid = "HYpervisor";
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        HypervisorId hypervisorId = new HypervisorId(hypervisorid);
-        hypervisorId.setOwner(owner);
+        HypervisorId hypervisorId = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorid);
+
         consumer.setHypervisorId(hypervisorId);
         consumer = consumerCurator.create(consumer);
         Consumer result = consumerCurator.getHypervisor(hypervisorid.toUpperCase(), owner);
@@ -1370,8 +1372,10 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         otherOwner = ownerCurator.create(otherOwner);
         String hypervisorid = "hypervisor";
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        HypervisorId hypervisorId = new HypervisorId(hypervisorid);
-        hypervisorId.setOwner(owner);
+        HypervisorId hypervisorId = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorid);
+
         consumer.setHypervisorId(hypervisorId);
         consumerCurator.create(consumer);
         Consumer result = consumerCurator.getHypervisor(hypervisorid, otherOwner);
@@ -1382,16 +1386,18 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void testGetHypervisorConsumerMap() {
         String hypervisorId1 = "Hypervisor";
         Consumer consumer1 = new Consumer("testConsumer", "testUser", owner, ct);
-        HypervisorId hypervisorId = new HypervisorId(hypervisorId1);
-        hypervisorId.setOwner(owner);
-        consumer1.setHypervisorId(hypervisorId);
+        HypervisorId hid1 = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorId1);
+        consumer1.setHypervisorId(hid1);
         consumer1 = consumerCurator.create(consumer1);
 
         String hypervisorId2 = "hyPERvisor2";
         Consumer consumer2 = new Consumer("testConsumer", "testUser", owner, ct);
-        HypervisorId hypervisorID2 = new HypervisorId(hypervisorId2);
-        hypervisorID2.setOwner(owner);
-        consumer2.setHypervisorId(hypervisorID2);
+        HypervisorId hid2 = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorId2);
+        consumer2.setHypervisorId(hid2);
         consumer2 = consumerCurator.create(consumer2);
 
         Set<String> hypervisorIds = new HashSet<>();
@@ -1410,9 +1416,10 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         String hypervisorId1 = "Hypervisor";
         Consumer consumer1 = new Consumer("testConsumer", "testUser", owner, ct);
         consumer1.setFact(Consumer.Facts.SYSTEM_UUID, "blah");
-        HypervisorId hypervisorId = new HypervisorId(hypervisorId1);
-        hypervisorId.setOwner(owner);
-        consumer1.setHypervisorId(hypervisorId);
+        HypervisorId hid1 = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorId1);
+        consumer1.setHypervisorId(hid1);
         consumer1 = consumerCurator.create(consumer1);
 
         List<Consumer> hypervisors = Collections.singletonList(consumer1);
@@ -1433,15 +1440,17 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         // next consumer set with the hypervisor, not the fact
         String hypervisorId2 = "hypervisor2";
         Consumer consumer2 = new Consumer("testConsumer2", "testUser2", owner, ct);
-        HypervisorId hypervisorId2Obj = new HypervisorId(hypervisorId2);
-        hypervisorId2Obj.setOwner(owner);
-        consumer2.setHypervisorId(hypervisorId2Obj);
+        HypervisorId hid2 = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorId2);
+        consumer2.setHypervisorId(hid2);
         consumer2 = consumerCurator.create(consumer2);
 
         // hypervisor report will have both the hypervisor and the fact
-        HypervisorId hypervisorId1Obj = new HypervisorId(hypervisorId1);
-        hypervisorId1Obj.setOwner(owner);
-        consumer1.setHypervisorId(hypervisorId1Obj);
+        HypervisorId hid1 = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorId1);
+        consumer1.setHypervisorId(hid1);
         List<Consumer> hypervisors = Arrays.asList(consumer1, consumer2);
 
         VirtConsumerMap hypervisorMap = consumerCurator.getHostConsumersMap(owner, hypervisors);
@@ -1454,8 +1463,10 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void testGetHypervisorsBulk() {
         String hypervisorid = "hypervisor";
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        HypervisorId hypervisorId = new HypervisorId(hypervisorid);
-        hypervisorId.setOwner(owner);
+        HypervisorId hypervisorId = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorid);
+
         consumer.setHypervisorId(hypervisorId);
         consumer = consumerCurator.create(consumer);
         List<String> hypervisorIds = new LinkedList<>();
@@ -1470,8 +1481,10 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void testGetHypervisorsBulkCaseInsensitive() {
         String hypervisorid = "hYPervisor";
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        HypervisorId hypervisorId = new HypervisorId(hypervisorid);
-        hypervisorId.setOwner(owner);
+        HypervisorId hypervisorId = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorid);
+
         consumer.setHypervisorId(hypervisorId);
         consumer = consumerCurator.create(consumer);
         List<String> hypervisorIds = new LinkedList<>();
@@ -1487,8 +1500,10 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void testGetHypervisorsBulkEmpty() {
         String hypervisorid = "hypervisor";
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        HypervisorId hypervisorId = new HypervisorId(hypervisorid);
-        hypervisorId.setOwner(owner);
+        HypervisorId hypervisorId = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorid);
+
         consumer.setHypervisorId(hypervisorId);
         consumerCurator.create(consumer);
         List<Consumer> results = consumerCurator
@@ -1500,19 +1515,27 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testGetHypervisorsByOwner() {
+        HypervisorId hid = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId("hypervisor");
+
         Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
-        HypervisorId hypervisorId = new HypervisorId("hypervisor");
-        hypervisorId.setOwner(owner);
-        consumer.setHypervisorId(hypervisorId);
+        consumer.setHypervisorId(hid);
         consumer = consumerCurator.create(consumer);
+
         Owner otherOwner = ownerCurator.create(new Owner("other owner"));
+
+        HypervisorId hid2 = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId("hypervisortwo");
+
         Consumer consumer2 = new Consumer("testConsumer2", "testUser2", otherOwner, ct);
-        HypervisorId hypervisorId2 = new HypervisorId("hypervisortwo");
-        hypervisorId2.setOwner(owner);
-        consumer2.setHypervisorId(hypervisorId2);
+        consumer2.setHypervisorId(hid2);
         consumerCurator.create(consumer2);
+
         Consumer nonHypervisor = new Consumer("testConsumer3", "testUser3", owner, ct);
         consumerCurator.create(nonHypervisor);
+
         List<Consumer> results = consumerCurator.getHypervisorsForOwner(owner.getId()).list();
         assertEquals(1, results.size());
         assertEquals(consumer, results.get(0));
@@ -1566,396 +1589,6 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         consumerCurator.delete(c);
         i = (BigInteger) em.createNativeQuery(countQuery).getSingleResult();
         assertEquals(new BigInteger("0"), i);
-    }
-
-    // select by owner
-    @Test
-    public void nullCollectionsShouldCountAllExistingConsumers() throws Exception {
-        createConsumer(owner);
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void emptyCollectionsShouldCountAllExistingConsumers() throws Exception {
-        createConsumer(owner);
-        typeLabels = new HashSet<>();
-        skus = new LinkedList<>();
-        subscriptionIds = new LinkedList<>();
-        contracts = new LinkedList<>();
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void countShouldThrowExceptionIfOwnerKeyIsNull() throws Exception {
-        String ownerKey = null;
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-            consumerCurator.countConsumers(ownerKey, typeLabels, skus, subscriptionIds, contracts)
-        );
-        assertEquals("Owner key can't be null or empty", ex.getMessage());
-    }
-
-    @Test
-    public void countShouldThrowExceptionIfOwnerKeyIsEmpty() throws Exception {
-        String ownerKey = "";
-
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-            consumerCurator.countConsumers(ownerKey, typeLabels, skus, subscriptionIds, contracts)
-        );
-        assertEquals("Owner key can't be null or empty", ex.getMessage());
-    }
-
-    @Test
-    public void countShouldReturnZeroIfOwnerHasNotAnyConsumers() throws Exception {
-        createConsumer(owner);
-        Owner ownerWithoutConsumers = createOwner();
-
-        int count = consumerCurator.countConsumers(ownerWithoutConsumers.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(0, count);
-    }
-
-    @Test
-    public void shouldCountConsumersOnlyOfGivenOwner() {
-        createConsumer(owner);
-        Owner otherOwner = createOwner();
-        createConsumer(otherOwner);
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void countShouldReturnZeroIfUnkownOwner() throws Exception {
-        createConsumer(owner);
-
-        int count = consumerCurator.countConsumers("unknown-key", typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(0, count);
-    }
-
-    //select by TypeLabels
-    @Test
-    public void shouldCountOwnerConsumersOnlyWithTypeLabels() {
-        Consumer c1 = createConsumer(owner);
-        Consumer c2 = createConsumer(owner);
-        ConsumerType c1t = consumerTypeCurator.getConsumerType(c1);
-        ConsumerType c2t = consumerTypeCurator.getConsumerType(c2);
-        String l1 = c1t.getLabel();
-        String l2 = c2t.getLabel();
-
-        assertNotEquals(l1, l2);
-        HashSet<String> typeLabels = new HashSet<>(1);
-        typeLabels.add(l1);
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void testDisjunctionInCountingWithTypeLabels() {
-        Consumer c1 = createConsumer(owner);
-        Consumer c2 = createConsumer(owner);
-        ConsumerType c1t = consumerTypeCurator.getConsumerType(c1);
-        ConsumerType c2t = consumerTypeCurator.getConsumerType(c2);
-        String l1 = c1t.getLabel();
-        String l2 = c2t.getLabel();
-
-        assertNotEquals(l1, l2);
-        HashSet<String> typeLabels = new HashSet<>(1);
-        typeLabels.add(l1);
-        typeLabels.add(l2);
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(2, count);
-    }
-
-    @Test
-    public void countShouldReturnZeroWhenUnknownLabel() throws Exception {
-        createConsumer(owner);
-        Set<String> labels = new HashSet<>();
-        labels.add("unknown-label");
-
-        int count = consumerCurator.countConsumers(owner.getKey(), labels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(0, count);
-    }
-
-    // select by SKUs
-    @Test
-    public void countWithSkuShouldWorkOnlyWithMarketingProducts() {
-        Consumer c = createConsumer(owner);
-        Product mktProduct = createMktProductAndBindItToConsumer(owner, c);
-        Product notMktproduct = createProductAndBindItToConsumer(owner, c);
-        List<String> skus = new ArrayList<>();
-        skus.add(notMktproduct.getId());
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(0, count);
-
-        skus.clear();
-        skus.add(mktProduct.getId());
-
-        count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void shouldCountConsumersOnlyWithSkus() {
-        Product p1 = createConsumerWithBindingToMKTProduct(owner);
-        Product p2 = createConsumerWithBindingToMKTProduct(owner);
-
-        assertNotEquals(p1.getId(), p2.getId());
-
-        List<String> skus = new ArrayList<>();
-        skus.add(p1.getId());
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void testDisjunctionInCountingWithSkus() {
-        Product p1 = createConsumerWithBindingToMKTProduct(owner);
-        Product p2 = createConsumerWithBindingToMKTProduct(owner);
-        List<String> skus = new ArrayList<>();
-        skus.add(p1.getId());
-        skus.add(p2.getId());
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(2, count);
-    }
-
-    @Test
-    public void countConsumerOnlyOnceIfMoreSkusMatchToSameConsumer() {
-        Consumer c = createConsumer(owner);
-        Product p1 = createMktProductAndBindItToConsumer(owner, c);
-        Product p2 = createMktProductAndBindItToConsumer(owner, c);
-        assertNotEquals(p1.getId(), p2.getId());
-
-        List<String> skus = new ArrayList<>();
-        skus.add(p1.getId());
-        skus.add(p2.getId());
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void countShouldReturnZeroIfUnknownSku() throws Exception {
-        createConsumer(owner);
-        List<String> skus = new ArrayList<>();
-        skus.add("unknown-sku");
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(0, count);
-    }
-
-    // select by subscriptionIds
-    @Test
-    public void shouldCountConsumersOnlyWithSubscriptionIds() throws Exception {
-        Product product = createProduct(owner);
-        Pool p1 = createConsumerWithBindingToProduct(owner, product);
-        Pool p2 = createConsumerWithBindingToProduct(owner, product);
-        assertNotEquals(p1.getSubscriptionId(), p2.getSubscriptionId());
-
-        List<String> ids = new ArrayList<>();
-        ids.add(p1.getSubscriptionId());
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, ids, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void testDisjunctionInCountingWithSubscriptionIds() throws Exception {
-        Product product = createProduct(owner);
-        Pool p1 = createConsumerWithBindingToProduct(owner, product);
-        Pool p2 = createConsumerWithBindingToProduct(owner, product);
-        assertNotEquals(p1.getSubscriptionId(), p2.getSubscriptionId());
-
-        List<String> ids = new ArrayList<>();
-        ids.add(p1.getSubscriptionId());
-        ids.add(p2.getSubscriptionId());
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, ids, contracts);
-
-        assertEquals(2, count);
-    }
-
-    @Test
-    public void countConsumerOnlyOnceIfMoreSubIdsMatchToSameConsumer() throws Exception {
-        Consumer c = createConsumer(owner);
-        Pool p1 = createPoolAndBindItToConsumer(owner, c);
-        Pool p2 = createPoolAndBindItToConsumer(owner, c);
-        assertNotEquals(p1.getSubscriptionId(), p2.getSubscriptionId());
-
-        List<String> ids = new ArrayList<>();
-        ids.add(p1.getSubscriptionId());
-        ids.add(p2.getSubscriptionId());
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, ids, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void countShouldReturnZeroIfUnknownSubscriptionId() throws Exception {
-        createConsumer(owner);
-        List<String> ids = new ArrayList<>();
-        ids.add("unknown-subId");
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, ids, contracts);
-
-        assertEquals(0, count);
-    }
-
-    // select by contract number
-    @Test
-    public void shouldCountConsumersOnlyWithContractNums() throws Exception {
-        Product product = createProduct(owner);
-        Pool p1 = createConsumerWithBindingToProduct(owner, product, "contract-1");
-        createConsumerAndEntitlement(owner, p1);
-        createConsumerWithBindingToProduct(owner, product, "contract-2");
-        List<String> c = new ArrayList<>();
-        c.add(p1.getContractNumber());
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, c);
-
-        assertEquals(2, count);
-    }
-
-    @Test
-    public void testDisjunctionInCountingWithContractNums() throws Exception {
-        Product product = createProduct(owner);
-        Pool p1 = createConsumerWithBindingToProduct(owner, product, "contract-1");
-        Pool p2 = createConsumerWithBindingToProduct(owner, product, "contract-2");
-        List<String> c = new ArrayList<>();
-        c.add(p1.getContractNumber());
-        c.add(p2.getContractNumber());
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, c);
-
-        assertEquals(2, count);
-    }
-
-    @Test
-    public void countConsumerOnlyOnceIfMoreContractsMatchToSameConsumer() throws Exception {
-        Consumer c = createConsumer(owner);
-        String contr1 = "contract-1";
-        String contr2 = "contract-2";
-        createProductAndBindItToConsumer(owner, c, contr1);
-        createProductAndBindItToConsumer(owner, c, contr2);
-        List<String> contracts = new ArrayList<>();
-        contracts.add(contr1);
-        contracts.add(contr2);
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels,
-            skus, subscriptionIds, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void countShouldReturnZeroIfUnknownContractNumber() throws Exception {
-        createConsumer(owner);
-        List<String> c = new ArrayList<>();
-        c.add("unknown-contract");
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels, skus, subscriptionIds, c);
-
-        assertEquals(0, count);
-    }
-
-    @Test
-    public void countShouldUseConjuctionBetweenAllParameters() throws Exception {
-        String sku = "sku";
-        String subscriptionId = "subscriptionId";
-        String poolContract = "contract";
-
-        Product skuProduct = createTransientMarketingProduct(sku);
-        skuProduct = createProduct(skuProduct, owner);
-
-        Consumer c1 = createConsumer(owner);
-        Consumer c2 = createConsumerAndBindItToProduct(owner, skuProduct);
-        Consumer c3 = createConsumerAndBindItToProduct(owner, skuProduct, subscriptionId);
-        Consumer c4 = createConsumerAndBindItToProduct(owner, skuProduct, subscriptionId, poolContract);
-        ConsumerType c1t = consumerTypeCurator.getConsumerType(c1);
-        ConsumerType c2t = consumerTypeCurator.getConsumerType(c2);
-        ConsumerType c3t = consumerTypeCurator.getConsumerType(c3);
-        ConsumerType c4t = consumerTypeCurator.getConsumerType(c4);
-
-        Set<String> labels = new HashSet<>();
-        List<String> skus = new ArrayList<>();
-        List<String> subIds = new ArrayList<>();
-        List<String> contracts = new ArrayList<>();
-        labels.add(c1t.getLabel());
-        labels.add(c2t.getLabel());
-        labels.add(c3t.getLabel());
-        labels.add(c4t.getLabel());
-        skus.add(sku);
-        subIds.add(subscriptionId);
-        contracts.add(poolContract);
-
-        int count = consumerCurator.countConsumers(owner.getKey(), typeLabels, skus, subIds, contracts);
-
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void countShouldBeIdempotent() throws Exception {
-        int n = 5;
-        int expectedCount = 0;
-        countConsumersAndAssertResultManyTimes(n, expectedCount);
-
-        for (int i = 0; i < n; i++) {
-            createConsumer(owner);
-        }
-
-        expectedCount = n;
-        countConsumersAndAssertResultManyTimes(n, expectedCount);
-    }
-
-    private void countConsumersAndAssertResultManyTimes(int many, int expectedCount) {
-        for (int i = 0; i < many; i++) {
-            int count = consumerCurator.countConsumers(owner.getKey(), typeLabels, skus,
-                subscriptionIds, contracts);
-            assertEquals(expectedCount, count);
-        }
     }
 
 }

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -543,8 +543,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         securityInterceptor.enable();
 
         assertThrows(NotFoundException.class, () ->
-            consumerResource.getEntitlementCertificates(consumer.getUuid(), null)
-        );
+            consumerResource.getEntitlementCertificates(consumer.getUuid(), null));
     }
 
     @Test
@@ -553,23 +552,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         securityInterceptor.enable();
 
         assertThrows(ForbiddenException.class, () ->
-            consumerResource.searchConsumers(null, null, null, new ArrayList<>(), null, null)
-        );
-    }
-
-    @Test
-    public void testConsumerCannotListWithUuidsAndOtherParameters() {
-        Consumer consumer = TestUtil.createConsumer(standardSystemType, owner);
-        consumerCurator.create(consumer);
-
-        setupAdminPrincipal("admin");
-        securityInterceptor.enable();
-        List<String> uuidList = new ArrayList<>();
-        uuidList.add(consumer.getUuid());
-        assertThrows(BadRequestException.class, () -> consumerResource.searchConsumers("username",
-            toSet("typeLabel"),
-            owner.getKey(), uuidList, null, null)
-        );
+            consumerResource.searchConsumers(null, null, null, new ArrayList<>(), null, null));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/HypervisorCloudProfileTest.java
+++ b/server/src/test/java/org/candlepin/resource/HypervisorCloudProfileTest.java
@@ -137,10 +137,12 @@ public class HypervisorCloudProfileTest extends DatabaseTestFixture {
         consumerTypeCurator.create(system);
 
         String hypervisorid = "test-host";
+        HypervisorId hid = new HypervisorId()
+            .setOwner(owner)
+            .setHypervisorId(hypervisorid);
+
         Consumer testConsumer = new Consumer(hypervisorid, someuser.getUsername(), owner, system);
-        HypervisorId hypervisorId = new HypervisorId(hypervisorid);
-        hypervisorId.setOwner(owner);
-        testConsumer.setHypervisorId(hypervisorId);
+        testConsumer.setHypervisorId(hid);
         testConsumer = consumerCurator.create(testConsumer);
 
         Map<String, List<String>> hostGuestMap = new HashMap<>();

--- a/server/src/test/java/org/candlepin/resource/JobResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/JobResourceTest.java
@@ -43,7 +43,7 @@ import org.candlepin.dto.api.v1.SchedulerStatusDTO;
 import org.candlepin.model.AsyncJobStatus;
 import org.candlepin.model.AsyncJobStatus.JobState;
 import org.candlepin.model.AsyncJobStatusCurator;
-import org.candlepin.model.AsyncJobStatusCurator.AsyncJobStatusQueryBuilder;
+import org.candlepin.model.AsyncJobStatusCurator.AsyncJobStatusQueryArguments;
 import org.candlepin.model.InvalidOrderKeyException;
 import org.candlepin.model.Owner;
 import org.candlepin.resource.util.JobStateMapper;
@@ -294,10 +294,10 @@ public class JobResourceTest extends DatabaseTestFixture {
         AsyncJobStatus status3 = mock(AsyncJobStatus.class);
         List<AsyncJobStatus> expected = Arrays.asList(status1, status2, status3);
 
-        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(ids, null, null, null, null,
@@ -305,7 +305,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertEquals(ids, builder.getJobIds());
@@ -337,10 +337,10 @@ public class JobResourceTest extends DatabaseTestFixture {
         AsyncJobStatus status3 = mock(AsyncJobStatus.class);
         List<AsyncJobStatus> expected = Arrays.asList(status1, status2, status3);
 
-        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, values, null, null, null,
@@ -348,7 +348,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -376,15 +376,15 @@ public class JobResourceTest extends DatabaseTestFixture {
     @ParameterizedTest
     @MethodSource("targetJobStatusesWithJobStatesProvider")
     public void testListJobStatusesWithJobStates(Set<String> stateNames, Set<JobState> expected) {
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, stateNames, null, null,
             null, null, null, null);
 
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -422,15 +422,15 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         Set<String> keys = Util.asSet(owner1.getKey(), owner2.getKey(), owner3.getKey());
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, null, keys, null,
             null, null, null, null);
 
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -461,15 +461,15 @@ public class JobResourceTest extends DatabaseTestFixture {
         Set<String> keys = Util.asSet("", owner1.getKey(), "bad_key", owner2.getKey(), null);
         Set<String> expected = Util.asSet("", owner1.getId(), "bad_key", owner2.getId(), null);
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, null, keys, null,
             null, null, null, null);
 
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -501,15 +501,15 @@ public class JobResourceTest extends DatabaseTestFixture {
         Set<String> keys = Util.asSet(owner1.getKey(), "null", owner2.getKey());
         Set<String> expected = Util.asSet(owner1.getId(), null, owner2.getId());
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, null, keys, null,
             null, null, null, null);
 
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -541,10 +541,10 @@ public class JobResourceTest extends DatabaseTestFixture {
         AsyncJobStatus status3 = mock(AsyncJobStatus.class);
         List<AsyncJobStatus> expected = Arrays.asList(status1, status2, status3);
 
-        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, null, null, values,
@@ -552,7 +552,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -584,10 +584,10 @@ public class JobResourceTest extends DatabaseTestFixture {
         AsyncJobStatus status3 = mock(AsyncJobStatus.class);
         List<AsyncJobStatus> expected = Arrays.asList(status1, status2, status3);
 
-        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, null, null, null,
@@ -595,7 +595,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -627,10 +627,10 @@ public class JobResourceTest extends DatabaseTestFixture {
         AsyncJobStatus status3 = mock(AsyncJobStatus.class);
         List<AsyncJobStatus> expected = Arrays.asList(status1, status2, status3);
 
-        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, null, null, null,
@@ -638,7 +638,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -670,10 +670,10 @@ public class JobResourceTest extends DatabaseTestFixture {
         AsyncJobStatus status3 = mock(AsyncJobStatus.class);
         List<AsyncJobStatus> expected = Arrays.asList(status1, status2, status3);
 
-        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, null, null, null,
@@ -681,7 +681,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -713,10 +713,10 @@ public class JobResourceTest extends DatabaseTestFixture {
         AsyncJobStatus status3 = mock(AsyncJobStatus.class);
         List<AsyncJobStatus> expected = Arrays.asList(status1, status2, status3);
 
-        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, null, null, null,
@@ -724,7 +724,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -762,10 +762,10 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         int expectedOffset = (pageRequest.getPage() - 1) * pageRequest.getPerPage();
 
-        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, null, null, null,
@@ -773,7 +773,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -814,10 +814,10 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         ResteasyContext.pushContext(PageRequest.class, pageRequest);
 
-        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).findJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         Stream<AsyncJobStatusDTO> result = resource.listJobStatuses(null, null, null, null, null,
@@ -825,7 +825,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         verify(this.jobManager, times(1)).findJobs(captor.capture());
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -843,7 +843,7 @@ public class JobResourceTest extends DatabaseTestFixture {
         assertNotNull(builder.getOrder());
         assertEquals(1, builder.getOrder().size());
 
-        AsyncJobStatusQueryBuilder.Order queryOrder = builder.getOrder().iterator().next();
+        AsyncJobStatusQueryArguments.Order queryOrder = builder.getOrder().iterator().next();
         assertNotNull(queryOrder);
         assertEquals(pageRequest.getSortBy(), queryOrder.column());
         assertEquals(pageRequest.getOrder() == PageRequest.Order.DESCENDING, queryOrder.reverse());
@@ -884,7 +884,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testListJobStatusesFailsWhenResultMaxLimitExceeded() {
-        doReturn(10001L).when(this.jobCurator).getJobCount(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(10001L).when(this.jobCurator).getJobCount(any(AsyncJobStatusQueryArguments.class));
 
         JobResource resource = this.buildJobResource();
         assertThrows(BadRequestException.class, () ->
@@ -893,7 +893,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testListJobStatusesDoesNotFailWhenResultMaxLimitNotExceeded() {
-        doReturn(10000L).when(this.jobCurator).getJobCount(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(10000L).when(this.jobCurator).getJobCount(any(AsyncJobStatusQueryArguments.class));
 
         JobResource resource = this.buildJobResource();
         assertDoesNotThrow(() ->
@@ -982,11 +982,11 @@ public class JobResourceTest extends DatabaseTestFixture {
 
     public void testCleanupTerminalJobsByIds(Set<String> values, boolean force) {
         int expected = new Random().nextInt();
-        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
-        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
+        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(values, null, null, null, null,
@@ -994,15 +994,15 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
 
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
         assertNotNull(builder);
         assertEquals(values, builder.getJobIds());
         assertNull(builder.getJobKeys());
@@ -1027,11 +1027,11 @@ public class JobResourceTest extends DatabaseTestFixture {
 
     public void testCleanupTerminalJobsByKeys(Set<String> values, boolean force) {
         int expected = new Random().nextInt();
-        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
-        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
+        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(null, values, null, null, null,
@@ -1039,15 +1039,15 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
 
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
         assertNotNull(builder);
         assertNull(builder.getJobIds());
         assertEquals(values, builder.getJobKeys());
@@ -1073,23 +1073,23 @@ public class JobResourceTest extends DatabaseTestFixture {
     public void testCleanupTerminalJobsWithJobStates(Set<String> stateNames, Set<JobState> expected,
         boolean force) {
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(null, null, stateNames, null, null, null, null,
             null, null, force);
 
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
 
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
         assertNotNull(builder);
         assertNull(builder.getJobIds());
         assertNull(builder.getJobKeys());
@@ -1136,22 +1136,22 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         Set<String> keys = Util.asSet(owner1.getKey(), owner2.getKey(), owner3.getKey());
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(null, null, null, keys, null, null,
             null, null, null, force);
 
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -1180,22 +1180,22 @@ public class JobResourceTest extends DatabaseTestFixture {
         Set<String> keys = Util.asSet("", owner1.getKey(), "key", owner2.getKey(), null);
         Set<String> expected = Util.asSet("", owner1.getId(), "key", owner2.getId(), null);
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(null, null, null, keys, null, null,
             null, null, null, force);
 
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -1225,23 +1225,23 @@ public class JobResourceTest extends DatabaseTestFixture {
         Set<String> keys = Util.asSet(owner1.getKey(), "null", owner2.getKey());
         Set<String> expected = Util.asSet(owner1.getId(), null, owner2.getId());
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(null, null, null, keys, null, null,
             null, null, null, force);
 
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
 
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
 
         assertNotNull(builder);
         assertNull(builder.getJobIds());
@@ -1272,11 +1272,11 @@ public class JobResourceTest extends DatabaseTestFixture {
 
     public void testCleanupTerminalJobsByPrincipals(Set<String> values, boolean force) {
         int expected = new Random().nextInt();
-        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
-        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
+        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(null, null, null, null, values,
@@ -1284,15 +1284,15 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
 
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
         assertNotNull(builder);
         assertNull(builder.getJobIds());
         assertNull(builder.getJobKeys());
@@ -1317,11 +1317,11 @@ public class JobResourceTest extends DatabaseTestFixture {
 
     public void testCleanupTerminalJobsByOrigins(Set<String> values, boolean force) {
         int expected = new Random().nextInt();
-        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
-        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
+        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(null, null, null, null, null,
@@ -1329,15 +1329,15 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
 
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
         assertNotNull(builder);
         assertNull(builder.getJobIds());
         assertNull(builder.getJobKeys());
@@ -1362,11 +1362,11 @@ public class JobResourceTest extends DatabaseTestFixture {
 
     public void testCleanupTerminalJobsByExecutors(Set<String> values, boolean force) {
         int expected = new Random().nextInt();
-        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
-        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
+        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(null, null, null, null, null,
@@ -1374,15 +1374,15 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
 
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
         assertNotNull(builder);
         assertNull(builder.getJobIds());
         assertNull(builder.getJobKeys());
@@ -1407,11 +1407,11 @@ public class JobResourceTest extends DatabaseTestFixture {
 
     public void testCleanupTerminalJobsByStartDate(Date value, boolean force) {
         int expected = new Random().nextInt();
-        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
-        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
+        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(null, null, null, null, null,
@@ -1419,15 +1419,15 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
 
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
         assertNotNull(builder);
         assertNull(builder.getJobIds());
         assertNull(builder.getJobKeys());
@@ -1452,11 +1452,11 @@ public class JobResourceTest extends DatabaseTestFixture {
 
     public void testCleanupTerminalJobsByEndDate(Date value, boolean force) {
         int expected = new Random().nextInt();
-        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
-        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+        doReturn(expected).when(this.jobManager).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
+        doReturn(expected).when(this.jobCurator).deleteJobs(any(AsyncJobStatusQueryArguments.class));
 
-        ArgumentCaptor<AsyncJobStatusQueryBuilder> captor =
-            ArgumentCaptor.forClass(AsyncJobStatusQueryBuilder.class);
+        ArgumentCaptor<AsyncJobStatusQueryArguments> captor =
+            ArgumentCaptor.forClass(AsyncJobStatusQueryArguments.class);
 
         JobResource resource = this.buildJobResource();
         int result = resource.cleanupTerminalJobs(null, null, null, null, null,
@@ -1464,15 +1464,15 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         // Verify the input passthrough is working properly
         if (force) {
-            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobManager, never()).cleanupJobs(any(AsyncJobStatusQueryArguments.class));
             verify(this.jobCurator, times(1)).deleteJobs(captor.capture());
         }
         else {
             verify(this.jobManager, times(1)).cleanupJobs(captor.capture());
-            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryBuilder.class));
+            verify(this.jobCurator, never()).deleteJobs(any(AsyncJobStatusQueryArguments.class));
         }
 
-        AsyncJobStatusQueryBuilder builder = captor.getValue();
+        AsyncJobStatusQueryArguments builder = captor.getValue();
         assertNotNull(builder);
         assertNull(builder.getJobIds());
         assertNull(builder.getJobKeys());


### PR DESCRIPTION
- /consumers and /owners/{owner_key}/consumers now force pagination
  if a query would fetch more than 1000 consumers in a single
  request
- The /consumers and /consumers/count endpoints no longer accept
  SKU, subscription ID, or contract number as selection criteria
- Updated several methods from HypervisorId and Consumer to be
  chainable for cleaner configuration and instantiation
- Updated the authentication framework to support "secure criteria"
  logic with JPA criteria queries