### PR TITLE
[M] ENT-3911: 1965208: derivedProvidedProducts is now null where it was previously []

### DIFF
--- a/server/spec/subscription_resource_spec.rb
+++ b/server/spec/subscription_resource_spec.rb
@@ -37,4 +37,33 @@ describe 'Subscription Resource' do
 
       @cp.activate_subscription(consumer.uuid, "mail", "locale")
   end
+
+  it 'subscriptions derived/provided products should return empty array when null' do
+
+      # Product does not have derived/provided products
+      pool = @cp.create_pool(@owner['key'], @some_product.id, { :quantity => 2, :subscriptionId => "test-subscription1" })
+      sublist = @cp.list_subscriptions(@owner['key'])
+      expect(sublist[0]['providedProducts']).to eq([])
+      expect(sublist[0]['derivedProvidedProducts']).to eq([])
+      @cp.delete_pool(pool.id)
+
+      # Product provided products only
+      provided_product = create_product(random_string('provided_product'))
+      product1 = create_product(random_string('product1'), random_string('product1'), {:providedProducts => [provided_product.id]})
+      pool = @cp.create_pool(@owner['key'], product1.id, { :quantity => 2, :subscriptionId => "test-subscription2" })
+      sublist = @cp.list_subscriptions(@owner['key'])
+      expect(sublist[0]['providedProducts']).to_not eq([])
+      expect(sublist[0]['derivedProvidedProducts']).to eq([])
+      @cp.delete_pool(pool.id)
+
+      # Product have derived provided products only
+      derived_product = create_product(random_string('derived_product'), nil, {:providedProducts => [provided_product.id]})
+      product2 = create_product(random_string('product2'), random_string('product2'), {:derivedProduct => derived_product})
+      pool = @cp.create_pool(@owner['key'], product2.id, { :quantity => 2, :subscriptionId => "test-subscription3" })
+      sublist = @cp.list_subscriptions(@owner['key'])
+      expect(sublist[0]['providedProducts']).to eq([])
+      expect(sublist[0]['derivedProvidedProducts']).to_not eq([])
+      @cp.delete_pool(pool.id)
+  end
+
 end

--- a/server/src/main/java/org/candlepin/dto/api/v1/PoolToSubscriptionTranslator.java
+++ b/server/src/main/java/org/candlepin/dto/api/v1/PoolToSubscriptionTranslator.java
@@ -91,7 +91,9 @@ public class PoolToSubscriptionTranslator implements ObjectTranslator<Pool, Subs
             .upstreamEntitlementId(source.getUpstreamEntitlementId())
             .upstreamPoolId(source.getUpstreamPoolId())
             .stacked(source.isStacked())
-            .stackId(source.getStackId());
+            .stackId(source.getStackId())
+            .providedProducts(Collections.emptySet())
+            .derivedProvidedProducts(Collections.emptySet());
 
         if (translator != null) {
 


### PR DESCRIPTION
 - In OpenAPI, autogenerated classes have collections initializes
   to null by default. It is found in the regression that it affects
   the Katello.
   Updated the `PoolToSubscriptionTranslator` to populate the
   `providedProducts` and `derivedProvidedProducts` with empty set.
   And it will get replaced with the appropritate values later.
 - Added spec test around this to test the required o/p.