### PR TITLE
[M] 1980370: Replace DELETE with TRUNCATE where possible [ENT-4065]

### DIFF
--- a/src/main/resources/db/changelog/20201103112757-purge-current-sca-certs.xml
+++ b/src/main/resources/db/changelog/20201103112757-purge-current-sca-certs.xml
@@ -6,7 +6,8 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <changeSet id="20201103112757-1" author="crog, sdhome">
+    <changeSet id="20201103112757-1" author="crog">
+        <validCheckSum>7:b060e85fd3270acbb9778b17c6d0a447</validCheckSum>
         <comment>
             Removes any existing SCA certs to address a problem with cert generation in some organizations
         </comment>
@@ -20,6 +21,7 @@
             <column name="cont_acc_cert_id"/> <!-- this sets the column value to null -->
         </update>
 
+        <!-- Below changes are made to fix the bug #1980370. -->
         <dropForeignKeyConstraint baseTableName="cp_consumer" constraintName="fk_cont_acc_cert" />
 
         <sql>


### PR DESCRIPTION
- Rollback the changes made for an author in this script.
  Because a changeset is uniquely tagged by both an author
  and an id attributes (author:id). It considers the changeset
  as a new entry if it differs.