### PR TITLE
[4.0] ENT-3911: 1964106: derivedProvidedProducts is now null where it was previously [] 

### DIFF
--- a/server/spec/subscription_resource_spec.rb
+++ b/server/spec/subscription_resource_spec.rb
@@ -48,4 +48,32 @@ describe 'Subscription Resource' do
           e.to_s.eql? "bad URI(is not URI?): pools/{pool_id}/cert"
       end
   end
+
+  it 'subscriptions derived/provided products should return empty array when null' do
+      # Product does not have derived/provided products
+      pool = @cp.create_pool(@owner['key'], @some_product.id, { :quantity => 2, :subscriptionId => "test-subscription1" })
+      sublist = @cp.list_subscriptions(@owner['key'])
+      expect(sublist[0]['providedProducts']).to eq([])
+      expect(sublist[0]['derivedProvidedProducts']).to eq([])
+      @cp.delete_pool(pool.id)
+
+      # Product provided products only
+      provided_product = create_product(random_string('provided_product'))
+      product1 = create_product(random_string('product1'), random_string('product1'), {:providedProducts => [provided_product.id]})
+      pool = @cp.create_pool(@owner['key'], product1.id, { :quantity => 2, :subscriptionId => "test-subscription2" })
+      sublist = @cp.list_subscriptions(@owner['key'])
+      expect(sublist[0]['providedProducts']).to_not eq([])
+      expect(sublist[0]['derivedProvidedProducts']).to eq([])
+      @cp.delete_pool(pool.id)
+
+      # Product have derived provided products only
+      derived_product = create_product(random_string('derived_product'), nil, {:providedProducts => [provided_product.id]})
+      product2 = create_product(random_string('product2'), random_string('product2'), {:derivedProduct => derived_product})
+      pool = @cp.create_pool(@owner['key'], product2.id, { :quantity => 2, :subscriptionId => "test-subscription3" })
+      sublist = @cp.list_subscriptions(@owner['key'])
+      expect(sublist[0]['providedProducts']).to eq([])
+      expect(sublist[0]['derivedProvidedProducts']).to_not eq([])
+      @cp.delete_pool(pool.id)
+  end
+
 end

--- a/server/src/main/java/org/candlepin/model/dto/Subscription.java
+++ b/server/src/main/java/org/candlepin/model/dto/Subscription.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -184,7 +185,7 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
 
     public Collection<ProductData> getProvidedProducts() {
         ProductData product = this.getProduct();
-        return product != null ? product.getProvidedProducts() : null;
+        return product != null ? product.getProvidedProducts() : Collections.emptySet();
     }
 
     public ProductData getDerivedProduct() {
@@ -194,7 +195,7 @@ public class Subscription extends CandlepinDTO implements Owned, Named, Eventful
 
     public Collection<ProductData> getDerivedProvidedProducts() {
         ProductData derived = this.getDerivedProduct();
-        return derived != null ? derived.getProvidedProducts() : null;
+        return derived != null ? derived.getProvidedProducts() : Collections.emptySet();
     }
 
     /**


### PR DESCRIPTION
 - This was changed while moving derived product from pool to product feature.
   Updated code to return the `Collections.emptySet()` instead of null.
 - Added spec test around this to test the required o/p.