### PR TITLE
[4.0] Print rspec results to file

### DIFF
--- a/buildSrc/src/main/groovy/Rspec.groovy
+++ b/buildSrc/src/main/groovy/Rspec.groovy
@@ -32,6 +32,9 @@ class Rspec extends DefaultTask {
     @Input
     String spec = ""
 
+    @Input
+    boolean fileOutput = true
+
     @Option(option = 'spec', description = 'The name of the spec file to search. Example: "core_and_ram"')
     void setSpec(final String specfile_name) {
         this.spec = specfile_name
@@ -40,6 +43,11 @@ class Rspec extends DefaultTask {
     @Option(option = 'test', description = 'Set the name of the spec test to run')
     void setTest(final String test_name) {
         this.test = test_name
+    }
+
+    @Option(option = 'no-file', description = 'Do not write output to an html file (the output is saved to a file by default)')
+    void setFileOutput(final boolean out) {
+        this.fileOutput = false
     }
 
     @TaskAction
@@ -51,6 +59,14 @@ class Rspec extends DefaultTask {
                 "--format", "ModifiedRSpec::FailuresFormatter",
                 "-I", "${project.getProjectDir()}/client/ruby"
         ]
+
+        if (fileOutput) {
+            rspec_args.add("--format")
+            rspec_args.add("h")
+            rspec_args.add("--force-color")
+            rspec_args.add("--out")
+            rspec_args.add("build/reports/tests/rspec/index.html")
+        }
 
         // Use --pattern to match the name of the spec file for the spec argument
         if (spec){

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -62,10 +62,13 @@ build_rspec() {
     RSPEC_FILTER=$1
 
     BUILDR_ARGS="rspec"
+    GRADLE_ARGS=""
     if [ ! -z "$RSPEC_FILTER" ]; then
         BUILDR_ARGS="rspec:${RSPEC_FILTER}"
         GRADLE_ARGS="--spec ${RSPEC_FILTER}"
     fi
+
+    GRADLE_ARGS="${GRADLE_ARGS} --no-file"
 
     if [ -f ../gradlew ]; then
         ../gradlew rspec ${GRADLE_ARGS}


### PR DESCRIPTION
- The gradle rspec command will now write the output to
  server/build/reports/tests/rspec/index.html by default
- Use '--no-file' to prevent the file from being generated
- When run in the container that Jenkins uses, it will not
  generate the file by default