### PR TITLE
[M] Various minor improvements to the cloud registration flow (ENT-4188)

### DIFF
--- a/src/main/java/org/candlepin/auth/CloudRegistrationAuth.java
+++ b/src/main/java/org/candlepin/auth/CloudRegistrationAuth.java
@@ -244,6 +244,11 @@ public class CloudRegistrationAuth implements AuthProvider {
     public String generateRegistrationToken(Principal principal, CloudRegistrationInfo cloudRegistrationInfo)
         throws CloudRegistrationAuthorizationException, MalformedCloudRegistrationException {
 
+        if (!this.enabled) {
+            throw new UnsupportedOperationException(
+                "Cloud registration is not enabled on this Candlepin instance");
+        }
+
         if (principal == null) {
             throw new IllegalArgumentException("principal is null");
         }

--- a/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
+++ b/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
@@ -54,7 +54,6 @@ public class CloudRegistrationResource implements CloudApi {
     @Override
     @SecurityHole(noAuth = true)
     public String cloudAuthorize(CloudRegistrationDTO cloudRegistrationDTO) {
-
         if (cloudRegistrationDTO == null) {
             throw new BadRequestException(this.i18n.tr("No cloud registration information provided"));
         }

--- a/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
@@ -146,6 +146,7 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         }
         else {
             for (AuthProvider provider : providers) {
+                log.debug("Attempting authentication with provider: {}", provider.getClass().getName());
                 principal = provider.getPrincipal(httpRequest);
 
                 if (principal != null) {


### PR DESCRIPTION
- Added an additional check to the cloud registration resource
  to prevent token generation when cloud registration is not enabled
- Added additional logging to the AuthenticationFilter to list the
  auth providers used during a given request
- Added logic to consumer registration to avoid proceeding in cases
  where no owner or principal information is available