### PR TITLE
[M] 1981887: Updated and separated job scheduling and execution configuration (ENT-4253)

### DIFF
--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -264,9 +264,11 @@ public class ConfigProperties {
 
     // Async Job Properties and utilities
     public static final String ASYNC_JOBS_THREADS = "candlepin.async.threads";
-    public static final String ASYNC_JOBS_WHITELIST = "candlepin.async.whitelist";
-    public static final String ASYNC_JOBS_BLACKLIST = "candlepin.async.blacklist";
     public static final String ASYNC_JOBS_SCHEDULER_ENABLED = "candlepin.async.scheduler.enabled";
+
+    public static final String ASYNC_JOBS_DISPATCH_ADDRESS = "candlepin.async.dispatch_address";
+    public static final String ASYNC_JOBS_RECEIVE_ADDRESS = "candlepin.async.receive_address";
+    public static final String ASYNC_JOBS_RECEIVE_FILTER = "candlepin.async.receive_filter";
 
     // Whether or not we should allow queuing new jobs on this node while the job manager is suspended/paused
     public static final String ASYNC_JOBS_QUEUE_WHILE_SUSPENDED = "candlepin.async.queue_while_suspended";
@@ -275,8 +277,10 @@ public class ConfigProperties {
     // to configure the schedule flag for the job TestJob1, the full configuration would be:
     // candlepin.async.jobs.TestJob1.schedule=0 0 0/3 * * ?
     public static final String ASYNC_JOBS_PREFIX = "candlepin.async.jobs.";
-    public static final String ASYNC_JOBS_JOB_ENABLED = "enabled";
     public static final String ASYNC_JOBS_JOB_SCHEDULE = "schedule";
+
+    // Special value used to denote a job's schedule should be manual rather than automatic.
+    public static final String ASYNC_JOBS_MANUAL_SCHEDULE = "manual";
 
     // "Temporary" configuration to limit the scope of the jobs/schedule endpoint. Only job keys
     // specified in this property will be allowed to be triggered via the schedule endpoint.
@@ -472,6 +476,10 @@ public class ConfigProperties {
             this.put(ASYNC_JOBS_QUEUE_WHILE_SUSPENDED, "true");
             this.put(ASYNC_JOBS_SCHEDULER_ENABLED, "true");
             this.put(ASYNC_JOBS_THREAD_SHUTDOWN_TIMEOUT, "600"); // 10 minutes
+
+            this.put(ASYNC_JOBS_DISPATCH_ADDRESS, "job");
+            this.put(ASYNC_JOBS_RECEIVE_ADDRESS, "jobs");
+            this.put(ASYNC_JOBS_RECEIVE_FILTER, "");
 
             this.put(jobConfig(ActiveEntitlementJob.JOB_KEY, ASYNC_JOBS_JOB_SCHEDULE),
                 ActiveEntitlementJob.DEFAULT_SCHEDULE);

--- a/src/main/resources/broker.xml
+++ b/src/main/resources/broker.xml
@@ -133,9 +133,9 @@
                 </multicast>
             </address>
             <address name="job">
-                <multicast>
-                    <queue name="jobs" />
-                </multicast>
+                <anycast>
+                    <queue name="jobs"/>
+                </anycast>
             </address>
         </addresses>
 
@@ -161,7 +161,6 @@
             </address-setting>
 
             <address-setting match="job">
-                <auto-create-queues>true</auto-create-queues>
                 <max-size-bytes>10485760</max-size-bytes>
 
                 <!-- By default, Artemis will page messages when the queue address is full. -->

--- a/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -981,112 +981,6 @@ public class JobManagerTest {
     }
 
     @Test
-    public void testJobIsEnabledDefaultsEnabledWithNoConfiguration() {
-        JobManager manager = this.createJobManager();
-
-        boolean result = manager.isJobEnabled(TestJob.JOB_KEY);
-        assertTrue(result);
-    }
-
-    @Test
-    public void testJobIsEnabledProperlyWhitelistsJobs() {
-        List<String> jobs = Arrays.asList("a", "b", "c", "d", "e");
-        List<String> whitelist = jobs.subList(1, 3);
-
-        this.config.setProperty(ConfigProperties.ASYNC_JOBS_WHITELIST, String.join(",", whitelist));
-
-        JobManager manager = this.createJobManager();
-
-        for (String jobKey : jobs) {
-            boolean expected = whitelist.contains(jobKey);
-            boolean result = manager.isJobEnabled(jobKey);
-
-            assertEquals(expected, result);
-        }
-    }
-
-    @Test
-    public void testJobIsEnabledProperlyBlacklistsJobs() {
-        List<String> jobs = Arrays.asList("a", "b", "c", "d", "e");
-        List<String> blacklist = jobs.subList(1, 3);
-
-        this.config.setProperty(ConfigProperties.ASYNC_JOBS_BLACKLIST, String.join(",", blacklist));
-
-        JobManager manager = this.createJobManager();
-
-        for (String jobKey : jobs) {
-            boolean expected = !blacklist.contains(jobKey);
-            boolean result = manager.isJobEnabled(jobKey);
-
-            assertEquals(expected, result);
-        }
-    }
-
-    @Test
-    public void testJobIsEnabledAllowsJobsToBeDisabled() {
-        List<String> jobs = Arrays.asList("a", "b", "c", "d", "e");
-        List<String> disabled = jobs.subList(1, 3);
-
-        for (String jobKey : disabled) {
-            this.config.setProperty(ConfigProperties.ASYNC_JOBS_PREFIX + jobKey + '.' +
-                ConfigProperties.ASYNC_JOBS_JOB_ENABLED, "false");
-        }
-
-        JobManager manager = this.createJobManager();
-
-        for (String jobKey : jobs) {
-            boolean expected = !disabled.contains(jobKey);
-            boolean result = manager.isJobEnabled(jobKey);
-
-            assertEquals(expected, result);
-        }
-    }
-
-    @Test
-    public void testJobIsEnabledProperlyCombinesWhitelistAndBlacklist() {
-        List<String> jobs = Arrays.asList("a", "b", "c", "d", "e");
-        List<String> whitelist = jobs.subList(1, 2);
-        List<String> blacklist = jobs.subList(2, 4);
-
-        this.config.setProperty(ConfigProperties.ASYNC_JOBS_WHITELIST, String.join(",", whitelist));
-        this.config.setProperty(ConfigProperties.ASYNC_JOBS_BLACKLIST, String.join(",", blacklist));
-
-        JobManager manager = this.createJobManager();
-
-        for (String jobKey : jobs) {
-            boolean expected = whitelist.contains(jobKey) && !blacklist.contains(jobKey);
-            boolean result = manager.isJobEnabled(jobKey);
-
-            assertEquals(expected, result);
-        }
-    }
-
-    @Test
-    public void testJobIsEnabledProperlyCombinesWhitelistAndBlacklistAndPerJobConfig() {
-        List<String> jobs = Arrays.asList("a", "b", "c", "d", "e");
-        List<String> whitelist = jobs.subList(1, 3);
-        List<String> blacklist = jobs.subList(2, 4);
-        List<String> disabled = jobs.subList(3, 5);
-
-        this.config.setProperty(ConfigProperties.ASYNC_JOBS_WHITELIST, String.join(",", whitelist));
-        this.config.setProperty(ConfigProperties.ASYNC_JOBS_BLACKLIST, String.join(",", blacklist));
-        for (String jobKey : disabled) {
-            this.config.setProperty(ConfigProperties.ASYNC_JOBS_PREFIX + jobKey + '.' +
-                ConfigProperties.ASYNC_JOBS_JOB_ENABLED, "false");
-        }
-
-        JobManager manager = this.createJobManager();
-
-        for (String jobKey : jobs) {
-            boolean expected = whitelist.contains(jobKey) && !blacklist.contains(jobKey) &&
-                !disabled.contains(jobKey);
-            boolean result = manager.isJobEnabled(jobKey);
-
-            assertEquals(expected, result);
-        }
-    }
-
-    @Test
     public void testJobScheduling() {
         String schedule = "%d * * * * ?";
         int jobs = 3;
@@ -1107,44 +1001,10 @@ public class JobManagerTest {
     }
 
     @Test
-    public void testJobSchedulingDoesNotScheduleDisabledJobs() {
+    public void testJobSchedulingDoesNotScheduleManualJobs() {
         this.config.setProperty(
             ConfigProperties.jobConfig(TestJob.JOB_KEY, ConfigProperties.ASYNC_JOBS_JOB_SCHEDULE),
-            "5 * * * * ?");
-
-        this.config.setProperty(
-            ConfigProperties.jobConfig(TestJob.JOB_KEY, ConfigProperties.ASYNC_JOBS_JOB_ENABLED),
-            "false");
-
-        JobManager manager = this.createJobManager();
-        manager.initialize();
-
-        // Verify the job is not scheduled
-        this.verifyNotScheduled(TestJob.JOB_KEY);
-    }
-
-    @Test
-    public void testJobSchedulingDoesNotScheduleBlacklistedJobs() {
-        this.config.setProperty(
-            ConfigProperties.jobConfig(TestJob.JOB_KEY, ConfigProperties.ASYNC_JOBS_JOB_SCHEDULE),
-            "5 * * * * ?");
-
-        this.config.setProperty(ConfigProperties.ASYNC_JOBS_BLACKLIST, "a,b," + TestJob.JOB_KEY + ",d,e");
-
-        JobManager manager = this.createJobManager();
-        manager.initialize();
-
-        // Verify the job is not scheduled
-        this.verifyNotScheduled(TestJob.JOB_KEY);
-    }
-
-    @Test
-    public void testJobSchedulingDoesNotScheduleJobsNotOnWhitelist() {
-        this.config.setProperty(
-            ConfigProperties.jobConfig(TestJob.JOB_KEY, ConfigProperties.ASYNC_JOBS_JOB_SCHEDULE),
-            "5 * * * * ?");
-
-        this.config.setProperty(ConfigProperties.ASYNC_JOBS_WHITELIST, "a,b,c,d,e");
+            ConfigProperties.ASYNC_JOBS_MANUAL_SCHEDULE);
 
         JobManager manager = this.createJobManager();
         manager.initialize();


### PR DESCRIPTION
- Updated the configuration behind job scheduling and job execution
  to separate the two functions entirely and avoid configuration
  difficulties associated with the two areas
- Jobs can no longer be disabled
- Removed the job blacklist, whitelist and enabled configurations
- Added a new special value for specifying a job should only run on
  a manual schedule: "manual"
- JobManager will now throw an exception if the job scheduler cannot
  be updated or configured as expected during startup
- Added new configurations for controlling job message flow:
  candlepin.async.dispatch_address, candlepin.async.receive_address,
  and candlepin.async.receive_filter
- Updated the packaged broker configuration