### PR TITLE
[4.0] 2008443: Fix to avoid exceeding the overall query parameter limit

### DIFF
--- a/server/src/main/java/org/candlepin/async/tasks/RegenProductEntitlementCertsJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/RegenProductEntitlementCertsJob.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 
 
@@ -153,8 +153,7 @@ public class RegenProductEntitlementCertsJob implements AsyncJob {
         boolean lazyRegen = args.getAsBoolean(ARG_LAZY_REGEN, true);
 
         // Find a set of owners that actually have the product...
-        List<Owner> owners = this.ownerCurator.getOwnersWithProducts(Collections.singleton(productId))
-            .list();
+        Set<Owner> owners = this.ownerCurator.getOwnersWithProducts(Collections.singleton(productId));
 
         // Regenerate if we found any...
         if (owners.size() > 0) {

--- a/server/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -16,32 +16,40 @@ package org.candlepin.model;
 
 import org.candlepin.controller.OwnerContentAccess;
 
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hibernate.Criteria;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.ReplicationMode;
-import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Property;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.criterion.Subqueries;
-import org.hibernate.sql.JoinType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Singleton;
+import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
-
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
 
 /**
  * OwnerCurator
@@ -189,55 +197,53 @@ public class OwnerCurator extends AbstractHibernateCurator<Owner> {
     }
 
     /**
-     * Retrieves a list of owners which have pools referencing one or more of the specified product
+     * Retrieves list of owners which have pools referencing one or more of the specified product
      * IDs. If no owners are associated with the given products, this method returns an empty list.
      *
      * @param productIds
      *  The product IDs for which to retrieve owners
      *
      * @return
-     *  a list of owners associated with the specified products
+     *  list of owners associated with the specified products
      */
     @SuppressWarnings("checkstyle:indentation")
-    public CandlepinQuery<Owner> getOwnersWithProducts(Collection<String> productIds) {
-        if (productIds != null && !productIds.isEmpty()) {
-            Session session = this.currentSession();
-
-            // Impl note:
-            // We have to break this up into two queries for proper cursor and pagination support.
-            // Hibernate currently has two nasty "features" which break these in their own special
-            // way:
-            // - Distinct, when applied in any way outside of direct SQL, happens in Hibernate
-            //   *after* the results are pulled down, if and only if the results are fetched as a
-            //   list. The filtering does not happen when the results are fetched with a cursor.
-            // - Because result limiting (first+last result specifications) happens at the query
-            //   level and distinct filtering does not, cursor-based pagination breaks due to
-            //   potential results being removed after a page of results is fetched.
-            Criteria idCriteria = session.createCriteria(Owner.class, "Owner")
-                .setProjection(Projections.distinct(Projections.id()))
-                .createAlias("Owner.pools", "Pool")
-                .createAlias("Pool.product", "Prod", JoinType.LEFT_OUTER_JOIN)
-                .createAlias("Prod.derivedProduct", "DProd", JoinType.LEFT_OUTER_JOIN)
-                .createAlias("Prod.providedProducts", "PProd", JoinType.LEFT_OUTER_JOIN)
-                .createAlias("DProd.providedProducts", "DPProd", JoinType.LEFT_OUTER_JOIN)
-                .add(Restrictions.or(
-                    CPRestrictions.in("Prod.id", productIds),
-                    CPRestrictions.in("DProd.id", productIds),
-                    CPRestrictions.in("PProd.id", productIds),
-                    CPRestrictions.in("DPProd.id", productIds)
-                ));
-
-            List<String> ownerIds = idCriteria.list();
-
-            if (ownerIds != null && !ownerIds.isEmpty()) {
-                DetachedCriteria criteria = DetachedCriteria.forClass(Owner.class)
-                    .add(CPRestrictions.in("id", ownerIds));
-
-                return this.cpQueryFactory.buildQuery(session, criteria);
-            }
+    public Set<Owner> getOwnersWithProducts(Collection<String> productIds) {
+        if (productIds == null || productIds.isEmpty()) {
+            return Collections.emptySet();
         }
 
-        return this.cpQueryFactory.<Owner>buildQuery();
+        CriteriaBuilder criteriaBuilder = this.entityManager.get().getCriteriaBuilder();
+        CriteriaQuery<Owner> query = criteriaBuilder.createQuery(Owner.class);
+        Root<Owner> owner = query.from(Owner.class);
+        query.distinct(true);
+        query.select(owner);
+
+        Join<Owner, Pool> pool = owner.join(Owner_.pools);
+        Join<Pool, Product> product = pool.join(Pool_.product, JoinType.LEFT);
+        Join<Product, Product> providedProducts = product.join(Product_.providedProducts, JoinType.LEFT);
+        Join<Product, Product> derivedProducts = product.join(Product_.derivedProduct, JoinType.LEFT);
+        Join<Product, Product> derivedProvidedProducts =
+            derivedProducts.join(Product_.providedProducts, JoinType.LEFT);
+
+        Expression<String> productExpr = product.get(Product_.id);
+        Expression<String> providedProductsExpr = providedProducts.get(Product_.id);
+        Expression<String> derivedProductsExpr = derivedProducts.get(Product_.id);
+        Expression<String> derivedPPExpr = derivedProvidedProducts.get(Product_.id);
+
+        // Block size reduced by 4 times to avoid exceeding the parameters limit as there
+        // are multiple IN clauses in the query below.
+        int blockSize = Math.min(this.getInBlockSize(), this.getQueryParameterLimit() / 4);
+        Set<Owner> owners = new HashSet<>();
+        EntityManager entityManager = this.entityManager.get();
+
+        for (List<String> block : Iterables.partition(productIds, blockSize)) {
+            Predicate predicate = criteriaBuilder.or(productExpr.in(block), providedProductsExpr.in(block),
+                derivedProductsExpr.in(block), derivedPPExpr.in(block));
+            query.where(predicate);
+            owners.addAll(entityManager.createQuery(query).getResultList());
+        }
+
+        return owners;
     }
 
     public CandlepinQuery<String> getConsumerIds(Owner owner) {

--- a/server/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/ProductResource.java
@@ -29,14 +29,12 @@ import org.candlepin.dto.api.v1.OwnerDTO;
 import org.candlepin.dto.api.v1.ProductCertificateDTO;
 import org.candlepin.dto.api.v1.ProductDTO;
 import org.candlepin.model.AsyncJobStatus;
-import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCertificate;
 import org.candlepin.model.ProductCertificateCurator;
 import org.candlepin.model.ProductCurator;
-import org.candlepin.model.ResultIterator;
 
 import com.google.inject.Inject;
 
@@ -51,9 +49,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.ws.rs.Consumes;
@@ -265,7 +264,7 @@ public class ProductResource {
     @GET
     @Path("/owners")
     @Produces(MediaType.APPLICATION_JSON)
-    public CandlepinQuery<OwnerDTO> getProductOwners(
+    public Stream<OwnerDTO> getProductOwners(
         @ApiParam(value = "Multiple product UUIDs", required = true)
         @QueryParam("product") List<String> productUuids) {
 
@@ -273,8 +272,10 @@ public class ProductResource {
             throw new BadRequestException(i18n.tr("No product IDs specified"));
         }
 
-        return this.translator.translateQuery(
-            this.ownerCurator.getOwnersWithProducts(productUuids), OwnerDTO.class);
+        Set<Owner> owners = this.ownerCurator.getOwnersWithProducts(productUuids);
+
+        return owners.stream().map(
+            this.translator.getStreamMapper(Owner.class, OwnerDTO.class));
     }
 
     @ApiOperation(notes = "Refreshes Pools by Product", value = "refreshPoolsForProduct",
@@ -297,30 +298,27 @@ public class ProductResource {
             return null;
         }
 
-        ResultIterator<Owner> iterator = this.ownerCurator.getOwnersWithProducts(productUuids).iterate();
-        List<JobConfig> jobConfigs = new LinkedList<>();
-        while (iterator.hasNext()) {
-            JobConfig config = RefreshPoolsJob.createJobConfig()
-                .setOwner(iterator.next())
-                .setLazyRegeneration(lazyRegen);
-            jobConfigs.add(config);
-        }
-        iterator.close();
+        Function<Owner, JobConfig> jobConfigMapper = (owner) -> RefreshPoolsJob.createJobConfig()
+            .setOwner(owner)
+            .setLazyRegeneration(lazyRegen);
 
-        List<AsyncJobStatus> statuses = new LinkedList<>();
-        for (JobConfig config : jobConfigs) {
+        Function<JobConfig, AsyncJobStatus> jobQueueMapper = (config) -> {
             try {
-                statuses.add(this.jobManager.queueJob(config));
+                return this.jobManager.queueJob(config);
             }
             catch (Exception e) {
-                statuses.add(new AsyncJobStatus()
+                log.debug("Exception occurred while queueing job: {}", config, e);
+                return new AsyncJobStatus()
                     .setName(RefreshPoolsJob.JOB_NAME)
                     .setState(AsyncJobStatus.JobState.FAILED)
-                    .setJobResult(e.toString()));
+                    .setJobResult(e.toString());
             }
-        }
+        };
 
-        return statuses.stream().map(
-            this.translator.getStreamMapper(AsyncJobStatus.class, AsyncJobStatusDTO.class));
+        return this.ownerCurator.getOwnersWithProducts(productUuids)
+            .stream()
+            .map(jobConfigMapper)
+            .map(jobQueueMapper)
+            .map(this.translator.getStreamMapper(AsyncJobStatus.class, AsyncJobStatusDTO.class));
     }
 }

--- a/server/src/test/java/org/candlepin/async/tasks/RegenProductEntitlementCertsJobTest.java
+++ b/server/src/test/java/org/candlepin/async/tasks/RegenProductEntitlementCertsJobTest.java
@@ -32,9 +32,9 @@ import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
 import org.candlepin.controller.PoolManager;
-import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
+import org.candlepin.util.Util;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,8 +43,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
@@ -133,12 +131,8 @@ public class RegenProductEntitlementCertsJobTest {
         Owner owner2 = new Owner("test_owner_key-2", "test_owner_name-2");
         Owner owner3 = new Owner("test_owner_key-3", "test_owner_name-3");
 
-        Collection<Owner> matchingOwners = Arrays.asList(owner1, owner2, owner3);
-
-        CandlepinQuery<Owner> ownerQuery = mock(CandlepinQuery.class);
-        doReturn(matchingOwners).when(ownerQuery).list();
-        doReturn(ownerQuery).when(this.mockOwnerCurator).getOwnersWithProducts(eq(productIds));
-
+        Set<Owner> matchingOwners = Util.asSet(owner1, owner2, owner3);
+        doReturn(matchingOwners).when(this.mockOwnerCurator).getOwnersWithProducts(eq(productIds));
         JobConfig config = RegenProductEntitlementCertsJob.createJobConfig()
             .setProductId(productId)
             .setLazyRegeneration(lazyRegen);
@@ -165,12 +159,8 @@ public class RegenProductEntitlementCertsJobTest {
         boolean lazyRegen = true;
 
         Set<String> productIds = Collections.singleton(productId);
-        Collection<Owner> matchingOwners = Arrays.asList();
-
-        CandlepinQuery<Owner> ownerQuery = mock(CandlepinQuery.class);
-        doReturn(matchingOwners).when(ownerQuery).list();
-        doReturn(ownerQuery).when(this.mockOwnerCurator).getOwnersWithProducts(eq(productIds));
-
+        Set<Owner> matchingOwners = Util.asSet();
+        doReturn(matchingOwners).when(this.mockOwnerCurator).getOwnersWithProducts(eq(productIds));
         JobConfig config = RegenProductEntitlementCertsJob.createJobConfig()
             .setProductId(productId)
             .setLazyRegeneration(lazyRegen);

--- a/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -25,7 +25,9 @@ import org.candlepin.controller.OwnerContentAccess;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
+import org.candlepin.util.Util;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import javax.persistence.PersistenceException;
 import javax.persistence.RollbackException;
@@ -291,24 +294,25 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
         Owner owner1 = owners.get(0);
         Owner owner2 = owners.get(1);
         Owner owner3 = owners.get(2);
+        Set<Owner> uniqueOwners = null;
 
-        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p4")).list();
-        assertEquals(Arrays.asList(owner1), owners);
+        uniqueOwners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p4"));
+        assertTrue(CollectionUtils.isEqualCollection(Util.asSet(owner1), uniqueOwners));
 
-        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p5d")).list();
-        assertEquals(Arrays.asList(owner2), owners);
+        uniqueOwners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p5d"));
+        assertTrue(CollectionUtils.isEqualCollection(Util.asSet(owner2), uniqueOwners));
 
-        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p1")).list();
-        assertEquals(Arrays.asList(owner1, owner2, owner3), owners);
+        uniqueOwners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p1"));
+        assertTrue(CollectionUtils.isEqualCollection(Util.asSet(owner1, owner2, owner3), uniqueOwners));
 
-        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p3")).list();
-        assertEquals(Arrays.asList(owner2, owner3), owners);
+        uniqueOwners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p3"));
+        assertTrue(CollectionUtils.isEqualCollection(Util.asSet(owner2, owner3), uniqueOwners));
 
-        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p4", "p6")).list();
-        assertEquals(Arrays.asList(owner1, owner3), owners);
+        uniqueOwners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("p4", "p6"));
+        assertTrue(CollectionUtils.isEqualCollection(Util.asSet(owner1, owner3), uniqueOwners));
 
-        owners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("nope")).list();
-        assertEquals(0, owners.size());
+        uniqueOwners = this.ownerCurator.getOwnersWithProducts(Arrays.asList("nope"));
+        assertEquals(0, uniqueOwners.size());
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyObject;
@@ -52,6 +53,7 @@ import org.candlepin.model.dto.Subscription;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -60,6 +62,7 @@ import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -245,18 +248,23 @@ public class ProductResourceTest extends DatabaseTestFixture {
         OwnerDTO ownerDTO2 = this.modelTranslator.translate(owner2, OwnerDTO.class);
         OwnerDTO ownerDTO3 = this.modelTranslator.translate(owner3, OwnerDTO.class);
 
-        List<OwnerDTO> ownersReturned = null;
+        List<OwnerDTO> ownersReturned;
 
-        ownersReturned = productResource.getProductOwners(Arrays.asList("p1")).list();
-        assertEquals(Arrays.asList(ownerDTO1, ownerDTO2), ownersReturned);
+        ownersReturned = productResource.getProductOwners(Collections.singletonList("p1"))
+            .collect(Collectors.toList());
+        assertTrue(CollectionUtils.isEqualCollection(Arrays.asList(ownerDTO1, ownerDTO2), ownersReturned));
 
-        ownersReturned = productResource.getProductOwners(Arrays.asList("p1", "p2")).list();
-        assertEquals(Arrays.asList(ownerDTO1, ownerDTO2, ownerDTO3), ownersReturned);
+        ownersReturned = productResource.getProductOwners(Arrays.asList("p1", "p2"))
+            .collect(Collectors.toList());
+        assertTrue(CollectionUtils
+            .isEqualCollection(Arrays.asList(ownerDTO1, ownerDTO2, ownerDTO3), ownersReturned));
 
-        ownersReturned = productResource.getProductOwners(Arrays.asList("p3")).list();
-        assertEquals(Arrays.asList(ownerDTO3), ownersReturned);
+        ownersReturned = productResource.getProductOwners(Collections.singletonList("p3"))
+            .collect(Collectors.toList());
+        assertEquals(Collections.singletonList(ownerDTO3), ownersReturned);
 
-        ownersReturned = productResource.getProductOwners(Arrays.asList("nope")).list();
+        ownersReturned = productResource.getProductOwners(Collections.singletonList("nope"))
+            .collect(Collectors.toList());
         assertEquals(0, ownersReturned.size());
     }
 


### PR DESCRIPTION
Final query was exceeding the overall query parameter limit for /products/owners endpoint. Broke the query to avoid exceeding the limit for IN clause & overall query parameter limit.

Backport (https://github.com/candlepin/candlepin/pull/3126)
