### PR TITLE
[M] Optimized refresh to avoid slow, repetitive operations (ENT-4489)

### DIFF
--- a/spec/refresh_pools_spec.rb
+++ b/spec/refresh_pools_spec.rb
@@ -1450,6 +1450,193 @@ describe 'Refresh Pools' do
     product_json['content'].should == []
   end
 
+  it 'regenerates entitlements when pool start date changes' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, {
+      :product => product,
+      :start_date => Date.today - 20,
+      :end_date => Date.today + 20
+    })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    user = user_client(owner, random_string('test_user'))
+    consumer = consumer_client(user, random_string('test_consumer'))
+
+    entitlements = consumer.consume_pool(pools.first['id'])
+    expect(entitlements.length).to eq(1)
+
+    consumer_entitlements = @cp.list_entitlements({:uuid => consumer.uuid})
+    expect(consumer_entitlements.length).to eq(1)
+    entitlement = consumer_entitlements.first
+
+    # Update subscription, then refresh. The entitlements should be regenerated
+    update_upstream_subscription(sub.id, { :start_date => Date.today - 10 })
+    @cp.refresh_pools(owner_key)
+
+    consumer_entitlements = @cp.list_entitlements({:uuid => consumer.uuid})
+    expect(consumer_entitlements.length).to eq(1)
+    new_entitlement = consumer_entitlements.first
+
+    expect(new_entitlement['pool']['id']).to eq(entitlement['pool']['id'])
+    expect(new_entitlement['certificates'].first['id']).to_not eq(entitlement['certificates'].first['id'])
+  end
+
+  it 'regenerates entitlements when pool end date changes' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('test_prod'))
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, {
+      :product => product,
+      :start_date => Date.today - 20,
+      :end_date => Date.today + 20
+    })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    user = user_client(owner, random_string('test_user'))
+    consumer = consumer_client(user, random_string('test_consumer'))
+
+    entitlements = consumer.consume_pool(pools.first['id'])
+    expect(entitlements.length).to eq(1)
+
+    consumer_entitlements = @cp.list_entitlements({:uuid => consumer.uuid})
+    expect(consumer_entitlements.length).to eq(1)
+    entitlement = consumer_entitlements.first
+
+    # Update subscription, then refresh. The entitlements should be regenerated
+    update_upstream_subscription(sub.id, { :end_date => Date.today + 10 })
+    @cp.refresh_pools(owner_key)
+
+    consumer_entitlements = @cp.list_entitlements({:uuid => consumer.uuid})
+    new_entitlement = consumer_entitlements.first
+
+    expect(new_entitlement['pool']['id']).to eq(entitlement['pool']['id'])
+    expect(new_entitlement['certificates'].first['id']).to_not eq(entitlement['certificates'].first['id'])
+  end
+
+  it 'regenerates entitlements when pool product changes' do
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    product = create_upstream_product(random_string('test_prod'), { :attributes => { 'attrib' => 'value' }})
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, { :product => product })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+
+    user = user_client(owner, random_string('test_user'))
+    consumer = consumer_client(user, random_string('test_consumer'))
+
+    entitlements = consumer.consume_pool(pools.first['id'])
+    expect(entitlements.length).to eq(1)
+
+    consumer_entitlements = @cp.list_entitlements({:uuid => consumer.uuid})
+    expect(consumer_entitlements.length).to eq(1)
+    entitlement = consumer_entitlements.first
+
+    # Update product, then refresh. The entitlements should be regenerated
+    update_upstream_product(product.id, { :attributes => { 'attrib' => 'new_value' }})
+    @cp.refresh_pools(owner_key)
+
+    consumer_entitlements = @cp.list_entitlements({:uuid => consumer.uuid})
+    new_entitlement = consumer_entitlements.first
+
+    expect(new_entitlement['pool']['id']).to eq(entitlement['pool']['id'])
+    expect(new_entitlement['certificates'].first['id']).to_not eq(entitlement['certificates'].first['id'])
+  end
+
+  it 'regenerates entitlements when derived pools are removed' do
+    # Testing for BZ 1567922:
+    # - We have a main pool with a finite quantity, and also a virt_limit attribute on it
+    # - A host consumes entitlement(s) from it; creating a derived pool as a result of that entitlement
+    #   attachment
+    # - The main pool is changed in one of two ways:
+    #   a) the quantity of it is reduced, resulting in the host's entitlement being revoked (because now it
+    #   would be overconsuming), and that would mean we need to delete the derived pool that was created
+    #   because of it, or
+    #   b) virt_limit is removed from the main pool's product (meaning it no longer should provide derived
+    #   pools), which would mean we need to delete the derived pool
+    # - That derived pool that was marked for deletion is attempted to be locked+updated later on, which
+    #   results on some kind of error
+
+    owner_key = random_string('test_owner')
+    owner = create_owner(owner_key)
+
+    derived_product = create_upstream_product(random_string('derived_prod'))
+
+    product = create_upstream_product(random_string('host_prod'), {
+      :derived_product => derived_product,
+      :attributes => {
+        'virt_limit' => 5
+      }
+    })
+
+    sub = create_upstream_subscription(random_string('test_sub'), owner_key, {
+      :product => product,
+      :quantity => 2
+    })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(2)
+
+    host_pool = pools.find {|pool| pool.type == 'NORMAL'}
+    guest_pool = pools.find {|pool| pool.type == 'BONUS'}
+
+    expect(host_pool).to_not be_nil
+    expect(guest_pool).to_not be_nil
+    expect(host_pool.id).to_not eq(guest_pool.id)
+
+
+    guest_uuid = random_string('system.uuid')
+    user = user_client(owner, random_string('test_user'))
+
+    host = user.register(random_string('host'), :system)
+    host_client = Candlepin.new(nil, nil, host['idCert']['cert'], host['idCert']['key'])
+
+    guest = user.register(random_string('guest'), :system, nil,
+      {'virt.uuid' => guest_uuid, 'virt.is_guest' => 'true', 'uname.machine' => 'x86_64'}, nil, nil, [], [])
+    guest_client = Candlepin.new(nil, nil, guest['idCert']['cert'], guest['idCert']['key'])
+
+    host_client.update_guestids([{'guestId' => guest_uuid}])
+
+    entitlements = host_client.consume_pool(host_pool.id)
+    expect(entitlements.length).to eq(1)
+    host_entitlement = entitlements.first
+
+    entitlements = guest_client.consume_pool(guest_pool.id)
+    expect(entitlements.length).to eq(1)
+    guest_entitlement = entitlements.first
+
+
+    # Update main sub product to no longer have a derived product
+    update_upstream_product(product.id, {
+      :derived_product => nil,
+      :attributes => {}
+    })
+
+    @cp.refresh_pools(owner_key)
+    pools = @cp.list_pools({:owner => owner.id})
+    expect(pools.length).to eq(1)
+    expect(pools.find {|pool| pool.type == 'BONUS'}).to be_nil
+
+    entitlements = @cp.list_entitlements({:uuid => host.uuid})
+    expect(entitlements.length).to eq(1)
+
+    entitlements = @cp.list_entitlements({:uuid => guest.uuid})
+    expect(entitlements.length).to eq(0)
+  end
+
   it 'deduplicates products and content' do
     # Create some orgs
     owners = []
@@ -1501,4 +1688,5 @@ describe 'Refresh Pools' do
     expect(product_uuids.size).to eq(owners.size)
     expect(product_uuids).to all(eq(product_uuids.first))
   end
+
 end

--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -92,7 +92,6 @@ import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -276,10 +275,10 @@ public class CandlepinPoolManager implements PoolManager {
         // Execute refresh!
         RefreshResult refreshResult = refresher.execute(owner);
 
-        List<EntityState> existingStates = Arrays.asList(
+        List<EntityState> existingStates = List.of(
             EntityState.CREATED, EntityState.UPDATED, EntityState.UNCHANGED);
 
-        List<EntityState> mutatedStates = Arrays.asList(
+        List<EntityState> mutatedStates = List.of(
             EntityState.CREATED, EntityState.UPDATED, EntityState.DELETED);
 
         Map<String, Product> existingProducts = refreshResult.getEntities(Product.class, existingStates);
@@ -287,6 +286,9 @@ public class CandlepinPoolManager implements PoolManager {
 
         // TODO: Move everything below this line to the refresher
         boolean poolsModified = false;
+
+        Map<String, List<Pool>> subscriptionPools = this.poolCurator
+            .mapPoolsBySubscriptionIds(subscriptionMap.keySet());
 
         log.debug("Refreshing {} pool(s)...", subscriptionMap.size());
         for (Iterator<? extends SubscriptionInfo> si = subscriptionMap.values().iterator(); si.hasNext();) {
@@ -302,9 +304,14 @@ public class CandlepinPoolManager implements PoolManager {
             log.debug("Processing subscription: {}", sub);
             Pool pool = this.convertToMasterPoolImpl(sub, owner, existingProducts);
             pool.setLocked(true);
-            this.refreshPoolsForMasterPool(pool, false, lazy, updatedProducts);
+
+            List<Pool> subPools = subscriptionPools.getOrDefault(sub.getId(), Collections.emptyList());
+            this.refreshPoolsForMasterPool(pool, false, lazy, updatedProducts, subPools);
             poolsModified = true;
         }
+
+        // Flush our newly created pools
+        this.poolCurator.flush();
 
         // delete pools whose subscription disappeared:
         log.debug("Deleting pools for absent subscriptions...");
@@ -388,7 +395,6 @@ public class CandlepinPoolManager implements PoolManager {
         return owner;
     }
 
-    @Transactional
     void refreshPoolsForMasterPool(Pool pool, boolean updateStackDerived, boolean lazy,
         Map<String, Product> changedProducts) {
 
@@ -397,6 +403,15 @@ public class CandlepinPoolManager implements PoolManager {
 
         if (pool.getSubscriptionId() != null) {
             subscriptionPools = this.poolCurator.getPoolsBySubscriptionId(pool.getSubscriptionId()).list();
+
+            if (log.isDebugEnabled()) {
+                log.debug("Found {} pools for subscription {}", subscriptionPools.size(),
+                    pool.getSubscriptionId());
+
+                for (Pool p : subscriptionPools) {
+                    log.debug("    owner={} - {}", p.getOwner().getKey(), p);
+                }
+            }
         }
         else {
             // If we don't have a subscription ID, this *is* the master pool, but we need to use
@@ -406,12 +421,12 @@ public class CandlepinPoolManager implements PoolManager {
                 Collections.<Pool>singletonList(pool);
         }
 
-        log.debug("Found {} pools for subscription {}", subscriptionPools.size(), pool.getSubscriptionId());
-        if (log.isDebugEnabled()) {
-            for (Pool p : subscriptionPools) {
-                log.debug("    owner={} - {}", p.getOwner().getKey(), p);
-            }
-        }
+        this.refreshPoolsForMasterPool(pool, updateStackDerived, lazy, changedProducts, subscriptionPools);
+    }
+
+    @Transactional
+    void refreshPoolsForMasterPool(Pool pool, boolean updateStackDerived, boolean lazy,
+        Map<String, Product> changedProducts, List<Pool> subscriptionPools) {
 
         // Update product references on the pools, I guess
         // TODO: Should this be performed by poolRules? Seems like that should be a thing.
@@ -439,7 +454,7 @@ public class CandlepinPoolManager implements PoolManager {
 
         // BZ 1012386: This will regenerate master/derived for bonus scenarios if only one of the
         // pair still exists.
-        createAndEnrichPools(pool, subscriptionPools);
+        this.createAndEnrichPools(pool, subscriptionPools, false);
 
         // don't update floating here, we'll do that later so we don't update anything twice
         Set<String> updatedMasterPools = updatePoolsForMasterPool(
@@ -552,16 +567,6 @@ public class CandlepinPoolManager implements PoolManager {
         List<PoolUpdate> updatedPools = poolRules.updatePools(pool, existingPools, originalQuantity,
             changedProducts);
 
-        /*
-         * 1567922: Due to poolRules.updatePools call above, some fields of a product on a pool might change.
-         * Hibernate does not persist these changes yet, and when those pool changes result in
-         * revocation of entitlements later in this process, and the same pool is attempted to be locked
-         * due to it, we get an error.
-         * Temporarily we are resorting to flush the changes here, there will be an investigation later, at
-         * which time, this line of the comment could be replaced with a refactor.
-         */
-        poolCurator.flush();
-
         String virtLimit = pool.getProduct().getAttributeValue(Product.Attributes.VIRT_LIMIT);
         boolean createsSubPools = !StringUtils.isBlank(virtLimit) && !"0".equals(virtLimit);
 
@@ -592,7 +597,6 @@ public class CandlepinPoolManager implements PoolManager {
     protected Set<String> processPoolUpdates(Map<String, EventBuilder> poolEvents,
         List<PoolUpdate> updatedPools) {
 
-        boolean flush = false;
         Set<String> existingUndeletedPoolIds = new HashSet<>();
         Set<Pool> poolsToDelete = new HashSet<>();
         Set<Pool> poolsToRegenEnts = new HashSet<>();
@@ -627,7 +631,6 @@ public class CandlepinPoolManager implements PoolManager {
 
             // save changes for the pool. We'll flush these changes later.
             this.poolCurator.merge(existingPool);
-            flush = true;
 
             // quantity has changed. delete any excess entitlements from pool
             // the quantity has not yet been expressed on the pool itself
@@ -649,11 +652,6 @@ public class CandlepinPoolManager implements PoolManager {
             else {
                 log.warn("Pool updated without an event builder: {}", existingPool);
             }
-        }
-
-        // Flush our merged changes
-        if (flush) {
-            this.poolCurator.flush();
         }
 
         // Check if we need to execute the revocation plan
@@ -742,7 +740,11 @@ public class CandlepinPoolManager implements PoolManager {
 
         // Hand off to rules to determine which pools need updating
         List<PoolUpdate> updatedPools = poolRules.updatePools(floatingPools, changedProducts);
-        regenerateCertificatesByEntIds(processPoolUpdates(poolEvents, updatedPools), lazy);
+
+        Set<String> entIds = processPoolUpdates(poolEvents, updatedPools);
+        this.poolCurator.flush();
+
+        regenerateCertificatesByEntIds(entIds, lazy);
     }
 
     /**
@@ -755,11 +757,19 @@ public class CandlepinPoolManager implements PoolManager {
     }
 
     public List<Pool> createAndEnrichPools(SubscriptionInfo sub, List<Pool> existingPools) {
+        return this.createAndEnrichPools(sub, existingPools, true);
+    }
+
+    public List<Pool> createAndEnrichPools(SubscriptionInfo sub, List<Pool> existingPools, boolean flush) {
         List<Pool> pools = poolRules.createAndEnrichPools(sub, existingPools);
         log.debug("Creating {} pools for subscription: {}", pools.size(), sub);
 
         for (Pool pool : pools) {
-            createPool(pool);
+            createPool(pool, false);
+        }
+
+        if (flush) {
+            this.poolCurator.flush();
         }
 
         return pools;
@@ -767,16 +777,25 @@ public class CandlepinPoolManager implements PoolManager {
 
     @Override
     public Pool createAndEnrichPools(Pool pool) {
-        return createAndEnrichPools(pool, Collections.<Pool>emptyList());
+        return createAndEnrichPools(pool, Collections.<Pool>emptyList(), true);
     }
 
     @Override
     public Pool createAndEnrichPools(Pool pool, List<Pool> existingPools) {
+        return this.createAndEnrichPools(pool, existingPools, true);
+    }
+
+    @Transactional
+    public Pool createAndEnrichPools(Pool pool, List<Pool> existingPools, boolean flush) {
         List<Pool> pools = poolRules.createAndEnrichPools(pool, existingPools);
         log.debug("Creating {} pools: ", pools.size());
 
         for (Pool p : pools) {
-            createPool(p);
+            createPool(p, false);
+        }
+
+        if (flush) {
+            this.poolCurator.flush();
         }
 
         return pool;
@@ -784,10 +803,14 @@ public class CandlepinPoolManager implements PoolManager {
 
     @Override
     public Pool createPool(Pool pool) {
+        return this.createPool(pool, true);
+    }
+
+    public Pool createPool(Pool pool, boolean flush) {
         if (pool != null) {
             // We're assuming that net-new pools will not yet have an ID
             if (pool.getId() == null) {
-                pool = this.poolCurator.create(pool);
+                pool = this.poolCurator.create(pool, flush);
                 log.debug("  created pool: {}", pool);
 
                 if (pool != null) {
@@ -1714,7 +1737,7 @@ public class CandlepinPoolManager implements PoolManager {
         // we might have changed the bonus pool quantities, revoke ents if needed.
         checkBonusPoolQuantities(consumer.getOwnerId(), entMap);
 
-        this.entitlementCurator.markEntitlementsDirty(Arrays.asList(entitlement.getId()));
+        this.entitlementCurator.markEntitlementsDirty(Collections.singleton(entitlement.getId()));
 
         /*
          * If the consumer is not a distributor, check consumer's new compliance

--- a/src/main/java/org/candlepin/hostedtest/HostedTestDataStore.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestDataStore.java
@@ -205,7 +205,9 @@ public class HostedTestDataStore {
 
         // Do product resolution here
         ProductData product = this.resolveProduct(sinfo.getProduct());
-        sdata.setProduct(product);
+        if (product != null) {
+            sdata.setProduct(product);
+        }
 
         // Set the other "safe" properties here...
         if (sinfo.getOwner() != null) {

--- a/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -243,13 +243,17 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     public void testDeletePool() {
         Pool pool = createPool(o, socketLimitedProduct, 100L,
             TestUtil.createDate(2000, 3, 2), TestUtil.createDate(2050, 3, 2));
-        poolCurator.create(pool);
+
         List<Pool> pools = poolCurator.listByOwner(o).list();
         assertEquals(5, poolCurator.listByOwner(o).list().size());
+
         poolManager.deletePools(Arrays.asList(pool, pools.get(0)));
+
         pools = poolCurator.listByOwner(o).list();
         assertEquals(3, pools.size());
+
         poolManager.deletePools(pools);
+
         pools = poolCurator.listByOwner(o).list();
         assertTrue(pools.isEmpty());
     }


### PR DESCRIPTION
- Substantially reduced the number of times flush is called
  during a refresh operation by removing the flush from the
  iterative sections to the end of each block where possible
- Changed how subscription pools are fetched during refresh
  to a single instance at the beginning of the operation,
  rather than once for every pool during refresh
- Fixed an issue with the hosted test adapter clearing a
  subscription's product when no change was intended
- Added additional tests surrounding refresh and entitlement
  generation