### PR TITLE
[M] Removed the OWASP Dependency Check plugin from maven build & added it to Gradle build.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,13 +87,13 @@ certain features. The available flags are as follows:
   compilation is done.
 
 ### Check for Dependencies with CVEs
-* `buildr dependency:check`
+* `./gradlew dependencyCheckAnalyze`
 
-The `dependency:check` task will check a project (and all sub-projects) using  
-the [OWASP Dependency  
-Check](https://www.owasp.org/index.php/OWASP_Dependency_Check) to see if any  dependencies have CVEs reported against them.  The maximum allowable CVSS  score can be modified by setting the `max_allowed_cvss` to a float value  
-between 1.0 and 10.0.  Any CVEs above the maximum allowed CVSS score will  
-cause the build to fail.
+The `dependencyCheckAnalyze` task will check a project using the [OWASP Dependency Check](https://www.owasp.org/index.php/OWASP_Dependency_Check) 
+to see if any dependencies have CVEs reported against them.
+The maximum allowable CVSS  score can be modified by setting the `max_allowed_cvss` to a float value 
+between 1.0 and 10.0.  Any CVEs above the maximum allowed CVSS score will cause the build to fail. 
+The reports will be generated automatically under build/reports folder.
 
 ### Checkstyle
 * `./gradlew checkstyleMain`

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     dependencies {
         classpath group: 'org.yaml', name: 'snakeyaml', version: '1.19'
         classpath "org.openapitools:openapi-generator-gradle-plugin:${openapi_version}"
+        classpath 'org.owasp:dependency-check-gradle:6.2.2'
     }
 }
 
@@ -29,6 +30,7 @@ apply plugin: "war"
 apply plugin: "checkstyle"
 apply plugin: Gettext
 apply plugin: Msgfmt
+apply plugin: 'org.owasp.dependencycheck'
 
 ext {
     logdriver_class = "net.rkbloom.logdriver.LogDriver"
@@ -845,23 +847,6 @@ task pom {
                                         }
                                     }
                                 }
-                            }
-                        }
-                        plugin {
-                            groupId 'org.owasp'
-                            artifactId 'dependency-check-maven'
-                            version '6.1.6'
-                            executions {
-                                execution {
-                                    goals {
-                                        goal 'check'
-                                    }
-                                }
-                            }
-                            configuration {
-                                skipProvidedScope 'true'
-                                format 'html'
-                                failOnError 'false'
                             }
                         }
                         plugin {

--- a/pom.xml
+++ b/pom.xml
@@ -573,23 +573,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.owasp</groupId>
-        <artifactId>dependency-check-maven</artifactId>
-        <version>6.1.6</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <skipProvidedScope>true</skipProvidedScope>
-          <format>html</format>
-          <failOnError>false</failOnError>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>


### PR DESCRIPTION
Changes -
Dependency check plugin rely on fetching the metadata from NVD (external network). Our MEAD build was failing as node don't have access to outside network. Therefore we removed the OWASP Dependency Check plugin from maven build & added it to gradle build. This way we have better control when to run dependency checks (& will not be the part of actual build).