### PR TITLE
ENT-3856: Fix to revoke SCA cert upon client unregistration

### DIFF
--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -1039,4 +1039,22 @@ describe 'Content Access' do
     expect(status['status']).to eq("disabled")
   end
 
+  it 'should revoke sca certs upon un-registration' do
+    consumer = consumer_client(@user, @consumername, type=:system, username=nil,
+      facts= {'system.certificate_version' => '3.3'})
+    certs = consumer.list_certificates()
+
+    expect(certs.length).to eq(1)
+
+    cert_serial = certs[0]['serial']
+
+    expect(cert_serial).to_not be_nil
+    expect(cert_serial.revoked).to be(false)
+
+    consumer.unregister(consumer.uuid)
+    serial_after_unregistration = @cp.get_serial(cert_serial.id)
+
+    expect(serial_after_unregistration.revoked).to be(true)
+  end
+
 end

--- a/server/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -663,12 +663,10 @@ public class ContentAccessManager {
 
     @Transactional
     public void removeContentAccessCert(Consumer consumer) {
-        if (consumer.getContentAccessCert() == null) {
-            return;
+        if (consumer.getContentAccessCert() != null) {
+            this.contentAccessCertificateCurator.delete(consumer.getContentAccessCert());
+            consumer.setContentAccessCert(null);
         }
-
-        this.contentAccessCertificateCurator.delete(consumer.getContentAccessCert());
-        consumer.setContentAccessCert(null);
     }
 
 

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1877,7 +1877,7 @@ public class ConsumerResource implements ConsumersApi {
         }
 
         consumerRules.onConsumerDelete(toDelete);
-
+        contentAccessManager.removeContentAccessCert(toDelete);
         Event event = eventFactory.consumerDeleted(toDelete);
         consumerCurator.delete(toDelete);
         identityCertService.deleteIdentityCert(toDelete);

--- a/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -282,6 +282,14 @@ public class ContentAccessManagerTest {
         return environment;
     }
 
+    private ContentAccessCertificate mockContentAccessCertificate(Consumer consumer) {
+        ContentAccessCertificate cert = new ContentAccessCertificate();
+        cert.setId("123456789");
+        cert.setKey("test-key");
+        cert.setConsumer(consumer);
+        return cert;
+    }
+
     @Test
     public void testContentAccessModeResolveNameWithValidNames() {
         ContentAccessMode output = ContentAccessMode.resolveModeName(entitlementMode);
@@ -676,5 +684,18 @@ public class ContentAccessManagerTest {
 
         verify(this.x509V3ExtensionUtil, times(1)).mapProduct(any(Product.class), any(Product.class),
             eq(expectedPrefix), any(Map.class), any(Consumer.class), any(Pool.class), any(Set.class));
+    }
+
+    @Test
+    public void testRemoveContentAccessCert() {
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+        ContentAccessManager manager = this.createManager();
+        ContentAccessCertificate cert = this.mockContentAccessCertificate(consumer);
+        consumer.setContentAccessCert(cert);
+        doNothing().when(this.mockContentAccessCertCurator).delete(any(ContentAccessCertificate.class));
+        manager.removeContentAccessCert(consumer);
+
+        assertNull(consumer.getContentAccessCert());
     }
 }


### PR DESCRIPTION
Changes
- Fix to revoke SCA cert when client unregisters.