### PR TITLE
[F] Support multiple environments on consumers [ENT-3896]

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -8493,6 +8493,10 @@ components:
                   $ref: '#/components/schemas/ConsumerActivationKeyDTO'
               serviceType:
                 type: string
+              environments:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EnvironmentDTO'
 
     ConsumerActivationKeyDTO:
       description: Represent activation keys used by consumer in registration
@@ -8535,8 +8539,6 @@ components:
               $ref: '#/components/schemas/ReleaseVerDTO'
             owner:
               $ref: '#/components/schemas/NestedOwnerDTO'
-            environment:
-              $ref: '#/components/schemas/EnvironmentDTO'
             entitlementCount:
               type: integer
               format: int64

--- a/client/ruby/candlepin.rb
+++ b/client/ruby/candlepin.rb
@@ -513,11 +513,7 @@ module Candlepin
           end
         end
 
-        if opts[:environment].nil?
-          path = "/consumers"
-        else
-          path = "/environments/#{opts[:environment]}/consumers"
-        end
+        path = "/consumers"
 
         query_args = opts.slice(:username, :owner).compact
         keys = opts[:activation_keys].join(",")

--- a/client/ruby/candlepin_api.rb
+++ b/client/ruby/candlepin_api.rb
@@ -106,7 +106,7 @@ class Candlepin
   # TODO: need to switch to a params hash, getting to be too many arguments.
   def register(name, type=:system, uuid=nil, facts={}, username=nil,
               owner_key=nil, activation_keys=[], installedProducts=[],
-              environment=nil, capabilities=[], hypervisor_id=nil,
+              environments=[], capabilities=[], hypervisor_id=nil,
               content_tags=[], created_date=nil, last_checkin_date=nil,
               annotations=nil, recipient_owner_key=nil, user_agent=nil,
               entitlement_count=0, id_cert=nil, serviceLevel=nil, role=nil, usage=nil,
@@ -119,6 +119,7 @@ class Candlepin
       :facts => facts,
       :installedProducts => installedProducts,
       :contentTags => content_tags,
+      :environments => environments,
     }
 
     consumer[:capabilities] = capabilities.collect { |name| {'name' => name} } if capabilities
@@ -142,13 +143,8 @@ class Candlepin
     consumer[:serviceType] = service_type if service_type
     params = {}
 
-    if environment.nil?
-      path = get_path("consumers")
-      params[:owner] = owner_key if not owner_key.nil?
-    else
-      path = "/environments/#{environment}/consumers"
-    end
-
+    path = get_path("consumers")
+    params[:owner] = owner_key if not owner_key.nil?
     params[:username] = username if username
     params[:activation_keys] = activation_keys.join(",") if activation_keys.length > 1
     params[:activation_keys] = activation_keys[0] if activation_keys.length == 1
@@ -241,7 +237,7 @@ class Candlepin
     consumer[:capabilities] = params[:capabilities].collect { |name| {'name' => name} } if params[:capabilities]
     consumer[:hypervisorId] = {:hypervisorId => params[:hypervisorId]} if params[:hypervisorId]
     consumer['contentAccessMode'] = params['contentAccessMode'] if params.key?('contentAccessMode')
-    consumer[:environment] = params[:environment] if params.key?(:environment)
+    consumer[:environments] = params[:environments] if params[:environments]
     consumer[:serviceType] = params[:serviceType] if params.has_key?(:serviceType)
 
     path = get_path("consumers")

--- a/spec/autobind_spec.rb
+++ b/spec/autobind_spec.rb
@@ -95,7 +95,7 @@ describe 'Autobind On Owner' do
     hypervisor_guests = [{"guestId"=>"myGuestId"}]
     hypervisor_uuid = random_string("hypervisor")
     hypervisor = @cp.register('hypervisor.bind.com',:system, hypervisor_uuid, hypervisor_facts, 'admin',
-      owner_key, [], [], nil, [], random_string('hypervisorid'))
+      owner_key, [], [], [], [], random_string('hypervisorid'))
     hypervisor = @cp.update_consumer({:uuid => hypervisor.uuid, :guestIds => hypervisor_guests})
 
     @cp.list_owner_pools(owner_key).length.should == 7
@@ -143,7 +143,7 @@ describe 'Autobind On Owner' do
         {'productId' => product2.id, 'productName' => product2['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ['addon1'])
     status = @cp.get_purpose_compliance(consumer['uuid'])
     status['status'].should == 'mismatched'
@@ -173,7 +173,7 @@ describe 'Autobind On Owner' do
         {:productId => product2.id, :productName => product2['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ['addon1'])
 
     entitlements = @cp.list_entitlements(:uuid => consumer.uuid)
@@ -201,7 +201,7 @@ describe 'Autobind On Owner' do
         {'productId' => product2.id, 'productName' => product2['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, 'role1', nil, [])
     status = @cp.get_purpose_compliance(consumer['uuid'])
     status['status'].should == 'mismatched'
@@ -237,7 +237,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, 'role1', nil, [])
     status = @cp.get_purpose_compliance(consumer['uuid'])
     status['status'].should == 'mismatched'
@@ -273,7 +273,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ['addon1'])
     status = @cp.get_purpose_compliance(consumer['uuid'])
     status['status'].should == 'mismatched'
@@ -305,7 +305,7 @@ describe 'Autobind On Owner' do
         {'productId' => product2.id, 'productName' => product2['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ['addon1','addon2'])
     status = @cp.get_purpose_compliance(consumer['uuid'])
     status['status'].should == 'mismatched'
@@ -342,7 +342,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, "my_usage", [])
     status = @cp.get_purpose_compliance(consumer['uuid'])
     status['status'].should == 'mismatched'
@@ -374,7 +374,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, "provided_role", nil, [])
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
@@ -407,7 +407,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ["provided_addon", "random_addon"])
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
@@ -441,7 +441,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, "provided_usage", [])
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
@@ -472,7 +472,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, "provided_sla", nil, nil, [])
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
@@ -528,7 +528,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-            random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+            random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
             nil, [], nil, nil, nil, nil, nil, 0, nil,
             "provided_sla", "provided_role", "provided_usage", ["provided_addon", "another_addon"])
 
@@ -593,7 +593,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
     consumer = @cp.register(
         random_string('systempurpose'), :system, nil, {"cpu.cpu_socket(s)" => 1}, nil, owner_key, [],
-        installed, nil, [], nil, [], nil, nil, nil, nil, nil, 0, nil,
+        installed, [], [], nil, [], nil, nil, nil, nil, nil, 0, nil,
         "mysla")
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -623,7 +623,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
     consumer = @cp.register(
         random_string('systempurpose'), :system, nil, {"virt.is_guest" => "True"}, nil, owner_key, [],
-        installed, nil, [], nil, [], nil, nil, nil, nil, nil, 0, nil,
+        installed, [], [], nil, [], nil, nil, nil, nil, nil, 0, nil,
         nil, nil, "my_usage", [])
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -653,7 +653,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
     consumer = @cp.register(
         random_string('systempurpose'), :system, nil, {"virt.is_guest" => "True"}, nil, owner_key, [],
-        installed, nil, [], nil, [], nil, nil, nil, nil, nil, 0, nil,
+        installed, [], [], nil, [], nil, nil, nil, nil, nil, 0, nil,
         "unsatisfied_sla", "unsatisfied_role", "unsatisfied_usage", [], nil, nil, nil, nil, "unsatisfied_support")
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -721,7 +721,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
     consumer = @cp.register(
         random_string('systempurpose'), :system, nil, {}, nil, owner_key, [],
-        installed, nil, [], nil, [], nil, nil, nil, nil, nil, 0, nil,
+        installed, [], [], nil, [], nil, nil, nil, nil, nil, 0, nil,
         "my_sla", "my_role", "my_usage", ["my_addon"])
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -750,7 +750,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-            random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+            random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
             nil, [], nil, nil, nil, nil, nil, 0, nil,
             nil, "PROVIDED_ROLE", nil, ["PROVIDED_ADDON", "ANOTHER_ADDON"])
 
@@ -793,7 +793,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {"virt.is_guest"=>"true"}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {"virt.is_guest"=>"true"}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, [])
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})
@@ -823,7 +823,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil,
         nil, "PROVIDED_ROLE", nil, ["PROVIDED_ADDON", "ANOTHER_ADDON"])
 
@@ -863,7 +863,7 @@ describe 'Autobind On Owner' do
         {'productId' => product2.id, 'productName' => product2['name']}]
 
     consumer = @cp.register(
-        random_string('system'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('system'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, 'Layered')
 
     @cp.consume_product(product2['id'], {:uuid => consumer.uuid})
@@ -915,7 +915,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, "test_support")
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
@@ -948,7 +948,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
 
     consumer = @cp.register(
-        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, owner_key, [], installed, [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, [], nil, nil, nil, nil, "provided_service_type");
 
     status = @cp.get_purpose_compliance(consumer['uuid'])
@@ -985,7 +985,7 @@ describe 'Autobind On Owner' do
         {'productId' => eng_product.id, 'productName' => eng_product['name']}]
     consumer = @cp.register(
         random_string('systempurpose'), :system, nil, {"virt.is_guest" => "True"}, nil, owner_key, [],
-        installed, nil, [], nil, [], nil, nil, nil, nil, nil, 0, nil,
+        installed, [], [], nil, [], nil, nil, nil, nil, nil, 0, nil,
         nil, nil, nil, [], nil, nil, nil, nil, "test_support")
 
     @cp.consume_product(nil, {:uuid => consumer.uuid})

--- a/spec/cloud_registration_spec.rb
+++ b/spec/cloud_registration_spec.rb
@@ -36,7 +36,7 @@ describe 'Cloud Registration' do
         owner = create_owner("test_org")
         token = generate_token(owner['key'])
 
-        consumer = @cp.register("cloud_consumer", :system, nil, {}, nil, owner['key'], [], [], nil, [],
+        consumer = @cp.register("cloud_consumer", :system, nil, {}, nil, owner['key'], [], [], [], [],
             nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, token)
 
         expect(consumer).to_not be_nil

--- a/spec/consumer_resource_activation_key_spec.rb
+++ b/spec/consumer_resource_activation_key_spec.rb
@@ -77,7 +77,7 @@ describe 'Consumer Resource Activation Key' do
     @cp.add_prod_id_to_key(key1['id'], prod1.id)
     consumer = @client.register(random_string('machine1'), :system, nil, {}, nil,
       @owner['key'], ["key1"], [{'productId' => prod1.id, 'productName' => prod1.name}],
-      nil, [], nil,
+      [], [], nil,
       [], nil, nil,
       nil, nil, nil,
       0, nil, nil, nil, nil,
@@ -100,7 +100,7 @@ describe 'Consumer Resource Activation Key' do
     @cp.add_prod_id_to_key(key1['id'], prod1.id)
     consumer = @client.register(random_string('machine1'), :system, nil, {}, nil,
       @owner['key'], ["key1"], [{'productId' => prod1.id, 'productName' => prod1.name}],
-      nil, [], nil,
+      [], [], nil,
       [], nil, nil,
       nil, nil, nil,
       0, nil, nil, nil, nil,
@@ -180,7 +180,7 @@ describe 'Consumer Resource Activation Key' do
     key1 = @cp.create_activation_key(@owner['key'], 'key1', nil, nil, 'ak-usage', 'ak-role', ['ak-addon1','ak-addon2'])
 
     consumer = @client.register(
-        random_string('machine1'), :system, nil, {}, nil, @owner['key'], ["key1"], nil, nil, nil, nil, nil, nil,
+        random_string('machine1'), :system, nil, {}, nil, @owner['key'], ["key1"], nil, [], nil, nil, nil, nil,
         nil, nil, nil, nil, nil, nil, "client-sla", "client-role", "client-usage", [])
     consumer.uuid.should_not be_nil
 
@@ -208,7 +208,7 @@ describe 'Consumer Resource Activation Key' do
     addons = ['consumer_addon-1', 'consumer_addon-2', 'consumer_addon-3']
 
     consumer = @client.register(random_string('machine1'), :system, nil, {}, nil, @owner['key'], ["key1"],
-      [], nil, [], nil, [], nil, nil, nil, nil, nil, 0, nil, service_level, role, usage, addons)
+      [], [], [], nil, [], nil, nil, nil, nil, nil, 0, nil, service_level, role, usage, addons)
 
     expect(consumer['uuid']).to_not be_nil
 

--- a/spec/consumer_resource_dev_spec.rb
+++ b/spec/consumer_resource_dev_spec.rb
@@ -98,7 +98,7 @@ describe 'Consumer Dev Resource' do
   it 'should not allow entitlement for consumer past expiration' do
     created_date = '2015-05-09T13:23:55+0000'
     consumer = @user.register(random_string('system'), type=:system, nil, facts = {:dev_sku => @dev_product_1['id']},
-      @username, @owner['key'], [], [], nil, [], nil, [], created_date)
+      @username, @owner['key'], [], [], [], [], nil, [], created_date)
     consumer_client = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
     expected_error = "Unable to attach subscription for the product \"#{@dev_product_1['id']}\": Subscriptions for #{@dev_product_1['id']} expired on:"
 

--- a/spec/derived_product_spec.rb
+++ b/spec/derived_product_spec.rb
@@ -38,7 +38,7 @@ describe 'Derived Products' do
     # For linking the host and the guest:
     @uuid = random_string('system.uuid')
 
-    @physical_sys = @user.register(random_string('host'), :system, nil, {"cpu.cpu_socket(s)" => 8}, nil, nil, [], [], nil)
+    @physical_sys = @user.register(random_string('host'), :system, nil, {"cpu.cpu_socket(s)" => 8}, nil, nil, [], [], [])
     @physical_client = Candlepin.new(nil, nil, @physical_sys['idCert']['cert'], @physical_sys['idCert']['key'])
     @physical_client.update_consumer({
       :facts => {"system.certificate_version" => "3.2"},
@@ -98,7 +98,7 @@ describe 'Derived Products' do
     @pools = @cp.list_owner_pools(@owner['key'], { :product => @datacenter_product['id'] })
     expect(@pools.size).to eq(1)
 
-    @distributor = @user.register(random_string('host'), :candlepin, nil, {}, nil, nil, [], [], nil)
+    @distributor = @user.register(random_string('host'), :candlepin, nil, {}, nil, nil, [], [], [])
     @distributor_client = Candlepin.new(nil, nil, @distributor['idCert']['cert'], @distributor['idCert']['key'])
   end
 

--- a/spec/distributor_capability_spec.rb
+++ b/spec/distributor_capability_spec.rb
@@ -66,7 +66,7 @@ describe 'Distributor Capability' do
     }
     capabilities = ["one","two"]
     consumer = @user.register(random_string("consumer"), :candlepin, nil, facts,
-                              nil, nil, [], [], nil, capabilities)
+                              nil, nil, [], [], [], capabilities)
     consumer.capabilities.size.should == 2
 
   end

--- a/spec/environment_cert_v3_spec.rb
+++ b/spec/environment_cert_v3_spec.rb
@@ -15,8 +15,8 @@ describe 'Environments Certificate V3' do
   it 'filters content not promoted to environment' do
     consumer = @org_admin.register(random_string('testsystem'), :system, nil,
         {'system.certificate_version' => '3.1'},
-        nil, nil, [], [], @env['id'])
-    consumer['environment'].should_not be_nil
+        nil, nil, [], [], [{'id' => @env['id']}])
+    expect(consumer['environments']).not_to be_nil
     consumer_cp = Candlepin.new(nil, nil, consumer['idCert']['cert'],
       consumer['idCert']['key'])
 
@@ -50,8 +50,8 @@ describe 'Environments Certificate V3' do
   it 'regenerates certificates after promoting/demoting content' do
     consumer = @org_admin.register(random_string('testsystem'), :system, nil,
         {'system.certificate_version' => '3.1'},
-        nil, nil, [], [], @env['id'])
-    consumer['environment'].should_not be_nil
+        nil, nil, [], [], [{'id' => @env['id']}])
+    expect(consumer['environments']).not_to be_nil
     consumer_cp = Candlepin.new(nil, nil, consumer['idCert']['cert'],
       consumer['idCert']['key'])
 

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -25,7 +25,7 @@ describe 'Environments' do
 
   it 'should cleanup consumers of deleted environment' do
     consumer = @org_admin.register(random_string('testsystem'), :system, nil, {},
-        nil, nil, [], [], @env['id'])
+        nil, nil, [], [], [{'id' => @env['id']}])
     id_cert_serial = consumer['idCert']['serial']['serial']
 
     @org_admin.delete_environment(@env['id'])
@@ -214,8 +214,8 @@ describe 'Environments' do
 
   it 'filters content not promoted to environment' do
     consumer = @org_admin.register(random_string('testsystem'), :system, nil, {},
-        nil, nil, [], [], @env['id'])
-    consumer['environment'].should_not be_nil
+        nil, nil, [], [], [{ 'id' => @env['id']}])
+    expect(consumer['environments']).not_to be_nil
     consumer_cp = Candlepin.new(nil, nil, consumer['idCert']['cert'],
       consumer['idCert']['key'])
 
@@ -247,8 +247,8 @@ describe 'Environments' do
   end
 
   it 'regenerates certificates after promoting/demoting content' do
-    consumer = @org_admin.register(random_string('testsystem'), :system, nil, {}, nil, nil, [], [], @env['id'])
-    consumer['environment'].should_not be_nil
+    consumer = @org_admin.register(random_string('testsystem'), :system, nil, {}, nil, nil, [], [], [{ 'id' => @env['id']}])
+    expect(consumer['environments']).not_to be_nil
     consumer_cp = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
 
     product = create_product
@@ -317,8 +317,8 @@ describe 'Environments' do
     wait_for_job(job['id'], 15)
     job = @cp.promote_content(env3['id'], [{:contentId => content2['id']}])
     wait_for_job(job['id'], 15)
-    @cp.register(random_string("consumer1"), :system, nil, {}, random_string("consumer1"), @owner['key'], [], [], env3['id'])
-    @cp.register(random_string("consumer2"), :system, nil, {}, random_string("consumer2"), @owner['key'], [], [], env3['id'])
+    @cp.register(random_string("consumer1"), :system, nil, {}, random_string("consumer1"), @owner['key'], [], [], [{ 'id' => env3['id']}])
+    @cp.register(random_string("consumer2"), :system, nil, {}, random_string("consumer2"), @owner['key'], [], [], [{ 'id' => env3['id']}])
 
     environments = @cp.list_environments(@owner['key'])
     expect(environments.length).to be >= 3

--- a/spec/hypervisor_check_in_spec.rb
+++ b/spec/hypervisor_check_in_spec.rb
@@ -16,7 +16,7 @@ describe 'Hypervisor Resource', :type => :virt do
     # we must register the consumer to use it as a client
     # hypervisor check in creation does not result in a client cert
     consumer = @user.register(@expected_host_name, :hypervisor, nil, {"test_fact" => "fact_value"},
-        nil, nil, [], [], nil, [], @expected_host_hyp_id)
+        nil, nil, [], [], [], [], @expected_host_hyp_id)
 
     # Check in to associate guests.
     host_guest_mapping = get_host_guest_mapping(@expected_host_hyp_id, @expected_guest_ids)
@@ -772,9 +772,9 @@ describe 'Hypervisor Resource', :type => :virt do
     guests = [{:guestId => uuid1}]
 
     host_consumer = user.register(random_string('host1'), :hypervisor, nil,
-      {}, nil, owner['key'], [], [], nil, [], 'hypervisor_id_1')
+      {}, nil, owner['key'], [], [], [], [], 'hypervisor_id_1')
     new_host_consumer = user.register(random_string('host2'), :hypervisor, nil,
-      {}, nil, owner['key'], [], [], nil, [], 'hypervisor_id_2')
+      {}, nil, owner['key'], [], [], [], [], 'hypervisor_id_2')
 
     guest_consumer = user.register(random_string('guest'), :system, nil,
       {'virt.uuid' => uuid1, 'virt.is_guest' => 'true'}, nil, owner['key'], [], [])
@@ -831,9 +831,9 @@ describe 'Hypervisor Resource', :type => :virt do
     guests = [{:guestId => uuid1}]
 
     host_consumer = user.register(random_string('host1'), :hypervisor, nil,
-      {}, nil, owner['key'], [], [], nil, [], 'hypervisor_id_1')
+      {}, nil, owner['key'], [], [], [], [], 'hypervisor_id_1')
     new_host_consumer = user.register(random_string('host2'), :system, nil,
-      {}, nil, owner['key'], [], [], nil, [], 'hypervisor_id_2')
+      {}, nil, owner['key'], [], [], [], [], 'hypervisor_id_2')
 
     guest_consumer = user.register(random_string('guest'), :system, nil,
       {'virt.uuid' => uuid1, 'virt.is_guest' => 'true'}, nil, owner['key'], [], [])
@@ -970,7 +970,7 @@ describe 'Hypervisor Resource', :type => :virt do
     hypervisor_guests = [{"guestId"=>"myGuestId"}]
     hypervisor_id = random_string('hypervisorid')
     hypervisor = @cp.register('hypervisor.bind.com',:system, nil, hypervisor_facts, 'admin',
-      owner_key, [], [{"productId" => prod.id, "productName" => "taylor swift"}], nil, [], hypervisor_id)
+      owner_key, [], [{"productId" => prod.id, "productName" => "taylor swift"}], [], [], hypervisor_id)
     hypervisor = @cp.update_consumer({:uuid => hypervisor.uuid, :guestIds => hypervisor_guests})
     @cp.consume_product(nil, {:uuid => guest.uuid})
     @cp.list_entitlements({:uuid => guest.uuid}).length.should == 1
@@ -1152,7 +1152,7 @@ describe 'Hypervisor Resource', :type => :virt do
     guest_set = [{"guestId"=>"g1"},{"guestId"=>"g2"}]
     guests = ['g1', 'g2']
 
-    test_host = user.register(host_hyp_id_1, :hypervisor, nil, {"dmi.system.uuid" => host_system_id, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id_1)
+    test_host = user.register(host_hyp_id_1, :hypervisor, nil, {"dmi.system.uuid" => host_system_id, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], [], [], host_hyp_id_1)
     @cp.update_consumer({:uuid => test_host.uuid, :guestIds => guest_set})
     @cp.get_consumer(test_host.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_1
 
@@ -1171,7 +1171,7 @@ describe 'Hypervisor Resource', :type => :virt do
     guest_set = [{"guestId"=>"g1"},{"guestId"=>"g2"}]
     guests = ['g1', 'g2']
 
-    test_host = user.register(host_name, :hypervisor, nil, {"virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [])
+    test_host = user.register(host_name, :hypervisor, nil, {"virt.is_guest"=>"false"}, nil, owner['key'], [], [], [], [])
     @cp.update_consumer({:uuid => test_host.uuid, :guestIds => guest_set, :facts => {"dmi.system.uuid" => host_system_id, "virt.is_guest"=>"false"}})
     expect(@cp.get_consumer(test_host.uuid)['hypervisorId']).to be_nil
 
@@ -1225,7 +1225,7 @@ describe 'Hypervisor Resource', :type => :virt do
     guest_set = [{"guestId"=>"g1"},{"guestId"=>"g2"}]
     guests = ['g1', 'g2']
 
-    test_host = user.register(host_hyp_id, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id)
+    test_host = user.register(host_hyp_id, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], [], [], host_hyp_id)
     @cp.update_consumer({:uuid => test_host.uuid, :guestIds => guest_set})
     @cp.get_consumer(test_host.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id
 
@@ -1257,15 +1257,15 @@ describe 'Hypervisor Resource', :type => :virt do
     guest_set_3 = [{"guestId"=>"g5"},{"guestId"=>"g6"}]
     guests_3 = ['g5', 'g6']
 
-    test_host_1 = user.register(host_hyp_id_1, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id_1)
+    test_host_1 = user.register(host_hyp_id_1, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], [], [], host_hyp_id_1)
     @cp.update_consumer({:uuid => test_host_1.uuid, :guestIds => guest_set_1})
     @cp.get_consumer(test_host_1.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_1
 
-    test_host_2 = user.register(host_hyp_id_2, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_2, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id_2)
+    test_host_2 = user.register(host_hyp_id_2, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_2, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], [], [], host_hyp_id_2)
     @cp.update_consumer({:uuid => test_host_2.uuid, :guestIds => guest_set_2})
     @cp.get_consumer(test_host_2.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_2
 
-    test_host_3 = user.register(host_hyp_id_3, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_3, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id_3)
+    test_host_3 = user.register(host_hyp_id_3, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_3, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], [], [], host_hyp_id_3)
     @cp.update_consumer({:uuid => test_host_3.uuid, :guestIds => guest_set_3})
     @cp.get_consumer(test_host_3.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_3
 
@@ -1296,7 +1296,7 @@ describe 'Hypervisor Resource', :type => :virt do
     guest_set_1 = [{"guestId"=>"g1"},{"guestId"=>"g2"}]
     guests_1 = ['g1', 'g2']
 
-    test_host_1 = user.register(host_hyp_id_1, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id_1)
+    test_host_1 = user.register(host_hyp_id_1, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], [], [], host_hyp_id_1)
     @cp.update_consumer({:uuid => test_host_1.uuid, :guestIds => guest_set_1})
     @cp.get_consumer(test_host_1.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_1
 
@@ -1316,7 +1316,7 @@ describe 'Hypervisor Resource', :type => :virt do
     guest_set_1 = [{"guestId"=>"g1"},{"guestId"=>"g2"}]
     guests_1 = ['g1', 'g2']
 
-    test_host_1 = user.register(host_hyp_id_1, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], nil, [], host_hyp_id_1)
+    test_host_1 = user.register(host_hyp_id_1, :hypervisor, nil, {"dmi.system.uuid" => host_system_id_1, "virt.is_guest"=>"false"}, nil, owner['key'], [], [], [], [], host_hyp_id_1)
     test_host_name = test_host_1['name']
     @cp.update_consumer({:uuid => test_host_1.uuid, :guestIds => guest_set_1})
     @cp.get_consumer(test_host_1.uuid)['hypervisorId']['hypervisorId'].should == host_hyp_id_1

--- a/spec/hypervisor_heartbeat_spec.rb
+++ b/spec/hypervisor_heartbeat_spec.rb
@@ -20,7 +20,7 @@ describe 'Hypervisor Resource - Heartbeat Endpoint', :type => :virt do
     # we must register the consumer to use it as a client
     # hypervisor check in creation does not result in a client cert
     @consumer = @user.register(@expected_host_name, :hypervisor, nil, {"test_fact" => "fact_value"},
-      nil, @owner['key'], [], [], nil, [], @expected_host_hyp_id,
+      nil, @owner['key'], [], [], [], [], @expected_host_hyp_id,
       [], nil, '2010-01-18T19:25:41+0000', nil, nil, nil, 0, nil, nil, nil, nil, [], @expected_reporter_id)
 
     @client = consumer_client(@user, random_string("consumer"))

--- a/spec/instance_spec.rb
+++ b/spec/instance_spec.rb
@@ -21,7 +21,7 @@ describe 'Instance Based Subscriptions' do
     @uuid = random_string('system.uuid')
 
     @physical_sys = @user.register(random_string('host'), :system, nil,
-      {"cpu.cpu_socket(s)" => 8}, nil, nil, [], installed_prods, nil)
+      {"cpu.cpu_socket(s)" => 8}, nil, nil, [], installed_prods, [])
     @physical_client = Candlepin.new(nil, nil, @physical_sys['idCert']['cert'], @physical_sys['idCert']['key'])
     @physical_client.update_consumer({:guestIds => [{'guestId' => @uuid}]})
 

--- a/spec/one_sub_pool_per_stack_spec.rb
+++ b/spec/one_sub_pool_per_stack_spec.rb
@@ -421,10 +421,10 @@ describe 'One Sub Pool Per Stack' do
     # Create some consumers, and have them consume the pool
     for i in 0..2 do
       owner1_consumer_name = random_string('test_system')
-      owner1_consumer = @cp.register(owner1_consumer_name, :system, nil, {}, nil, owner1['key'], [], [], nil)
+      owner1_consumer = @cp.register(owner1_consumer_name, :system, nil, {}, nil, owner1['key'], [], [], [])
 
       owner2_consumer_name = random_string('test_system')
-      owner2_consumer = @cp.register(owner2_consumer_name, :system, nil, {}, nil, owner2['key'], [], [], nil)
+      owner2_consumer = @cp.register(owner2_consumer_name, :system, nil, {}, nil, owner2['key'], [], [], [])
 
       @cp.consume_pool(owner1_pool['id'], { :uuid => owner1_consumer['uuid'] })
       @cp.consume_pool(owner2_pool['id'], { :uuid => owner2_consumer['uuid'] })

--- a/spec/owner_resource_spec.rb
+++ b/spec/owner_resource_spec.rb
@@ -689,16 +689,16 @@ describe 'Owner Resource' do
     user1 = user_client(owner1, username1)
 
     consumer1 = user1.register(random_string('consumer1'), :system, nil, {}, random_string('consumer1'), owner1_key,
-      [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, 'sla1', 'common_role', 'usage1', ['addon1'],
+      [], [], [], [], nil, [], nil, nil, nil, nil, nil, nil, nil, 'sla1', 'common_role', 'usage1', ['addon1'],
       nil, nil, nil, nil, 'test_service-type1')
     consumer2 = user1.register(random_string('consumer2'), :system, nil, {}, random_string('consumer2'), owner1_key,
-      [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, 'sla2', 'common_role', 'usage2', ['addon2'],
+      [], [], [], [], nil, [], nil, nil, nil, nil, nil, nil, nil, 'sla2', 'common_role', 'usage2', ['addon2'],
       nil, nil, nil, nil, 'test_service-type2')
     consumer3 = user1.register(random_string('consumer3'), :system, nil, {}, random_string('consumer3'), owner1_key,
-      [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, nil, nil, 'usage3', [''],
+      [], [], [], [], nil, [], nil, nil, nil, nil, nil, nil, nil, nil, nil, 'usage3', [''],
       nil, nil, nil, nil, 'test_service-type3')
     consumer4 = user1.register(random_string('consumer4'), :system, nil, {}, random_string('consumer4'), owner1_key,
-      [], [], nil, [], nil, [], nil, nil, nil, nil, nil, nil, nil, nil, '', 'usage4', nil,
+      [], [], [], [], nil, [], nil, nil, nil, nil, nil, nil, nil, nil, '', 'usage4', nil,
       nil, nil, nil, nil, 'test_service-type4')
 
     user1.list_owner_consumers(owner1_key).length.should == 4

--- a/spec/sku_level_enable_override_spec.rb
+++ b/spec/sku_level_enable_override_spec.rb
@@ -74,8 +74,8 @@ describe 'SKU Level Enable Override' do
       "My Test Env 1", "For test systems only.")
     consumer = @org_admin.register(random_string('consumer'), :system, nil,
       {'system.certificate_version' => '3.2'},
-      nil, nil, [], [], env['id'])
-    consumer['environment'].should_not be_nil
+      nil, nil, [], [], [{'id' => env['id']}])
+    expect(consumer['environments']).to_not be_nil
     consumer_cp = Candlepin.new(nil, nil, consumer['idCert']['cert'],
       consumer['idCert']['key'])
     providedProduct = create_product
@@ -151,8 +151,8 @@ describe 'SKU Level Enable Override' do
       "My Test Env 1", "For test systems only.")
     consumer = @org_admin.register(random_string('consumer'), :system, nil,
         {'system.certificate_version' => '1.0'},
-        nil, nil, [], [], env['id'])
-    consumer['environment'].should_not be_nil
+        nil, nil, [], [], [{'id' => env['id']}])
+    expect(consumer['environments']).not_to be_nil
     consumer_cp = Candlepin.new(nil, nil, consumer['idCert']['cert'],
       consumer['idCert']['key'])
 

--- a/spec/system_purpose_compliance_spec.rb
+++ b/spec/system_purpose_compliance_spec.rb
@@ -16,7 +16,7 @@ describe 'System purpose compliance' do
 
   it 'should be not specified for a consumer sans purpose preference' do
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       status['status'].should == 'not specified'
@@ -24,7 +24,7 @@ describe 'System purpose compliance' do
 
   it 'should be mismatched for unsatisfied role' do
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, 'unsatisfied-role', nil, nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       status['status'].should == 'mismatched'
@@ -45,7 +45,7 @@ describe 'System purpose compliance' do
       p = create_pool_and_subscription(@owner2['key'], product.id, nil, nil, nil, nil, nil, start_date, end_date)
 
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, 'myrole', nil, nil)
 
       status = @user2.get_purpose_compliance(consumer['uuid'], on_date=Date.new(2037, 5, 5))
@@ -83,7 +83,7 @@ describe 'System purpose compliance' do
 
       # check that the status has been calculated during consumer registration
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, 'myrole', nil, nil)
       consumer = @user2.get_consumer(consumer['uuid'])
       consumer.systemPurposeStatus.should == 'mismatched'
@@ -114,7 +114,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       p = create_pool_and_subscription(@owner2['key'], product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, 'myrole', nil, nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       status['status'].should == 'mismatched'
@@ -133,7 +133,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       p = create_pool_and_subscription(@owner2['key'], product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
@@ -149,7 +149,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       p = create_pool_and_subscription(@owner2['key'], product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
@@ -165,7 +165,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       p = create_pool_and_subscription(@owner2['key'], product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
@@ -181,7 +181,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       p = create_pool_and_subscription(@owner2['key'], product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
@@ -192,7 +192,7 @@ describe 'System purpose compliance' do
 
   it 'should be mismatched for unsatisfied usage' do
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, 'taylor', nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       status['status'].should == 'mismatched'
@@ -210,7 +210,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       p = create_pool_and_subscription(@owner2['key'], product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, 'myusage', nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       status['status'].should == 'mismatched'
@@ -224,7 +224,7 @@ describe 'System purpose compliance' do
 
   it 'should be mismatched for unsatisfied addon' do
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ['addon1', 'addon2'])
       status = @user2.get_purpose_compliance(consumer['uuid'])
       status['status'].should == 'mismatched'
@@ -252,7 +252,7 @@ describe 'System purpose compliance' do
       p2 = create_pool_and_subscription(@owner2['key'], product2.id)
 
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, ['addon1', 'addon2'])
       status = @user2.get_purpose_compliance(consumer['uuid'])
       status['status'].should == 'mismatched'
@@ -281,7 +281,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       create_pool_and_subscription(@owner2['key'], product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, 'mysla', nil, nil, nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       status['status'].should == 'mismatched'
@@ -315,7 +315,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       p = create_pool_and_subscription(@owner2['key'], product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, 'mysla', nil, nil, nil)
       status = @user2.get_purpose_compliance(consumer['uuid'])
       status['status'].should == 'mismatched'
@@ -339,7 +339,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       another_p = create_pool_and_subscription(@owner2['key'], another_product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, 'mysla', nil, nil, nil)
       @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
       @user2.consume_pool(another_p.id, params={:uuid=>consumer.uuid})
@@ -361,7 +361,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       another_p = create_pool_and_subscription(@owner2['key'], another_product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, 'myusage', nil)
       @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
       @user2.consume_pool(another_p.id, params={:uuid=>consumer.uuid})
@@ -378,7 +378,7 @@ describe 'System purpose compliance' do
                                :owner => @owner2['key']})
       p = create_pool_and_subscription(@owner2['key'], product.id)
       consumer = @user2.register(
-          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+          random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
           nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, 'myusage', nil)
       @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
       status = @user2.get_purpose_compliance(consumer['uuid'])
@@ -409,7 +409,7 @@ describe 'System purpose compliance' do
           @owner2['key'],
           [],
           [],
-          nil,
+          [],
           [],
           nil,
           [],
@@ -466,7 +466,7 @@ describe 'System purpose compliance' do
           @owner2['key'],
           [],
           [],
-          nil,
+          [],
           [],
           nil,
           [],
@@ -536,7 +536,7 @@ describe 'System purpose compliance' do
           @owner2['key'],
           [],
           [],
-          nil,
+          [],
           [],
           nil,
           [],
@@ -596,7 +596,7 @@ describe 'System purpose compliance' do
     p = create_pool_and_subscription(@owner2['key'], product.id)
 
     consumer = @user2.register(
-        random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
     @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})
@@ -608,7 +608,7 @@ describe 'System purpose compliance' do
 
   it 'should be mismatched for unsatisfied service type' do
     consumer = @user2.register(
-        random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, "test_service_type")
     status = @user2.get_purpose_compliance(consumer['uuid'])
     expect(status['status']).to eq('mismatched')
@@ -626,7 +626,7 @@ describe 'System purpose compliance' do
                               :owner => @owner2['key']})
     p = create_pool_and_subscription(@owner2['key'], product.id)
     consumer = @user2.register(
-        random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, 'test_service_type')
 
     status = @user2.get_purpose_compliance(consumer['uuid'])
@@ -652,7 +652,7 @@ describe 'System purpose compliance' do
     another_p = create_pool_and_subscription(@owner2['key'], another_product.id)
 
     consumer = @user2.register(
-        random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], nil, [],
+        random_string('systempurpose'), :system, nil, {}, nil, @owner2['key'], [], [], [], [],
         nil, [], nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, "L1")
 
     @user2.consume_pool(p.id, params={:uuid=>consumer.uuid})

--- a/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -166,7 +166,7 @@ public class StandardTranslator extends SimpleModelTranslator {
             Consumer.class, org.candlepin.dto.api.v1.ConsumerDTO.class);
         this.registerTranslator(
             new org.candlepin.dto.api.v1.ConsumerArrayElementTranslator(
-            consumerTypeCurator, environmentCurator, ownerCurator),
+            consumerTypeCurator, ownerCurator),
             Consumer.class, org.candlepin.dto.api.v1.ConsumerDTOArrayElement.class);
         this.registerTranslator(
             new ConsumerInstalledProductTranslator(), ConsumerInstalledProduct.class,

--- a/src/main/java/org/candlepin/dto/api/v1/ConsumerArrayElementTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ConsumerArrayElementTranslator.java
@@ -21,8 +21,6 @@ import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
-import org.candlepin.model.Environment;
-import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Release;
@@ -41,18 +39,13 @@ import java.util.Set;
 public class ConsumerArrayElementTranslator implements ObjectTranslator<Consumer, ConsumerDTOArrayElement> {
 
     protected ConsumerTypeCurator consumerTypeCurator;
-    protected EnvironmentCurator environmentCurator;
     private OwnerCurator ownerCurator;
 
     public ConsumerArrayElementTranslator(ConsumerTypeCurator consumerTypeCurator,
-        EnvironmentCurator environmentCurator, OwnerCurator ownerCurator) {
+        OwnerCurator ownerCurator) {
 
         if (consumerTypeCurator == null) {
             throw new IllegalArgumentException("ConsumerTypeCurator is null");
-        }
-
-        if (environmentCurator == null) {
-            throw new IllegalArgumentException("environmentCurator is null");
         }
 
         if (ownerCurator == null) {
@@ -61,7 +54,6 @@ public class ConsumerArrayElementTranslator implements ObjectTranslator<Consumer
 
         this.ownerCurator = ownerCurator;
         this.consumerTypeCurator = consumerTypeCurator;
-        this.environmentCurator = environmentCurator;
     }
 
     /**
@@ -137,9 +129,6 @@ public class ConsumerArrayElementTranslator implements ObjectTranslator<Consumer
                 dest.setOwner(owner != null ? translator.translate(owner, NestedOwnerDTO.class) : null);
             }
 
-            Environment environment = this.environmentCurator.getConsumerEnvironment(source);
-            dest.setEnvironment(translator.translate(environment, EnvironmentDTO.class));
-
             Set<ConsumerInstalledProduct> installedProducts = source.getInstalledProducts();
             if (installedProducts != null) {
                 ObjectTranslator<ConsumerInstalledProduct, ConsumerInstalledProductDTO> cipTranslator =
@@ -191,7 +180,6 @@ public class ConsumerArrayElementTranslator implements ObjectTranslator<Consumer
         else {
             dest.setReleaseVer(null);
             dest.setOwner(null);
-            dest.setEnvironment(null);
             dest.setInstalledProducts(null);
             dest.setCapabilities(null);
             dest.setHypervisorId(null);

--- a/src/main/java/org/candlepin/dto/api/v1/ConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ConsumerTranslator.java
@@ -33,7 +33,10 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 
 /**
  * The ConsumerTranslator provides translation from Consumer model objects to
@@ -137,8 +140,17 @@ public class ConsumerTranslator implements ObjectTranslator<Consumer, ConsumerDT
                 dest.setOwner(owner != null ? translator.translate(owner, NestedOwnerDTO.class) : null);
             }
 
-            Environment environment = this.environmentCurator.getConsumerEnvironment(source);
-            dest.setEnvironment(translator.translate(environment, EnvironmentDTO.class));
+            if (source.getEnvironmentIds() != null && !source.getEnvironmentIds().isEmpty()) {
+                List<EnvironmentDTO> environments = this.environmentCurator.getConsumerEnvironments(source)
+                    .stream()
+                    .map(translator.getStreamMapper(Environment.class, EnvironmentDTO.class))
+                    .collect(Collectors.toList());
+
+                dest.setEnvironments(environments);
+            }
+            else {
+                dest.setEnvironments(null);
+            }
 
             Set<ConsumerInstalledProduct> installedProducts = source.getInstalledProducts();
             if (installedProducts != null) {
@@ -206,7 +218,7 @@ public class ConsumerTranslator implements ObjectTranslator<Consumer, ConsumerDT
         else {
             dest.setReleaseVer(null);
             dest.setOwner(null);
-            dest.setEnvironment(null);
+            dest.setEnvironments(null);
             dest.setInstalledProducts(null);
             dest.setCapabilities(null);
             dest.setHypervisorId(null);

--- a/src/main/java/org/candlepin/exceptions/DuplicateEntryException.java
+++ b/src/main/java/org/candlepin/exceptions/DuplicateEntryException.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.exceptions;
+
+/**
+ * DuplicateEntryException
+ *
+ * Thrown when a request attempts to add same entry in Entity that
+ * has already been added.
+ *
+ */
+public class DuplicateEntryException extends IllegalArgumentException {
+
+    public DuplicateEntryException(String message) {
+        super(message);
+    }
+    public DuplicateEntryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -56,6 +56,7 @@ import org.candlepin.dto.api.v1.ContentAccessDTO;
 import org.candlepin.dto.api.v1.ContentOverrideDTO;
 import org.candlepin.dto.api.v1.DeleteResult;
 import org.candlepin.dto.api.v1.EntitlementDTO;
+import org.candlepin.dto.api.v1.EnvironmentDTO;
 import org.candlepin.dto.api.v1.GuestIdDTO;
 import org.candlepin.dto.api.v1.GuestIdDTOArrayElement;
 import org.candlepin.dto.api.v1.HypervisorIdDTO;
@@ -66,6 +67,7 @@ import org.candlepin.dto.api.v1.ReleaseVerDTO;
 import org.candlepin.dto.api.v1.SystemPurposeComplianceStatusDTO;
 import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.CandlepinException;
+import org.candlepin.exceptions.ConflictException;
 import org.candlepin.exceptions.ForbiddenException;
 import org.candlepin.exceptions.GoneException;
 import org.candlepin.exceptions.IseException;
@@ -95,7 +97,6 @@ import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.EntitlementFilterBuilder;
-import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.GuestIdCurator;
@@ -768,15 +769,6 @@ public class ConsumerResource implements ConsumersApi {
             entity.setReleaseVer(new Release(dto.getReleaseVer().getReleaseVer()));
         }
 
-        if (dto.getEnvironment() != null) {
-            Environment env = environmentCurator.get(dto.getEnvironment().getId());
-            if (env == null) {
-                throw new NotFoundException(i18n.tr("Environment \"{0}\" could not be found.",
-                    dto.getEnvironment().getId()));
-            }
-            entity.setEnvironment(env);
-        }
-
         if (dto.getLastCheckin() != null) {
             entity.setLastCheckin(Util.toDate(dto.getLastCheckin()));
         }
@@ -1001,6 +993,8 @@ public class ConsumerResource implements ConsumersApi {
         try {
             Date createdDate = consumerToCreate.getCreated();
             Date lastCheckIn = consumerToCreate.getLastCheckin();
+
+            this.updateEnvironments(consumer, consumerToCreate, false);
 
             // create sets created to current time.
             consumerToCreate = consumerCurator.create(consumerToCreate);
@@ -1534,7 +1528,7 @@ public class ConsumerResource implements ConsumersApi {
 
         changesMade = updateSystemPurposeData(updated, toUpdate) || changesMade;
 
-        changesMade = updateEnvironment(updated, toUpdate) || changesMade;
+        changesMade = updateEnvironments(updated, toUpdate, true) || changesMade;
 
         // like the other values in an update, if consumer name is null, act as if
         // it should remain the same
@@ -1604,57 +1598,83 @@ public class ConsumerResource implements ConsumersApi {
     }
 
     /**
-     * Updates consumer environment either by environment name or id, reset & re-generate CA certs.
+     * Validates and updates consumer's multiple environments.
+     *
+     * @param updated
+     *  The incoming consumer DTO for which to fetch multiple environments object
+     * @param toUpdate
+     *  The consumer instance to set the validated environments
+     * @param existing
+     *  This identifies whether the consumer is new or existing
+     *  if existing=true, it will regenerate the certificates
+     *
+     * @throws NotFoundException
+     *  if environment is not found by provided id or name
+     *
+     * @throws ConflictException
+     *  if environment is specified more than once
+     *
      * @return boolean status whether any updates are made or not.
      */
-    private boolean updateEnvironment(ConsumerDTO updated, Consumer toUpdate) {
-        if (updated.getEnvironment() == null) {
+    private boolean updateEnvironments(ConsumerDTO updated, Consumer toUpdate, boolean existing) {
+        List<EnvironmentDTO> environments = updated.getEnvironments();
+
+        if (environments == null) {
             return false;
         }
-
         boolean changesMade = false;
-        String environmentId = updated.getEnvironment() == null ? null : updated.getEnvironment().getId();
-        String environmentName = updated.getEnvironment() == null ? null : updated.getEnvironment().getName();
-        String validatedEnvId = null;
+        List<String> validatedEnvIds = new ArrayList<>();
 
-        if (environmentId != null) {
-            if (toUpdate.getEnvironmentId() == null || !toUpdate.getEnvironmentId().equals(environmentId)) {
+        if (environments != null) {
+            for (EnvironmentDTO environment : environments) {
+                String environmentId = environment == null ? null : environment.getId();
+                String environmentName = environment == null ? null : environment.getName();
 
-                if (!environmentCurator.exists(environmentId)) {
-                    throw new NotFoundException(i18n.tr(
-                        "Environment with ID \"{0}\" could not be found.", environmentId));
+                if (environmentId != null) {
+                    if (!environmentCurator.exists(environmentId)) {
+                        throw new NotFoundException(i18n.tr(
+                            "Environment with ID \"{0}\" could not be found.", environmentId));
+                    }
+                }
+                else if (environmentName != null) {
+                    environmentId = this.environmentCurator
+                        .getEnvironmentIdByName(toUpdate.getOwnerId(), environmentName);
+
+                    if (environmentId == null) {
+                        throw new NotFoundException(i18n.tr(
+                            "Environment with name \"{0}\" could not be found.", environmentName));
+                    }
+                }
+                else {
+                    throw new NotFoundException(i18n.tr("Environment could not be" +
+                        " found using provided details."));
                 }
 
-                validatedEnvId = environmentId;
-            }
+                if (validatedEnvIds.contains(environmentId)) {
+                    throw new ConflictException(i18n.tr("Environment \"{0}\"" +
+                        " specified more than once." + environmentId));
+                }
 
-        }
-        else if (environmentName != null) {
-            String envId = this.environmentCurator.
-                getEnvironmentIdByName(toUpdate.getOwnerId(), environmentName);
-
-            if (envId == null) {
-                throw new NotFoundException(i18n.tr(
-                    "Environment with name \"{0}\" could not be found.", environmentName));
-            }
-
-            if (toUpdate.getEnvironmentId() == null || !envId.equals(toUpdate.getEnvironmentId())) {
-                validatedEnvId = envId;
+                validatedEnvIds.add(environmentId);
             }
         }
 
-        if (validatedEnvId != null) {
-            toUpdate.setEnvironmentId(validatedEnvId);
-            // reset content access cert
-            Owner owner = ownerCurator.findOwnerById(toUpdate.getOwnerId());
+        if (validatedEnvIds.size() > 0) {
+            toUpdate.setEnvironmentIds(validatedEnvIds);
 
-            if (owner.isUsingSimpleContentAccess()) {
-                toUpdate.setContentAccessCert(null);
-                this.contentAccessManager.removeContentAccessCert(toUpdate);
+            if (existing) {
+                // reset content access cert
+                Owner owner = ownerCurator.findOwnerById(toUpdate.getOwnerId());
+
+                if (owner.isUsingSimpleContentAccess()) {
+                    toUpdate.setContentAccessCert(null);
+                    this.contentAccessManager.removeContentAccessCert(toUpdate);
+                }
+
+                // lazily regenerate certs, so the client can still work
+                poolManager.regenerateCertificatesOf(toUpdate, true);
             }
 
-            // lazily regenerate certs, so the client can still work
-            poolManager.regenerateCertificatesOf(toUpdate, true);
             changesMade = true;
         }
 
@@ -3050,5 +3070,4 @@ public class ConsumerResource implements ConsumersApi {
             }
         }
     }
-
 }

--- a/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -153,7 +154,7 @@ public class EnvironmentResource implements EnvironmentsApi {
             throw new NotFoundException(i18n.tr("No such environment: {0}", envId));
         }
 
-        List<Consumer> consumers = this.envCurator.getEnvironmentConsumers(environment).list();
+        List<Consumer> consumers = this.envCurator.getEnvironmentConsumers(environment);
         deleteConsumers(environment, consumers);
 
         log.info("Deleting environment: {}", environment);
@@ -305,8 +306,10 @@ public class EnvironmentResource implements EnvironmentsApi {
         this.validator.validateCollectionElementsNotNull(consumer::getInstalledProducts,
             consumer::getGuestIds, consumer::getCapabilities);
 
+        //TODO: This needs to support backward compatibility.
+        // Kept as it is to be handled in other task of multi-environment feature.
         Environment e = lookupEnvironment(envId);
-        consumer.setEnvironment(translator.translate(e, EnvironmentDTO.class));
+        consumer.setEnvironments(Arrays.asList(translator.translate(e, EnvironmentDTO.class)));
         return this.consumerResource.createConsumer(consumer, userName,
             e.getOwner().getKey(), activationKeys, true);
     }

--- a/src/main/java/org/candlepin/resteasy/JsonProvider.java
+++ b/src/main/java/org/candlepin/resteasy/JsonProvider.java
@@ -39,6 +39,7 @@ import org.candlepin.dto.api.v1.DeletedConsumerDTO;
 import org.candlepin.dto.api.v1.DistributorVersionCapabilityDTO;
 import org.candlepin.dto.api.v1.DistributorVersionDTO;
 import org.candlepin.dto.api.v1.EntitlementDTO;
+import org.candlepin.dto.api.v1.EnvironmentDTO;
 import org.candlepin.dto.api.v1.GuestIdDTO;
 import org.candlepin.dto.api.v1.GuestIdDTOArrayElement;
 import org.candlepin.dto.api.v1.HypervisorConsumerDTO;
@@ -216,6 +217,7 @@ public class JsonProvider extends JacksonJsonProvider {
         mapper.addMixIn(DistributorVersionCapabilityDTO.class, DynamicPropertyFilterMixIn.class);
         mapper.addMixIn(DistributorVersionDTO.class, DynamicPropertyFilterMixIn.class);
         mapper.addMixIn(EntitlementDTO.class, DynamicPropertyFilterMixIn.class);
+        mapper.addMixIn(EnvironmentDTO.class, DynamicPropertyFilterMixIn.class);
         mapper.addMixIn(GuestIdDTO.class, DynamicPropertyFilterMixIn.class);
         mapper.addMixIn(GuestIdDTOArrayElement.class, DynamicPropertyFilterMixIn.class);
         mapper.addMixIn(HypervisorIdDTO.class, DynamicPropertyFilterMixIn.class);

--- a/src/main/resources/db/changelog/20210817145050-add-consumer-environments.xml
+++ b/src/main/resources/db/changelog/20210817145050-add-consumer-environments.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20210817145050-1" author="sdhome">
+        <createTable tableName="cp_consumer_environments">
+            <column name="cp_consumer_id" type="VARCHAR(32)">
+                <constraints nullable="false"
+                    references="cp_consumer(id)"
+                    foreignKeyName="cp_consumer_environments_fk1"
+                    deleteCascade="true"/>
+            </column>
+            <column name="environment_id" type="VARCHAR(32)">
+                <constraints nullable="false"
+                    references="cp_environment(id)"
+                    foreignKeyName="cp_consumer_environments_fk2"
+                    deleteCascade="true"/>
+            </column>
+            <column name="priority" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addPrimaryKey tableName="cp_consumer_environments"
+            columnNames="cp_consumer_id, environment_id"
+            constraintName="cp_consumer_environments_pkey"/>
+
+        <createIndex indexName="cp_consumer_environments_idx" tableName="cp_consumer_environments" unique="false">
+            <column name="cp_consumer_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1255,4 +1255,5 @@
     <include file="db/changelog/20210412145432-drop_content_cache.xml"/>
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
+    <include file="db/changelog/20210817145050-add-consumer-environments.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2347,4 +2347,5 @@
     <include file="db/changelog/20210412145432-drop_content_cache.xml"/>
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
+    <include file="db/changelog/20210817145050-add-consumer-environments.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -164,4 +164,5 @@
     <include file="db/changelog/20210412145432-drop_content_cache.xml"/>
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
+    <include file="db/changelog/20210817145050-add-consumer-environments.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
@@ -106,7 +106,7 @@ public class ContentAccessManagerDBTest extends DatabaseTestFixture {
         Consumer consumer = this.createConsumer(owner);
 
         consumer.setFact("system.certificate_version", "3.0");
-        consumer.setEnvironment(environment);
+        consumer.addEnvironment(environment);
 
         return this.consumerCurator.merge(consumer);
     }

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -280,7 +280,7 @@ public class ContentAccessManagerTest {
         Environment environment = new Environment("test_environment", "test_environment", owner);
         environment.setEnvironmentContent(Util.asSet(new EnvironmentContent(environment, content, true)));
 
-        consumer.setEnvironment(environment);
+        consumer.addEnvironment(environment);
 
         doReturn(environment).when(this.mockEnvironmentCurator).get(eq(environment.getId()));
         doReturn(environment).when(this.mockEnvironmentCurator).getConsumerEnvironment(eq(consumer));

--- a/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
+++ b/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.when;
 import org.candlepin.audit.Event;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
-import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.Content;
 import org.candlepin.model.Entitlement;
@@ -238,7 +237,7 @@ public class EntitlementCertificateGeneratorTest {
     public void testLazyRegnerateForEnvironmentContent() {
         String environmentId = "env_id_1";
         List<Entitlement> entitlements = this.generateEntitlements();
-        CandlepinQuery cqmock = mock(CandlepinQuery.class);
+        List cqmock = mock(List.class);
         when(cqmock.iterator()).thenReturn(entitlements.iterator());
         when(this.mockEntitlementCurator.listByEnvironment(environmentId)).thenReturn(cqmock);
 
@@ -261,7 +260,7 @@ public class EntitlementCertificateGeneratorTest {
             ecMap.put(entitlement.getPool().getId(), new EntitlementCertificate());
         }
 
-        CandlepinQuery<Entitlement> cqmock = mock(CandlepinQuery.class);
+        List<Entitlement> cqmock = mock(List.class);
         when(cqmock.iterator()).thenReturn(entitlements.iterator());
         when(this.mockEntitlementCurator.listByEnvironment(environmentId)).thenReturn(cqmock);
         when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),

--- a/src/test/java/org/candlepin/dto/api/v1/ConsumerArrayElementTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ConsumerArrayElementTranslatorTest.java
@@ -29,7 +29,6 @@ import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
-import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
 import org.candlepin.model.Owner;
@@ -77,7 +76,7 @@ public class ConsumerArrayElementTranslatorTest extends
         this.mockOwnerCurator = mock(OwnerCurator.class);
 
         this.translator = new ConsumerArrayElementTranslator(this.mockConsumerTypeCurator,
-            this.mockEnvironmentCurator, this.mockOwnerCurator);
+            this.mockOwnerCurator);
 
         return this.translator;
     }
@@ -98,7 +97,6 @@ public class ConsumerArrayElementTranslatorTest extends
     @Override
     protected Consumer initSourceObject() {
         ConsumerType ctype = this.consumerTypeTranslatorTest.initSourceObject();
-        Environment environment = this.environmentTranslatorTest.initSourceObject();
         Owner owner = this.ownerTranslatorTest.initSourceObject();
         when(mockOwnerCurator.findOwnerById(eq(owner.getId()))).thenReturn(owner);
 
@@ -116,7 +114,6 @@ public class ConsumerArrayElementTranslatorTest extends
         consumer.setServiceType("consumer_service_type");
         consumer.setReleaseVer(new Release("releaseVer"));
         consumer.setOwner(owner);
-        consumer.setEnvironment(environment);
         consumer.setEntitlementCount(0L);
         consumer.setLastCheckin(new Date());
         consumer.setCanActivate(Boolean.TRUE);
@@ -166,9 +163,6 @@ public class ConsumerArrayElementTranslatorTest extends
         when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
-        when(mockEnvironmentCurator.get(eq(environment.getId()))).thenReturn(environment);
-        when(mockEnvironmentCurator.getConsumerEnvironment(eq(consumer))).thenReturn(environment);
-
         return consumer;
     }
 
@@ -204,9 +198,6 @@ public class ConsumerArrayElementTranslatorTest extends
             if (childrenGenerated) {
                 ConsumerType ctype = this.mockConsumerTypeCurator.getConsumerType(source);
                 this.consumerTypeTranslatorTest.verifyOutput(ctype, dest.getType(), true);
-
-                Environment environment = this.mockEnvironmentCurator.getConsumerEnvironment(source);
-                this.environmentTranslatorTest.verifyOutput(environment, dest.getEnvironment(), true);
 
                 assertEquals(source.getReleaseVer().getReleaseVer(), dest.getReleaseVer().getReleaseVer());
                 String destOwnerId = null;
@@ -253,7 +244,6 @@ public class ConsumerArrayElementTranslatorTest extends
             else {
                 assertNull(dest.getReleaseVer());
                 assertNull(dest.getOwner());
-                assertNull(dest.getEnvironment());
                 assertNull(dest.getHypervisorId());
                 assertNull(dest.getType());
                 assertNull(dest.getInstalledProducts());

--- a/src/test/java/org/candlepin/dto/api/v1/ConsumerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ConsumerTranslatorTest.java
@@ -39,6 +39,7 @@ import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Release;
 import org.candlepin.util.Util;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -105,7 +106,11 @@ public class ConsumerTranslatorTest extends
     @Override
     protected Consumer initSourceObject() {
         ConsumerType ctype = this.consumerTypeTranslatorTest.initSourceObject();
-        Environment environment = this.environmentTranslatorTest.initSourceObject();
+        Environment environment1 = this.environmentTranslatorTest.initSourceObject();
+        environment1.setId("env-1");
+        Environment environment2 = this.environmentTranslatorTest.initSourceObject();
+        environment2.setId("env-2");
+        List<Environment> environments = Arrays.asList(environment1, environment2);
         Owner owner = this.ownerTranslatorTest.initSourceObject();
         when(mockOwnerCurator.findOwnerById(eq(owner.getId()))).thenReturn(owner);
 
@@ -123,7 +128,8 @@ public class ConsumerTranslatorTest extends
         consumer.setServiceType("consumer_service_type");
         consumer.setReleaseVer(new Release("releaseVer"));
         consumer.setOwner(owner);
-        consumer.setEnvironment(environment);
+        consumer.addEnvironment(environment1);
+        consumer.addEnvironment(environment2);
         consumer.setEntitlementCount(0L);
         consumer.setLastCheckin(new Date());
         consumer.setCanActivate(Boolean.TRUE);
@@ -186,8 +192,9 @@ public class ConsumerTranslatorTest extends
         when(mockConsumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
         when(mockConsumerTypeCurator.getConsumerType(eq(consumer))).thenReturn(ctype);
 
-        when(mockEnvironmentCurator.get(eq(environment.getId()))).thenReturn(environment);
-        when(mockEnvironmentCurator.getConsumerEnvironment(eq(consumer))).thenReturn(environment);
+        when(mockEnvironmentCurator.get(eq(environment1.getId()))).thenReturn(environment1);
+        when(mockEnvironmentCurator.get(eq(environment2.getId()))).thenReturn(environment2);
+        when(mockEnvironmentCurator.getConsumerEnvironments(eq(consumer))).thenReturn(environments);
 
         return consumer;
     }
@@ -199,6 +206,7 @@ public class ConsumerTranslatorTest extends
     }
 
     @Override
+    @SuppressWarnings("checkstyle:methodlength")
     protected void verifyOutput(Consumer source, ConsumerDTO dest, boolean childrenGenerated) {
 
         if (source != null) {
@@ -226,8 +234,27 @@ public class ConsumerTranslatorTest extends
                 ConsumerType ctype = this.mockConsumerTypeCurator.getConsumerType(source);
                 this.consumerTypeTranslatorTest.verifyOutput(ctype, dest.getType(), true);
 
-                Environment environment = this.mockEnvironmentCurator.getConsumerEnvironment(source);
-                this.environmentTranslatorTest.verifyOutput(environment, dest.getEnvironment(), true);
+                List<Environment> srcEnvironments = mockEnvironmentCurator.getConsumerEnvironments(source);
+                List<EnvironmentDTO> destEnvironments = dest.getEnvironments();
+
+                if (srcEnvironments != null && destEnvironments != null) {
+
+                    assertEquals(srcEnvironments.size(), dest.getEnvironments().size());
+
+                    for (int i = 0; i < srcEnvironments.size(); i++) {
+
+                        Environment srcEnvironment = srcEnvironments.get(i);
+                        EnvironmentDTO destEnvironmentDTO = destEnvironments.get(i);
+
+                        assertNotNull(srcEnvironment);
+                        assertNotNull(destEnvironmentDTO);
+
+                        this.environmentTranslatorTest.verifyOutput(srcEnvironment, destEnvironmentDTO, true);
+                    }
+                }
+                else {
+                    assertNull(dest.getEnvironments());
+                }
 
                 assertEquals(source.getReleaseVer().getReleaseVer(), dest.getReleaseVer().getReleaseVer());
                 String destOwnerId = null;
@@ -291,7 +318,7 @@ public class ConsumerTranslatorTest extends
             else {
                 assertNull(dest.getReleaseVer());
                 assertNull(dest.getOwner());
-                assertNull(dest.getEnvironment());
+                assertNull(dest.getEnvironments());
                 assertNull(dest.getHypervisorId());
                 assertNull(dest.getType());
                 assertNull(dest.getIdCert());

--- a/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -39,8 +39,6 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 
-
-
 public class ConsumerTest extends DatabaseTestFixture {
 
     @Inject private ConsumerResource consumerResource;

--- a/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -81,7 +81,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         environmentCurator.create(environment);
 
         consumer = createConsumer(owner);
-        consumer.setEnvironment(environment);
+        consumer.addEnvironment(environment);
         consumerCurator.create(consumer);
 
         testProduct = TestUtil.createProduct();
@@ -293,7 +293,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void listByEnvironment() {
-        List<Entitlement> ents = entitlementCurator.listByEnvironment(environment).list();
+        List<Entitlement> ents = entitlementCurator.listByEnvironment(environment);
         assertEquals(2, ents.size());
     }
 
@@ -469,7 +469,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         productCurator.create(product);
 
         Consumer otherConsumer = createConsumer(owner);
-        otherConsumer.setEnvironment(environment);
+        otherConsumer.addEnvironment(environment);
         consumerCurator.create(otherConsumer);
 
         List<Entitlement> createdEntitlements = new LinkedList<>();

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -568,4 +568,12 @@ public class ConsumerResourceCreationTest {
         // no compliantUntil, and not update the consumer record
         verify(complianceRules).getStatus(any(Consumer.class), isNull(), eq(false), eq(false));
     }
+
+    @Test
+    public void registerWithNoEnvironments() {
+        Principal p = new TrustedUserPrincipal("anyuser");
+        when(this.principalProvider.get()).thenReturn(p);
+        ConsumerDTO consumer = TestUtil.createConsumerDTO("consumerName", null, null, systemDto);
+        resource.createConsumer(consumer, USER, owner.getKey(), null, true);
+    }
 }

--- a/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
@@ -65,6 +65,7 @@ import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
 @ExtendWith(MockitoExtension.class)
@@ -161,7 +162,7 @@ class EnvironmentResourceTest {
     @Test
     void canDeleteEmptyEnvironment() {
         when(this.envCurator.get(anyString())).thenReturn(this.environment1);
-        CandlepinQuery<Consumer> mockedQuery = mockedQueryOf();
+        List<Consumer> mockedQuery = mockedQueryOf().list();
         when(this.envCurator.getEnvironmentConsumers(eq(this.environment1)))
             .thenReturn(mockedQuery);
 
@@ -182,7 +183,7 @@ class EnvironmentResourceTest {
         consumer2.setIdCert(null);
         consumer2.setContentAccessCert(null);
         when(this.envCurator.get(anyString())).thenReturn(this.environment1);
-        CandlepinQuery<Consumer> mockedQuery = mockedQueryOf(consumer1, consumer2);
+        List<Consumer> mockedQuery = mockedQueryOf(consumer1, consumer2).list();
         when(this.envCurator.getEnvironmentConsumers(eq(this.environment1)))
             .thenReturn(mockedQuery);
 
@@ -212,7 +213,7 @@ class EnvironmentResourceTest {
         Consumer consumer = new Consumer("c1", "u1", this.owner, cType);
         consumer.setIdCert(TestUtil.createIdCert());
         consumer.setContentAccessCert(createContentAccessCert());
-        consumer.setEnvironment(environment);
+        consumer.addEnvironment(environment);
         return consumer;
     }
 

--- a/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -526,7 +526,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         Environment e = this.mockEnvironment(new Environment("env1", "Env 1", owner));
 
         e.getEnvironmentContent().add(new EnvironmentContent(e, content, true));
-        this.consumer.setEnvironment(e);
+        this.consumer.addEnvironment(e);
 
         Map<String, EnvironmentContent> promotedContent = new HashMap<>();
         promotedContent.put(content.getId(), e.getEnvironmentContent().iterator().next());
@@ -588,7 +588,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         // Setup an environment for the consumer:
         Environment e = this.mockEnvironment(new Environment("env1", "Awesome Environment #1", owner));
         e.getEnvironmentContent().add(new EnvironmentContent(e, content, true));
-        this.consumer.setEnvironment(e);
+        this.consumer.addEnvironment(e);
 
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
@@ -609,7 +609,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         // Setup an environment for the consumer:
         Environment e = this.mockEnvironment(new Environment("env1", "Awesome Environment #1", owner));
         e.getEnvironmentContent().add(new EnvironmentContent(e, content, true));
-        this.consumer.setEnvironment(e);
+        this.consumer.addEnvironment(e);
 
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
@@ -721,7 +721,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         // Make sure that we filter by environment when asked.
         Environment environment = this.mockEnvironment(new Environment());
-        consumer.setEnvironment(environment);
+        consumer.addEnvironment(environment);
 
         Map<String, EnvironmentContent> promotedContent = new HashMap<>();
         promotedContent.put(normalContent.getId(), new EnvironmentContent(environment, normalContent, true));

--- a/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -554,7 +554,7 @@ public class DatabaseTestFixture {
         // Update consumers to point to the new environment
         if (consumers != null) {
             for (Consumer consumer : consumers) {
-                consumer.setEnvironmentId(environment.getId());
+                consumer.addEnvironment(environment);
                 this.consumerCurator.merge(consumer);
             }
         }

--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -128,7 +128,9 @@ public class TestUtil {
             .entitlementCount(0L)
             .facts(new HashMap<>())
             .installedProducts(new HashSet<>())
-            .guestIds(new ArrayList<>());
+            .guestIds(new ArrayList<>())
+            .environments(new ArrayList<>());
+
 
         if (owner != null) {
             consumer.setOwner(new NestedOwnerDTO()


### PR DESCRIPTION
 - Added environments in ConsumerDTO/ConsumerDTOArrayElement and
   environmentIds in Consumer Entity.
 - Updated the `PUT /consumers/{consumer_uuid}`
   and the `POST /consumers` endpoint to support
   multiple environment additions from the DTO.
 - Added and updated the spec tests/ unit tests.
 - Adding/removing/re-prioritizing enviornments
   is done on consumer update.