### PR TITLE
Changed the key server URL to import the keys

### DIFF
--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -74,7 +74,7 @@ git clone https://github.com/candlepin/candlepin.git /candlepin
 cd /candlepin
 
 # Setup and install rvm, ruby and pals
-gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+gpg2 --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 # turning off verbose mode, rvm is nuts with this
 set +v
 curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer


### PR DESCRIPTION
Changes to fix docker build -
- Replaced the unreachable keyserver URL from ```hkp://keys.gnupg.net``` to ```hkp://keyserver.ubuntu.com:80```