### PR TITLE
ENT-3811: Trim whitespace in addons and roles

### DIFF
--- a/common/src/main/java/org/candlepin/common/config/PropertyConverter.java
+++ b/common/src/main/java/org/candlepin/common/config/PropertyConverter.java
@@ -14,13 +14,14 @@
  */
 package org.candlepin.common.config;
 
+import org.candlepin.common.util.Util;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -146,8 +147,7 @@ public class PropertyConverter {
 
     public static List<String> toList(Object value) {
         if (value instanceof String) {
-            String[] parts = ((String) value).trim().split("\\s*,\\s*");
-            return Arrays.asList(parts);
+            return Util.toList((String) value);
         }
         else {
             String msg = formatErrorMessage(value, List.class);
@@ -158,8 +158,7 @@ public class PropertyConverter {
 
     public static Set<String> toSet(Object value) {
         if (value instanceof String) {
-            String[] parts = ((String) value).trim().split("\\s*,\\s*");
-            return new HashSet<>(Arrays.asList(parts));
+            return new HashSet<>(Util.toList((String) value));
         }
         else {
             String msg = formatErrorMessage(value, Set.class);

--- a/common/src/main/java/org/candlepin/common/util/Util.java
+++ b/common/src/main/java/org/candlepin/common/util/Util.java
@@ -15,10 +15,14 @@
 package org.candlepin.common.util;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Basic utilities.
@@ -41,4 +45,14 @@ public class Util {
             return new String(data);
         }
     }
+
+    // TODO A copy of Util.toList from server module. Delete after modules are merged
+    @Deprecated
+    public static List<String> toList(String list) {
+        if (StringUtils.isBlank(list)) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(list.trim().split("\\s*,[\\s,]*"));
+    }
+
 }

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -105,7 +105,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.inject.Provider;
@@ -120,7 +119,6 @@ public class CandlepinPoolManager implements PoolManager {
 
     private static final Logger log = LoggerFactory.getLogger(CandlepinPoolManager.class);
     private static final int MAX_ENTITLE_RETRIES = 3;
-    private static final Pattern ATTRIBUTE_VALUE_DELIMITER = Pattern.compile("\\s*,\\s*");
 
     private final I18n i18n;
     private final PoolCurator poolCurator;
@@ -1466,7 +1464,7 @@ public class CandlepinPoolManager implements PoolManager {
 
                 // Since we need a case-insensitive lookup here, we can't use the set's
                 // .contains method. :(
-                for (String prodAddon : ATTRIBUTE_VALUE_DELIMITER.split(prodAddons.trim())) {
+                for (String prodAddon : Util.toList(prodAddons)) {
                     for (String consumerAddon : consumerAddons) {
                         if (consumerAddon != null &&
                             prodAddon.equalsIgnoreCase(consumerAddon.trim())) {
@@ -1498,7 +1496,7 @@ public class CandlepinPoolManager implements PoolManager {
         // Check if the product's roles match the consumer's role
         String prodRoles = pool.getProductAttributes().get(Product.Attributes.ROLES);
         if (prodRoles != null) {
-            for (String prodRole : ATTRIBUTE_VALUE_DELIMITER.split(prodRoles)) {
+            for (String prodRole : Util.toList(prodRoles)) {
                 if (prodRole.equalsIgnoreCase(consumer.getRole())) {
                     return true;
                 }

--- a/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
+++ b/server/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
@@ -24,6 +24,7 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
 import org.candlepin.policy.js.compliance.hash.ComplianceStatusHasher;
+import org.candlepin.util.Util;
 
 import com.google.inject.Inject;
 
@@ -33,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -187,9 +187,7 @@ public class SystemPurposeComplianceRules {
             for (Product product : entitlementProducts) {
                 if (StringUtils.isNotEmpty(unsatisfedRole) &&
                     product.hasAttribute(Product.Attributes.ROLES)) {
-                    List<String> roles =
-                        Arrays.asList(product.getAttributeValue(Product.Attributes.ROLES)
-                        .trim().split("\\s*,\\s*"));
+                    List<String> roles = Util.toList(product.getAttributeValue(Product.Attributes.ROLES));
 
                     final String unsatisfedRoleFinalCopy = unsatisfedRole;
                     if (roles.stream()
@@ -202,9 +200,7 @@ public class SystemPurposeComplianceRules {
                 Set<String> addonsFound = new HashSet<>();
                 if (CollectionUtils.isNotEmpty(unsatisfiedAddons) &&
                     product.hasAttribute(Product.Attributes.ADDONS)) {
-                    List<String> addOns =
-                        Arrays.asList(product.getAttributeValue(Product.Attributes.ADDONS)
-                        .trim().split("\\s*,\\s*"));
+                    List<String> addOns = Util.toList(product.getAttributeValue(Product.Attributes.ADDONS));
                     for (String addOn: unsatisfiedAddons) {
                         if (addOns.stream().anyMatch(str -> str.equalsIgnoreCase(addOn.trim()))) {
                             status.addCompliantAddOn(addOn, entitlement);

--- a/server/src/main/java/org/candlepin/resource/JobResource.java
+++ b/server/src/main/java/org/candlepin/resource/JobResource.java
@@ -26,6 +26,7 @@ import org.candlepin.common.exceptions.IseException;
 import org.candlepin.common.exceptions.NotFoundException;
 import org.candlepin.common.paging.Page;
 import org.candlepin.common.paging.PageRequest;
+import org.candlepin.common.util.Util;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.v1.AsyncJobStatusDTO;
@@ -360,7 +361,7 @@ public class JobResource implements JobsApi {
 
             String jobList = this.config.getString(ConfigProperties.ASYNC_JOBS_TRIGGERABLE_JOBS, null);
             if (jobList != null) {
-                for (String job : jobList.split("\\s*,\\s*")) {
+                for (String job : Util.toList(jobList)) {
                     if (job.length() > 0) {
                         this.triggerableJobKeys.add(job.toLowerCase());
                     }

--- a/server/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1719,7 +1719,7 @@ public class OwnerResource implements OwnersApi {
                 String purposeValue = p.getAttributeValue(type.toString());
                 Set<String> purposes = new LinkedHashSet<>();
                 if (purposeValue != null) {
-                    purposes = new LinkedHashSet<>(Arrays.asList(purposeValue.split("\\s*,\\s*")));
+                    purposes = new LinkedHashSet<>(Util.toList(purposeValue));
                 }
                 dtoMap.get(type.toString()).addAll(purposes);
             }

--- a/server/src/main/java/org/candlepin/util/Arch.java
+++ b/server/src/main/java/org/candlepin/util/Arch.java
@@ -54,7 +54,7 @@ public class Arch {
 
         // split on comma, but try to include any whitespace
         // or repeated commas
-        for (String arch : arches.split(",[\\s,]*")) {
+        for (String arch : Util.toList(arches)) {
             if (!arch.isEmpty()) {
                 archesSet.add(arch.trim());
             }

--- a/server/src/main/java/org/candlepin/util/Util.java
+++ b/server/src/main/java/org/candlepin/util/Util.java
@@ -603,15 +603,18 @@ public class Util {
     }
 
     /**
-     * Split a given string and return in as a List
+     * Splits a given string by comma and returns it as a List.
+     *
+     * Handles redundant whitespace and repeated commas.
+     *
      * @param list a string to be split
      * @return a list of values
      */
     public static List<String> toList(String list) {
-        if (list == null) {
+        if (StringUtils.isBlank(list)) {
             return Collections.emptyList();
         }
-        return Arrays.asList(list.split(","));
+        return Arrays.asList(list.trim().split("\\s*,[\\s,]*"));
     }
 
     /*

--- a/server/src/main/resources/rules/rules.js
+++ b/server/src/main/resources/rules/rules.js
@@ -1,4 +1,4 @@
-// Version: 5.41
+// Version: 5.42
 
 /*
  * Default Candlepin rule set.
@@ -308,7 +308,7 @@ function createPool(pool, consumer) {
         }
         else {
             if (attribute === 'addons' || attribute === 'roles') {
-                poolSet = this.getProductAttribute(attribute).split(',');
+                poolSet = this.getProductAttribute(attribute).trim().split(/\s*,[\s,]*/);
             }
             else if (attribute === 'support_level' || attribute === 'usage') {
                 poolSet = [this.getProductAttribute(attribute)];

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -751,7 +751,8 @@ public class AutobindRulesTest {
         // --- No satisfied syspurpose attributes on the consumer ---
 
         // Candidate pools:
-        Product prod1 = createSysPurposeProduct(null, "RHEL Server", "RHEL EUS", null, "Production");
+        Product prod1 = createSysPurposeProduct(
+            null, " RHEL Server , RHEL Server2 ", "RHEL EUS", null, "Production");
         prod1.addProvidedProduct(product69);
 
         Pool p1 = TestUtil.createPool(owner, prod1)
@@ -1718,7 +1719,7 @@ public class AutobindRulesTest {
         // --- No satisfied syspurpose attributes on the consumer ---
 
         // Candidate pools:
-        Product prodMCT1650 = createSysPurposeProduct(null, null, "Smart Management,Other Management",
+        Product prodMCT1650 = createSysPurposeProduct(null, null, " Smart Management , Other Management ",
             null, null);
         prodMCT1650.addProvidedProduct(product69);
         Pool MCT1650 = TestUtil.createPool(owner, prodMCT1650);
@@ -4017,7 +4018,7 @@ public class AutobindRulesTest {
         consumer.setRole("JBoss");
 
         // Product with multiple roles:
-        Product prod1 = createSysPurposeProduct(null, "RHEL Server,  JBoss,  Satellite", null, null, null);
+        Product prod1 = createSysPurposeProduct(null, " RHEL Server ,  JBoss,  Satellite", null, null, null);
         Pool p1 = TestUtil.createPool(owner, prod1);
         p1.setId("p1");
         List<Pool> pools = new ArrayList<>();
@@ -4042,7 +4043,7 @@ public class AutobindRulesTest {
         consumer.setAddOns(addons);
 
         // Product with multiple addons:
-        Product prod1 = createSysPurposeProduct(null, null, "RHEL EUS,   RHEL ELS ", null, null);
+        Product prod1 = createSysPurposeProduct(null, null, " RHEL EUS ,,   RHEL ELS ", null, null);
         Pool p1 = TestUtil.createPool(owner, prod1);
         p1.setId("p1");
         List<Pool> pools = new ArrayList<>();

--- a/server/src/test/java/org/candlepin/policy/SystemPurposeComplianceRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/SystemPurposeComplianceRulesTest.java
@@ -33,8 +33,8 @@ import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
 import org.candlepin.test.TestUtil;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.xnap.commons.i18n.I18n;
@@ -49,9 +49,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-/**
- * Tests for SystemPurposeComplianceRules
- */
+
+
 public class SystemPurposeComplianceRulesTest {
 
     private SystemPurposeComplianceRules complianceRules;
@@ -62,7 +61,7 @@ public class SystemPurposeComplianceRulesTest {
     @Mock private ConsumerTypeCurator consumerTypeCurator;
     @Mock private PoolCurator poolCurator;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         Locale locale = new Locale("en_US");

--- a/server/src/test/java/org/candlepin/util/UtilTest.java
+++ b/server/src/test/java/org/candlepin/util/UtilTest.java
@@ -38,7 +38,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 
@@ -426,4 +430,31 @@ public class UtilTest {
         OffsetDateTime actualDate = Util.parseOffsetDateTime(formatter, "Mon, 11 Jan 2021");
         Assertions.assertEquals("2021-01-11T00:00Z", actualDate.toString());
     }
+
+    @Nested
+    class ToListTest {
+
+        @Test
+        @DisplayName("A null cannot be split")
+        void nullString() {
+            assertTrue(Util.toList(null).isEmpty());
+        }
+
+        @ParameterizedTest(name = "An invalid value: \"{0}\" cannot be split")
+        @ValueSource(strings = { "", " ", " , " })
+        void emptyString(String list) {
+            assertTrue(Util.toList(list).isEmpty());
+        }
+
+        @ParameterizedTest(name = "A valid value: \"{0}\" can be split")
+        @ValueSource(strings = { "item1, item2", " item1,item2 ", " item1 , item2 " })
+        void validString(String list) {
+            List<String> items = Util.toList(list);
+
+            assertEquals(2, items.size());
+            assertTrue(items.contains("item1"));
+            assertTrue(items.contains("item2"));
+        }
+    }
+
 }

--- a/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
+++ b/server/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
@@ -14,9 +14,10 @@
  */
 package org.candlepin.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import org.candlepin.TestingModules;
@@ -24,7 +25,6 @@ import org.candlepin.common.config.Configuration;
 import org.candlepin.model.Branding;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Content;
-import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
@@ -42,8 +42,8 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.name.Named;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -53,16 +53,13 @@ import java.util.Set;
 
 
 
-/**
- * X509V3ExtensionUtilTest
- */
 public class X509V3ExtensionUtilTest {
     private Configuration config;
     private EntitlementCurator ec;
     private X509V3ExtensionUtil util;
     @Inject @Named("X509V3ExtensionUtilObjectMapper") private ObjectMapper mapper;
 
-    @Before
+    @BeforeEach
     public void init() {
         config = mock(Configuration.class);
         ec = mock(EntitlementCurator.class);
@@ -84,25 +81,25 @@ public class X509V3ExtensionUtilTest {
         assertEquals(np, np1);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void nullCompareTo() {
         PathNode pn = util.new PathNode();
         NodePair np = new NodePair("name", pn);
-        assertEquals(1, np.compareTo(null));
+        assertThrows(NullPointerException.class, () -> np.compareTo(null));
     }
 
     @Test
     public void nullEquals() {
         PathNode pn = util.new PathNode();
         NodePair np = new NodePair("name", pn);
-        assertFalse(np.equals(null));
+        assertNotEquals(null, np);
     }
 
     @Test
     public void otherObjectEquals() {
         PathNode pn = util.new PathNode();
         NodePair np = new NodePair("name", pn);
-        assertFalse(np.equals(pn));
+        assertNotEquals(np, pn);
     }
 
     @Test
@@ -111,12 +108,11 @@ public class X509V3ExtensionUtilTest {
         NodePair np = new NodePair("name", pn);
         NodePair np1 = new NodePair("diff", pn);
         assertTrue(np.compareTo(np1) > 0);
-        assertFalse(np.equals(np1));
+        assertNotEquals(np, np1);
     }
 
     @Test
     public void testPrefixLogic() {
-        Owner owner = new Owner("Test Corporation");
         Product p = new Product("JarJar", "Binks");
         Content c = new Content();
         c.setContentUrl("/some/path");
@@ -161,7 +157,6 @@ public class X509V3ExtensionUtilTest {
         Pool pool = TestUtil.createPool(mktProd);
         Consumer consumer = new Consumer();
         consumer.setOwner(owner);
-        Entitlement e = new Entitlement(pool, consumer, owner, 10);
 
         List<org.candlepin.model.dto.Product> certProds = util.createProducts(mktProd,
             prods, "", new HashMap<>(), consumer, pool);
@@ -205,25 +200,27 @@ public class X509V3ExtensionUtilTest {
     }
 
     @Test
-    public void susbcriptionWithSyspurposeAttributes() throws JsonProcessingException {
+    public void subscriptionWithSysPurposeAttributes() throws JsonProcessingException {
         Owner owner = new Owner("Test Corporation");
         Product mktProd = new Product("mkt", "MKT SKU");
         mktProd.setAttribute(Product.Attributes.USAGE, "my_usage");
         mktProd.setAttribute(Product.Attributes.SUPPORT_LEVEL, "my_support_level");
         mktProd.setAttribute(Product.Attributes.SUPPORT_TYPE, "my_support_type");
-        mktProd.setAttribute(Product.Attributes.ROLES, " my_role1, my_role2 ");
-        mktProd.setAttribute(Product.Attributes.ADDONS, " my_addon1, my_addon2 ");
+        mktProd.setAttribute(Product.Attributes.ROLES, " my_role1, my_role2 , my_role3 ");
+        mktProd.setAttribute(Product.Attributes.ADDONS, " my_addon1, my_addon2 , my_addon3 ");
         Pool pool = TestUtil.createPool(owner, mktProd);
 
         TinySubscription subscription = util.createSubscription(pool);
         String output = this.mapper.writeValueAsString(subscription);
-        assertTrue("The serialized data should contain usage!", output.contains("my_usage"));
-        assertTrue("The serialized data should contain support level!", output.contains("my_support_level"));
-        assertTrue("The serialized data should contain support type!", output.contains("my_support_type"));
-        assertTrue("The serialized data should contain role!", output.contains("my_role1"));
-        assertTrue("The serialized data should contain role!", output.contains("my_role2"));
-        assertTrue("The serialized data should contain addon!", output.contains("my_addon1"));
-        assertTrue("The serialized data should contain addon!", output.contains("my_addon2"));
+        assertTrue(output.contains("my_usage"), "The serialized data should contain usage!");
+        assertTrue(output.contains("my_support_level"), "The serialized data should contain support level!");
+        assertTrue(output.contains("my_support_type"), "The serialized data should contain support type!");
+        assertTrue(output.contains("my_role1"), "The serialized data should contain role!");
+        assertTrue(output.contains("my_role2"), "The serialized data should contain role!");
+        assertTrue(output.contains("my_role3"), "The serialized data should contain role!");
+        assertTrue(output.contains("my_addon1"), "The serialized data should contain addon!");
+        assertTrue(output.contains("my_addon2"), "The serialized data should contain addon!");
+        assertTrue(output.contains("my_addon3"), "The serialized data should contain addon!");
     }
 
 }


### PR DESCRIPTION
- Extracted utillity method Util.toList
- Reused toList for other places where we handled whitespace
- Updated rules to handle whitespace when splitting addons and roles