### PR TITLE
Update msgfmt task & openapi tasks to support cached input/output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ ext {
     async_scheduler_enabled = !project.findProperty("async_scheduler_enabled") ||
             "true".equals(project.findProperty("async_scheduler_enabled"))
 
-    generatedMetamodels = "${buildDir}/generated/src/gen/java"
+    generatedMetamodels = "${buildDir}/generated/api/src/gen/java"
 }
 
 ext.versions = [
@@ -457,19 +457,11 @@ repositories {
     maven { url "https://barnabycourt.fedorapeople.org/repo/candlepin/" }
 }
 
-tasks.withType(JavaCompile) {
-    options.encoding = "UTF-8"
-    // options.compilerArgs << "-Xlint:deprecation"
-    // options.compilerArgs.addAll(['--release', '8'])
-}
-
-
 openApiGenerate {
     generatorName = "jaxrs-spec"
     inputSpec = api_spec_path
     configFile = config_file
-    outputDir = "$buildDir/generated"
-    skipValidateSpec = true
+    outputDir = "$buildDir/generated/api"
     configOptions = [
             interfaceOnly: 'true',
             generatePom: 'false',
@@ -496,20 +488,12 @@ task generateApiDocs(type: org.openapitools.generator.gradle.plugin.tasks.Genera
 task generateOpenApiJson(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
     generatorName = "openapi"
     inputSpec = api_spec_path
-    outputDir = "$buildDir/generated"
+    outputDir = "$buildDir/generated/json"
     generateApiDocumentation = true
     generateModelDocumentation = true
     generateModelTests = false
     generateApiTests = false
     withXml = false
-}
-
-processResources {
-    from "$buildDir/generated/openapi.json"
-    from api_spec_path
-    rename { String fileName ->
-        api_spec_path.endsWith(fileName) ? 'openapi.yaml' : fileName  // rename yaml to openapi.yaml
-    }
 }
 
 //Update the compileJava & processResourcesTasks depend on the openapi generation so that the generated classes
@@ -662,6 +646,14 @@ war {
     from("./api") {
         include "candlepin-api-spec.yaml"
         into("docs")
+    }
+    from("$buildDir/generated/api/src/main/openapi") {
+        include "openapi.yaml"
+        into("WEB-INF/classes")
+    }
+    from("$buildDir/generated/json") {
+        include "openapi.json"
+        into("WEB-INF/classes")
     }
 }
 

--- a/buildSrc/src/main/groovy/Msgfmt.groovy
+++ b/buildSrc/src/main/groovy/Msgfmt.groovy
@@ -14,71 +14,86 @@
  */
 
 
+import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
 
 class MsgfmtExtension {
     String resource = "foo"
 }
+
+class MsgfmtTask extends DefaultTask {
+    @InputDirectory
+    File getInputDir() {
+        return project.file("po")
+    }
+
+    @OutputDirectory
+    File getOutputDir() {
+        return project.file("${project.buildDir}/msgfmt/generated_source")
+    }
+
+    @TaskAction
+    void execute() {
+        def po_dir = project.file("po")
+        def msgfmt_target_directory = project.file("${project.buildDir}/msgfmt/generated_source")
+        def msgfmt_root_directory = new File("${project.buildDir}/msgfmt")
+        if (!msgfmt_root_directory.exists()) {
+            msgfmt_root_directory.mkdirs()
+        }
+
+        def msgfmt_directory = new File("${project.buildDir}/msgfmt/source-1")
+        if (!msgfmt_directory.exists()) {
+            msgfmt_directory.mkdirs()
+        }
+        if (!msgfmt_target_directory.exists()) {
+            msgfmt_target_directory.mkdirs()
+        }
+
+        // msgfmt does not allow us to convert more than one PO file at a time due to the need
+        // to specify the locale directly for the java command.
+        // For this reason we do the initial generation in source1 & then copy over to source2
+        // Loop over all the .po files and run msgfmt for them to generate compiled message bundles form the po files
+        def extension = project.extensions.getByName("msgfmt")
+        po_dir.eachFileMatch(~/.*.po/) {
+            File po_file ->
+                // Remove the org directory from generated-source since the
+                // --source argument complains if it already exists
+                project.delete("${project.buildDir}/msgfmt/source-1/org")
+
+                def locale = po_file.name[0..<po_file.name.lastIndexOf('.')]
+                List msgfmt_args = ["--java2", "--source",
+                                    "--resource", extension.resource,
+                                    "-d", "${project.buildDir}/msgfmt/source-1",
+                                    "-l", locale,
+                                    "${po_file.canonicalPath}"
+                ]
+
+                project.exec {
+                    executable "msgfmt"
+                    args msgfmt_args
+                }
+                project.copy {
+                    from "${msgfmt_directory}"
+                    into "${msgfmt_target_directory}"
+                }
+        }
+    }
+}
+
 class Msgfmt implements Plugin<Project> {
     void apply(Project project) {
-        def extension = project.extensions.create('msgfmt', MsgfmtExtension)
-
+        project.extensions.create('msgfmt', MsgfmtExtension)
         // Add the generated sources for all the i18n files to the main java source dirs so that they will be compiled
         // during the normal compileJava step
         def msgfmt_target_directory = project.file("${project.buildDir}/msgfmt/generated_source")
         project.sourceSets {
             main.java.srcDir msgfmt_target_directory
         }
-
-        def msgfmt_task = project.task('msgfmt') {
-            doLast {
-                def po_dir = project.file("po")
-                def msgfmt_root_directory = new File("${project.buildDir}/msgfmt")
-                if (!msgfmt_root_directory.exists()) {
-                    msgfmt_root_directory.mkdirs()
-                }
-
-                def msgfmt_directory = new File("${project.buildDir}/msgfmt/source-1")
-                if (!msgfmt_directory.exists()) {
-                    msgfmt_directory.mkdirs()
-                }
-                if (!msgfmt_target_directory.exists()) {
-                    msgfmt_target_directory.mkdirs()
-                }
-
-                // msgfmt does not allow us to convert more than one PO file at a time due to the need
-                // to specify the locale directly for the java command.
-                // For this reason we do the initial generation in source1 & then copy over to source2
-                // Loop over all the .po files and run msgfmt for them to generate compiled message bundles form the po files
-
-                po_dir.eachFileMatch(~/.*.po/) {
-                    File po_file ->
-                        // Remove the org directory from generated-source since the
-                        // --source argument complains if it already exists
-                        project.delete("${project.buildDir}/msgfmt/source-1/org")
-
-                        def locale = po_file.name[0..<po_file.name.lastIndexOf('.')]
-                        List msgfmt_args = ["--java2", "--source",
-                                            "--resource", extension.resource,
-                                            "-d", "${project.buildDir}/msgfmt/source-1",
-                                            "-l", locale,
-                                            "${po_file.canonicalPath}"
-                        ]
-
-                        project.exec {
-                            executable "msgfmt"
-                            args msgfmt_args
-                        }
-                        project.copy {
-                            from "${msgfmt_directory}"
-                            into "${msgfmt_target_directory}"
-                        }
-                }
-
-            }
-
-        }
+        def msgfmt_task = project.tasks.register("msgfmt", MsgfmtTask)
         project.compileJava.dependsOn msgfmt_task
     }
 }


### PR DESCRIPTION
The msgfmt custom task was updated to specify it's input & output files
so that the gradle cache can skip it if there are no updates to perform.

Previously the openapi generation tasks were using the same generation directory
 which meant that every time one of the tasks ran it invalidated the cache entry
 for the other. Using separate target directories allows gradle to properly track
 whether the task needs to be re-run.

To test, if you run "gradle war" and especially "gradle war --build-cache" you will start to see tasks being skipped because they are already up to date & builds running considerably faster on each run. In addition you will only see the output from the openapi generation tasks the first time things are run. A gradle clean will still force a rebuild of everything. 