### PR TITLE
[4.0] Addressed issues with Product.equals and immutable entity versioning (ENT-4464)

### DIFF
--- a/server/spec/refresh_pools_spec.rb
+++ b/server/spec/refresh_pools_spec.rb
@@ -1384,4 +1384,56 @@ describe 'Refresh Pools' do
     product_json = json_body['products'].find {|p| p['id'] == main_product['id']}
     product_json['content'].should == []
   end
+
+  it 'deduplicates products and content' do
+    # Create some orgs
+    owners = []
+    3.times do |i|
+      key = random_string("test_owner-#{i}")
+      owners << create_owner(key)
+    end
+
+    # Create products and content to be shared across all orgs
+    provided = []
+    3.times do |i|
+      content = create_upstream_content(random_string("prov_content-#{i}"), {'name' => "prov content #{i}"})
+      prov_product = create_upstream_product(random_string("provided-#{i}"))
+      add_content_to_product_upstream(prov_product['id'], content['id'])
+
+      provided << prov_product
+    end
+
+    product = create_upstream_product(random_string('test_prod'), :providedProducts => provided)
+
+    # Set up orgs with different subscriptions containing the product
+    owners.each do |owner|
+      create_upstream_subscription(random_string('test_sub'), owner['key'], {
+        :product => product
+      })
+    end
+
+    # Refresh orgs in serial (note: this *cannot* safely be done in parallel)
+    owners.each do |owner|
+      @cp.refresh_pools(owner['key'])
+    end
+
+    # Verify that the products used by both org is the same underlying product (i.e. same product UUID)
+    product_uuids = []
+    owners.each do |owner|
+      pools = @cp.list_pools({:owner => owner['id']})
+      expect(pools).to_not be_nil
+      expect(pools.size).to eq(1)
+
+      product = @cp.get_product(owner['key'], pools.first['productId'])
+
+      expect(product).to_not be_nil
+      expect(product).to have_key('uuid')
+      expect(product['uuid']).to_not be_nil
+
+      product_uuids << product['uuid']
+    end
+
+    expect(product_uuids.size).to eq(owners.size)
+    expect(product_uuids).to all(eq(product_uuids.first))
+  end
 end

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -333,6 +333,7 @@ public class CandlepinPoolManager implements PoolManager {
         if (pids != null && pids.size() > 0) {
             log.error("One or more pools references a product which no longer belongs to its " +
                 "organization: {}", pids);
+
             throw new IllegalStateException("One or more pools was left in an undefined state: " + pids);
         }
 

--- a/server/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
@@ -231,7 +231,7 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
         });
 
         for (Content candidate : entityMap.getOrDefault(entity.getId(), Collections.emptyList())) {
-            if (entityVersion == candidate.getEntityVersion(true) && entity.equals(candidate)) {
+            if (entityVersion == candidate.getEntityVersion() && entity.equals(candidate)) {
                 return candidate;
             }
         }

--- a/server/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
@@ -229,7 +229,7 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
     private Product resolveEntityVersion(EntityNode<Product, ProductInfo> node) {
         Owner owner = node.getOwner();
         Product entity = node.getMergedEntity();
-        int entityVersion = entity.getEntityVersion(false);
+        int entityVersion = entity.getEntityVersion();
 
         Map<String, List<Product>> entityMap = this.ownerVersionedEntityMap.computeIfAbsent(owner, key -> {
             Set<Integer> versions = this.ownerEntityVersions.remove(key);
@@ -240,7 +240,7 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
         });
 
         for (Product candidate : entityMap.getOrDefault(entity.getId(), Collections.emptyList())) {
-            if (entityVersion == candidate.getEntityVersion(true) && entity.equals(candidate)) {
+            if (entityVersion == candidate.getEntityVersion() && entity.equals(candidate)) {
                 return candidate;
             }
         }

--- a/server/src/main/java/org/candlepin/model/OwnerProduct.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProduct.java
@@ -102,6 +102,11 @@ public class OwnerProduct implements Persisted, Serializable {
         this.product = product;
     }
 
+    @Override
+    public String toString() {
+        return String.format("OwnerProduct [%s => %s]", this.getOwner(), this.getProduct());
+    }
+
     /**
      * Sets the database object IDs this join object uses to link owners to content. If either the
      * owner or content are not present or have not been persisted with a valid ID or UUID, this

--- a/server/src/main/java/org/candlepin/model/ProductContent.java
+++ b/server/src/main/java/org/candlepin/model/ProductContent.java
@@ -33,7 +33,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
-import javax.xml.bind.annotation.XmlTransient;
 
 
 /**
@@ -80,7 +79,6 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
     }
 
     @Override
-    @XmlTransient
     public Serializable getId() {
         return this.id;
     }
@@ -110,7 +108,6 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
     /**
      * @return the product
      */
-    @XmlTransient
     public Product getProduct() {
         return product;
     }
@@ -139,12 +136,8 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
         if (obj instanceof ProductContent) {
             ProductContent that = (ProductContent) obj;
 
-            // We're only interested in ensuring the mapping between the two objects is the same.
-            String thisContentUuid = this.getContent() != null ? this.getContent().getUuid() : null;
-            String thatContentUuid = that.getContent() != null ? that.getContent().getUuid() : null;
-
             return new EqualsBuilder()
-                .append(thisContentUuid, thatContentUuid)
+                .append(this.getContent(), that.getContent())
                 .append(this.isEnabled(), that.isEnabled())
                 .isEquals();
         }
@@ -154,14 +147,8 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
 
     @Override
     public int hashCode() {
-        // Impl note:
-        // Product is not included in this calculation because it only exists in this object to
-        // properly map products to content -- it should not be used for comparing two
-        // instances.
-
         return new HashCodeBuilder(3, 23)
-            .append(this.getContent() != null ? this.getContent().getUuid() : null)
-            .append(this.isEnabled())
+            .append(this.getContent() != null ? this.getContent().getId() : null)
             .toHashCode();
     }
 
@@ -173,12 +160,10 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
      *  a version hash for this entity
      */
     public int getEntityVersion() {
-        int hash = 17;
-
-        hash = 7 * hash + (this.content != null ? this.content.getEntityVersion() : 0);
-        hash = 7 * hash + (this.enabled ? 1 : 0);
-
-        return hash;
+        return new HashCodeBuilder(7, 19)
+            .append(this.getContent() != null ? this.getContent().getEntityVersion() : 0)
+            .append(this.isEnabled())
+            .toHashCode();
     }
 
     /**
@@ -192,9 +177,7 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
     }
 
     public String toString() {
-        return String.format(
-            "ProductContent [id: %s, product = %s, content = %s, enabled = %s]",
-            this.getId(), this.getProduct(), this.getContent(), this.isEnabled()
-        );
+        return String.format("ProductContent [id: %s, product = %s, content = %s, enabled = %s]",
+            this.getId(), this.getProduct(), this.getContent(), this.isEnabled());
     }
 }


### PR DESCRIPTION
- Fixed a bug in Product.equals and ProductContent.equals which
  would fail to properly compare products when either had children
  that did not yet have a UUID
- Updated how entity versioning is calculated and cached for both
  products and content: the entity version will be retained until
  any mutator which would affect a field that is used in the
  version is called
- Product.equals and Content.equals now attempt to use the UUID
  and entity versions to avoid checking individual fields wherever
  possible
- Product.equals and ProductContent.equals will now perform
  recursive calls to its children where necessary
- Product.setDerivedProduct, Product.addProvidedProduct, and
  Product.setProvidedProducts now attempt to check for a cycle
  in the product definitions and will throw an exception if
  one is detected
- Added an additional test to verify that the refresh operation
  is resulting in deduplicated products where possible