### PR TITLE
[3.1] 1958127: Serials left unrevoked after update

### DIFF
--- a/server/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -304,6 +304,7 @@ public class ContentAccessManager {
         if (isX509CertExpired) {
             Validity oneYearValidity = Validity.oneYear();
             KeyPair keyPair = this.keyPairCurator.getConsumerKeyPair(consumer);
+            this.serialCurator.revokeById(existing.getSerial().getId());
             CertificateSerial serial = createSerial(oneYearValidity);
             existing.setSerial(serial);
             existing.setCert(createX509Cert(consumer, owner, serial, keyPair, oneYearValidity));

--- a/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
+++ b/server/src/main/java/org/candlepin/model/CertificateSerialCurator.java
@@ -219,4 +219,22 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
             .setParameter("nowDate", new Date())
             .getResultList();
     }
+
+    /**
+     * Revokes serial specified by the given serial id
+     *
+     * @param serialToRevoke id of the serial to be revoked
+     */
+    @Transactional
+    public void revokeById(Long serialToRevoke) {
+        String query = "UPDATE CertificateSerial s" +
+            " SET s.revoked = true, s.updated = :updated" +
+            " WHERE s.revoked = false AND s.id = :serial_id";
+
+        this.currentSession().createQuery(query)
+            .setParameter("updated", new Date())
+            .setParameter("serial_id", serialToRevoke)
+            .executeUpdate();
+    }
+
 }


### PR DESCRIPTION
- Fixed case where after updated certificate got a new serial the old serial was left
  unrevoked.