### PR TITLE
Refactor consumer cleanup of environment deletion

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1845,6 +1845,12 @@ public class CandlepinPoolManager implements PoolManager {
         return revokeEntitlements(entsToRevoke, null, true);
     }
 
+    @Override
+    @Transactional
+    public void revokeEntitlements(List<Entitlement> entsToRevoke, boolean regenCertsAndStatuses) {
+        revokeEntitlements(entsToRevoke, null, regenCertsAndStatuses);
+    }
+
     public void revokeEntitlements(List<Entitlement> entsToRevoke, Set<String> alreadyDeletedPools) {
         revokeEntitlements(entsToRevoke, alreadyDeletedPools, true);
     }

--- a/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/src/main/java/org/candlepin/controller/PoolManager.java
@@ -146,6 +146,7 @@ public interface PoolManager {
     int revokeAllEntitlements(Consumer consumer, boolean regenCertsAndStatuses);
 
     Set<Pool> revokeEntitlements(List<Entitlement> ents);
+    void revokeEntitlements(List<Entitlement> ents, boolean regenCertsAndStatuses);
     void revokeEntitlement(Entitlement entitlement);
 
     Pool setPoolQuantity(Pool pool, long set);

--- a/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -90,6 +90,7 @@ import org.candlepin.messaging.impl.artemis.ArtemisUtil;
 import org.candlepin.messaging.impl.noop.NoopContextListener;
 import org.candlepin.messaging.impl.noop.NoopSessionFactory;
 import org.candlepin.model.CPRestrictions;
+import org.candlepin.model.ConsumerService;
 import org.candlepin.model.UeberCertificateGenerator;
 import org.candlepin.pki.CertificateReader;
 import org.candlepin.pki.PKIUtility;
@@ -239,6 +240,7 @@ public class CandlepinModule extends AbstractModule {
         bind(Enforcer.class).to(EntitlementRules.class);
         bind(EntitlementRulesTranslator.class);
         bind(PoolManager.class).to(CandlepinPoolManager.class);
+        bind(ConsumerService.class);
         bind(CandlepinModeManager.class).asEagerSingleton();
         bind(SuspendModeTransitioner.class).asEagerSingleton();
         bind(ScheduledExecutorService.class).toProvider(ScheduledExecutorServiceProvider.class);

--- a/src/main/java/org/candlepin/model/ConsumerService.java
+++ b/src/main/java/org/candlepin/model/ConsumerService.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2009 - 2012 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.candlepin.auth.Principal;
+import org.candlepin.controller.PoolManager;
+import org.candlepin.exceptions.BadRequestException;
+import org.candlepin.exceptions.NotFoundException;
+import org.candlepin.guice.PrincipalProvider;
+import org.candlepin.util.FactValidator;
+import org.candlepin.util.Util;
+
+import com.google.common.collect.Iterables;
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hibernate.Criteria;
+import org.hibernate.FetchMode;
+import org.hibernate.Hibernate;
+import org.hibernate.Query;
+import org.hibernate.ReplicationMode;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.Disjunction;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Restrictions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.MapJoin;
+import javax.persistence.criteria.Order;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+
+@Singleton
+public class ConsumerService {
+    private static final Logger log = LoggerFactory.getLogger(ConsumerService.class);
+
+    @Inject private EntitlementCurator entitlementCurator;
+    @Inject private ConsumerTypeCurator consumerTypeCurator;
+    @Inject private ConsumerCurator consumerCurator;
+    @Inject private DeletedConsumerCurator deletedConsumerCurator;
+    @Inject private PrincipalProvider principalProvider;
+    @Inject private PoolManager poolManager;
+    @Inject private IdentityCertificateCurator identityCertificateCurator;
+    @Inject private ContentAccessCertificateCurator contentAccessCertificateCurator;
+    @Inject private CertificateSerialCurator certificateSerialCurator;
+    @Inject private FactValidator factValidator;
+
+    public void delete(Consumer consumer) {
+        log.debug("Deleting consumer: {}", consumer);
+        this.bulkDelete(Collections.singletonList(consumer));
+    }
+
+    public void bulkDelete(List<Consumer> consumers) {
+        if (consumers == null || consumers.isEmpty()) {
+            return;
+        }
+
+        List<String> uuidsToDelete = new ArrayList<>(consumers.size());
+        List<Long> serialsToRevoke = new ArrayList<>(consumers.size());
+        List<String> idCertsToDelete = new ArrayList<>(consumers.size());
+        List<String> caCertsToDelete = new ArrayList<>(consumers.size());
+
+        for (Consumer c : consumers) {
+            log.info("Deleting consumer: {}", c);
+
+            uuidsToDelete.add(c.getUuid());
+
+            IdentityCertificate idCert = c.getIdCert();
+            if (idCert != null) {
+                idCertsToDelete.add(idCert.getId());
+                serialsToRevoke.add(idCert.getSerial().getId());
+            }
+
+            ContentAccessCertificate contentAccessCert = c.getContentAccessCert();
+            if (contentAccessCert != null) {
+                caCertsToDelete.add(contentAccessCert.getId());
+                serialsToRevoke.add(contentAccessCert.getSerial().getId());
+            }
+        }
+
+        List<Entitlement> entsToRevoke = this.entitlementCurator.listByConsumerUuids(uuidsToDelete);
+        // We're about to delete these consumers; no need to regen/dirty their dependent
+        // entitlements or recalculate status.
+        this.poolManager.revokeEntitlements(entsToRevoke, false);
+
+        this.deleteConsumers(consumers);
+
+        int deletedIdCerts = this.identityCertificateCurator.deleteByIds(idCertsToDelete);
+        log.debug("Deleted {} identity certificates", deletedIdCerts);
+
+        int deletedCaCerts = this.contentAccessCertificateCurator.deleteByIds(caCertsToDelete);
+        log.debug("Deleted {} content access certificates", deletedCaCerts);
+
+        int revokedSerials = this.certificateSerialCurator.revokeByIds(serialsToRevoke);
+        log.debug("Revoked {} certificate serials", revokedSerials);
+    }
+
+    private void deleteConsumers(Collection<Consumer> consumers) {
+        if (consumers == null || consumers.isEmpty()) {
+            return;
+        }
+
+        log.debug("Deleting {} consumer(s)", consumers.size());
+
+        Map<String, Consumer> consumerMap = consumers.stream()
+            .collect(Collectors.toMap(Consumer::getUuid, Function.identity()));
+
+        int deleted = this.consumerCurator.deleteByUuids(consumerMap.keySet());
+        log.debug("Deleted {} consumer(s)", deleted);
+
+        Collection<DeletedConsumer> dcRecords = this.buildDeletedConsumerRecords(consumerMap);
+        this.deletedConsumerCurator.saveOrUpdateAll(dcRecords, false, false);
+    }
+
+    private List<DeletedConsumer> buildDeletedConsumerRecords(Map<String, Consumer> consumerMap) {
+        Principal principal = this.principalProvider.get();
+        String principalName = principal != null ? principal.getName() : null;
+
+        Map<String, DeletedConsumer> dcs = this.deletedConsumerCurator
+            .findByConsumerUuids(consumerMap.keySet()).stream()
+            .collect(Collectors.toMap(DeletedConsumer::getConsumerUuid, Function.identity()));
+
+        Function<Consumer, DeletedConsumer> mapper = (consumer) -> {
+            DeletedConsumer dc = dcs.get(consumer.getUuid());
+            if (dc == null) {
+                dc = new DeletedConsumer();
+            }
+
+            Owner owner = consumer.getOwner();
+
+            return dc.setConsumerUuid(consumer.getUuid())
+                .setOwnerId(owner.getOwnerId())
+                .setOwnerKey(owner.getKey())
+                .setOwnerDisplayName(owner.getDisplayName())
+                .setPrincipalName(principalName);
+        };
+
+        return consumerMap.values()
+            .stream()
+            .map(mapper)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Candlepin supports the notion of a user being a consumer. When in effect
+     * a consumer will exist in the system who is tied to a particular user.
+     *
+     * @param user User
+     * @return Consumer for this user if one exists, null otherwise.
+     */
+    @Transactional
+    public Consumer findByUser(User user) {
+        return user != null ? this.findByUsername(user.getUsername()) : null;
+    }
+
+    /**
+     * Candlepin supports the notion of a user being a consumer. When in effect
+     * a consumer will exist in the system who is tied to a particular user.
+     *
+     * @param username the username to use to find a consumer
+     * @return Consumer for this user if one exists, null otherwise.
+     */
+    @Transactional
+    public Consumer findByUsername(String username) {
+        ConsumerType person = consumerTypeCurator
+            .getByLabel(ConsumerType.ConsumerTypeEnum.PERSON.getLabel());
+
+        // todo
+        return this.consumerCurator.findByUsername(username, person);
+    }
+
+
+    /**
+     * Updates an existing consumer with the state specified by the given Consumer instance. If the
+     * consumer has not yet been created, it will be created.
+     * <p></p>
+     * <strong>Warning:</strong> Using an pre-existing and persisted Consumer entity as the update
+     * to apply may cause issues, as Hibernate may opt to save changes to nested collections
+     * (facts, guestIds, tags, etc.) when any other database operation is performed. To avoid this
+     * issue, it is advised to use only detached or otherwise unmanaged entities for the updated
+     * consumer to pass to this method.
+     *
+     * @param updatedConsumer
+     *  A Consumer instance representing the updated state of a consumer
+     *
+     * @param flush
+     *  Whether or not to flush pending database operations after creating or updating the given
+     *  consumer
+     *
+     * @return
+     *  The persisted, updated consumer
+     */
+    @Transactional
+    public Consumer update(Consumer updatedConsumer, boolean flush) {
+        // TODO: FIXME:
+        // We really need to use a DTO here. Hibernate has so many pitfalls with this approach that
+        // can and will lead to odd, broken or out-of-order behavior.
+
+        // Validate inbound facts before even attempting to apply the update
+        this.factValidator.validate(updatedConsumer);
+
+        Consumer existingConsumer = this.consumerCurator.get(updatedConsumer.getId());
+
+        if (existingConsumer == null) {
+            return this.consumerCurator.create(updatedConsumer, flush);
+        }
+
+        // TODO: Are any of these read-only?
+        existingConsumer.setEntitlements(entitlementCurator.bulkUpdate(updatedConsumer.getEntitlements()));
+
+        // This set of updates is strange. We're ignoring the "null-as-no-change" semantics we use
+        // everywhere else, and just blindly copying everything over.
+        existingConsumer.setFacts(updatedConsumer.getFacts());
+        existingConsumer.setName(updatedConsumer.getName());
+        existingConsumer.setOwner(updatedConsumer.getOwner());
+
+        // Set TypeId only if the existing consumer and update consumer typeId is not equal.
+        // This check has been added for updating Swatch timestamp
+        if (updatedConsumer.getTypeId() != null &&
+            !Util.equals(existingConsumer.getTypeId(), updatedConsumer.getTypeId())) {
+            existingConsumer.setTypeId(updatedConsumer.getTypeId());
+        }
+
+        existingConsumer.setUuid(updatedConsumer.getUuid());
+
+        if (flush) {
+            this.consumerCurator.save(existingConsumer);
+        }
+
+        return existingConsumer;
+    }
+
+}

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -82,6 +82,7 @@ import org.candlepin.model.ConsumerContentOverrideCurator;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerCurator.ConsumerQueryArguments;
 import org.candlepin.model.ConsumerInstalledProduct;
+import org.candlepin.model.ConsumerService;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
@@ -189,6 +190,7 @@ public class ConsumerResource implements ConsumersApi {
     private static final int MAX_CONSUMERS_PER_REQUEST = 1000;
 
     private final ConsumerCurator consumerCurator;
+    private final ConsumerService consumerService;
     private final ConsumerTypeCurator consumerTypeCurator;
     private final SubscriptionServiceAdapter subAdapter;
     private final ProductServiceAdapter prodAdapter;
@@ -231,7 +233,9 @@ public class ConsumerResource implements ConsumersApi {
 
     @Inject
     @SuppressWarnings({ "checkstyle:parameternumber" })
-    public ConsumerResource(ConsumerCurator consumerCurator,
+    public ConsumerResource(
+        ConsumerCurator consumerCurator,
+        ConsumerService consumerService,
         ConsumerTypeCurator consumerTypeCurator,
         SubscriptionServiceAdapter subAdapter,
         ProductServiceAdapter prodAdapter,
@@ -270,6 +274,7 @@ public class ConsumerResource implements ConsumersApi {
         ConsumerContentOverrideCurator ccoCurator) {
 
         this.consumerCurator = Objects.requireNonNull(consumerCurator);
+        this.consumerService = Objects.requireNonNull(consumerService);
         this.consumerTypeCurator = Objects.requireNonNull(consumerTypeCurator);
         this.subAdapter = Objects.requireNonNull(subAdapter);
         this.prodAdapter = Objects.requireNonNull(prodAdapter);
@@ -1978,7 +1983,7 @@ public class ConsumerResource implements ConsumersApi {
         consumerRules.onConsumerDelete(toDelete);
         contentAccessManager.removeContentAccessCert(toDelete);
         Event event = eventFactory.consumerDeleted(toDelete);
-        consumerCurator.delete(toDelete);
+        consumerService.delete(toDelete);
         identityCertService.deleteIdentityCert(toDelete);
         sink.queueEvent(event);
     }

--- a/src/main/java/org/candlepin/util/FactValidator.java
+++ b/src/main/java/org/candlepin/util/FactValidator.java
@@ -16,11 +16,13 @@ package org.candlepin.util;
 
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
+import org.candlepin.model.Consumer;
 
 import com.google.inject.Inject;
 
 import org.xnap.commons.i18n.I18n;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Provider;
@@ -61,4 +63,29 @@ public class FactValidator extends PropertyValidator {
         this.globalValidators.add(new PropertyValidator.LengthValidator(i18nProvider, "fact",
             FACT_MAX_LENGTH));
     }
+
+    /**
+     * Validates the facts associated with the given consumer. If any fact fails validation a
+     * PropertyValidationException will be thrown.
+     *
+     * @param consumer
+     *  The consumer containing the facts to validate
+     */
+    public void validate(Consumer consumer) {
+        // Impl note:
+        // Unlike the previous implementation, we are no longer attempting to "fix" anything here;
+        // if it's broken at this point, we're in trouble, so we're going to throw an exception
+        // instead of waiting for CP to die with a DB exception sometime in the very near future.
+        //
+        // Also, we're no longer using ConfigProperties.CONSUMER_FACTS_MATCHER at this point, as
+        // it's something that belongs with the other input validation and filtering.
+
+        Map<String, String> facts = consumer.getFacts();
+        if (facts != null) {
+            for (Map.Entry<String, String> fact : facts.entrySet()) {
+                this.validate(fact.getKey(), fact.getValue());
+            }
+        }
+    }
+
 }

--- a/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
@@ -19,8 +19,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
@@ -28,113 +28,152 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-/**
- * DeletedConsumerCuratorTest
- */
+
+
 public class DeletedConsumerCuratorTest extends DatabaseTestFixture {
-    @Inject private DeletedConsumerCurator dcc;
 
-    private Date twoResultsDate;
-    private Date oneResultDate;
+    public static final String OWNER_ID_1 = "10";
+    private static final String CONSUMER_UUID_1 = "abcde";
+    private static final String CONSUMER_UUID_2 = "fghij";
+    private static final String CONSUMER_UUID_3 = "klmno";
+    private static final String UNKNOWN_UUID = "dontfind";
+    private static final Date OLDEST_DATE = TestUtil.createDate(2019, 5, 20);
+    private static final Date OLD_DATE = TestUtil.createDate(2020, 5, 20);
 
-
-    @BeforeEach
-    @Override
-    public void init() throws Exception {
-        super.init();
-
-        DeletedConsumer dc = new DeletedConsumer("abcde", "10", "key", "name");
-        dcc.create(dc);
-        try {
-            Thread.sleep(5);
-        }
-        catch (InterruptedException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-
-
-        // save the current time, DCs created after this will have
-        // a created timestamp after this time
-        twoResultsDate = new Date();
-        dc = new DeletedConsumer("fghij", "10", "key", "name");
-        dcc.create(dc);
-        try {
-            Thread.sleep(5);
-        }
-        catch (InterruptedException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-
-        oneResultDate = new Date();
-        dc = new DeletedConsumer("klmno", "20", "key", "name");
-        dcc.create(dc);
-    }
+    @Inject
+    private DeletedConsumerCurator dcc;
 
     @Test
     public void byConsumerId() {
-        DeletedConsumer found = dcc.findByConsumerUuid("abcde");
-        assertEquals("abcde", found.getConsumerUuid());
+        createDeletedConsumer(CONSUMER_UUID_1);
+
+        DeletedConsumer found = dcc.findByConsumerUuid(CONSUMER_UUID_1);
+        assertEquals(CONSUMER_UUID_1, found.getConsumerUuid());
     }
 
     @Test
     public void byConsumer() {
-        Consumer c = mock(Consumer.class);
-        when(c.getUuid()).thenReturn("abcde");
+        createDeletedConsumer(CONSUMER_UUID_1);
+        Consumer c = createConsumer(CONSUMER_UUID_1);
+
         DeletedConsumer found = dcc.findByConsumer(c);
-        assertEquals("abcde", found.getConsumerUuid());
+        assertEquals(CONSUMER_UUID_1, found.getConsumerUuid());
     }
 
     @Test
     public void byOwnerId() {
-        List<DeletedConsumer> found = dcc.findByOwnerId("10").list();
+        createDeletedConsumer(CONSUMER_UUID_1);
+        createDeletedConsumer(CONSUMER_UUID_2);
+
+        List<DeletedConsumer> found = dcc.findByOwnerId(OWNER_ID_1).list();
         assertEquals(2, found.size());
     }
 
     @Test
     public void byOwner() {
-        Owner o = mock(Owner.class);
-        when(o.getId()).thenReturn("20");
+        createDeletedConsumer(CONSUMER_UUID_1);
+        Owner o = createMockOwner(OWNER_ID_1);
+
         List<DeletedConsumer> found = dcc.findByOwner(o).list();
         assertEquals(1, found.size());
     }
 
     @Test
     public void countByConsumerId() {
-        assertEquals(1, dcc.countByConsumerUuid("abcde"));
-        assertEquals(0, dcc.countByConsumerUuid("dontfind"));
-        assertEquals(1, dcc.countByConsumerUuid("fghij"));
+        createDeletedConsumer(CONSUMER_UUID_1);
+        createDeletedConsumer(CONSUMER_UUID_2);
+
+        assertEquals(1, dcc.countByConsumerUuid(CONSUMER_UUID_1));
+        assertEquals(1, dcc.countByConsumerUuid(CONSUMER_UUID_2));
+        assertEquals(0, dcc.countByConsumerUuid(UNKNOWN_UUID));
     }
 
     @Test
     public void countByConsumer() {
-        Consumer c = mock(Consumer.class);
-        when(c.getUuid()).thenReturn("abcde");
-        assertEquals(1, dcc.countByConsumer(c));
+        createDeletedConsumer(CONSUMER_UUID_1);
+        Consumer consumer = createConsumer(CONSUMER_UUID_1);
+        Consumer unknownConsumer = createConsumer(UNKNOWN_UUID);
 
-        c = mock(Consumer.class);
-        when(c.getUuid()).thenReturn("dontfind");
-        assertEquals(0, dcc.countByConsumer(c));
+        assertEquals(1, dcc.countByConsumer(consumer));
+        assertEquals(0, dcc.countByConsumer(unknownConsumer));
     }
 
     @Test
-    public void findByDate() throws InterruptedException {
-        assertEquals(2, dcc.findByDate(twoResultsDate).list().size());
-        assertEquals(1, dcc.findByDate(oneResultDate).list().size());
-        Thread.sleep(2000);
+    public void findByDate() {
+        createDeletedConsumer(CONSUMER_UUID_1, OLDEST_DATE);
+        createDeletedConsumer(CONSUMER_UUID_2, OLD_DATE);
+        createDeletedConsumer(CONSUMER_UUID_3);
+
+        assertEquals(3, dcc.findByDate(OLDEST_DATE).list().size());
+        assertEquals(2, dcc.findByDate(OLD_DATE).list().size());
         assertEquals(0, dcc.findByDate(new Date()).list().size());
     }
 
     @Test
     public void descOrderByDate() {
-        DeletedConsumer newest = dcc.findByDate(twoResultsDate).list().get(0);
-        assertEquals("klmno", newest.getConsumerUuid());
+        createDeletedConsumer(CONSUMER_UUID_1, OLDEST_DATE);
+        createDeletedConsumer(CONSUMER_UUID_2, OLD_DATE);
+        createDeletedConsumer(CONSUMER_UUID_3);
+
+        DeletedConsumer newest = dcc.findByDate(OLDEST_DATE).list().get(0);
+        assertEquals(CONSUMER_UUID_3, newest.getConsumerUuid());
     }
 
     @Test
     public void descOrderByOwnerId() {
-        DeletedConsumer newest = dcc.findByOwnerId("10").list().get(0);
-        assertEquals("fghij", newest.getConsumerUuid());
+        createDeletedConsumer(CONSUMER_UUID_1, OLD_DATE);
+        createDeletedConsumer(CONSUMER_UUID_2);
+
+        DeletedConsumer newest = dcc.findByOwnerId(OWNER_ID_1).list().get(0);
+        assertEquals(CONSUMER_UUID_2, newest.getConsumerUuid());
     }
+
+    @Test
+    public void shouldFindExistingDeletedConsumer() {
+        createDeletedConsumer(CONSUMER_UUID_1);
+        createDeletedConsumer(CONSUMER_UUID_2);
+        createDeletedConsumer(CONSUMER_UUID_3);
+
+        List<DeletedConsumer> deletedConsumers = dcc.findByConsumerUuids(List.of(
+            CONSUMER_UUID_1,
+            CONSUMER_UUID_2,
+            CONSUMER_UUID_3
+        ));
+
+        assertEquals(3, deletedConsumers.size());
+    }
+
+    @Test
+    public void nothingToFind() {
+        assertEquals(0, dcc.findByConsumerUuids(null).size());
+        assertEquals(0, dcc.findByConsumerUuids(List.of()).size());
+        assertEquals(0, dcc.findByConsumerUuids(List.of(UNKNOWN_UUID)).size());
+    }
+
+    private void createDeletedConsumer(String uuid, String ownerId, Date created) {
+        DeletedConsumer dc = new DeletedConsumer(uuid, ownerId, "key", "name");
+        dc.setCreated(created);
+        dcc.create(dc);
+    }
+
+    private void createDeletedConsumer(String uuid) {
+        createDeletedConsumer(uuid, OWNER_ID_1, new Date());
+    }
+
+    private void createDeletedConsumer(String uuid, Date created) {
+        createDeletedConsumer(uuid, OWNER_ID_1, created);
+    }
+
+    private Consumer createConsumer(String uuid) {
+        Consumer c = mock(Consumer.class);
+        when(c.getUuid()).thenReturn(uuid);
+        return c;
+    }
+
+    private Owner createMockOwner(String ownerId) {
+        Owner o = mock(Owner.class);
+        when(o.getId()).thenReturn(ownerId);
+        return o;
+    }
+
 }

--- a/src/test/java/org/candlepin/model/KeyPairCuratorTest.java
+++ b/src/test/java/org/candlepin/model/KeyPairCuratorTest.java
@@ -16,18 +16,21 @@ package org.candlepin.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.Test;
 
 import java.security.KeyPair;
+import java.util.List;
 
 import javax.inject.Inject;
 
-/**
- * KeyPairCuratorTest
- */
+
+
 public class KeyPairCuratorTest extends DatabaseTestFixture {
     @Inject private KeyPairCurator keyPairCurator;
 
@@ -53,7 +56,59 @@ public class KeyPairCuratorTest extends DatabaseTestFixture {
         KeyPair keyPair1 = keyPairCurator.getConsumerKeyPair(consumer1);
         KeyPair keyPair2 = keyPairCurator.getConsumerKeyPair(consumer2);
 
-        assertFalse(keyPair1.getPrivate().equals(keyPair2.getPrivate()));
+        assertNotEquals(keyPair1.getPrivate(), keyPair2.getPrivate());
+    }
+
+    @Test
+    public void shouldListKeyPairs() {
+        Owner owner = this.ownerCurator.create(new Owner("test-owner", "Test Owner"));
+        ConsumerType ct = this.consumerTypeCurator.create(new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
+        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
+        consumer.setKeyPair(new org.candlepin.model.KeyPair());
+        consumer = this.consumerCurator.create(consumer);
+        Consumer consumer2 = new Consumer("testConsumer", "testUser", owner, ct);
+        consumer2.setKeyPair(new org.candlepin.model.KeyPair());
+        consumer2 = this.consumerCurator.create(consumer2);
+
+        List<String> found = this.keyPairCurator
+            .findKeyPairIdsOf(List.of(consumer.getId(), consumer2.getId()));
+
+        assertEquals(2, found.size());
+        for (String keyPairId : found) {
+            assertNotNull(keyPairId);
+        }
+    }
+
+    @Test
+    public void shouldDeleteKeyPairs() {
+        Owner owner = this.ownerCurator.create(new Owner("test-owner", "Test Owner"));
+        ConsumerType ct = this.consumerTypeCurator.create(new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM));
+        KeyPair keyPair = keyPairCurator.getKeyPair();
+        Consumer consumer = new Consumer("testConsumer", "testUser", owner, ct);
+        consumer.setKeyPair(new org.candlepin.model.KeyPair(keyPair.getPrivate(), keyPair.getPublic()));
+        consumer = this.consumerCurator.create(consumer);
+        Consumer consumer2 = new Consumer("testConsumer", "testUser", owner, ct);
+        consumer2.setKeyPair(new org.candlepin.model.KeyPair(keyPair.getPrivate(), keyPair.getPublic()));
+        consumer2 = this.consumerCurator.create(consumer2);
+
+        int unlinked = this.keyPairCurator
+            .unlinkKeyPairsFromConsumers(List.of(consumer.getId(), consumer2.getId()));
+        int deleted = this.keyPairCurator
+            .bulkDeleteKeyPairs(List.of(consumer.getKeyPair().getId(), consumer2.getKeyPair().getId()));
+        this.keyPairCurator.flush();
+        this.keyPairCurator.clear();
+
+        assertEquals(2, unlinked);
+        assertEquals(2, deleted);
+        assertNull(this.consumerCurator.getConsumer(consumer.getUuid()).getKeyPair());
+        assertNull(this.consumerCurator.getConsumer(consumer2.getUuid()).getKeyPair());
+    }
+
+    @Test
+    public void nokeyPairsToDelete() {
+        assertEquals(0, keyPairCurator.bulkDeleteKeyPairs(null));
+        assertEquals(0, keyPairCurator.bulkDeleteKeyPairs(List.of()));
+        assertEquals(0, keyPairCurator.bulkDeleteKeyPairs(List.of("unknown")));
     }
 
 }

--- a/src/test/java/org/candlepin/resource/ConsumerContentOverrideResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerContentOverrideResourceTest.java
@@ -39,6 +39,7 @@ import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerContentOverride;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerService;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.DeletedConsumerCurator;
 import org.candlepin.model.DistributorVersionCurator;
@@ -91,6 +92,7 @@ import javax.inject.Provider;
 public class ConsumerContentOverrideResourceTest extends DatabaseTestFixture {
 
     @Mock private ConsumerCurator consumerCurator;
+    @Mock private ConsumerService consumerService;
     @Mock private OwnerCurator ownerCurator;
     @Mock private EntitlementCertServiceAdapter entitlementCertServiceAdapter;
     @Mock private SubscriptionServiceAdapter subscriptionServiceAdapter;
@@ -144,6 +146,7 @@ public class ConsumerContentOverrideResourceTest extends DatabaseTestFixture {
 
         this.resource = new ConsumerResource(
             this.consumerCurator,
+            this.consumerService,
             this.consumerTypeCurator,
             this.subscriptionServiceAdapter,
             this.mockProductServiceAdapter,

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -54,6 +54,7 @@ import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerContentOverrideCurator;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerService;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
@@ -134,6 +135,7 @@ public class ConsumerResourceCreationTest {
     @Mock protected ProductServiceAdapter productService;
     @Mock protected SubscriptionServiceAdapter subscriptionService;
     @Mock protected ConsumerCurator consumerCurator;
+    @Mock protected ConsumerService consumerService;
     @Mock protected ConsumerTypeCurator consumerTypeCurator;
     @Mock protected OwnerCurator ownerCurator;
     @Mock private EntitlementCurator entitlementCurator;
@@ -185,6 +187,7 @@ public class ConsumerResourceCreationTest {
         this.config = initConfig();
         this.resource = new ConsumerResource(
             this.consumerCurator,
+            this.consumerService,
             this.consumerTypeCurator,
             this.subscriptionService,
             this.productService,

--- a/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -72,6 +72,7 @@ import org.candlepin.model.ConsumerContentOverrideCurator;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerCurator.ConsumerQueryArguments;
 import org.candlepin.model.ConsumerInstalledProduct;
+import org.candlepin.model.ConsumerService;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
@@ -166,6 +167,7 @@ public class ConsumerResourceTest {
     private FactValidator factValidator;
 
     @Mock private ConsumerCurator consumerCurator;
+    @Mock private ConsumerService consumerService;
     @Mock private OwnerCurator ownerCurator;
     @Mock private EntitlementCertServiceAdapter entitlementCertServiceAdapter;
     @Mock private SubscriptionServiceAdapter subscriptionServiceAdapter;
@@ -219,6 +221,7 @@ public class ConsumerResourceTest {
 
         this.consumerResource = new ConsumerResource(
             this.consumerCurator,
+            this.consumerService,
             this.consumerTypeCurator,
             this.subscriptionServiceAdapter,
             this.mockProductServiceAdapter,
@@ -415,6 +418,7 @@ public class ConsumerResourceTest {
 
         ConsumerResource consumerResource = new ConsumerResource(
             this.consumerCurator,
+            this.consumerService,
             this.consumerTypeCurator,
             this.subscriptionServiceAdapter,
             this.mockProductServiceAdapter,

--- a/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -64,6 +64,7 @@ import org.candlepin.model.ConsumerCapability;
 import org.candlepin.model.ConsumerContentOverrideCurator;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerInstalledProduct;
+import org.candlepin.model.ConsumerService;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.DeletedConsumerCurator;
@@ -139,6 +140,7 @@ public class ConsumerResourceUpdateTest {
 
     @Mock private IdentityCertServiceAdapter idCertService;
     @Mock private ConsumerCurator consumerCurator;
+    @Mock private ConsumerService consumerService;
     @Mock private OwnerCurator ownerCurator;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
     @Mock private EventSink sink;
@@ -190,6 +192,7 @@ public class ConsumerResourceUpdateTest {
 
         this.resource = new ConsumerResource(
             this.consumerCurator,
+            this.consumerService,
             this.consumerTypeCurator,
             this.subscriptionServiceAdapter,
             this.productService,

--- a/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
@@ -46,6 +46,7 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentAccessCertificate;
 import org.candlepin.model.ContentAccessCertificateCurator;
+import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentContentCurator;
 import org.candlepin.model.EnvironmentCurator;
@@ -99,8 +100,8 @@ class EnvironmentResourceTest {
     private IdentityCertificateCurator identityCertificateCurator;
     @Mock
     private ContentAccessCertificateCurator contentAccessCertificateCurator;
-    private I18n i18n;
-    private ModelTranslator translator;
+    @Mock
+    private EntitlementCurator entitlementCurator;
 
     private EnvironmentResource environmentResource;
 
@@ -109,29 +110,30 @@ class EnvironmentResourceTest {
 
     @BeforeEach
     void setUp() {
-        this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        this.translator = new SimpleModelTranslator();
-        this.translator.registerTranslator(new EnvironmentTranslator(),
+        I18n i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
+        ModelTranslator translator = new SimpleModelTranslator();
+        translator.registerTranslator(new EnvironmentTranslator(),
             Environment.class, EnvironmentDTO.class);
-        this.translator.registerTranslator(new ContentTranslator(), Content.class, ContentDTO.class);
-        this.translator.registerTranslator(new NestedOwnerTranslator(), Owner.class, NestedOwnerDTO.class);
+        translator.registerTranslator(new ContentTranslator(), Content.class, ContentDTO.class);
+        translator.registerTranslator(new NestedOwnerTranslator(), Owner.class, NestedOwnerDTO.class);
 
         this.environmentResource = new EnvironmentResource(
             this.envCurator,
-            this.i18n,
+            i18n,
             this.envContentCurator,
             this.consumerResource,
             this.poolManager,
             this.consumerCurator,
             this.ownerContentCurator,
             this.rdbmsExceptionTranslator,
-            this.translator,
+            translator,
             this.jobManager,
             this.validator,
             this.contentAccessManager,
             this.certificateSerialCurator,
             this.identityCertificateCurator,
-            this.contentAccessCertificateCurator
+            this.contentAccessCertificateCurator,
+            this.entitlementCurator
         );
 
         this.owner = new Owner("owner1", "Owner 1");

--- a/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
@@ -42,6 +42,7 @@ import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerService;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentAccessCertificate;
@@ -102,6 +103,8 @@ class EnvironmentResourceTest {
     private ContentAccessCertificateCurator contentAccessCertificateCurator;
     @Mock
     private EntitlementCurator entitlementCurator;
+    @Mock
+    private ConsumerService consumerService;
 
     private EnvironmentResource environmentResource;
 
@@ -122,18 +125,13 @@ class EnvironmentResourceTest {
             i18n,
             this.envContentCurator,
             this.consumerResource,
-            this.poolManager,
-            this.consumerCurator,
             this.ownerContentCurator,
             this.rdbmsExceptionTranslator,
             translator,
             this.jobManager,
             this.validator,
             this.contentAccessManager,
-            this.certificateSerialCurator,
-            this.identityCertificateCurator,
-            this.contentAccessCertificateCurator,
-            this.entitlementCurator
+            this.consumerService
         );
 
         this.owner = new Owner("owner1", "Owner 1");

--- a/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -49,6 +49,7 @@ import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerContentOverrideCurator;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerService;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
@@ -110,6 +111,7 @@ public class GuestIdResourceTest {
     private I18n i18n;
 
     @Mock private ConsumerCurator consumerCurator;
+    @Mock private ConsumerService consumerService;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
     @Mock private OwnerCurator ownerCurator;
     @Mock private GuestIdCurator guestIdCurator;
@@ -169,6 +171,7 @@ public class GuestIdResourceTest {
         this.consumer = new Consumer("consumer", "test", owner, ct).setUuid(Util.generateUUID());
         this.resource = new ConsumerResource(
             this.consumerCurator,
+            this.consumerService,
             this.consumerTypeCurator,
             this.subscriptionServiceAdapter,
             this.productService,

--- a/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -48,6 +48,7 @@ import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerContentOverrideCurator;
 import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerService;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
@@ -120,6 +121,7 @@ public class HypervisorResourceTest {
     @Mock private ProductServiceAdapter productService;
     @Mock private SubscriptionServiceAdapter subscriptionService;
     @Mock private ConsumerCurator consumerCurator;
+    @Mock private ConsumerService consumerService;
     @Mock private ConsumerTypeCurator consumerTypeCurator;
     @Mock private OwnerCurator ownerCurator;
     @Mock private EventSink sink;
@@ -173,6 +175,7 @@ public class HypervisorResourceTest {
 
         ConsumerResource consumerResource = new ConsumerResource(
             this.consumerCurator,
+            this.consumerService,
             this.consumerTypeCurator,
             this.subscriptionService,
             this.productService,


### PR DESCRIPTION
- Refactored cleanup of entitlements to run in bulk instead of per-consumer
- Refactored deletion of consumers to run in bulk instead of per-consumer

Note: This is a follow-up PR to the [No consumer deletion cleanup when deleting Environment](https://github.com/candlepin/candlepin/pull/3128) with changes not directly related to the task.