### PR TITLE
[4.0] Fixed an error when deleting products associated with activation keys (ENT-4436)

### DIFF
--- a/server/spec/owner_product_resource_spec.rb
+++ b/server/spec/owner_product_resource_spec.rb
@@ -479,5 +479,25 @@ describe 'Owner Product Resource' do
     expect(updated_prod_uuid).not_to eq(original_prod_uuid)
   end
 
+  it 'should allow deleting a product associated with an activation key' do
+    owner = create_owner(random_string('test_owner'))
+    product = @cp.create_product(owner['key'], random_string('test_prod'), 'Test product')
+    actkey = @cp.create_activation_key(owner['key'], random_string('test_key'))
+    @cp.add_prod_id_to_key(actkey['id'], product['id'])
+
+    # The activation key should have the product associated with it
+    actkey2 = @cp.get_activation_key(actkey['id'])
+    expect(actkey2).to_not be_nil
+    expect(actkey2['products'].find { |elem| elem['productId'] == product['id'] }).to_not be_nil
+
+    # Deleting the product should remove its reference from the activation key
+    @cp.delete_product(owner['key'], product['id'])
+
+    # The activation key should still exist, but should no longer reference the product
+    actkey2 = @cp.get_activation_key(actkey['id'])
+    expect(actkey2).to_not be_nil
+    expect(actkey2['products'].find { |elem| elem['productId'] == product['id'] }).to be_nil
+  end
+
 end
 

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -775,9 +775,9 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
 
                 count = 0;
                 if (akIds != null && !akIds.isEmpty()) {
-                    String sql = "DELETE FROM cp2_activation_key_products akp " +
-                        "WHERE akp.key_id IN (:ak_ids) " +
-                        "AND akp.product_uuid IN (:product_uuids)";
+                    String sql = "DELETE FROM cp2_activation_key_products " +
+                        "WHERE key_id IN (:ak_ids) " +
+                        "AND product_uuid IN (:product_uuids)";
 
                     Query query = entityManager.createNativeQuery(sql)
                         .setParameter("product_uuids", block);

--- a/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 
+
 /**
  * Test suite for the OwnerProductCurator class
  */


### PR DESCRIPTION
- Fixed an internal server error that could occur when attempting to
  delete a product, or remove it from an organization, that has been
  associated with an activation key