### PR TITLE
[M] Include contentAccessMode in nested Owner [ENT-4349]

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -9069,6 +9069,8 @@ components:
           type: string
         href:
           type: string
+        contentAccessMode:
+          type: string
 
     OwnerDTO:
       description: DTO representing an owner/organization

--- a/src/main/java/org/candlepin/dto/api/v1/NestedOwnerDTOTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/NestedOwnerDTOTranslator.java
@@ -53,6 +53,7 @@ public class NestedOwnerDTOTranslator implements ObjectTranslator<NestedOwnerDTO
         dest.setKey(source.getKey());
         dest.setDisplayName(source.getDisplayName());
         dest.setHref(source.getHref());
+        dest.setContentAccessMode(source.getContentAccessMode());
 
         return dest;
     }

--- a/src/main/java/org/candlepin/dto/api/v1/NestedOwnerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/NestedOwnerTranslator.java
@@ -52,7 +52,8 @@ public class NestedOwnerTranslator implements ObjectTranslator<Owner, NestedOwne
         dest.id(source.getId())
             .key(source.getKey())
             .displayName(source.getDisplayName())
-            .href(source.getHref());
+            .href(source.getHref())
+            .contentAccessMode(source.getContentAccessMode());
 
         return dest;
     }


### PR DESCRIPTION
* ENT-4349
* It is usefull to get information about content access mode,
  when system is registered and JSON document with consumer
  is returned
* TODO:
  - Spec tests
  - Unit tests
  - Anything else?