### PR TITLE
[M] Removed non-nullable restriction from the SCA cert cache table

### DIFF
--- a/src/main/resources/db/changelog/20210412145432-drop_content_cache.xml
+++ b/src/main/resources/db/changelog/20210412145432-drop_content_cache.xml
@@ -16,9 +16,7 @@
 
     <changeSet id="20210412145432-3" author="ojanus">
         <addColumn tableName="cp_cont_access_cert">
-            <column name="content" type="LONGTEXT">
-                <constraints nullable="false"/>
-            </column>
+            <column name="content" type="LONGTEXT"/>
         </addColumn>
         <dropTable tableName="cp_owner_env_content_access"/>
     </changeSet>


### PR DESCRIPTION
- The cp_cont_access_cert table no longer requires the content column
  to be non-null to address a potential problem with the migration
  of an already-populated table