### PR TITLE
[4.0] Optimized refresh to avoid slow, repetitive operations (ENT-4489)

### DIFF
--- a/server/src/main/java/org/candlepin/hostedtest/HostedTestDataStore.java
+++ b/server/src/main/java/org/candlepin/hostedtest/HostedTestDataStore.java
@@ -205,7 +205,9 @@ public class HostedTestDataStore {
 
         // Do product resolution here
         ProductData product = this.resolveProduct(sinfo.getProduct());
-        sdata.setProduct(product);
+        if (product != null) {
+            sdata.setProduct(product);
+        }
 
         // Set the other "safe" properties here...
         if (sinfo.getOwner() != null) {

--- a/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -246,13 +246,17 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     public void testDeletePool() {
         Pool pool = createPool(o, socketLimitedProduct, 100L,
             TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
-        poolCurator.create(pool);
+
         List<Pool> pools = poolCurator.listByOwner(o).list();
         assertEquals(5, poolCurator.listByOwner(o).list().size());
+
         poolManager.deletePools(Arrays.asList(pool, pools.get(0)));
+
         pools = poolCurator.listByOwner(o).list();
         assertEquals(3, pools.size());
+
         poolManager.deletePools(pools);
+
         pools = poolCurator.listByOwner(o).list();
         assertTrue(pools.isEmpty());
     }

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -931,7 +931,7 @@ public class PoolManagerTest {
         this.manager.getRefresher(mockSubAdapter, mockProdAdapter).add(owner).run();
 
         assertPoolsAreEqual(TestUtil.copyFromSub(s), argPool.getValue());
-        verify(this.mockPoolCurator, times(1)).create(any(Pool.class));
+        verify(this.mockPoolCurator, times(1)).create(any(Pool.class), anyBoolean());
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -997,7 +997,7 @@ public class PoolManagerTest {
         when(poolRulesMock.createAndEnrichPools(eq(s), anyList())).thenReturn(newPools);
 
         this.manager.createAndEnrichPools(s);
-        verify(this.mockPoolCurator, times(1)).create(any(Pool.class));
+        verify(this.mockPoolCurator, times(1)).create(any(Pool.class), anyBoolean());
     }
 
     @Test
@@ -1008,7 +1008,7 @@ public class PoolManagerTest {
         when(poolRulesMock.createAndEnrichPools(eq(p), anyList())).thenReturn(newPools);
 
         this.manager.createAndEnrichPools(p);
-        verify(this.mockPoolCurator, times(1)).create(any(Pool.class));
+        verify(this.mockPoolCurator, times(1)).create(any(Pool.class), anyBoolean());
     }
 
     @Test
@@ -1486,10 +1486,8 @@ public class PoolManagerTest {
         for (Pool pool : pools) {
             String subid = pool.getSubscriptionId();
             if (subid != null) {
-                if (!subToPools.containsKey(subid)) {
-                    subToPools.put(subid, new LinkedList<>());
-                }
-                subToPools.get(subid).add(pool);
+                subToPools.computeIfAbsent(subid, (sid) -> new LinkedList<>())
+                    .add(pool);
             }
             else {
                 floating.add(pool);
@@ -1501,6 +1499,19 @@ public class PoolManagerTest {
             when(cqmock.list()).thenReturn(subToPools.get(subid));
             when(mockPoolCurator.getPoolsBySubscriptionId(eq(subid))).thenReturn(cqmock);
         }
+
+        doAnswer(iom -> {
+            Collection<String> subids = (Collection<String>) iom.getArgument(0);
+            Map<String, List<Pool>> map = new HashMap<>();
+
+            for (String subid : subids) {
+                if (subToPools.containsKey(subid)) {
+                    map.put(subid, subToPools.get(subid));
+                }
+            }
+
+            return map;
+        }).when(mockPoolCurator).mapPoolsBySubscriptionIds(anyCollection());
 
         when(mockPoolCurator.getOwnersFloatingPools(any(Owner.class))).thenReturn(floating);
         when(mockPoolCurator.getPoolsFromBadSubs(any(Owner.class), anyCollection()))


### PR DESCRIPTION
- Substantially reduced the number of times flush is called
  during a refresh operation by removing the flush from the
  iterative sections to the end of each block where possible
- Changed how subscription pools are fetched during refresh
  to a single instance at the beginning of the operation,
  rather than once for every pool during refresh