### PR TITLE
Fixed version conflicts for spock dependency

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,8 +1,16 @@
 apply plugin: "java"
 apply plugin: "java-gradle-plugin"
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     implementation gradleApi()
+
+    // Spock 2.0-groovy-2.5 can only be executed with Groovy 2.5.x (Gradle 2.5.6)
+    // This dependency is specifically introduced to work with appropriate Groovy/Gradle variant.
+    compile('org.spockframework:spock-core:2.0-groovy-2.5')
 }
 
 gradlePlugin {


### PR DESCRIPTION
Fixed
- Version conflict for Spock dependency. Spock is a transitive dependency, which resulted in version conflicts.


Ref - [Spock Groovy version compatibility](https://spockframework.org/spock/docs/2.0/known_issues.html)