### PR TITLE
[3.2] 1989541: Fix for pool quantity calculations (ENT-3974)

### DIFF
--- a/server/src/main/java/org/candlepin/model/Pool.java
+++ b/server/src/main/java/org/candlepin/model/Pool.java
@@ -1160,7 +1160,7 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
     @JsonIgnore
     public boolean isOverflowing() {
         // Unlimited pools can't be overflowing:
-        if (this.quantity == -1) {
+        if (this.quantity < 0) {
             return false;
         }
         return getConsumed() > this.quantity;

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -93,6 +93,7 @@ public class EntitlementRules implements Enforcer {
     private ModelTranslator translator;
 
     private static final String POST_PREFIX = "post_";
+    private static final long UNLIMITED_QUANTITY = -1L;
 
     @Inject
     public EntitlementRules(DateSource dateSource,
@@ -516,17 +517,41 @@ public class EntitlementRules implements Enforcer {
             String virtLimit = attributes.get(Product.Attributes.VIRT_LIMIT);
 
             if (!"unlimited".equals(virtLimit)) {
-                // As we have unbound an entitlement from a physical pool that was previously
-                // exported, we need to add back the reduced bonus pool quantity.
+                /*
+                 * Case I
+                 * As we have unbound an entitlement from a physical pool that was previously
+                 * exported, we need to add back the reduced bonus pool quantity.
+                 *
+                 * Case II
+                 * If Master pool quantity is unlimited, with non-zero virt_limit & pool under
+                 * consideration is of type Unmapped guest or Bonus pool, set its quantity to be
+                 * unlimited.
+                 */
                 int virtQuantity = Integer.parseInt(virtLimit) * entitlement.getQuantity();
                 if (virtQuantity > 0) {
                     List<Pool> pools = poolManager.getBySubscriptionId(pool.getOwner(),
                         pool.getSubscriptionId());
+                    boolean isMasterPoolUnlimited = false;
+
+                    for (Pool poolToCheck : pools) {
+                        if (poolToCheck.getQuantity() == UNLIMITED_QUANTITY) {
+                            isMasterPoolUnlimited = true;
+                        }
+                    }
+
                     for (int idex = 0; idex < pools.size(); idex++) {
                         Pool derivedPool = pools.get(idex);
+
                         if (derivedPool.getAttributeValue(Pool.Attributes.DERIVED_POOL) != null) {
-                            poolManager.setPoolQuantity(derivedPool,
-                                derivedPool.adjustQuantity(virtQuantity));
+                            if (isMasterPoolUnlimited && (derivedPool.getType() == Pool.PoolType.BONUS ||
+                                derivedPool.getType() == Pool.PoolType.UNMAPPED_GUEST)) {
+                                // Set pool quantity to be unlimited.
+                                poolManager.setPoolQuantity(derivedPool, UNLIMITED_QUANTITY);
+                            }
+                            else {
+                                poolManager.setPoolQuantity(derivedPool,
+                                    derivedPool.adjustQuantity(virtQuantity));
+                            }
                         }
                     }
                 }
@@ -672,23 +697,47 @@ public class EntitlementRules implements Enforcer {
             if (!hostLimited) {
                 String virtLimit = attributes.get(Product.Attributes.VIRT_LIMIT);
                 if (!"unlimited".equals(virtLimit)) {
-                    /* if the bonus pool is not unlimited, then the bonus pool
+                    /*
+                     * Case I
+                     * if the bonus pool is not unlimited, then the bonus pool
                      * quantity needs to be adjusted based on the virt limit
                      *
-                     * poolQuantity map contains the quantity change requested in the entitlement.
+                     * NOTE : poolQuantity map contains the quantity change requested in the entitlement.
                      * If this is a bind, then change = entitlement quantity, as change is always > 0.
                      * But if this is an entitlement update, change can be positive or negative, hence
                      * we may need to increment or decrement the bonus pool quantity based on the change
+                     *
+                     * Case II
+                     * Master pool quantity is unlimited, with non-zero virt_limit & pool under
+                     * consideration is of type Unmapped guest or Bonus pool, set its quantity to be
+                     * unlimited.
                      */
                     int virtQuantity = Integer.parseInt(virtLimit) *
                         poolQuantityMap.get(pool.getId()).getQuantity();
                     if (virtQuantity != 0) {
                         List<Pool> pools = subscriptionPoolMap.get(pool.getSubscriptionId());
+
+                        boolean isMasterPoolUnlimited = false;
+
+                        for (Pool poolToCheck : pools) {
+                            if (poolToCheck.getQuantity() == UNLIMITED_QUANTITY) {
+                                isMasterPoolUnlimited = true;
+                            }
+                        }
+
                         for (int idex = 0; idex < pools.size(); idex++) {
                             Pool derivedPool = pools.get(idex);
                             if (derivedPool.getAttributeValue(Pool.Attributes.DERIVED_POOL) != null) {
-                                long adjust = derivedPool.adjustQuantity(-1L * virtQuantity);
-                                poolOperationCallback.setQuantityToPool(derivedPool, adjust);
+                                // If master pool is of unlimited quantity, set pool quantity as unlimited
+                                // if pool type is bonus or unmapped_guest pool.
+                                if (isMasterPoolUnlimited && (derivedPool.getType() == Pool.PoolType.BONUS ||
+                                    derivedPool.getType() == Pool.PoolType.UNMAPPED_GUEST)) {
+                                    poolOperationCallback.setQuantityToPool(derivedPool, UNLIMITED_QUANTITY);
+                                }
+                                else {
+                                    long adjust = derivedPool.adjustQuantity(-1L * virtQuantity);
+                                    poolOperationCallback.setQuantityToPool(derivedPool, adjust);
+                                }
                             }
                         }
                     }

--- a/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -22,6 +22,7 @@ import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.Pool;
+import org.candlepin.model.Pool.PoolType;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.model.SourceSubscription;
@@ -55,6 +56,8 @@ public class PoolRules {
 
     private static final Logger log = LoggerFactory.getLogger(PoolRules.class);
 
+    private static final long UNLIMITED_QUANTITY = -1L;
+
     private final PoolManager poolManager;
     private final Configuration config;
     private final EntitlementCurator entCurator;
@@ -73,6 +76,13 @@ public class PoolRules {
     }
 
     private long calculateQuantity(long quantity, Product product, String upstreamPoolId) {
+        // Pool quantities that are less than -1:
+        // a) are not considered valid and will be treated as 'unlimited' quantity (-1) and
+        // b) should never be multiplied with product multiplier or instance_multiplier
+        if (quantity < 0) {
+            return UNLIMITED_QUANTITY;
+        }
+
         long result = quantity * (product.getMultiplier() != null ? product.getMultiplier() : 1);
 
         // In hosted, we increase the quantity on the subscription. However in standalone,
@@ -184,7 +194,6 @@ public class PoolRules {
         // for a source subscription should be removed.
         if (poolManager.isManaged(masterPool) && virtQuantity != null &&
             !hasBonusPool(existingPools)) {
-
             boolean hostLimited = "true".equals(attributes.get(Product.Attributes.HOST_LIMITED));
             HashMap<String, String> virtAttributes = new HashMap<>();
             virtAttributes.put(Pool.Attributes.VIRT_ONLY, "true");
@@ -243,15 +252,18 @@ public class PoolRules {
     /*
      * Returns null if invalid
      */
-    private String getVirtQuantity(String virtLimit, long quantity) {
-        if ("unlimited".equals(virtLimit)) {
-            return virtLimit;
+    private String getVirtQuantity(String virtLimit, long masterPoolQuantity) {
+        if (virtLimit != null &&
+            ("unlimited".equals(virtLimit) || masterPoolQuantity == UNLIMITED_QUANTITY)) {
+            return String.valueOf(UNLIMITED_QUANTITY);
         }
 
         try {
             int virtLimitInt = Integer.parseInt(virtLimit);
+
             if (virtLimitInt > 0) {
-                return String.valueOf(virtLimitInt * quantity);
+                long quantity = virtLimitInt * masterPoolQuantity;
+                return String.valueOf(quantity);
             }
         }
         catch (NumberFormatException nfe) {
@@ -329,7 +341,6 @@ public class PoolRules {
 
             update.setQuantityChanged(checkForQuantityChange(masterPool, existingPool, originalQuantity,
                 existingPools, attributes));
-
             if (!existingPool.isMarkedForDelete()) {
                 boolean useDerived = masterPool.getDerivedProduct() != null &&
                     existingPool.isDerived();
@@ -797,20 +808,36 @@ public class PoolRules {
                             // adjustment for exported quantities if there are multiple
                             // pools in play.
                             long adjust = 0L;
+                            boolean isMasterUnlimited = false;
+
                             for (Pool derivedPool : existingPools) {
                                 String isDerived =
                                     derivedPool.getAttributeValue(Pool.Attributes.DERIVED_POOL);
 
                                 if (isDerived == null) {
                                     adjust = derivedPool.getExported();
+
+                                    if (derivedPool.getQuantity() == UNLIMITED_QUANTITY) {
+                                        isMasterUnlimited = true;
+                                    }
                                 }
                             }
-                            expectedQuantity = (expectedQuantity - adjust) * virtLimit;
+
+                            // If master pool quantity is unlimited & existingPool is of type
+                            // virt bonus or unmapped guest pool, set its quantity as unlimited.
+                            if (isMasterUnlimited && (existingPool.getType() == PoolType.BONUS ||
+                                existingPool.getType() == PoolType.UNMAPPED_GUEST)) {
+                                expectedQuantity = UNLIMITED_QUANTITY;
+                            }
+                            else {
+                                expectedQuantity = (expectedQuantity - adjust) * virtLimit;
+                            }
+
                         }
                     }
                     catch (NumberFormatException nfe) {
                         // Nothing to update if we get here.
-//                            continue;
+                        // continue;
                     }
                 }
             }


### PR DESCRIPTION
Changes :

- All unlimited pools are restricted to -1 quantity.
- Unmapped guest & Bonus pools specifically to have unlimited quantity in both cases: a) the master pool quantity is unlimited, b) virt_limit is unlimited.