### PR TITLE
[4.0] Reverted removal of XmlTransient tags in ProductContent

### DIFF
--- a/server/src/main/java/org/candlepin/model/ProductContent.java
+++ b/server/src/main/java/org/candlepin/model/ProductContent.java
@@ -33,6 +33,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+import javax.xml.bind.annotation.XmlTransient;
+
 
 
 /**
@@ -79,6 +81,7 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
     }
 
     @Override
+    @XmlTransient
     public Serializable getId() {
         return this.id;
     }
@@ -108,6 +111,7 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
     /**
      * @return the product
      */
+    @XmlTransient
     public Product getProduct() {
         return product;
     }


### PR DESCRIPTION
- The @XmlTransient annotations have been restored in ProductContent
  to avoid an infinite recursion that would otherwise occur during
  testing