### PR TITLE
[M] Add back 'docker-compose down' to docker/test script

### DIFF
--- a/docker/test
+++ b/docker/test
@@ -62,6 +62,7 @@ if [ "$DETACHED" == "1" ]; then
 else
     docker-compose $PROJ_NAME $COMPOSE_ARGS run --rm candlepin $TEST_CMD
     RETVAL=$?
+    docker-compose $PROJ_NAME down
 fi
 
 echo "return value: $RETVAL"


### PR DESCRIPTION
- Even though we do this cleanup in a Jenkins post script, it
  is a good idea to also do it within the docker/test script
  to perform the cleanup when one runs the script manually