### PR TITLE
Deserialization of LinkedHashSet in OpenAPI to preserve order

### DIFF
--- a/buildSrc/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/buildSrc/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -105,6 +105,8 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
             setUseTags(convertPropertyToBoolean(USE_TAGS));
         }
 
+        importMapping.put("JsonDeserialize", "com.fasterxml.jackson.databind.annotation.JsonDeserialize");
+
         writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
     }
 
@@ -312,5 +314,17 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
     @VisibleForTesting
     public void setUseTags(boolean useTags) {
         this.useTags = useTags;
+    }
+
+    @Override
+    public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
+       super.postProcessModelProperty(model, property);
+       if (!fullJavaUtil) {
+           if ("set".equals(property.containerType)) {
+               model.imports.add("LinkedHashSet");
+               model.imports.add("JsonDeserialize");
+               property.vendorExtensions.put("x-setter-extra-annotation", "@JsonDeserialize(as = LinkedHashSet.class)");
+           }
+        }
     }
 }

--- a/buildSrc/src/main/resources/templates/pojo.mustache
+++ b/buildSrc/src/main/resources/templates/pojo.mustache
@@ -52,7 +52,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
     return {{name}};
   }
 
-  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+ {{#vendorExtensions.x-setter-extra-annotation}}{{{vendorExtensions.x-setter-extra-annotation}}}
+ {{/vendorExtensions.x-setter-extra-annotation}}public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
   }
 


### PR DESCRIPTION
Currently, We are facing an issue with the insertion order of arrays
with uniqueItems=true, as they are not preserving the order. 
The issue mentioned is [issue](https://github.com/OpenAPITools/openapi-generator/issues/10167).
To solve this issue, added the `@JsonDeserialize(as = LinkedHashSet.class)`
on setter method.

Note: I am not able to create such a scenario in our code for spec test/unit test.
           But this works for the Upcoming PR of having multiple environments on consumer.


