### PR TITLE
[M] Ignore Maven dependency-check failure on missing NVD file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -861,6 +861,7 @@ task pom {
                             configuration {
                                 skipProvidedScope 'true'
                                 format 'html'
+                                failOnError 'false'
                             }
                         }
                         plugin {

--- a/pom.xml
+++ b/pom.xml
@@ -586,6 +586,7 @@
         <configuration>
           <skipProvidedScope>true</skipProvidedScope>
           <format>html</format>
+          <failOnError>false</failOnError>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Changes : 
Maven dependency check plugin tries to download NVDCVE metadata file, which fails when host is not reachable.
Additional configuration is added to ignore such failure without affecting the maven build.