### PR TITLE
Update mysql.cnf file owner to be readable in mariadb container

### DIFF
--- a/bin/deployment/bash_functions
+++ b/bin/deployment/bash_functions
@@ -166,10 +166,9 @@ init_mysql_jdbc() {
     # JDBC_DRIVER="org.mariadb.jdbc.Driver"
     # JDBC_JAR="/usr/lib/java/mariadb-java-client.jar"
     # JDBC_URL="jdbc:mariadb://$db_host/$db_name"
-
-    local isolation_level=$(mysql -h $db_host $db_name  --user=$db_user --password="$password"  -e 'select @@global.tx_isolation')
-    local READ_COMMITTED="READ-COMMITTED"
-    if [[ $isolation_level != *$READ_COMMITTED* ]]; then
+    local isolation_level=$(mysql -h $db_host $db_name  --user=$db_user --password="$password" -s -N -e 'select @@global.tx_isolation')
+    echo "isolation_level : $isolation_level"
+    if [[ $isolation_level != "READ-COMMITTED" ]]; then
         err_msg "WARNING: candlepin requires READ-COMMITTED isolation level"
     fi
 }

--- a/docker/mysql.cnf
+++ b/docker/mysql.cnf
@@ -6,7 +6,6 @@ default-character-set=utf8mb4
 
 [mysqld]
 symbolic-links=0
-transaction-isolation=READ-COMMITTED
 # MySQL/MariaDB "utf8" charset only supports characters up to three bytes wide
 # (i.e. no emojis).  To get full unicode support, we need to use "utf8mb4"
 # See https://mathiasbynens.be/notes/mysql-utf8mb4
@@ -14,3 +13,4 @@ init-connect='SET NAMES utf8mb4'
 collation-server=utf8mb4_unicode_ci
 character-set-server=utf8mb4
 character-set-client-handshake=FALSE
+transaction-isolation=READ-COMMITTED

--- a/docker/test
+++ b/docker/test
@@ -26,7 +26,8 @@ while getopts ":c:mn:pld" opt; do
   case $opt in
     c) TEST_CMD="$OPTARG";;
     m) COMPOSE_ARGS="-f $DIR/docker-compose-mysql.yml";
-       chcon -Rt svirt_sandbox_file_t $DIR/mysql.cnf;;
+       chcon -Rt svirt_sandbox_file_t $DIR/mysql.cnf;
+       sudo chown 999:999 $DIR/mysql.cnf;;
     n) PROJ_NAME="-p $OPTARG";;
     p) COMPOSE_ARGS="-f $DIR/docker-compose-postgres.yml";;
     l) USE_CACHE="1";;

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -4,7 +4,7 @@ library identifier: 'fh-pipeline-library@master', retriever: modernSCM(
    credentialsId: 'github-api-token-as-username-password'])
 
 pipeline {
-    agent { label 'docker' }
+    agent { label 'candlepin' }
     options {
         skipDefaultCheckout true
         timeout(time: 16, unit: 'HOURS')
@@ -22,7 +22,7 @@ pipeline {
             parallel {
                 stage('unit') {
                     // ensures that this stage will get assigned its own workspace
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
                         checkout scm
@@ -31,7 +31,7 @@ pipeline {
                     }
                 }
                 stage('checkstyle') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
                         checkout scm
@@ -40,7 +40,7 @@ pipeline {
                     }
                 }
                 stage('rspec-postgresql') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     environment {
                         CANDLEPIN_DATABASE = 'postgresql'
                         CP_TEST_ARGS = '-r'
@@ -53,7 +53,7 @@ pipeline {
                     }
                 }
                 stage('rspec-mysql') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     environment {
                         CANDLEPIN_DATABASE = 'mysql'
                         CP_TEST_ARGS = '-r'
@@ -66,7 +66,7 @@ pipeline {
                     }
                 }
                 stage('rspec-postgres-hosted') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     environment {
                         CANDLEPIN_DATABASE = 'postgresql'
                         CP_TEST_ARGS = '-H -k'
@@ -79,7 +79,7 @@ pipeline {
                     }
                 }
                 stage('rspec-mysql-hosted') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     environment {
                         CANDLEPIN_DATABASE = 'mysql'
                         CP_TEST_ARGS = '-H -k'
@@ -103,7 +103,7 @@ pipeline {
                     }
                 }
                 stage('validate-translation') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
                         checkout scm


### PR DESCRIPTION
This is to investigate/fix the misbehavior of the spec test
in the environment created for #3001
    
- Added below options to get the isolation level
  -N : Don't write column names in results.
  -s : This option results in nontabular output
  format and escaping of special characters.
- Updated the mysql.cnf file permission and
  the file owner to MySQL user and group.
