### PR TITLE
ENT-3900: Add support for multi-env entitlement cert regeneration

### DIFF
--- a/client/ruby/candlepin_api.rb
+++ b/client/ruby/candlepin_api.rb
@@ -373,6 +373,7 @@ class Candlepin
     displayName = params['displayName'] || name
     contentAccessModeList = params['contentAccessModeList'] || nil
     contentAccessMode = params['contentAccessMode'] || nil
+    contentPrefix = params[:contentPrefix] || nil
 
     owner = {
       'key' => key,
@@ -381,6 +382,7 @@ class Candlepin
 
     owner['contentAccessModeList'] = contentAccessModeList unless contentAccessModeList.nil?
     owner['contentAccessMode'] = contentAccessMode unless contentAccessMode.nil?
+    owner['contentPrefix'] = contentPrefix unless contentPrefix.nil?
     owner['parentOwner'] = parent if !parent.nil?
 
     post('/owners', {}, owner)

--- a/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -17,6 +17,9 @@ package org.candlepin.controller;
 import org.candlepin.audit.EventSink;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
+import org.candlepin.controller.util.ContentPrefix;
+import org.candlepin.controller.util.PromotedContent;
+import org.candlepin.controller.util.ScaContentPrefix;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.Consumer;
@@ -29,7 +32,6 @@ import org.candlepin.model.ContentAccessCertificate;
 import org.candlepin.model.ContentAccessCertificateCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Environment;
-import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.KeyPairCurator;
 import org.candlepin.model.Owner;
@@ -55,18 +57,14 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -453,22 +451,6 @@ public class ContentAccessManager {
         return entitlementVersion != null && entitlementVersion.startsWith("3.");
     }
 
-    private Map<String, EnvironmentContent> getPromotedContent(Environment environment) {
-        // Build a set of all content IDs promoted to the consumer's environment so
-        // we can determine if anything needs to be skipped:
-        Map<String, EnvironmentContent> promotedContent = new HashMap<>();
-        if (environment != null) {
-            log.debug("Consumer has an environment, checking for promoted content in: {}", environment);
-
-            for (EnvironmentContent envContent : environment.getEnvironmentContent()) {
-                log.debug("  promoted content: {}", envContent.getContent().getId());
-                promotedContent.put(envContent.getContent().getId(), envContent);
-            }
-        }
-
-        return promotedContent;
-    }
-
     /**
      * Fetches the path to use for content used to generate the ENTITLEMENT_DATA certificate
      * extension
@@ -482,53 +464,18 @@ public class ContentAccessManager {
      * @return
      *  the container content path for the given owner and environment
      */
-    private String getContainerContentPath(Owner owner, Environment environment) throws IOException {
+    private String getContainerContentPath(Owner owner, Environment environment) {
         // Fix for BZ 1866525:
         // - In hosted, SCA entitlement content path needs to use a dummy value to prevent existing
         //   clients from breaking, while still being clear the path is present for SCA
         // - In satellite (standalone), the path should simply be the content prefix
 
-        return this.standalone ?
-            this.getContentPrefix(owner, environment) :
-            "/sca/" + URLEncoder.encode(owner.getKey(), StandardCharsets.UTF_8.toString());
-    }
-
-    /**
-     * Fetches the content prefix to apply to content specified in the entitlement payload.
-     *
-     * @param owner
-     *  the owner of the entitlement for which the content prefix is being generated
-     *
-     * @param environment
-     *  the environment to which the consumer receiving the entitlement belongs
-     *
-     * @return
-     *  the content prefix for the given owner and environment
-     */
-    private String getContentPrefix(Owner owner, Environment environment) throws IOException {
-        StringBuilder prefix = new StringBuilder();
-
-        // Fix for BZ 1866525:
-        // - In hosted, SCA entitlement content paths should not have any prefix
-        // - In satellite (standalone), the prefix should use the owner key and environment name
-        //   if available
-
         if (this.standalone) {
-            String charset =  StandardCharsets.UTF_8.toString();
-
-            prefix.append('/').append(URLEncoder.encode(owner.getKey(), charset));
-
-            if (environment != null) {
-                for (String chunk : environment.getName().split("/")) {
-                    if (!chunk.isEmpty()) {
-                        prefix.append("/");
-                        prefix.append(URLEncoder.encode(chunk, charset));
-                    }
-                }
-            }
+            String envId = environment == null ? null : environment.getId();
+            List<Environment> envs = environment == null ? List.of() : List.of(environment);
+            return ScaContentPrefix.from(owner, this.standalone, envs).get(envId);
         }
-
-        return prefix.toString();
+        return "/sca/" + Util.encodeUrl(owner.getKey());
     }
 
     private String createDN(Consumer consumer, Owner owner) {
@@ -558,7 +505,7 @@ public class ContentAccessManager {
         throws IOException {
         List<org.candlepin.model.dto.Product> products = new ArrayList<>();
         products.add(container);
-        return v3extensionUtil.getByteExtensions(null, products, null,  null);
+        return v3extensionUtil.getByteExtensions(products);
     }
 
     private byte[] createContentAccessDataPayload(Owner owner, Environment environment, Consumer consumer)
@@ -586,10 +533,12 @@ public class ContentAccessManager {
         Set<String> entitledProductIds = new HashSet<>();
         entitledProductIds.add("content-access");
 
-        Map<String, EnvironmentContent> promotedContent = getPromotedContent(environment);
-        String contentPrefix = this.getContentPrefix(owner, environment);
+        List<Environment> environments = this.environmentCurator.getConsumerEnvironments(consumer);
+        ContentPrefix contentPrefix = ScaContentPrefix.from(owner, this.standalone, environments);
+        PromotedContent promotedContent = new PromotedContent(contentPrefix).withAll(environments);
+
         org.candlepin.model.dto.Product productModel = v3extensionUtil.mapProduct(container, skuProduct,
-            contentPrefix, promotedContent, consumer, emptyPool, entitledProductIds);
+            promotedContent, consumer, emptyPool, entitledProductIds);
 
         List<org.candlepin.model.dto.Product> productModels = new ArrayList<>();
         productModels.add(productModel);

--- a/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -27,7 +27,6 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Product;
-import org.candlepin.model.ProductCurator;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.util.CertificateSizeException;
 import org.candlepin.version.CertVersionConflictException;
@@ -61,25 +60,23 @@ import java.util.stream.Collectors;
  * preferred to singular ones.
  */
 public class EntitlementCertificateGenerator {
-    private static Logger log = LoggerFactory.getLogger(EntitlementCertificateGenerator.class);
+    private static final Logger log = LoggerFactory.getLogger(EntitlementCertificateGenerator.class);
 
-    private EntitlementCertificateCurator entitlementCertificateCurator;
-    private EntitlementCertServiceAdapter entCertServiceAdapter;
-    private ContentAccessManager contentAccessManager;
-    private OwnerCurator ownerCurator;
-    private EntitlementCurator entitlementCurator;
-    private PoolCurator poolCurator;
-    private ProductCurator productCurator;
-    private EventSink eventSink;
-    private EventFactory eventFactory;
+    private final EntitlementCertificateCurator entitlementCertificateCurator;
+    private final EntitlementCertServiceAdapter entCertServiceAdapter;
+    private final ContentAccessManager contentAccessManager;
+    private final OwnerCurator ownerCurator;
+    private final EntitlementCurator entitlementCurator;
+    private final PoolCurator poolCurator;
+    private final EventSink eventSink;
+    private final EventFactory eventFactory;
 
 
     @Inject
     public EntitlementCertificateGenerator(EntitlementCertificateCurator entitlementCertificateCurator,
         EntitlementCertServiceAdapter entCertServiceAdapter, EntitlementCurator entitlementCurator,
         PoolCurator poolCurator, EventSink eventSink, EventFactory eventFactory,
-        ProductCurator productCurator, ContentAccessManager contentAccessManager,
-        OwnerCurator ownerCurator) {
+        ContentAccessManager contentAccessManager, OwnerCurator ownerCurator) {
 
         this.entitlementCertificateCurator = entitlementCertificateCurator;
         this.entCertServiceAdapter = entCertServiceAdapter;
@@ -90,7 +87,6 @@ public class EntitlementCertificateGenerator {
 
         this.eventSink = eventSink;
         this.eventFactory = eventFactory;
-        this.productCurator = productCurator;
     }
 
     /**
@@ -118,11 +114,8 @@ public class EntitlementCertificateGenerator {
             return this.entCertServiceAdapter.generateEntitlementCerts(consumer, poolQuantities,
                 entitlements, products, save);
         }
-        catch (CertVersionConflictException cvce) {
+        catch (CertVersionConflictException | CertificateSizeException cvce) {
             throw cvce;
-        }
-        catch (CertificateSizeException cse) {
-            throw cse;
         }
         // Fixme throw custom exception instead of generic RuntimeException
         catch (Exception ex) {

--- a/src/main/java/org/candlepin/controller/util/ContentPrefix.java
+++ b/src/main/java/org/candlepin/controller/util/ContentPrefix.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller.util;
+
+/**
+ * Defines a contract for requesting environment specific content prefixes.
+ */
+@FunctionalInterface
+public interface ContentPrefix {
+
+    /**
+     * Returns a content prefix for the given environment id.
+     *
+     * @param environmentId id of an environment for which to return a content prefix
+     * @return environment specific content prefix
+     */
+    String get(String environmentId);
+
+}

--- a/src/main/java/org/candlepin/controller/util/EntitlementContentPrefix.java
+++ b/src/main/java/org/candlepin/controller/util/EntitlementContentPrefix.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller.util;
+
+import org.candlepin.model.Environment;
+import org.candlepin.model.Owner;
+import org.candlepin.util.Util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Content prefix implementation for entitlement certificates.
+ */
+public class EntitlementContentPrefix implements ContentPrefix {
+
+    /**
+     * A factory method constructs an instance and prepares prefixes for the given environments.
+     *
+     * @param owner an owner to be used in construction of content prefixes
+     * @param environments environments for which to prepare content prefixes
+     * @return content prefix instance
+     */
+    public static ContentPrefix from(Owner owner, List<Environment> environments) {
+        EntitlementContentPrefix prefixes = new EntitlementContentPrefix(owner);
+        for (Environment environment : environments) {
+            prefixes.add(environment);
+        }
+        return prefixes;
+    }
+
+    private final Map<String, String> prefixes = new HashMap<>();
+    private final String ownerPrefix;
+
+    /**
+     * A constructor
+     *
+     * @param owner an owner to be used in construction of content prefixes
+     */
+    private EntitlementContentPrefix(Owner owner) {
+        this.ownerPrefix = owner.getContentPrefix();
+    }
+
+    /**
+     * Returns a content prefix for the requested environment
+     *
+     * If the owner prefix contains an environment placeholder "$env" and an
+     * environment is available the placeholder is expanded. Otherwise the owner
+     * prefix is used as-is.
+     *
+     * E.G. With owner prefix /some/org/$env/ and an environment with name Env21
+     * the prefix becomes /some/org/Env21/
+     *
+     * In case the owner prefix is missing an empty prefix "" is always returned.
+     *
+     * @param environmentId an id of environment for which to return a content prefix
+     * @return content prefix
+     */
+    @Override
+    public String get(String environmentId) {
+        if (ownerPrefixIsMissing()) {
+            return "";
+        }
+        return this.prefixes.getOrDefault(environmentId, ownerPrefix());
+    }
+
+    private void add(Environment env) {
+        if (ownerPrefixIsMissing() || env == null || env.getId() == null) {
+            return;
+        }
+
+        String contentPrefix = this.ownerPrefix.replaceAll("\\$env", env.getName());
+        this.prefixes.put(env.getId(), this.cleanUpPrefix(contentPrefix));
+    }
+
+    private boolean ownerPrefixIsMissing() {
+        return this.ownerPrefix == null || this.ownerPrefix.isBlank();
+    }
+
+    private String ownerPrefix() {
+        return this.cleanUpPrefix(this.ownerPrefix);
+    }
+
+    // Encode the entire prefix in case any part of it is not
+    // URL friendly. Any $ is put back in order to preserve
+    // the ability to pass $env to the client
+    private String cleanUpPrefix(String contentPrefix) {
+        if (contentPrefix == null) {
+            return "";
+        }
+        StringBuilder output = new StringBuilder("/");
+        for (String part : contentPrefix.split("/")) {
+            if (!part.equals("")) {
+                output.append(Util.encodeUrl(part));
+                output.append("/");
+            }
+        }
+        return output.toString().replace("%24", "$");
+    }
+
+}

--- a/src/main/java/org/candlepin/controller/util/PromotedContent.java
+++ b/src/main/java/org/candlepin/controller/util/PromotedContent.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller.util;
+
+import org.candlepin.model.Environment;
+import org.candlepin.model.EnvironmentContent;
+import org.candlepin.model.ProductContent;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+
+/**
+ * A collection of content promoted to environments.
+ *
+ * Stored content from the added environments is de-duplicated based on the environment priority order.
+ */
+public class PromotedContent {
+
+    private static final Logger log = LoggerFactory.getLogger(PromotedContent.class);
+
+    private final Map<String, EnvironmentContent> contents;
+    private final ContentPrefix prefix;
+
+    /**
+     * A constructor
+     *
+     * @param prefix prefixes to be used in path construction
+     */
+    public PromotedContent(ContentPrefix prefix) {
+        this.prefix = Objects.requireNonNull(prefix);
+        this.contents = new HashMap<>();
+    }
+
+    /**
+     * Adds content of the given environment to the promoted content.
+     *
+     * It is important for the environments for come ordered by priority from
+     * highest to lowest as content collected in earlier calls takes precedence.
+     *
+     * @param environment an environment from which to collect content
+     * @return this instance of {@link PromotedContent}
+     */
+    public PromotedContent with(Environment environment) {
+        if (environment == null) {
+            return this;
+        }
+
+        log.debug("Checking for promoted content in environment: {}", environment.getName());
+        for (EnvironmentContent envContent : environment.getEnvironmentContent()) {
+            log.debug("  promoted content: {}", envContent.getContent());
+
+            this.contents.putIfAbsent(envContent.getContent().getId(), envContent);
+        }
+
+        return this;
+    }
+
+    /**
+     * Collects promoted content from all given environments.
+     *
+     * Expects environments to be sorted by priority (from highest to lowest) in
+     * order to deduplicate the promoted content.
+     *
+     * @param environments environments from which to collect promoted content
+     * @return an instance of {@link PromotedContent}
+     */
+    public PromotedContent withAll(List<Environment> environments) {
+        if (environments == null || environments.isEmpty()) {
+            log.debug("No environments to check for promoted content.");
+            return this;
+        }
+
+        for (Environment environment : environments) {
+            this.with(environment);
+        }
+
+        return this;
+    }
+
+    /**
+     * Returns an id of environment to which is the given {@link ProductContent} promoted.
+     *
+     * @param pc a product content for which to find environment
+     * @return an environment id
+     */
+    public String environmentIdOf(ProductContent pc) {
+        if (pc == null || pc.getContent() == null) {
+            return null;
+        }
+        String contentId = pc.getContent().getId();
+        EnvironmentContent environmentContent = this.contents.get(contentId);
+        if (environmentContent == null) {
+            log.debug("Environment not found for content: {}", contentId);
+            return null;
+        }
+        return environmentContent.getEnvironment().getId();
+    }
+
+    /**
+     * Checks if the given {@link ProductContent} is promoted into any environment.
+     *
+     * @param pc a product content to check
+     * @return true if the product content is promoted into any environment
+     */
+    public boolean contains(ProductContent pc) {
+        if (pc == null || pc.getContent() == null) {
+            return false;
+        }
+        return this.contents.containsKey(pc.getContent().getId());
+    }
+
+    /**
+     * Checks if the given product content is enabled.
+     *
+     * @param pc a product content to check
+     * @return true if the given product content is enabled
+     */
+    public Boolean isEnabled(ProductContent pc) {
+        if (!contains(pc)) {
+            return false;
+        }
+        return this.contents.get(pc.getContent().getId()).getEnabled();
+    }
+
+    /**
+     * Constructs a content path from environment specific prefix and given content.
+     *
+     * The format of the resulting content path will depend on the prefix class
+     * used. For the details of prefix construction refer to the {@link ContentPrefix}
+     * and its implementations.
+     *
+     * @param pc content for which to create a content path
+     * @return full content path
+     */
+    public String getPath(ProductContent pc) {
+        String contentPath = getContentUrl(pc);
+        String contentPrefix = this.prefix.get(this.environmentIdOf(pc));
+        String fullContentPath = createFullContentPath(contentPrefix, contentPath);
+        log.trace("Full content path for product content is: {}", fullContentPath);
+        return fullContentPath;
+    }
+
+    private String getContentUrl(ProductContent pc) {
+        if (pc == null || pc.getContent() == null) {
+            return null;
+        }
+        return pc.getContent().getContentUrl();
+    }
+
+    private String createFullContentPath(String contentPrefix, String contentPath) {
+        // Allow for the case where the content URL is a true URL.
+        // If that is true, then return it as is.
+        if (contentPath != null && (contentPath.startsWith("http://") ||
+            contentPath.startsWith("file://") ||
+            contentPath.startsWith("https://") ||
+            contentPath.startsWith("ftp://"))) {
+
+            return contentPath;
+        }
+
+        String prefix = "/";
+        if (!StringUtils.isEmpty(contentPrefix)) {
+            // Ensure there is no double // in the URL. See BZ952735
+            // remove them all except one.
+            prefix = StringUtils.stripEnd(contentPrefix, "/") + prefix;
+        }
+
+        contentPath = StringUtils.stripStart(contentPath, "/");
+        return prefix + contentPath;
+    }
+
+}

--- a/src/main/java/org/candlepin/controller/util/ScaContentPrefix.java
+++ b/src/main/java/org/candlepin/controller/util/ScaContentPrefix.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller.util;
+
+import org.candlepin.model.Environment;
+import org.candlepin.model.Owner;
+import org.candlepin.util.Util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Content prefix implementation for simple content access certificates.
+ */
+public class ScaContentPrefix implements ContentPrefix {
+
+    /**
+     * A factory method constructs an instance and prepares prefixes for the given environments.
+     *
+     * @param owner an owner to be used in construction of content prefixes
+     * @param standalone flag denoting whether we are in hosted or standalone deployment
+     * @param environments environments for which to prepare content prefixes
+     * @return content prefix instance
+     */
+    public static ContentPrefix from(Owner owner, boolean standalone, List<Environment> environments) {
+        ScaContentPrefix prefixes = new ScaContentPrefix(owner, standalone);
+        for (Environment environment : environments) {
+            prefixes.add(environment);
+        }
+        return prefixes;
+    }
+
+    private final Map<String, String> prefixes = new HashMap<>();
+    private final String ownerKey;
+    private final boolean standalone;
+
+    /**
+     * A constructor
+     *
+     * @param owner an owner to be used in construction of content prefixes
+     * @param standalone flag denoting whether we are in hosted or standalone deployment
+     */
+    private ScaContentPrefix(Owner owner, boolean standalone) {
+        this.ownerKey = owner.getKey();
+        this.standalone = standalone;
+    }
+
+    /**
+     * Returns a content prefix for the requested environment.
+     *
+     * In hosted, SCA entitlement content paths should not have any prefix. The
+     * returned prefix is always empty "".
+     *
+     * In satellite (standalone), the prefix is created by appending the owner key and
+     * environment name if available. E.G. /some_org_key/an_env_name
+     *
+     * The environment name is omitted from prefix in case an invalid environment id was provided.
+     *
+     * @param environmentId an id of environment for which to return a content prefix
+     * @return content prefix
+     */
+    @Override
+    public String get(String environmentId) {
+        return this.prefixes.getOrDefault(environmentId, ownerPrefix());
+    }
+
+    // Fix for BZ 1866525:
+    // - In hosted, SCA entitlement content paths should not have any prefix
+    // - In satellite (standalone), the prefix should use the owner key and environment name
+    //   if available
+    private void add(Environment environment) {
+        if (!this.standalone || environment == null || environment.getId() == null) {
+            return;
+        }
+
+        StringBuilder prefix = new StringBuilder();
+        prefix.append(this.ownerPrefix());
+
+        for (String chunk : environment.getName().split("/")) {
+            if (!chunk.isEmpty()) {
+                prefix.append("/");
+                prefix.append(Util.encodeUrl(chunk));
+            }
+        }
+
+        this.prefixes.put(environment.getId(), prefix.toString());
+    }
+
+    private String ownerPrefix() {
+        if (this.standalone) {
+            return "/" + Util.encodeUrl(this.ownerKey);
+        }
+        return "";
+    }
+
+}

--- a/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -16,6 +16,9 @@ package org.candlepin.service.impl;
 
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
+import org.candlepin.controller.util.ContentPrefix;
+import org.candlepin.controller.util.EntitlementContentPrefix;
+import org.candlepin.controller.util.PromotedContent;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.Consumer;
@@ -28,7 +31,6 @@ import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Environment;
-import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.KeyPairCurator;
 import org.candlepin.model.Owner;
@@ -37,7 +39,6 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductContent;
-import org.candlepin.model.ProductCurator;
 import org.candlepin.pki.PKIUtility;
 import org.candlepin.pki.X509ByteExtensionWrapper;
 import org.candlepin.pki.X509ExtensionWrapper;
@@ -59,7 +60,6 @@ import org.xnap.commons.i18n.I18n;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
@@ -77,20 +77,19 @@ import java.util.Set;
  * DefaultEntitlementCertServiceAdapter
  */
 public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertServiceAdapter {
-    private static Logger log = LoggerFactory.getLogger(DefaultEntitlementCertServiceAdapter.class);
+    private static final Logger log = LoggerFactory.getLogger(DefaultEntitlementCertServiceAdapter.class);
 
-    private PKIUtility pki;
-    private X509ExtensionUtil extensionUtil;
-    private X509V3ExtensionUtil v3extensionUtil;
-    private KeyPairCurator keyPairCurator;
-    private CertificateSerialCurator serialCurator;
-    private OwnerCurator ownerCurator;
-    private EntitlementCurator entCurator;
-    private I18n i18n;
-    private Configuration config;
-    private ProductCurator productCurator;
-    private ConsumerTypeCurator consumerTypeCurator;
-    private EnvironmentCurator environmentCurator;
+    private final PKIUtility pki;
+    private final X509ExtensionUtil extensionUtil;
+    private final X509V3ExtensionUtil v3extensionUtil;
+    private final KeyPairCurator keyPairCurator;
+    private final CertificateSerialCurator serialCurator;
+    private final OwnerCurator ownerCurator;
+    private final EntitlementCurator entCurator;
+    private final I18n i18n;
+    private final Configuration config;
+    private final ConsumerTypeCurator consumerTypeCurator;
+    private final EnvironmentCurator environmentCurator;
 
     @Inject
     public DefaultEntitlementCertServiceAdapter(PKIUtility pki,
@@ -102,7 +101,6 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
         OwnerCurator ownerCurator,
         EntitlementCurator entCurator, I18n i18n,
         Configuration config,
-        ProductCurator productCurator,
         ConsumerTypeCurator consumerTypeCurator,
         EnvironmentCurator environmentCurator) {
 
@@ -116,7 +114,6 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
         this.entCurator = entCurator;
         this.i18n = i18n;
         this.config = config;
-        this.productCurator = productCurator;
         this.consumerTypeCurator = consumerTypeCurator;
         this.environmentCurator = environmentCurator;
     }
@@ -172,7 +169,7 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
     public X509Certificate createX509Certificate(Consumer consumer, Owner owner, Pool pool,
         Entitlement ent, Product product, Set<Product> products,
         List<org.candlepin.model.dto.Product> productModels, BigInteger serialNumber,
-        KeyPair keyPair, boolean useContentPrefix)
+        KeyPair keyPair, PromotedContent promotedContent)
         throws GeneralSecurityException, IOException {
 
         // oidutil is busted at the moment, so do this manually
@@ -180,16 +177,12 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
         Set<X509ByteExtensionWrapper> byteExtensions = new LinkedHashSet<>();
         products.add(product);
 
-        Map<String, EnvironmentContent> promotedContent = getPromotedContent(consumer);
-        String contentPrefix = getContentPrefix(consumer, owner, useContentPrefix);
-
         if (shouldGenerateV3(consumer)) {
             extensions = prepareV3Extensions();
-            byteExtensions = prepareV3ByteExtensions(product, productModels, contentPrefix, promotedContent);
+            byteExtensions = this.v3extensionUtil.getByteExtensions(productModels);
         }
         else {
-            extensions = prepareV1Extensions(products, pool, consumer, ent.getQuantity(), contentPrefix,
-                promotedContent);
+            extensions = prepareV1Extensions(products, pool, consumer, ent.getQuantity(), promotedContent);
         }
 
         Date endDate = setupEntitlementEndDate(pool, consumer);
@@ -203,11 +196,9 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
             startDate = calMinusHour.getTime();
         }
 
-        X509Certificate x509Cert =  this.pki.createX509Certificate(
+        return this.pki.createX509Certificate(
             createDN(ent, owner), extensions, byteExtensions, startDate,
             endDate, keyPair, serialNumber, null);
-
-        return x509Cert;
     }
 
     /**
@@ -287,57 +278,8 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
         return false;
     }
 
-    /**
-     * @param consumer
-     * @param useContentPrefix
-     * @throws IOException
-     */
-    private String getContentPrefix(Consumer consumer, Owner owner, boolean useContentPrefix)
-        throws IOException {
-        String contentPrefix = null;
-
-        if (useContentPrefix) {
-            contentPrefix = owner.getContentPrefix();
-            Environment env = this.environmentCurator.getConsumerEnvironment(consumer);
-
-            if (contentPrefix != null && !contentPrefix.equals("")) {
-                if (env != null) {
-                    contentPrefix = contentPrefix.replaceAll("\\$env", env.getName());
-                }
-
-                contentPrefix = this.cleanUpPrefix(contentPrefix);
-            }
-        }
-
-        return contentPrefix;
-    }
-
-    /**
-     * @param consumer
-     * @return
-     */
-    private Map<String, EnvironmentContent> getPromotedContent(Consumer consumer) {
-        // Build a set of all content IDs promoted to the consumer's environment so
-        // we can determine if anything needs to be skipped:
-        Map<String, EnvironmentContent> promotedContent = new HashMap<>();
-
-        if (consumer.getEnvironmentId() != null) {
-            Environment environment = this.environmentCurator.getConsumerEnvironment(consumer);
-            log.debug("Consumer has an environment; checking for promoted content in: {}", environment);
-
-            for (EnvironmentContent envContent : environment.getEnvironmentContent()) {
-                log.debug("  promoted content: {}", envContent.getContent());
-
-                promotedContent.put(envContent.getContent().getId(), envContent);
-            }
-        }
-
-        return promotedContent;
-    }
-
     public Set<X509ExtensionWrapper> prepareV1Extensions(Set<Product> products,
-        Pool pool, Consumer consumer, Integer quantity, String contentPrefix,
-        Map<String, EnvironmentContent> promotedContent) {
+        Pool pool, Consumer consumer, Integer quantity, PromotedContent promotedContent) {
         Set<X509ExtensionWrapper> result = new LinkedHashSet<>();
 
         Set<String> entitledProductIds = entCurator.listEntitledProductIds(
@@ -364,7 +306,7 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
 
             log.debug("Adding X509 extensions for content: {}", filteredContent);
             result.addAll(extensionUtil.contentExtensions(filteredContent,
-                contentPrefix, promotedContent, consumer, skuProd));
+                promotedContent, consumer, skuProd));
         }
 
         // For V1 certificates we're going to error out if we exceed a limit which is
@@ -399,31 +341,6 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
         return result;
     }
 
-    public Set<X509ByteExtensionWrapper> prepareV3ByteExtensions(Product sku,
-        List<org.candlepin.model.dto.Product> productModels, String contentPrefix,
-        Map<String, EnvironmentContent> promotedContent) throws IOException {
-
-        Set<X509ByteExtensionWrapper> result = v3extensionUtil.getByteExtensions(sku,
-            productModels, contentPrefix, promotedContent);
-        return result;
-    }
-
-    // Encode the entire prefix in case any part of it is not
-    // URL friendly. Any $ is put back in order to preseve
-    // the ability to pass $env to the client
-    public String cleanUpPrefix(String contentPrefix) throws IOException {
-
-
-        StringBuffer output = new StringBuffer("/");
-        for (String part : contentPrefix.split("/")) {
-            if (!part.equals("")) {
-                output.append(URLEncoder.encode(part, "UTF-8"));
-                output.append("/");
-            }
-        }
-        return output.toString().replace("%24", "$");
-    }
-
     /**
      * @param entitlements a map of entitlements indexed by pool ids to generate
      *        the certs of
@@ -455,6 +372,11 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
         log.debug("Persisting new certificate serials");
         serialCurator.saveOrUpdateAll(serialMap.values(), false, false);
 
+        List<Environment> environments = this.environmentCurator.getConsumerEnvironments(consumer);
+        ContentPrefix contentPrefix = EntitlementContentPrefix.from(owner, environments);
+        PromotedContent promotedContent = new PromotedContent(contentPrefix)
+            .withAll(environments);
+
         Map<String, EntitlementCertificate> entitlementCerts = new HashMap<>();
         for (Entry<String, PoolQuantity> entry : poolQuantities.entrySet()) {
             Pool pool = entry.getValue().getPool();
@@ -475,17 +397,14 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
             products.addAll(getDerivedProductsForDistributor(pool, consumer));
             products.add(product);
 
-            Map<String, EnvironmentContent> promotedContent = getPromotedContent(consumer);
-            String contentPrefix = getContentPrefix(consumer, owner, true);
-
             log.info("Creating X509 cert for product: {}", product);
             log.debug("Provided products: {}", products);
             List<org.candlepin.model.dto.Product> productModels = v3extensionUtil.createProducts(product,
-                products, contentPrefix, promotedContent, consumer, pool);
+                products, promotedContent, consumer, pool);
 
             X509Certificate x509Cert = createX509Certificate(consumer, owner, pool, ent,
                 product, products, productModels,
-                BigInteger.valueOf(serial.getId()), keyPair, true);
+                BigInteger.valueOf(serial.getId()), keyPair, promotedContent);
 
             log.debug("Getting PEM encoded cert.");
             String pem = new String(this.pki.getPemEncoded(x509Cert));
@@ -494,7 +413,7 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
                 log.debug("Generating v3 entitlement data");
 
                 byte[] payloadBytes = v3extensionUtil.createEntitlementDataPayload(productModels,
-                        consumer, pool, ent.getQuantity());
+                    consumer, pool, ent.getQuantity());
 
                 String payload = "-----BEGIN ENTITLEMENT DATA-----\n";
                 payload += Util.toBase64(payloadBytes);
@@ -558,11 +477,7 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
     }
 
     private String createDN(Entitlement ent, Owner owner) {
-        StringBuilder sb = new StringBuilder("CN=");
-        sb.append(ent.getId());
-        sb.append(", O=");
-        sb.append(owner.getKey());
-        return sb.toString();
+        return "CN=" + ent.getId() + ", O=" + owner.getKey();
     }
 
     public List<Long> listEntitlementSerialIds(Consumer consumer) {

--- a/src/main/java/org/candlepin/util/Util.java
+++ b/src/main/java/org/candlepin/util/Util.java
@@ -34,6 +34,8 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -602,5 +604,15 @@ public class Util {
         else {
             return LocalDate.from(temporalAccessor).atStartOfDay().atOffset(ZoneOffset.UTC);
         }
+    }
+
+    /**
+     * Method encodes given text into a format usable in URLs in UTF-8 encoding.
+     *
+     * @param text a chunk of text to be encoded
+     * @return encoded string
+     */
+    public static String encodeUrl(String text) {
+        return URLEncoder.encode(text, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/org/candlepin/util/X509ExtensionUtil.java
+++ b/src/main/java/org/candlepin/util/X509ExtensionUtil.java
@@ -16,8 +16,8 @@ package org.candlepin.util;
 
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
+import org.candlepin.controller.util.PromotedContent;
 import org.candlepin.model.Consumer;
-import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductContent;
@@ -34,7 +34,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -194,9 +193,8 @@ public class X509ExtensionUtil  extends X509Util{
         return toReturn;
     }
 
-    public Set<X509ExtensionWrapper> contentExtensions(
-        Collection<ProductContent> productContentList, String contentPrefix,
-        Map<String, EnvironmentContent> promotedContent, Consumer consumer, Product skuProduct) {
+    public Set<X509ExtensionWrapper> contentExtensions(Collection<ProductContent> productContentList,
+        PromotedContent promotedContent, Consumer consumer, Product skuProduct) {
 
         Set<ProductContent> productContent = new HashSet<>(productContentList);
         Set<X509ExtensionWrapper> toReturn = new LinkedHashSet<>();
@@ -210,8 +208,7 @@ public class X509ExtensionUtil  extends X509Util{
         // likely going to generate a certificate too large for the CDN, and return an
         // informative error message to the user.
         for (ProductContent pc : productContent) {
-            // augment the content path with the prefix if it is passed in
-            String contentPath = this.createFullContentPath(contentPrefix, pc);
+            String contentPath = promotedContent.getPath(pc);
 
             // If we get a content type we don't have content type OID for
             // skip it. see rhbz#997970
@@ -224,7 +221,7 @@ public class X509ExtensionUtil  extends X509Util{
             String contentOid = OIDUtil.REDHAT_OID +
                 "." +
                 OIDUtil.TOPLEVEL_NAMESPACES.get(OIDUtil.CHANNEL_FAMILY_NAMESPACE_KEY) + "." +
-                pc.getContent().getId().toString() + "." +
+                pc.getContent().getId() + "." +
                 OIDUtil.CF_REPO_TYPE.get(pc.getContent().getType());
             toReturn.add(new X509ExtensionWrapper(contentOid, false, pc
                 .getContent().getType()));
@@ -257,9 +254,9 @@ public class X509ExtensionUtil  extends X509Util{
 
             // Check if we should override the enabled flag due to setting on promoted
             // content:
-            if (enableEnvironmentFiltering && consumer.getEnvironmentId() != null) {
+            if (enableEnvironmentFiltering && !consumer.getEnvironmentIds().isEmpty()) {
                 // we know content has been promoted at this point:
-                Boolean enabledOverride = promotedContent.get(pc.getContent().getId()).getEnabled();
+                Boolean enabledOverride = promotedContent.isEnabled(pc);
                 if (enabledOverride != null) {
                     log.debug("overriding enabled flag: {}", enabledOverride);
                     enabled = enabledOverride;

--- a/src/main/java/org/candlepin/util/X509Util.java
+++ b/src/main/java/org/candlepin/util/X509Util.java
@@ -14,8 +14,8 @@
  */
 package org.candlepin.util;
 
+import org.candlepin.controller.util.PromotedContent;
 import org.candlepin.model.Consumer;
-import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductContent;
 
@@ -27,13 +27,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 
-/**
- * X509Util
- */
+
 public abstract class X509Util {
 
     private static Logger log = LoggerFactory.getLogger(X509Util.class);
@@ -88,14 +85,14 @@ public abstract class X509Util {
      * @return ProductContent to include in the certificate.
      */
     public Set<ProductContent> filterProductContent(Product prod, Consumer consumer,
-        Map<String, EnvironmentContent> promotedContent, boolean filterEnvironment,
+        PromotedContent promotedContent, boolean filterEnvironment,
         Set<String> entitledProductIds, boolean contentAccessMode) {
         Set<ProductContent> filtered = new HashSet<>();
 
         for (ProductContent pc : prod.getProductContent()) {
             // Filter any content not promoted to environment.
-            if (filterEnvironment && consumer.getEnvironmentId() != null &&
-                !promotedContent.containsKey(pc.getContent().getId())) {
+            if (filterEnvironment && !consumer.getEnvironmentIds().isEmpty() &&
+                !promotedContent.contains(pc)) {
 
                 log.debug("Skipping content not promoted to environment: {}", pc.getContent());
                 continue;
@@ -124,36 +121,6 @@ public abstract class X509Util {
             }
         }
         return filtered;
-    }
-
-    /**
-     * Creates a Content URL from the prefix and the path
-     * @param contentPrefix to prepend to the path
-     * @param pc the product content
-     * @return the complete content path
-     */
-    public String createFullContentPath(String contentPrefix, ProductContent pc) {
-        String prefix = "/";
-        String contentPath = pc.getContent().getContentUrl();
-
-        // Allow for the case where the content URL is a true URL.
-        // If that is true, then return it as is.
-        if (contentPath != null && (contentPath.startsWith("http://") ||
-            contentPath.startsWith("file://") ||
-            contentPath.startsWith("https://") ||
-            contentPath.startsWith("ftp://"))) {
-
-            return contentPath;
-        }
-
-        if (!StringUtils.isEmpty(contentPrefix)) {
-            // Ensure there is no double // in the URL. See BZ952735
-            // remove them all except one.
-            prefix = StringUtils.stripEnd(contentPrefix, "/") + prefix;
-        }
-
-        contentPath = StringUtils.stripStart(contentPath, "/");
-        return prefix + contentPath;
     }
 
     /**

--- a/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
+++ b/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
@@ -17,9 +17,9 @@ package org.candlepin.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyMapOf;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
@@ -43,7 +43,6 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Product;
-import org.candlepin.model.ProductCurator;
 import org.candlepin.model.SourceSubscription;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.test.TestUtil;
@@ -86,7 +85,6 @@ public class EntitlementCertificateGeneratorTest {
     @Mock private PoolCurator mockPoolCurator;
     @Mock private EventSink mockEventSink;
     @Mock private EventFactory mockEventFactory;
-    @Mock private ProductCurator mockProductCurator;
     @Mock private OwnerCurator mockOwnerCurator;
 
     @Captor private ArgumentCaptor<Map<String, Entitlement>> entMapCaptor;
@@ -99,7 +97,7 @@ public class EntitlementCertificateGeneratorTest {
     public void init() throws Exception {
         this.ecGenerator = new EntitlementCertificateGenerator(
             this.mockEntCertCurator, this.mockEntCertAdapter, this.mockEntitlementCurator,
-            this.mockPoolCurator, this.mockEventSink, this.mockEventFactory, this.mockProductCurator,
+            this.mockPoolCurator, this.mockEventSink, this.mockEventFactory,
             this.mockContentAccessManager, this.mockOwnerCurator);
     }
 
@@ -107,7 +105,7 @@ public class EntitlementCertificateGeneratorTest {
     public void testGenerateEntitlementCertificate() throws GeneralSecurityException, IOException {
         this.ecGenerator = new EntitlementCertificateGenerator(this.mockEntCertCurator,
                 this.mockEntCertAdapter, this.mockEntitlementCurator, this.mockPoolCurator,
-                this.mockEventSink, this.mockEventFactory, this.mockProductCurator,
+                this.mockEventSink, this.mockEventFactory,
                 this.mockContentAccessManager, this.mockOwnerCurator);
 
         Consumer consumer = mock(Consumer.class);
@@ -132,7 +130,7 @@ public class EntitlementCertificateGeneratorTest {
     public void testGenerateEntitlementCertificates() throws GeneralSecurityException, IOException {
         this.ecGenerator = new EntitlementCertificateGenerator(this.mockEntCertCurator,
             this.mockEntCertAdapter, this.mockEntitlementCurator, this.mockPoolCurator,
-            this.mockEventSink, this.mockEventFactory, this.mockProductCurator,
+            this.mockEventSink, this.mockEventFactory,
                 this.mockContentAccessManager, this.mockOwnerCurator);
         Consumer consumer = mock(Consumer.class);
         Product product = mock(Product.class);
@@ -227,8 +225,6 @@ public class EntitlementCertificateGeneratorTest {
 
         p.setId("" + lastPoolId++);
         System.out.println("Caching providedProducts for Pool:" + p.getId());
-        when(mockProductCurator.getPoolProvidedProductsCached(p.getId())).
-            thenReturn((Set<Product>) p.getProduct().getProvidedProducts());
         return p;
     }
 
@@ -237,7 +233,7 @@ public class EntitlementCertificateGeneratorTest {
     public void testLazyRegnerateForEnvironmentContent() {
         String environmentId = "env_id_1";
         List<Entitlement> entitlements = this.generateEntitlements();
-        List cqmock = mock(List.class);
+        List<Entitlement> cqmock = mock(List.class);
         when(cqmock.iterator()).thenReturn(entitlements.iterator());
         when(this.mockEntitlementCurator.listByEnvironment(environmentId)).thenReturn(cqmock);
 
@@ -263,8 +259,8 @@ public class EntitlementCertificateGeneratorTest {
         List<Entitlement> cqmock = mock(List.class);
         when(cqmock.iterator()).thenReturn(entitlements.iterator());
         when(this.mockEntitlementCurator.listByEnvironment(environmentId)).thenReturn(cqmock);
-        when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),
-            any(Map.class), any(Map.class), anyBoolean())).thenReturn(ecMap);
+        when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), anyMap(),
+            anyMap(), anyMap(), anyBoolean())).thenReturn(ecMap);
         when(mockEventFactory.entitlementChanged(any(Entitlement.class))).thenReturn(mock(Event.class));
         this.ecGenerator.regenerateCertificatesOf(environmentId, Arrays.asList("c1", "c2", "c4"), false);
 
@@ -280,7 +276,7 @@ public class EntitlementCertificateGeneratorTest {
     }
 
     @Test
-    public void testLazyRegenerationForProductById() throws Exception {
+    public void testLazyRegenerationForProductById() {
         Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
         Consumer consumer = TestUtil.createConsumer(owner);
         Product product = TestUtil.createProduct();
@@ -316,8 +312,8 @@ public class EntitlementCertificateGeneratorTest {
 
         when(this.mockPoolCurator.listAvailableEntitlementPools(isNull(), eq(owner),
             eq(product.getId()), any(Date.class))).thenReturn(Arrays.asList(pool));
-        when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),
-            any(Map.class), any(Map.class), anyBoolean())).thenReturn(ecMap);
+        when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), anyMap(),
+            anyMap(), anyMap(), anyBoolean())).thenReturn(ecMap);
 
         when(mockEventFactory.entitlementChanged(any(Entitlement.class))).thenReturn(mock(Event.class));
         this.ecGenerator.regenerateCertificatesOf(owner, product.getId(), false);
@@ -359,9 +355,7 @@ public class EntitlementCertificateGeneratorTest {
         entCerts.put(pool.getId(), new EntitlementCertificate());
 
         when(this.mockEntCertAdapter.generateEntitlementCerts(
-            any(Consumer.class), anyMapOf(String.class, PoolQuantity.class),
-            anyMapOf(String.class, Entitlement.class),
-            anyMapOf(String.class, Product.class), anyBoolean())).thenReturn(entCerts);
+            any(Consumer.class), anyMap(), anyMap(), anyMap(), anyBoolean())).thenReturn(entCerts);
         when(mockEventFactory.entitlementChanged(any(Entitlement.class))).thenReturn(mock(Event.class));
         Consumer consumer = TestUtil.createConsumer(owner);
         Entitlement entitlement = new Entitlement(pool, consumer, owner, 1);
@@ -382,7 +376,7 @@ public class EntitlementCertificateGeneratorTest {
 
 
     @Test
-    public void testLazyRegenerationByEntitlementId() throws Exception {
+    public void testLazyRegenerationByEntitlementId() {
         Owner owner = TestUtil.createOwner("test-owner", "Test Owner");
         Consumer consumer = TestUtil.createConsumer(owner);
         Product product = TestUtil.createProduct();
@@ -412,14 +406,14 @@ public class EntitlementCertificateGeneratorTest {
         Entitlement entitlement = TestUtil.createEntitlement(owner, consumer, pool, null);
         entitlement.setId("test-ent-id");
         Collection<String> entitlements = Arrays.asList(entitlement.getId());
-        pool.setEntitlements(new HashSet(Arrays.asList(entitlement)));
+        pool.setEntitlements(new HashSet<>(Arrays.asList(entitlement)));
 
         HashMap<String, EntitlementCertificate> ecMap = new HashMap<>();
         ecMap.put(pool.getId(), new EntitlementCertificate());
 
         when(this.mockEntitlementCurator.get(eq(entitlement.getId()))).thenReturn(entitlement);
-        when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), any(Map.class),
-            any(Map.class), any(Map.class), anyBoolean())).thenReturn(ecMap);
+        when(this.mockEntCertAdapter.generateEntitlementCerts(any(Consumer.class), anyMap(),
+            anyMap(), anyMap(), anyBoolean())).thenReturn(ecMap);
         when(mockEventFactory.entitlementChanged(any(Entitlement.class))).thenReturn(mock(Event.class));
         this.ecGenerator.regenerateCertificatesByEntitlementIds(entitlements, false);
 

--- a/src/test/java/org/candlepin/controller/util/EntitlementContentPrefixTest.java
+++ b/src/test/java/org/candlepin/controller/util/EntitlementContentPrefixTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.model.Environment;
+import org.candlepin.model.Owner;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+class EntitlementContentPrefixTest {
+
+    private static final String ENV_ID = "env_id_1";
+    private static final String UNKNOWN_ENV_ID = "unknown";
+    private static final String ORG_PREFIX = "/someorg/";
+    private static final String EMPTY_PREFIX = "";
+
+    @Test
+    void prefixIsEmptyIfOwnerPrefixMissing() {
+        Owner owner = ownerWithoutPrefix();
+        ContentPrefix prefixes = EntitlementContentPrefix.from(owner, List.of());
+
+        assertEquals(EMPTY_PREFIX, prefixes.get(ENV_ID));
+        assertEquals(EMPTY_PREFIX, prefixes.get(null));
+    }
+
+    @Test
+    void shouldUseOrgPrefixForUnknownEnvironments() {
+        Owner owner = ownerWithPrefix(ORG_PREFIX);
+        ContentPrefix prefixes = EntitlementContentPrefix.from(owner, List.of());
+
+        assertEquals(ORG_PREFIX, prefixes.get(UNKNOWN_ENV_ID));
+    }
+
+    @Test
+    void shouldUseOrgPrefixForInvalidEnvIds() {
+        Owner owner = ownerWithPrefix(ORG_PREFIX);
+        ContentPrefix prefixes = EntitlementContentPrefix.from(owner, List.of());
+
+        assertEquals(ORG_PREFIX, prefixes.get(""));
+        assertEquals(ORG_PREFIX, prefixes.get(" "));
+    }
+
+    @Test
+    void shouldUseOwnerPrefixWhenNoEnvironmentsAreAvailable() {
+        Owner owner = ownerWithPrefix(ORG_PREFIX);
+        ContentPrefix prefixes = EntitlementContentPrefix.from(owner, List.of());
+
+        assertEquals(ORG_PREFIX, prefixes.get(null));
+    }
+
+    @Test
+    void prefixShouldExpandEnvironmentIfAvailable() {
+        Owner owner = ownerWithPrefix("/someorg/$env/");
+        List<Environment> environments = List.of(createEnv(ENV_ID, "AnAwesomeEnvironment1"));
+        ContentPrefix prefixes = EntitlementContentPrefix.from(owner, environments);
+
+        assertEquals("/someorg/AnAwesomeEnvironment1/", prefixes.get(ENV_ID));
+    }
+
+    @Test
+    void prefixShouldIgnoreEnvironmentIfConsumerHasNone() {
+        Owner owner = ownerWithPrefix("/someorg/$env/");
+        ContentPrefix prefixes = EntitlementContentPrefix.from(owner, List.of());
+
+        assertEquals("/someorg/$env/", prefixes.get(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("prefixEncodingSource")
+    void prefixShouldBeEncoded(String ownerPrefix, String envName, String expectedPrefix) {
+        Owner owner = ownerWithPrefix(ownerPrefix);
+        List<Environment> environments = List.of(createEnv(ENV_ID, envName));
+        ContentPrefix prefixes = EntitlementContentPrefix.from(owner, environments);
+
+        assertEquals(expectedPrefix, prefixes.get(ENV_ID));
+    }
+
+    public static Stream<Arguments> prefixEncodingSource() {
+        return Stream.of(
+            Arguments.of("/some org/$env/", "An Awesome Environment #1",
+                "/some+org/An+Awesome+Environment+%231/"),
+            Arguments.of(
+                "/org! #$%&'()*+,/123:;=?@[]\"-.<>\\^_`{|}~£円/$env/",
+                "foo/test environment #1/bar",
+                "/org%21+%23$%25%26%27%28%29*%2B%2C/123%3A%3B%3D%3F%40%5B%5D%22" +
+                    "-.%3C%3E%5C%5E_%60%7B%7C%7D%7E%C2%A3%E5%86%86/foo/test+environment+%231/bar/")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("cleanPrefixes")
+    public void testCleanUpPrefixNoChange(String ownerPrefix) {
+        Owner owner = ownerWithPrefix(ownerPrefix);
+        List<Environment> environments = List.of(createEnv(ENV_ID, "envName"));
+        ContentPrefix prefixes = EntitlementContentPrefix.from(owner, environments);
+
+        assertEquals(ownerPrefix, prefixes.get(ENV_ID));
+    }
+
+    public static Stream<Arguments> cleanPrefixes() {
+        return Stream.of(
+            Arguments.of("/"),
+            Arguments.of("/some_prefix/"),
+            Arguments.of("/some-prefix/"),
+            Arguments.of("/some.prefix/"),
+            Arguments.of("/Some1Prefix2/")
+        );
+    }
+
+    private Environment createEnv(String id, String name) {
+        Environment environment = new Environment();
+        environment.setId(id);
+        environment.setName(name);
+        return environment;
+    }
+
+    private Owner ownerWithoutPrefix() {
+        return new Owner();
+    }
+
+    private Owner ownerWithPrefix(String prefix) {
+        return new Owner().setContentPrefix(prefix);
+    }
+
+}

--- a/src/test/java/org/candlepin/controller/util/PromotedContentTest.java
+++ b/src/test/java/org/candlepin/controller/util/PromotedContentTest.java
@@ -1,0 +1,346 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerCapability;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.Content;
+import org.candlepin.model.Environment;
+import org.candlepin.model.EnvironmentContent;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Product;
+import org.candlepin.model.ProductContent;
+import org.candlepin.util.Util;
+import org.candlepin.util.X509V3ExtensionUtil;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+class PromotedContentTest {
+
+    public static final String ENV_ID = "env_id_1";
+    public static final String CONTENT_ID = "content_id_1";
+
+    @Test
+    void nullProductContent() {
+        PromotedContent promotedContent = new PromotedContent(emptyPrefix());
+
+        String environmentId = promotedContent.environmentIdOf(null);
+
+        assertNull(environmentId);
+    }
+
+    @Test
+    void environmentNotFound() {
+        Content content = this.mockContent();
+        Product product = this.mockProduct(content);
+        ProductContent pc = new ProductContent(product, content, true);
+        PromotedContent promotedContent = new PromotedContent(emptyPrefix());
+
+        String environmentId = promotedContent.environmentIdOf(pc);
+
+        assertNull(environmentId);
+    }
+
+    @Test
+    void environmentFound() {
+        Content content = this.mockContent();
+        Environment environment = createEnvironment(content);
+        Product product = this.mockProduct(content);
+        ProductContent pc = new ProductContent(product, content, true);
+        PromotedContent promotedContent = new PromotedContent(emptyPrefix())
+            .with(environment);
+
+        String environmentId = promotedContent.environmentIdOf(pc);
+
+        assertEquals(environment.getId(), environmentId);
+    }
+
+    @Test
+    void contentShouldBeDeDuplicated() {
+        Content content1 = this.mockContent("content_1");
+        Content content2 = this.mockContent("content_2");
+        Product product = this.mockProduct(content1, content2);
+        ProductContent pc1 = new ProductContent(product, content1, true);
+        ProductContent pc2 = new ProductContent(product, content2, true);
+        Environment environment1 = createEnvironment(content1);
+        Environment environment2 = createEnvironment(content2);
+
+        PromotedContent promotedContent = new PromotedContent(emptyPrefix())
+            .with(environment1)
+            .with(environment2);
+
+        assertEquals(environment1.getId(), promotedContent.environmentIdOf(pc1));
+        assertEquals(environment1.getId(), promotedContent.environmentIdOf(pc2));
+    }
+
+    @Test
+    void nullIsNotPromoted() {
+        PromotedContent promotedContent = new PromotedContent(emptyPrefix());
+
+        boolean isPromoted = promotedContent.contains(null);
+
+        assertFalse(isPromoted);
+    }
+
+    @Test
+    void unknownContentIsNotPromoted() {
+        Content content = this.mockContent();
+        Product product = this.mockProduct(content);
+        ProductContent pc = new ProductContent(product, content, true);
+        PromotedContent promotedContent = new PromotedContent(emptyPrefix());
+
+        boolean isPromoted = promotedContent.contains(pc);
+
+        assertFalse(isPromoted);
+    }
+
+    @Test
+    void knownPromotedContent() {
+        Content content = this.mockContent();
+        Environment environment = createEnvironment(content);
+        Product product = this.mockProduct(content);
+        ProductContent pc = new ProductContent(product, content, true);
+        PromotedContent promotedContent = new PromotedContent(emptyPrefix())
+            .with(environment);
+
+        boolean isPromoted = promotedContent.contains(pc);
+
+        assertTrue(isPromoted);
+    }
+
+    @Test
+    void nullIsNotEnabled() {
+        PromotedContent promotedContent = new PromotedContent(emptyPrefix());
+
+        boolean isEnabled = promotedContent.isEnabled(null);
+
+        assertFalse(isEnabled);
+    }
+
+    @Test
+    void unknownContentIsNotEnabled() {
+        Content content = this.mockContent();
+        Product product = this.mockProduct(content);
+        ProductContent pc = new ProductContent(product, content, true);
+        PromotedContent promotedContent = new PromotedContent(emptyPrefix());
+
+        boolean isEnabled = promotedContent.isEnabled(pc);
+
+        assertFalse(isEnabled);
+    }
+
+    @Test
+    void knownEnabledContent() {
+        Content content = this.mockContent();
+        Environment environment = createEnvironment(content);
+        Product product = this.mockProduct(content);
+        ProductContent pc = new ProductContent(product, content, true);
+        PromotedContent promotedContent = new PromotedContent(emptyPrefix())
+            .with(environment);
+
+        boolean isEnabled = promotedContent.isEnabled(pc);
+
+        assertTrue(isEnabled);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidPrefix")
+    public void invalidPrefixIsOmitted(String prefix) {
+        PromotedContent promotedContent = createPromotedContent(prefix);
+        ProductContent pc = createContent("some/path");
+
+        assertEquals("/some/path", promotedContent.getPath(pc));
+    }
+
+    public static Stream<Arguments> invalidPrefix() {
+        return Stream.of(
+            Arguments.of((String) null),
+            Arguments.of("")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("endingSlash")
+    public void shouldHandleRepeatedSlashesInPrefix(String prefix) {
+        PromotedContent promotedContent = createPromotedContent(prefix);
+        ProductContent pc = createContent("/some/path");
+
+        assertEquals("/this/is/some/path", promotedContent.getPath(pc));
+    }
+
+    public static Stream<Arguments> endingSlash() {
+        return Stream.of(
+            Arguments.of("/this/is"),
+            Arguments.of("/this/is/"),
+            Arguments.of("/this/is///")
+        );
+    }
+
+    @Test
+    public void missingStartingSlashInContentUrl() {
+        PromotedContent promotedContent = createPromotedContent("/this/is///");
+        ProductContent pc = createContent("some/path");
+
+        assertEquals("/this/is/some/path", promotedContent.getPath(pc));
+    }
+
+    @Test
+    public void repeatedStartingSlashInContentUrl() {
+        PromotedContent promotedContent = createPromotedContent("/this/is///");
+        ProductContent pc = createContent("/////////some/path");
+
+        assertEquals("/this/is/some/path", promotedContent.getPath(pc));
+    }
+
+    @ParameterizedTest
+    @MethodSource("endingSlash")
+    public void shouldHandleStartingSlash(String prefix) {
+        PromotedContent promotedContent = createPromotedContent(prefix);
+        ProductContent pc = createContent("some/path");
+
+        assertEquals("/this/is/some/path", promotedContent.getPath(pc));
+    }
+
+    @ParameterizedTest
+    @MethodSource("urlsWithProtocol")
+    public void urlsWithProtocolShouldNotBePrefixed(String contentUrl) {
+        PromotedContent promotedContent = createPromotedContent("/this/is");
+        ProductContent pc = createContent(contentUrl);
+
+        assertEquals(contentUrl, promotedContent.getPath(pc));
+    }
+
+    public static Stream<Arguments> urlsWithProtocol() {
+        return Stream.of(
+            Arguments.of("http://some/path"),
+            Arguments.of("https://some/path"),
+            Arguments.of("ftp://some/path"),
+            Arguments.of("file://some/path")
+        );
+    }
+
+    private Environment createEnvironment(Content content) {
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+        Environment environment = this.mockEnvironment(owner, consumer, content);
+        environment.getEnvironmentContent().add(new EnvironmentContent(environment, content, true));
+        return environment;
+    }
+
+
+    private Owner mockOwner() {
+        Owner owner = new Owner();
+        owner.setId("test_owner");
+        owner.setKey("test_owner");
+
+        return owner;
+    }
+
+    private Consumer mockConsumer(Owner owner) {
+        ConsumerType type = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
+        type.setId("test-id");
+
+        Consumer consumer = new Consumer("Test Consumer", "bob", owner, type);
+        consumer.setUuid("test-consumer-uuid");
+        consumer.setId("test-consumer-id");
+
+        consumer.setFact("system.certificate_version", X509V3ExtensionUtil.CERT_VERSION);
+        consumer.setCapabilities(Util.asSet(new ConsumerCapability(consumer, "cert_v3")));
+
+        return consumer;
+    }
+
+    private Content mockContent() {
+        return mockContent("test_content");
+    }
+
+    private Content mockContent(String name) {
+        Content content = new Content();
+        content.setUuid("test_content-uuid");
+        content.setId("1234");
+        content.setName(name);
+        content.setLabel("test_content-label");
+        content.setType("yum");
+        content.setVendor("vendor");
+        content.setContentUrl("/content/dist/rhel/$releasever/$basearch/os");
+        content.setGpgUrl("gpgUrl");
+        content.setArches("x86_64");
+        content.setMetadataExpiration(3200L);
+        content.setRequiredTags("TAG1,TAG2");
+
+        return content;
+    }
+
+    private Product mockProduct(Content... contents) {
+        Product product = new Product("test_product_id", "test_product", null);
+        product.setAttribute(Product.Attributes.VERSION, "version");
+        product.setAttribute(Product.Attributes.VARIANT, "variant");
+        product.setAttribute(Product.Attributes.TYPE, "SVC");
+        product.setAttribute(Product.Attributes.ARCHITECTURE, "x86_64");
+        for (Content content : contents) {
+            product.addContent(content, false);
+        }
+
+        return product;
+    }
+
+    private Environment mockEnvironment(Owner owner, Consumer consumer, Content content) {
+        Environment environment = new Environment("test_environment", "test_environment", owner);
+        environment.setEnvironmentContent(Util.asSet(new EnvironmentContent(environment, content, true)));
+
+        consumer.addEnvironment(environment);
+
+        return environment;
+    }
+
+    private ProductContent createContent(String contentUrl) {
+        ProductContent productContent = new ProductContent();
+        Content content = new Content()
+            .setId(CONTENT_ID)
+            .setContentUrl(contentUrl);
+        productContent.setContent(content);
+        return productContent;
+    }
+
+    private PromotedContent createPromotedContent(String prefix) {
+        Environment environment = new Environment(ENV_ID, "env1", new Owner());
+        environment.getEnvironmentContent()
+            .add(new EnvironmentContent(environment, new Content(CONTENT_ID), true));
+
+        return new PromotedContent(prefix(prefix))
+            .with(environment);
+    }
+
+    private ContentPrefix emptyPrefix() {
+        return envId -> "";
+    }
+
+    private ContentPrefix prefix(String prefix) {
+        return envId -> prefix;
+    }
+
+}

--- a/src/test/java/org/candlepin/controller/util/ScaContentPrefixTest.java
+++ b/src/test/java/org/candlepin/controller/util/ScaContentPrefixTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.model.Environment;
+import org.candlepin.model.Owner;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+class ScaContentPrefixTest {
+
+    private static final boolean HOSTED = false;
+    private static final boolean STANDALONE = true;
+    private static final String ENV_ID = "env_id_1";
+    private static final String UNKNOWN_ENV_ID = "unknown_env_id_1";
+    private static final String EMPTY_PREFIX = "";
+
+    @Test
+    void prefixShouldBeOmittedInHosted() {
+        Owner owner = ownerWithKey("owner_key_1");
+        ContentPrefix prefixes = ScaContentPrefix.from(owner, HOSTED, List.of());
+
+        assertEquals(EMPTY_PREFIX, prefixes.get(null));
+    }
+
+    @Test
+    void shouldUseOwnerPrefixForNullEnvironments() {
+        Owner owner = ownerWithKey("owner_key_1");
+        ContentPrefix prefixes = ScaContentPrefix.from(owner, STANDALONE, List.of());
+
+        assertEquals("/owner_key_1", prefixes.get(null));
+    }
+
+    @Test
+    void shouldUseOwnerPrefixForUnknownEnvironments() {
+        Owner owner = ownerWithKey("owner_key_1");
+        List<Environment> environments = List.of(createEnv("AnAwesomeEnvironment1"));
+        ContentPrefix prefixes = ScaContentPrefix.from(owner, STANDALONE, environments);
+
+        assertEquals("/owner_key_1", prefixes.get(UNKNOWN_ENV_ID));
+    }
+
+    @Test
+    void prefixShouldAppendEnvIfAvailable() {
+        Owner owner = ownerWithKey("owner_key_1");
+        List<Environment> environments = List.of(createEnv("AnAwesomeEnvironment1"));
+        ContentPrefix prefixes = ScaContentPrefix.from(owner, STANDALONE, environments);
+
+        assertEquals("/owner_key_1/AnAwesomeEnvironment1", prefixes.get(ENV_ID));
+    }
+
+    @ParameterizedTest
+    @MethodSource("prefixEncodingSource")
+    void prefixShouldBeEncoded(String ownerKey, String envName, String expectedPrefix) {
+        Owner owner = ownerWithKey(ownerKey);
+        List<Environment> environments = List.of(createEnv(envName));
+        ContentPrefix prefixes = ScaContentPrefix.from(owner, STANDALONE, environments);
+
+        assertEquals(expectedPrefix, prefixes.get(ENV_ID));
+    }
+
+    public static Stream<Arguments> prefixEncodingSource() {
+        return Stream.of(
+            Arguments.of("owner key #1", "An/Awesome/Environment/#1",
+                "/owner+key+%231/An/Awesome/Environment/%231"),
+            Arguments.of(
+                "org! #$%&'()*+,/123:;=?@[]\"-.<>\\^_`{|}~£円",
+                "foo/test environment #1/bar",
+                "/org%21+%23%24%25%26%27%28%29*%2B%2C%2F123%3A%3B%3D%3F%40%5B%5D%22" +
+                    "-.%3C%3E%5C%5E_%60%7B%7C%7D%7E%C2%A3%E5%86%86/foo/test+environment+%231/bar")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"An/AwesomeEnvironment1", "An/Awesome/Environment1", "An/Awesome/Environment/1"})
+    void prefixShouldNotEncodeSlashesInEnvNames(String envName) {
+        Owner owner = ownerWithKey("owner_key_1");
+        List<Environment> environments = List.of(createEnv(envName));
+        ContentPrefix prefixes = ScaContentPrefix.from(owner, STANDALONE, environments);
+
+        assertEquals("/owner_key_1/" + envName, prefixes.get(ENV_ID));
+    }
+
+    private Environment createEnv(String name) {
+        Environment environment = new Environment();
+        environment.setId(ENV_ID);
+        environment.setName(name);
+        return environment;
+    }
+
+    private Owner ownerWithKey(String key) {
+        return new Owner().setKey(key);
+    }
+
+}

--- a/src/test/java/org/candlepin/util/UtilTest.java
+++ b/src/test/java/org/candlepin/util/UtilTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
@@ -360,19 +361,36 @@ public class UtilTest {
         }
 
         @ParameterizedTest(name = "An invalid value: \"{0}\" cannot be split")
-        @ValueSource(strings = { "", " ", " , " })
+        @ValueSource(strings = {"", " ", " , "})
         void emptyString(String list) {
             assertTrue(Util.toList(list).isEmpty());
         }
 
         @ParameterizedTest(name = "A valid value: \"{0}\" can be split")
-        @ValueSource(strings = { "item1, item2", " item1,item2 ", " item1 , item2 " })
+        @ValueSource(strings = {"item1, item2", " item1,item2 ", " item1 , item2 "})
         void validString(String list) {
             List<String> items = Util.toList(list);
 
             assertEquals(2, items.size());
             assertTrue(items.contains("item1"));
             assertTrue(items.contains("item2"));
+        }
+    }
+
+    @Nested
+    class EncodeUrlTest {
+
+        @Test
+        void nullString() {
+            assertThrows(NullPointerException.class, () -> Util.encodeUrl(null));
+        }
+
+        @Test
+        void encodesSpecialCharacters() {
+            String text = "/org!  #$%&'()*+,/123:;=?@[]\"-.<>\\^_`{|}~£円/$env/";
+            String expected = "%2Forg%21++%23%24%25%26%27%28%29*%2B%2C%2F123%3A%3B%3D%3F%40%5B%5D%22-." +
+                "%3C%3E%5C%5E_%60%7B%7C%7D%7E%C2%A3%E5%86%86%2F%24env%2F";
+            assertEquals(expected, Util.encodeUrl(text));
         }
     }
 


### PR DESCRIPTION
- Generate entitlement cert using multiple environments
- Deduplicate promoted content
- Handle environment-specific content paths

Note: Due to the high amount of shared code I had to handle all content prefixes not just entitlement ones. 