### PR TITLE
updating ca-certs so the ansible provisioner can run

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       #
       # domain.volume_cache = "unsafe"
     end
-
+    config.vm.provision "shell", inline: "yum -y update yum python ca-certificates"
     config.vm.provision "ansible" do |ansible|
       ansible.playbook = "vagrant/candlepin.yml"
       ansible.galaxy_role_file = "vagrant/requirements.yml"


### PR DESCRIPTION
This allows the ansible provisioner to use things like urllib and requests so it can install things.  There are other options like a full yum update to the image or turning off SSL checking at this stage (possible more info here https://access.redhat.com/articles/2039753#red-hat-enterprise-linux-7-resolution-4 ), but this seems the fastest and cleanest.

To test this: vagrant destroy; vagrant up  should now work