### PR TITLE
[4.0] Update JUnit5 version to 5.7

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -77,7 +77,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -217,7 +217,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>
@@ -297,7 +297,7 @@
       <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>javax.persistence</groupId>
@@ -377,7 +377,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ ext.versions = [
     jackson_general: "2.10.5",
     guice     : "4.2.3",
     checkstyle: "8.29",
-    junit5    : "5.4.2"
+    junit5    : "5.7.0"
 ]
 
 ext.libraries = [

--- a/checks/pom.xml
+++ b/checks/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -187,7 +187,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>
@@ -267,7 +267,7 @@
       <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>javax.persistence</groupId>
@@ -347,7 +347,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -331,7 +331,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -471,7 +471,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>
@@ -551,7 +551,7 @@
       <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>javax.persistence</groupId>
@@ -631,7 +631,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -457,7 +457,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -597,7 +597,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>
@@ -677,7 +677,7 @@
       <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>javax.persistence</groupId>
@@ -757,7 +757,7 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>5.4.2</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
- Bump JUnit version to prevent JUnit vintage from failing to parse version of junit: 4.13.1