### PR TITLE
[M] Addressed issues with Product.equals and immutable entity versioning (ENT-4464)

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -330,6 +330,7 @@ public class CandlepinPoolManager implements PoolManager {
         if (pids != null && pids.size() > 0) {
             log.error("One or more pools references a product which no longer belongs to its " +
                 "organization: {}", pids);
+
             throw new IllegalStateException("One or more pools was left in an undefined state: " + pids);
         }
 

--- a/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
@@ -231,7 +231,7 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
         });
 
         for (Content candidate : entityMap.getOrDefault(entity.getId(), Collections.emptyList())) {
-            if (entityVersion == candidate.getEntityVersion(true) && entity.equals(candidate)) {
+            if (entityVersion == candidate.getEntityVersion() && entity.equals(candidate)) {
                 return candidate;
             }
         }

--- a/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
@@ -229,7 +229,7 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
     private Product resolveEntityVersion(EntityNode<Product, ProductInfo> node) {
         Owner owner = node.getOwner();
         Product entity = node.getMergedEntity();
-        int entityVersion = entity.getEntityVersion(false);
+        int entityVersion = entity.getEntityVersion();
 
         Map<String, List<Product>> entityMap = this.ownerVersionedEntityMap.computeIfAbsent(owner, key -> {
             Set<Integer> versions = this.ownerEntityVersions.remove(key);
@@ -240,7 +240,7 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
         });
 
         for (Product candidate : entityMap.getOrDefault(entity.getId(), Collections.emptyList())) {
-            if (entityVersion == candidate.getEntityVersion(true) && entity.equals(candidate)) {
+            if (entityVersion == candidate.getEntityVersion() && entity.equals(candidate)) {
                 return candidate;
             }
         }

--- a/src/main/java/org/candlepin/model/OwnerProduct.java
+++ b/src/main/java/org/candlepin/model/OwnerProduct.java
@@ -102,6 +102,11 @@ public class OwnerProduct implements Persisted, Serializable {
         this.product = product;
     }
 
+    @Override
+    public String toString() {
+        return String.format("OwnerProduct [%s => %s]", this.getOwner(), this.getProduct());
+    }
+
     /**
      * Sets the database object IDs this join object uses to link owners to content. If either the
      * owner or content are not present or have not been persisted with a valid ID or UUID, this

--- a/src/main/java/org/candlepin/model/ProductContent.java
+++ b/src/main/java/org/candlepin/model/ProductContent.java
@@ -36,6 +36,7 @@ import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlTransient;
 
 
+
 /**
  * ProductContent
  */
@@ -139,12 +140,8 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
         if (obj instanceof ProductContent) {
             ProductContent that = (ProductContent) obj;
 
-            // We're only interested in ensuring the mapping between the two objects is the same.
-            String thisContentUuid = this.getContent() != null ? this.getContent().getUuid() : null;
-            String thatContentUuid = that.getContent() != null ? that.getContent().getUuid() : null;
-
             return new EqualsBuilder()
-                .append(thisContentUuid, thatContentUuid)
+                .append(this.getContent(), that.getContent())
                 .append(this.isEnabled(), that.isEnabled())
                 .isEquals();
         }
@@ -154,14 +151,8 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
 
     @Override
     public int hashCode() {
-        // Impl note:
-        // Product is not included in this calculation because it only exists in this object to
-        // properly map products to content -- it should not be used for comparing two
-        // instances.
-
         return new HashCodeBuilder(3, 23)
-            .append(this.getContent() != null ? this.getContent().getUuid() : null)
-            .append(this.isEnabled())
+            .append(this.getContent() != null ? this.getContent().getId() : null)
             .toHashCode();
     }
 
@@ -173,12 +164,10 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
      *  a version hash for this entity
      */
     public int getEntityVersion() {
-        int hash = 17;
-
-        hash = 7 * hash + (this.content != null ? this.content.getEntityVersion() : 0);
-        hash = 7 * hash + (this.enabled ? 1 : 0);
-
-        return hash;
+        return new HashCodeBuilder(7, 19)
+            .append(this.getContent() != null ? this.getContent().getEntityVersion() : 0)
+            .append(this.isEnabled())
+            .toHashCode();
     }
 
     /**
@@ -192,9 +181,7 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
     }
 
     public String toString() {
-        return String.format(
-            "ProductContent [id: %s, product = %s, content = %s, enabled = %s]",
-            this.getId(), this.getProduct(), this.getContent(), this.isEnabled()
-        );
+        return String.format("ProductContent [id: %s, product = %s, content = %s, enabled = %s]",
+            this.getId(), this.getProduct(), this.getContent(), this.isEnabled());
     }
 }


### PR DESCRIPTION
- Fixed a bug in Product.equals and ProductContent.equals which
  would fail to properly compare products when either had children
  that did not yet have a UUID
- Updated how entity versioning is calculated and cached for both
  products and content: the entity version will be retained until
  any mutator which would affect a field that is used in the
  version is called
- Product.equals and Content.equals now attempt to use the UUID
  and entity versions to avoid checking individual fields wherever
  possible
- Product.equals and ProductContent.equals will now perform
  recursive calls to its children where necessary
- Product.setDerivedProduct, Product.addProvidedProduct, and
  Product.setProvidedProducts now attempt to check for a cycle
  in the product definitions and will throw an exception if
  one is detected
- Added an additional test to verify that the refresh operation
  is resulting in deduplicated products where possible