### PR TITLE
[4.0] 1989474: Fix for pool quantity calculations (ENT-3974)

### DIFF
--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -1005,7 +1005,7 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
      */
     public boolean isOverflowing() {
         // Unlimited pools can't be overflowing:
-        if (this.quantity == -1) {
+        if (this.quantity < 0) {
             return false;
         }
         return getConsumed() > this.quantity;


### PR DESCRIPTION
Changes :

- All unlimited pools are restricted to -1 quantity.
- Unmapped guest & Bonus pools specifically to have unlimited quantity in both cases: a) the master pool quantity is unlimited, b) virt_limit is unlimited.