### PR TITLE
[M] Upload code coverage report with sonarqube

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,9 @@ between 1.0 and 10.0.  Any CVEs above the maximum allowed CVSS score will cause 
 The reports will be generated automatically under build/reports folder.
 
 ### Checkstyle
-* `./gradlew checkstyleMain`
+* `./gradlew checkstyle` Runs checkstyle for both production and test code.
+* `./gradlew checkstyleMain` Runs checkstyle only for production code.
+* `./gradlew checkstyleTest` Runs checkstyle only for test code.
 
 Buildr provides a Checkstyle task, but we have our own that reads from the  
 Eclipse Checkstyle Plugin configuration.  The Eclipse configuration defines  
@@ -118,7 +120,15 @@ path to `checks.xml` and drop the result into `.checkstyle` in your Eclipse
 project directory.
 
 ### Unit Tests
-* `./gradlew tasks` runs Unit tests
+* `./gradlew test` runs all of the unit tests.
+* `./gradlew test --tests org.candlepin.controller.Cdn*` runs only the unit  
+   tests matched by the given package/class and wildcard(s).
+
+#### Unit Test Coverage
+We use JaCoCo for unit test coverage, by means of the gradle jacoco plugin.
+* `./gradlew test coverage` will run the unit tests and then generate a coverage report  
+  based on the unit test report. If you only run a subset of the tests, then the non-exercised  
+  classes/methods/lines will look uncovered in the report.
 
 ### Spec Tests
 * `./gradlew rspec` runs RSpec tests serially

--- a/build.gradle
+++ b/build.gradle
@@ -375,9 +375,19 @@ jacocoTestReport {
     reports {
         xml.enabled true
     }
+
+    doLast {
+        println "Generated unit test coverage report at $buildDir/reports/jacoco/test/html/index.html"
+    }
 }
 
-project.tasks["sonarqube"].dependsOn "jacocoTestReport"
+// User-friendly alias for jacocoTestReport task
+task coverage {
+    dependsOn jacocoTestReport
+}
+
+project.tasks["sonarqube"].dependsOn "test"
+project.tasks["sonarqube"].dependsOn "coverage"
 
 wrapper {
     distributionType = Wrapper.DistributionType.ALL

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -56,10 +56,10 @@ sonarqube_upload() {
     if [ -f ./gradlew ]; then
         if [ ! -z "$CHANGE_ID" ]  && [ ! -z "$CHANGE_TARGET" ]; then
           #Uploading a PR to the SonarQube
-          ./gradlew --no-daemon sonarqube -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${CHECKOUT}  -Dsonar.projectKey=org.candlepin:candlepin-parent
+          ./gradlew --no-daemon test --fail-fast sonarqube -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${CHECKOUT}  -Dsonar.projectKey=org.candlepin:candlepin-parent
         else
           #Uploading a Branch to the SonarQube
-          ./gradlew --no-daemon sonarqube -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.branch.branch=${CHECKOUT}  -Dsonar.projectKey=org.candlepin:candlepin-parent
+          ./gradlew --no-daemon test --fail-fast sonarqube -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.branch.branch=${CHECKOUT}  -Dsonar.projectKey=org.candlepin:candlepin-parent
         fi
     fi
 }
@@ -233,7 +233,7 @@ OPTIONS:
   -v                enable verbose/debug output
   -i                internationalization - validate translation files
   -k                run cloud registration rspec test suite (only for "hosted" mode)
-  -n                uploading PR/Branch on SonarQube cloud
+  -n                uploading PR/Branch on SonarQube server
                     Below arguments are passed:
                     1) SONAR_HOST_URL
                     2) CHANGE_ID, pull request ID (when Uploading PR)
@@ -406,7 +406,7 @@ if [ "$TRANSLATE" == "1" ]; then
 fi
 
 if [ "$SONARQUBE" == "1" ]; then
-    echo "Uploading code on SonarQube cloud..."
+    echo "Uploading code on SonarQube server..."
     CLEAN_CP=1
 
     SONAR_HOST_URL=$1 # SONARQUBE Host URL

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -35,6 +35,42 @@ pipeline {
                         }
                     }
                 }
+                stage('Upload-PR-to-SonarQube') {
+                    agent { label 'candlepin' }
+                    steps {
+                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
+                        checkout scm
+                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
+                        sh 'sh jenkins/upload-on-sonarqube.sh'
+                    }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
+                    }
+                }
+                stage('Upload-Branch-to-SonarQube') {
+                    agent { label 'candlepin' }
+                    environment {
+                        BRANCH_UPLOAD = 'true'
+                    }
+                    when {
+                        not {
+                            changeRequest()
+                        }
+                    }
+                    steps {
+                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
+                        checkout scm
+                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
+                        sh 'sh jenkins/upload-on-sonarqube.sh'
+                    }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
+                    }
+                }
                 stage('checkstyle') {
                     agent { label 'candlepin' }
                     steps {
@@ -139,46 +175,6 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/candlepin-validate-text.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
-                        }
-                    }
-                }
-            }
-        }
-        stage('SonarQube') {
-            parallel {
-                stage('Upload-PR-to-SonarQube') {
-                    agent { label 'candlepin' }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/upload-on-sonarqube.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
-                        }
-                    }
-                }
-                stage('Upload-Branch-to-SonarQube') {
-                    agent { label 'candlepin' }
-                    environment {
-                        BRANCH_UPLOAD = 'true'
-                    }
-                    when {
-                        not {
-                            changeRequest()
-                        }
-                    }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/upload-on-sonarqube.sh'
                     }
                     post {
                         always {


### PR DESCRIPTION
- Sonarqube gradle task now depends on the test task.
- When sonarqube is run from within our test container,
  fail-fast the unit tests to save cycles on Jenkins nodes.
- Run sonarqube stage in parallel with the rest of the
  stages in Jenkins to avoid extending the overall
  duration of the pipeline.
- Print location of JaCoCo code coverage report.