### PR TITLE
Remove unused ldapjdk library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,6 @@ dependencies {
     //Javascript Engine
     implementation "org.mozilla:rhino:1.7R3"
 
-    implementation "ldapjdk:ldapjdk:4.19"
     implementation "org.quartz-scheduler:quartz:2.3.2"
 
     //keycloak


### PR DESCRIPTION
I can't find any references to what is provided by this library in our code. Trying it through the test pipeline to see if anything breaks. 