### PR TITLE
[4.0] Duplicate entity versions are now disallowed per-ID (ENT-4509)

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -530,6 +530,33 @@ class Candlepin
     end
   end
 
+  def wait_for_job(job_id, max_wait_time=30, cleanup_job=true)
+    finished_states = ['ABORTED', 'FINISHED', 'CANCELED', 'FAILED']
+
+    iterations = 0
+
+    while true
+      status = get_job(job_id)
+
+      if finished_states.include?(status['state'].upcase)
+        break
+      end
+
+      iterations += 1
+      if iterations >= max_wait_time
+        raise "Timeout occurred while waiting for job: #{job_id}"
+      end
+
+      sleep 1
+    end
+
+    if cleanup_job
+      delete('/jobs', {:id => job_id}, nil, true)
+    end
+
+    return status
+  end
+
   def create_consumer_type(type_label, manifest=false)
     consumer_type =  {
       'label' => type_label,

--- a/server/spec/content_versioning_spec.rb
+++ b/server/spec/content_versioning_spec.rb
@@ -204,32 +204,6 @@ describe 'Content Versioning' do
     content[0]["uuid"].should eq(content2["uuid"])
   end
 
-  it "should not converge with an orphaned content" do
-    # NOTE:
-    # This test should be removed/disabled if in-place updating/converging is reenabled, as orphans
-    # will not be created in such a case
-
-    owner1 = create_owner random_string('test_owner')
-    owner2 = create_owner random_string('test_owner')
-
-    id = random_string('test_content')
-    label = "shared content"
-    type = "shared_content_type"
-    vendor = "generous vendor"
-
-    orphan = @cp.create_content(owner1["key"], id, id, label, type, vendor)
-    content1 = @cp.update_content(owner1["key"], id, { :name => "#{id}-update" })
-    content2 = @cp.create_content(owner2["key"], id, id, label, type, vendor)
-
-    expect(orphan['uuid']).to_not eq(content1['uuid'])
-    expect(orphan['uuid']).to_not eq(content2['uuid'])
-    expect(content1['uuid']).to_not eq(content2['uuid'])
-
-    expect(@cp.get_content_by_uuid(orphan['uuid'])).to_not be_nil
-    expect(@cp.get_content_by_uuid(content1['uuid'])).to_not be_nil
-    expect(@cp.get_content_by_uuid(content2['uuid'])).to_not be_nil
-  end
-
   it 'should cleanup orphans without interfering with normal actions' do
     # NOTE:
     # This test takes advantage of the immutable nature of contents with the in-place update branch

--- a/server/spec/product_versioning_spec.rb
+++ b/server/spec/product_versioning_spec.rb
@@ -391,29 +391,6 @@ describe 'Product Versioning' do
     prod6["uuid"].should eq(prod5["uuid"])
   end
 
-  it "should not converge with an orphaned product" do
-    # NOTE:
-    # This test should be removed/disabled if in-place updating/converging is reenabled, as orphans
-    # will not be created in such a case
-
-    owner1 = create_owner random_string('test_owner')
-    owner2 = create_owner random_string('test_owner')
-
-    id = random_string('test_product')
-
-    orphan = @cp.create_product(owner1["key"], id, id)
-    product1 = @cp.update_product(owner1["key"], id, { :name => "#{id}-update" })
-    product2 = @cp.create_product(owner2["key"], id, id)
-
-    expect(orphan['uuid']).to_not eq(product1['uuid'])
-    expect(orphan['uuid']).to_not eq(product2['uuid'])
-    expect(product1['uuid']).to_not eq(product2['uuid'])
-
-    expect(@cp.get_product_by_uuid(orphan['uuid'])).to_not be_nil
-    expect(@cp.get_product_by_uuid(product1['uuid'])).to_not be_nil
-    expect(@cp.get_product_by_uuid(product2['uuid'])).to_not be_nil
-  end
-
   it 'should cleanup orphans without interfering with normal actions' do
     # NOTE:
     # This test takes advantage of the immutable nature of products with the in-place update branch

--- a/server/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
+++ b/server/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
@@ -57,7 +57,8 @@ public class RefreshPoolsJob implements AsyncJob {
         public RefreshPoolsJobConfig() {
             this.setJobKey(JOB_KEY)
                 .setJobName(JOB_NAME)
-                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY));
+                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY))
+                .setRetryCount(3);
         }
 
         /**

--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -151,7 +151,7 @@ public class ContentManager {
 
         // Check if we have an alternate version we can use instead.
         List<Content> alternateVersions = this.ownerContentCurator
-            .getContentByVersions(owner, Collections.singleton(entity.getEntityVersion()))
+            .getContentByVersions(Collections.singleton(entity.getEntityVersion()))
             .get(entity.getId());
 
         if (alternateVersions != null) {
@@ -249,7 +249,7 @@ public class ContentManager {
         // their own version.
         // This is probably going to be a very expensive operation, though.
         List<Content> alternateVersions = this.ownerContentCurator
-            .getContentByVersions(owner, Collections.singleton(updated.getEntityVersion()))
+            .getContentByVersions(Collections.singleton(updated.getEntityVersion()))
             .get(updated.getId());
 
         if (alternateVersions != null) {

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -251,7 +251,7 @@ public class ProductManager {
 
         // Check if we have an alternate version we can use instead.
         List<Product> alternateVersions = this.ownerProductCurator
-            .getProductsByVersions(owner, Collections.singleton(entity.getEntityVersion()))
+            .getProductsByVersions(Collections.singleton(entity.getEntityVersion()))
             .get(entity.getId());
 
         if (alternateVersions != null) {
@@ -351,7 +351,7 @@ public class ProductManager {
         // their own version.
         // This is probably going to be a very expensive operation, though.
         List<Product> alternateVersions = this.ownerProductCurator
-            .getProductsByVersions(owner, Collections.singleton(updated.getEntityVersion()))
+            .getProductsByVersions(Collections.singleton(updated.getEntityVersion()))
             .get(updated.getId());
 
         if (alternateVersions != null) {
@@ -472,7 +472,7 @@ public class ProductManager {
         // their own version.
         // This is probably going to be a very expensive operation, though.
         List<Product> alternateVersions = this.ownerProductCurator
-            .getProductsByVersions(owner, Collections.singleton(updated.getEntityVersion()))
+            .getProductsByVersions(Collections.singleton(updated.getEntityVersion()))
             .get(updated.getId());
 
         if (alternateVersions != null) {

--- a/server/src/main/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapper.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapper.java
@@ -175,7 +175,23 @@ public abstract class AbstractEntityMapper<E extends AbstractHibernateObject, I 
      */
     @Override
     public void clear() {
+        this.clearExistingEntities();
+        this.clearImportedEntities();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clearExistingEntities() {
         this.existingEntities.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clearImportedEntities() {
         this.importedEntities.clear();
     }
 }

--- a/server/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
@@ -223,8 +223,17 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
     int addImportedEntities(Collection<I> entities);
 
     /**
-     * Clears this entity mapper, removing all known existing and imported entities, and clearing any
-     * provided candidate entities map.
+     * Clears this entity mapper, removing all known existing and imported entities
      */
     void clear();
+
+    /**
+     * Clears any existing entities from this mapper
+     */
+    void clearExistingEntities();
+
+    /**
+     * Clears any imported entities from this mapper
+     */
+    void clearImportedEntities();
 }

--- a/server/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
@@ -226,12 +226,20 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
             Set<Integer> versions = this.ownerEntityVersions.remove(key);
 
             return versions != null ?
-                this.ownerContentCurator.getContentByVersions(key, versions) :
+                this.ownerContentCurator.getContentByVersions(versions) :
                 Collections.emptyMap();
         });
 
         for (Content candidate : entityMap.getOrDefault(entity.getId(), Collections.emptyList())) {
-            if (entityVersion == candidate.getEntityVersion() && entity.equals(candidate)) {
+            if (entityVersion == candidate.getEntityVersion()) {
+                if (!entity.equals(candidate)) {
+                    String errmsg = String.format("Entity version collision detected: %s != %s",
+                        entity, candidate);
+
+                    log.error(errmsg);
+                    throw new IllegalStateException(errmsg);
+                }
+
                 return candidate;
             }
         }

--- a/server/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
@@ -235,12 +235,20 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
             Set<Integer> versions = this.ownerEntityVersions.remove(key);
 
             return versions != null ?
-                this.ownerProductCurator.getProductsByVersions(key, versions) :
+                this.ownerProductCurator.getProductsByVersions(versions) :
                 Collections.emptyMap();
         });
 
         for (Product candidate : entityMap.getOrDefault(entity.getId(), Collections.emptyList())) {
-            if (entityVersion == candidate.getEntityVersion() && entity.equals(candidate)) {
+            if (entityVersion == candidate.getEntityVersion()) {
+                if (!entity.equals(candidate)) {
+                    String errmsg = String.format("Entity version collision detected: %s != %s",
+                        entity, candidate);
+
+                    log.error(errmsg);
+                    throw new IllegalStateException(errmsg);
+                }
+
                 return candidate;
             }
         }

--- a/server/src/main/java/org/candlepin/controller/util/EntityVersioningRetryWrapper.java
+++ b/server/src/main/java/org/candlepin/controller/util/EntityVersioningRetryWrapper.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller.util;
+
+import org.hibernate.exception.ConstraintViolationException;
+
+import java.util.function.Supplier;
+
+
+
+/**
+ * Wrapper class providing retry logic to handle ConstraintViolationExceptions occuring as a result
+ * of parallel requests attempting to create the same versioned entities at the same time. In many
+ * cases, only a single retry is needed; but for operations which create many entities (such as
+ * refresh), several retries may be necessary to avoid complete failure.
+ */
+public class EntityVersioningRetryWrapper {
+
+    /** The name of the constraint that will trigger a retry when violated */
+    public static final String CONSTRAINT_STRING = "entity_version";
+
+    private int maxRetries;
+
+    /**
+     * Creates a new retry wrapper with the default max retry value of 2.
+     */
+    public EntityVersioningRetryWrapper() {
+        this.maxRetries = 2;
+    }
+
+    /**
+     * Sets the number of times to retry execution of this wrapper if a failure occurs. If a
+     * negative value is provided, this method throws an exception.
+     *
+     * @param attempts
+     *  the maximum number of times to retry execution of this wrapper upon failure
+     *
+     * @throws IllegalArgumentException
+     *  if attempts is negative
+     *
+     * @return
+     *  this retry wrapper
+     */
+    public EntityVersioningRetryWrapper retries(int attempts) {
+        if (attempts < 0) {
+            throw new IllegalArgumentException("max attempts is less than zero");
+        }
+
+        this.maxRetries = attempts;
+        return this;
+    }
+
+    /**
+     * Executes this retry wrapper with the provided action. The action will always be executed at
+     * least once, and will retry the action if a specific constraint violation exception occurs.
+     * <p></p>
+     * If the action fails with a versioning-related constraint violation, it will be retried
+     * up to the maximum number of retries specified with the <tt>retries</tt> method. Any other
+     * exceptions are immediately rethrown without any attempts to process them or retry the action.
+     * <p></p>
+     * If the action fails with a versioning-related constraint violation, but is at the retry
+     * limit, this method throws the constraint violation exception.
+     *
+     * @param action
+     *  the action to retry until successful completion
+     *
+     * @return
+     *  the result of the provided action
+     */
+    public <O> O execute(Supplier<O> action) {
+        // Retry this operation if we hit a constraint violation on the entity version constraint
+        int retries = 0;
+
+        while (true) {
+            try {
+                return action.get();
+            }
+            catch (Exception e) {
+                if (retries++ < this.maxRetries && isEntityVersioningConstraintViolation(e)) {
+                    continue;
+                }
+
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Checks if the given exception is one originating from a constraint violation related to
+     * entity versioning.
+     *
+     * @param exception
+     *  the exception to check
+     *
+     * @return
+     *  true if the exception originates from an entity versioning constraint violation; false
+     *  otherwise
+     */
+    public static boolean isEntityVersioningConstraintViolation(Exception exception) {
+        for (Throwable cause = exception; cause != null; cause = cause.getCause()) {
+            if (cause instanceof ConstraintViolationException) {
+                ConstraintViolationException cve = (ConstraintViolationException) cause;
+                String cname = cve.getConstraintName();
+
+                if (cname != null && cname.contains(CONSTRAINT_STRING)) {
+                    return true;
+                }
+
+                break;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/server/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -280,7 +280,7 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
         MapConfiguration defaults = new MapConfiguration(ConfigProperties.DEFAULT_PROPERTIES);
 
         // Default to Postgresql if jpa.config.hibernate.dialect is unset
-        DatabaseConfigFactory.SupportedDatabase db = determinDatabaseConfiguration(systemConfig.getString
+        DatabaseConfigFactory.SupportedDatabase db = determineDatabaseConfiguration(systemConfig.getString
             ("jpa.config.hibernate.dialect", PostgreSQL92Dialect.class.getName()));
         log.info("Running under {}", db.getLabel());
         Configuration databaseConfig = DatabaseConfigFactory.fetchConfig(db);
@@ -292,7 +292,7 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
         return EncryptedConfiguration.merge(systemConfig, databaseConfig, defaults);
     }
 
-    private DatabaseConfigFactory.SupportedDatabase determinDatabaseConfiguration(String dialect) {
+    private DatabaseConfigFactory.SupportedDatabase determineDatabaseConfiguration(String dialect) {
         if (StringUtils.containsIgnoreCase(
             dialect, DatabaseConfigFactory.SupportedDatabase.MYSQL.getLabel())) {
             return DatabaseConfigFactory.SupportedDatabase.MYSQL;

--- a/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/server/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -66,10 +66,13 @@ import javax.persistence.EntityTransaction;
 import javax.persistence.LockModeType;
 import javax.persistence.NonUniqueResultException;
 import javax.persistence.OptimisticLockException;
+import javax.persistence.TransactionRequiredException;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
+
+
 
 /**
  * AbstractHibernateCurator base class for all Candlepin curators. Curators are
@@ -678,7 +681,18 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
     public void flush() {
         try {
-            getEntityManager().flush();
+            EntityManager entityManager = this.getEntityManager();
+            EntityTransaction transaction = entityManager.getTransaction();
+
+            // If there's no transaction or it's not active, there's no reason to flush. Attempting
+            // to do so will trigger an exception. Instead, just toss out a warning about it.
+            if (transaction != null && transaction.isActive()) {
+                entityManager.flush();
+            }
+            else {
+                String errmsg = "flush issued outside of a transaction";
+                log.warn(errmsg, log.isDebugEnabled() ? new TransactionRequiredException(errmsg) : "");
+            }
         }
         catch (OptimisticLockException e) {
             throw new ConcurrentModificationException(getConcurrentModificationMessage(), e);
@@ -713,7 +727,18 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     }
 
     /**
-     * Creates a new transactional wrapper using the specified action.
+     * Creates a new transactional wrapper from the backing entity manager
+     *
+     * @return
+     *  a Transactional wrapper configured to execute the specified action
+     */
+    public <O> org.candlepin.util.Transactional<O> transactional() {
+        return new org.candlepin.util.Transactional<O>(this.getEntityManager());
+    }
+
+    /**
+     * Creates a new transactional wrapper from the backing entity manager using the specified
+     * action.
      *
      * @param action
      *  The action to perform in a transaction
@@ -724,10 +749,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     public <O> org.candlepin.util.Transactional<O> transactional(
         org.candlepin.util.Transactional.Action<O> action) {
 
-        return new org.candlepin.util.Transactional<O>(this.getEntityManager())
-            .wrap(action);
+        return this.<O>transactional()
+            .run(action);
     }
-
 
     /**
      * Fetches the natural ID loader for this entity. This loader can be used and reused to

--- a/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/server/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -20,7 +20,6 @@ import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.common.config.Configuration;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.controller.PoolManager;
-import org.candlepin.controller.ProductManager;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.rules.v1.ConsumerDTO;
 import org.candlepin.dto.rules.v1.EntitlementDTO;
@@ -32,8 +31,6 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
-import org.candlepin.model.OwnerCurator;
-import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Product;
@@ -71,6 +68,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+
+
 /**
  * Enforces entitlement rules for normal (non-manifest) consumers.
  */
@@ -86,9 +85,6 @@ public class EntitlementRules implements Enforcer {
     private ConsumerTypeCurator consumerTypeCurator;
     private ProductCurator productCurator;
     private RulesObjectMapper objectMapper;
-    private OwnerCurator ownerCurator;
-    private OwnerProductCurator ownerProductCurator;
-    private ProductManager productManager;
     private EventSink eventSink;
     private EventFactory eventFactory;
     private ModelTranslator translator;
@@ -100,9 +96,7 @@ public class EntitlementRules implements Enforcer {
     public EntitlementRules(DateSource dateSource,
         JsRunner jsRules, I18n i18n, Configuration config, ConsumerCurator consumerCurator,
         ConsumerTypeCurator consumerTypeCurator, ProductCurator productCurator, RulesObjectMapper mapper,
-        OwnerCurator ownerCurator, OwnerProductCurator ownerProductCurator,
-        ProductManager productManager, EventSink eventSink,
-        EventFactory eventFactory, ModelTranslator translator) {
+        EventSink eventSink, EventFactory eventFactory, ModelTranslator translator) {
 
         this.jsRules = jsRules;
         this.dateSource = dateSource;
@@ -112,9 +106,6 @@ public class EntitlementRules implements Enforcer {
         this.consumerTypeCurator = consumerTypeCurator;
         this.productCurator = productCurator;
         this.objectMapper = mapper;
-        this.ownerCurator = ownerCurator;
-        this.ownerProductCurator = ownerProductCurator;
-        this.productManager = productManager;
         this.eventSink = eventSink;
         this.eventFactory = eventFactory;
         this.translator = translator;

--- a/server/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/server/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1856,17 +1856,9 @@ public class ConsumerResource {
         }
 
         // we want to insert the content access cert to this list if appropriate
-        try {
-            Certificate cert = this.contentAccessManager.getCertificate(consumer);
-            if (cert != null) {
-                returnCerts.add(translator.translate(cert, CertificateDTO.class));
-            }
-        }
-        catch (IOException ioe) {
-            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), ioe);
-        }
-        catch (GeneralSecurityException gse) {
-            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), gse);
+        Certificate cert = this.contentAccessManager.getCertificate(consumer);
+        if (cert != null) {
+            returnCerts.add(translator.translate(cert, CertificateDTO.class));
         }
 
         return returnCerts;
@@ -1897,32 +1889,24 @@ public class ConsumerResource {
                 .build();
         }
 
-        ContentAccessListing result = new ContentAccessListing();
-
-        try {
-            ContentAccessCertificate cac = this.contentAccessManager.getCertificate(consumer);
-            if (cac == null) {
-                throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"));
-            }
-
-            String cert = cac.getCert();
-            String certificate = cert.substring(0, cert.indexOf("-----BEGIN ENTITLEMENT DATA-----\n"));
-            String json = cert.substring(cert.indexOf("-----BEGIN ENTITLEMENT DATA-----\n"));
-            List<String> pieces = new ArrayList<>();
-            pieces.add(certificate);
-            pieces.add(json);
-            result.setContentListing(cac.getSerial().getId(), pieces);
-            result.setLastUpdate(cac.getUpdated());
-
-            return Response.ok(result, MediaType.APPLICATION_JSON)
-                .build();
+        ContentAccessCertificate cac = this.contentAccessManager.getCertificate(consumer);
+        if (cac == null) {
+            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"));
         }
-        catch (IOException ioe) {
-            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), ioe);
-        }
-        catch (GeneralSecurityException gse) {
-            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate", gse));
-        }
+
+        String cert = cac.getCert();
+        String certificate = cert.substring(0, cert.indexOf("-----BEGIN ENTITLEMENT DATA-----\n"));
+        String json = cert.substring(cert.indexOf("-----BEGIN ENTITLEMENT DATA-----\n"));
+        List<String> pieces = new ArrayList<>();
+        pieces.add(certificate);
+        pieces.add(json);
+
+        ContentAccessListing result = new ContentAccessListing()
+            .setContentListing(cac.getSerial().getId(), pieces)
+            .setLastUpdate(cac.getUpdated());
+
+        return Response.ok(result, MediaType.APPLICATION_JSON)
+            .build();
     }
 
     @ApiOperation(notes = "Retrieves a Compressed File of Entitlement Certificates",
@@ -2012,18 +1996,10 @@ public class ConsumerResource {
         }
 
         // add content access cert if needed
-        try {
-            ContentAccessCertificate cac = this.contentAccessManager.getCertificate(consumer);
-            if (cac != null) {
-                allCerts.add(new CertificateSerialDTO().setSerial(
-                    BigInteger.valueOf(cac.getSerial().getId())));
-            }
-        }
-        catch (IOException ioe) {
-            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), ioe);
-        }
-        catch (GeneralSecurityException gse) {
-            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate", gse));
+        ContentAccessCertificate cac = this.contentAccessManager.getCertificate(consumer);
+        if (cac != null) {
+            allCerts.add(new CertificateSerialDTO().setSerial(
+                BigInteger.valueOf(cac.getSerial().getId())));
         }
 
         return allCerts;

--- a/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/server/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -75,6 +75,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+
+
 /**
  * API Gateway into /product
  *
@@ -254,7 +256,7 @@ public class OwnerProductResource {
         ProductDTO pdto) {
 
         Owner owner = this.getOwnerByKey(ownerKey);
-        Product entity = productManager.createProduct(owner, pdto);
+        Product entity = this.productManager.createProduct(owner, pdto);
 
         return this.translator.translate(entity, ProductDTO.class);
     }
@@ -295,7 +297,6 @@ public class OwnerProductResource {
         }
 
         Product updated = this.productManager.updateProduct(owner, update, true);
-
         return this.translator.translate(updated, ProductDTO.class);
     }
 

--- a/server/src/main/java/org/candlepin/resource/dto/ContentAccessListing.java
+++ b/server/src/main/java/org/candlepin/resource/dto/ContentAccessListing.java
@@ -26,16 +26,18 @@ public class ContentAccessListing {
     private Date lastUpdate;
     private Map<Long, List<String>> content = new HashMap<>();
 
-    public void setLastUpdate(Date lastUpdate) {
+    public ContentAccessListing setLastUpdate(Date lastUpdate) {
         this.lastUpdate = lastUpdate;
+        return this;
     }
 
     public Date getLastUpdate() {
         return this.lastUpdate;
     }
 
-    public void setContentListing(Long serial, List<String> contentListing) {
+    public ContentAccessListing setContentListing(Long serial, List<String> contentListing) {
         this.content.put(serial, contentListing);
+        return this;
     }
 
     public Map<Long, List<String>> getContentListing() {

--- a/server/src/main/java/org/candlepin/sync/Exporter.java
+++ b/server/src/main/java/org/candlepin/sync/Exporter.java
@@ -59,7 +59,6 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -68,6 +67,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+
 
 /**
  * Exporter
@@ -399,8 +400,8 @@ public class Exporter {
             if ((serials == null) || (serials.contains(cert.getSerial().getId()))) {
                 log.debug("Exporting entitlement certificate: {}", cert.getSerial());
                 File file = new File(entCertDir.getCanonicalPath(), cert.getSerial().getId() + ".pem");
-                CertificateExporter crt = new CertificateExporter();
-                crt.exportCertificate(cert, file);
+
+                new CertificateExporter().exportCertificate(cert, file);
             }
         }
     }
@@ -419,24 +420,17 @@ public class Exporter {
      *  Throws IO exception if unable to export content access certs for the consumer.
      */
     private void exportContentAccessCerts(File baseDir, Consumer consumer) throws IOException {
-        ContentAccessCertificate contentAccessCert = null;
-
-        try {
-            contentAccessCert = this.contentAccessManager.getCertificate(consumer);
-        }
-        catch (GeneralSecurityException gse) {
-            throw new IOException("Cannot retrieve content access certificate", gse);
-        }
+        ContentAccessCertificate contentAccessCert = this.contentAccessManager.getCertificate(consumer);
 
         if (contentAccessCert != null) {
-            File contentAccessCertDir = new File(baseDir.getCanonicalPath(),
-                "content_access_certificates");
+            File contentAccessCertDir = new File(baseDir.getCanonicalPath(), "content_access_certificates");
             contentAccessCertDir.mkdir();
-            log.debug("Exporting content access certificate: " + contentAccessCert.getSerial());
+
+            log.debug("Exporting content access certificate: {}", contentAccessCert.getSerial());
             File file = new File(contentAccessCertDir.getCanonicalPath(),
                 contentAccessCert.getSerial().getId() + ".pem");
-            CertificateExporter crt = new CertificateExporter();
-            crt.exportCertificate(contentAccessCert, file);
+
+            new CertificateExporter().exportCertificate(contentAccessCert, file);
         }
     }
 

--- a/server/src/main/java/org/candlepin/util/TransactionExecutionException.java
+++ b/server/src/main/java/org/candlepin/util/TransactionExecutionException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+
+
+/**
+ * The TransactionExecutionException is thrown when an exception occurs during execution of a
+ * transactional block.
+ */
+public class TransactionExecutionException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with the specified cause.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public TransactionExecutionException(Throwable cause) {
+        super("Unexpected exception occured while executing transactional block", cause);
+    }
+}

--- a/server/src/main/resources/db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml
+++ b/server/src/main/resources/db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20211110083000-1" author="crog">
+        <comment>
+            Removes existing entity versions to avoid conflicts with any existing duplicates, and
+            resets entity versioning to allow a rebuild of the versioning without a migration.
+        </comment>
+
+        <sql>
+            UPDATE cp2_products SET entity_version = NULL;
+            UPDATE cp2_content SET entity_version = NULL;
+        </sql>
+    </changeSet>
+
+    <changeSet id="20211110083000-2" author="crog">
+        <addUniqueConstraint tableName="cp2_products"
+            columnNames="product_id, entity_version"
+            constraintName="cp2_product_entity_version"
+            deferrable="true"
+            initiallyDeferred="false"/>
+    </changeSet>
+
+    <changeSet id="20211110083000-3" author="crog">
+        <addUniqueConstraint tableName="cp2_content"
+            columnNames="content_id, entity_version"
+            constraintName="cp2_content_entity_version"
+            deferrable="true"
+            initiallyDeferred="false"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1255,4 +1255,5 @@
     <include file="db/changelog/20210412145432-drop_content_cache.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
+    <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2347,4 +2347,5 @@
     <include file="db/changelog/20210412145432-drop_content_cache.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
+    <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -164,4 +164,5 @@
     <include file="db/changelog/20210412145432-drop_content_cache.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
+    <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -89,11 +89,9 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.security.KeyPair;
-import java.security.PrivateKey;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -101,6 +99,8 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
+
+
 
 /**
  * Test suite for the ContentAccessManager class
@@ -721,22 +721,7 @@ public class ContentAccessManagerTest {
     }
 
     @Test
-    public void testGetCertificateThrowsIOException() throws Exception {
-        Owner owner = this.mockOwner();
-        Consumer consumer = this.mockConsumer(owner);
-        Content content = this.mockContent(owner);
-        Product product = this.mockProduct(owner, content);
-        Pool pool = this.mockPool(product);
-
-        PKIUtility mockPkiUtility = mock(PKIUtility.class);
-        doThrow(IOException.class).when(mockPkiUtility).getPemEncoded(any(PrivateKey.class));
-        ContentAccessManager manager = this.createManager(mockPkiUtility);
-
-        assertThrows(IOException.class, () -> manager.getCertificate(consumer));
-    }
-
-    @Test
-    public void testGetCertificateReturnsNullOnUnknownException() throws Exception {
+    public void testGetCertificateReturnsNullOnException() throws Exception {
         Owner owner = this.mockOwner();
         Consumer consumer = this.mockConsumer(owner);
         Content content = this.mockContent(owner);

--- a/server/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/server/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -139,8 +139,7 @@ public class EntitlerTest {
         this.refreshWorkerProvider = () -> refreshWorker;
 
         entitler = new Entitler(pm, cc, i18n, ef, sink, translator, entitlementCurator, config,
-            ownerCurator, poolCurator, productManager, productAdapter,
-            contentManager, consumerTypeCurator, this.refreshWorkerProvider);
+            ownerCurator, poolCurator, productAdapter, consumerTypeCurator, this.refreshWorkerProvider);
     }
 
     private void mockRefresh(Owner owner, Collection<Product> products, Collection<Content> contents) {

--- a/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -129,6 +129,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import javax.inject.Provider;
+import javax.persistence.EntityManager;
 
 
 
@@ -192,6 +193,11 @@ public class PoolManagerTest {
         product = TestUtil.createProduct();
         pool = TestUtil.createPool(owner, product);
 
+        TestUtil.mockTransactionalFunctionality(mock(EntityManager.class), mockPoolCurator,
+            mockProductCurator, entitlementCurator, certCuratorMock, consumerCuratorMock,
+            consumerTypeCuratorMock, mockOwnerCurator, mockOwnerContentCurator, mockOwnerProductCurator,
+            mockCdnCurator, mockContentCurator);
+
         when(mockOwnerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
 
         when(mockConfig.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
@@ -210,9 +216,9 @@ public class PoolManagerTest {
             mockPoolCurator, mockEventSink, eventFactory, mockConfig, enforcerMock, poolRulesMock,
             entitlementCurator, consumerCuratorMock, consumerTypeCuratorMock, certCuratorMock,
             mockECGenerator, complianceRules, systemPurposeComplianceRules, autobindRules,
-            activationKeyRules, mockProductCurator, mockProductManager, mockContentManager,
-            mockOwnerCurator, mockOwnerProductCurator, mockOwnerManager,
-            mockCdnCurator, i18n, mockBindChainFactory, jsonProvider, refreshWorkerProvider));
+            activationKeyRules, mockProductCurator, mockOwnerCurator, mockOwnerProductCurator,
+            mockOwnerManager, mockCdnCurator, i18n, mockBindChainFactory, jsonProvider,
+            refreshWorkerProvider));
 
         setupBindChain();
 

--- a/server/src/test/java/org/candlepin/controller/refresher/RefreshWorkerVersioningTest.java
+++ b/server/src/test/java/org/candlepin/controller/refresher/RefreshWorkerVersioningTest.java
@@ -46,7 +46,7 @@ public class RefreshWorkerVersioningTest extends DatabaseTestFixture {
 
     @BeforeEach
     public void init() throws Exception {
-        super.init();
+        super.init(false);
     }
 
     private RefreshWorker buildRefreshWorker() {

--- a/server/src/test/java/org/candlepin/controller/util/EntityVersioningRetryWrapperTest.java
+++ b/server/src/test/java/org/candlepin/controller/util/EntityVersioningRetryWrapperTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller.util;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+
+
+public class EntityVersioningRetryWrapperTest {
+
+    private Exception buildConstraintViolation(String constraintName) {
+        return new ConstraintViolationException("test exception", new SQLException(), constraintName);
+    }
+
+    @Test
+    public void testCorrectExceptionCorrectConstraintDetection() {
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+        boolean result = EntityVersioningRetryWrapper.isEntityVersioningConstraintViolation(exception);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testCorrectExceptionIncorrectConstraintDetection() {
+        Exception exception = this.buildConstraintViolation("some other constraint");
+        boolean result = EntityVersioningRetryWrapper.isEntityVersioningConstraintViolation(exception);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIncorrectExceptionDetection() {
+        Exception exception = new SQLException();
+
+        boolean result = EntityVersioningRetryWrapper.isEntityVersioningConstraintViolation(exception);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testNegativeRetriesValuesDisallowed() {
+        assertThrows(IllegalArgumentException.class, () -> new EntityVersioningRetryWrapper().retries(-5));
+    }
+
+    @Test
+    public void testExecuteSucceedsWithoutRetries() {
+        String expected = "success";
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+
+        Supplier<String> supplier = mock(Supplier.class);
+        doReturn(expected).doThrow(new RuntimeException("fail")).when(supplier).get();
+
+        String output = new EntityVersioningRetryWrapper()
+            .retries(0)
+            .execute(supplier);
+
+        verify(supplier, times(1)).get();
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testExecuteWontRetryWithoutRetries() {
+        String expected = "success";
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+
+        Supplier<String> supplier = mock(Supplier.class);
+        doThrow(exception).doReturn(expected).doThrow(new RuntimeException("fail")).when(supplier).get();
+
+        Exception actual = assertThrows(ConstraintViolationException.class, () -> {
+            new EntityVersioningRetryWrapper()
+                .retries(0)
+                .execute(supplier);
+        });
+
+        verify(supplier, times(1)).get();
+        assertEquals(exception, actual);
+    }
+
+    @Test
+    public void testExecuteReturnsUponSuccess() {
+        String expected = "success";
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+
+        Supplier<String> supplier = mock(Supplier.class);
+        doReturn(expected).doThrow(new RuntimeException("fail")).when(supplier).get();
+
+        String output = new EntityVersioningRetryWrapper()
+            .retries(2)
+            .execute(supplier);
+
+        verify(supplier, times(1)).get();
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testExecuteRetriesOnVersioningConstraintViolation() {
+        String expected = "success";
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+
+        Supplier<String> supplier = mock(Supplier.class);
+        doThrow(exception).doReturn(expected).doThrow(new RuntimeException("fail")).when(supplier).get();
+
+        String output = new EntityVersioningRetryWrapper()
+            .retries(2)
+            .execute(supplier);
+
+        verify(supplier, times(2)).get();
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testExecuteLimitsRetriesOnVersioningConstraintViolation() {
+        String expected = "success";
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+
+        Supplier<String> supplier = mock(Supplier.class);
+        doThrow(exception).doThrow(exception).doThrow(exception).doReturn(expected).when(supplier).get();
+
+        Exception actual = assertThrows(ConstraintViolationException.class, () -> {
+            new EntityVersioningRetryWrapper()
+                .retries(2)
+                .execute(supplier);
+        });
+
+        verify(supplier, times(3)).get();
+        assertEquals(exception, actual);
+    }
+
+}

--- a/server/src/test/java/org/candlepin/model/ConsumerCuratorSearchTest.java
+++ b/server/src/test/java/org/candlepin/model/ConsumerCuratorSearchTest.java
@@ -721,19 +721,15 @@ public class ConsumerCuratorSearchTest extends DatabaseTestFixture {
         Consumer otherConsumer = new Consumer("testConsumer2", "testUser2", owner2, ct);
         otherConsumer = consumerCurator.create(otherConsumer);
 
-        // Two owners, two different products, but with the same SKU
-        Product product1 = TestUtil.createProduct("SKU1", "Product 1");
-        product1.setAttribute(Product.Attributes.TYPE, "MKT");
+        // Two owners, two different pools, but with the same SKU
+        Product product = TestUtil.createProduct("SKU1", "Product 1")
+            .setAttribute(Product.Attributes.TYPE, "MKT");
 
-        Product product2 = TestUtil.createProduct("SKU1", "Product 1");
-        product2.setAttribute(Product.Attributes.TYPE, "MKT");
-
-        productCurator.create(product1);
-        productCurator.create(product2);
+        this.createProduct(product, owner, owner2);
 
         Pool pool1 = new Pool()
             .setOwner(owner)
-            .setProduct(product1)
+            .setProduct(product)
             .setQuantity(10L)
             .setStartDate(TestUtil.createDateOffset(-1, 0, 0))
             .setEndDate(TestUtil.createDateOffset(1, 0, 0))
@@ -744,7 +740,7 @@ public class ConsumerCuratorSearchTest extends DatabaseTestFixture {
 
         Pool pool2 = new Pool()
             .setOwner(owner2)
-            .setProduct(product2)
+            .setProduct(product)
             .setQuantity(10L)
             .setStartDate(TestUtil.createDateOffset(-1, 0, 0))
             .setEndDate(TestUtil.createDateOffset(1, 0, 0))

--- a/server/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -14,21 +14,24 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 
-import javax.inject.Inject;
+import javax.persistence.PersistenceException;
+
+
 
 /**
  * ContentCuratorTest
  */
 public class ContentCuratorTest extends DatabaseTestFixture {
-    @Inject private ContentCurator contentCurator;
-    @Inject private OwnerCurator ownerCurator;
 
     private Content updates;
     private Owner owner;
@@ -53,5 +56,27 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         updates.setReleaseVersion("releaseVer");
         updates.setMetadataExpiration(new Long(1));
         updates.setModifiedProductIds(new HashSet<String>() { { add("productIdOne"); } });
+    }
+
+    @Test
+    public void testCannotPersistIdenticalProducts() {
+        Content c1 = new Content()
+            .setId("test-content")
+            .setName("test-content")
+            .setType("content-type")
+            .setLabel("content-label")
+            .setVendor("content-vendor");
+
+        this.contentCurator.create(c1, true);
+        this.contentCurator.clear();
+
+        Content c2 = new Content()
+            .setId("test-content")
+            .setName("test-content")
+            .setType("content-type")
+            .setLabel("content-label")
+            .setVendor("content-vendor");
+
+        assertThrows(PersistenceException.class, () -> this.contentCurator.create(c2, true));
     }
 }

--- a/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -866,23 +866,32 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         Consumer consumer1 = this.createConsumer(owner1);
         Consumer consumer2 = this.createConsumer(owner2);
 
-        List<Product> reqProducts1 = Arrays.asList(
-            this.createProduct("req_prod_1", "req_prod_1", owner1),
-            this.createProduct("req_prod_2", "req_prod_2", owner1));
-
-        List<Product> reqProducts2 = Arrays.asList(
-            this.createProduct("req_prod_1", "req_prod_1", owner2),
-            this.createProduct("req_prod_2", "req_prod_2", owner2));
+        List<Product> reqProds = Arrays.asList(
+            this.createProduct("req_prod_1", "req_prod_1", owner1, owner2),
+            this.createProduct("req_prod_2", "req_prod_2", owner1, owner2));
 
         List<Product> dependentProductA = this.createDependentProducts(owner1, 1, "test_dep_prod_a",
-            reqProducts1.subList(0, 1));
+            reqProds.subList(0, 1));
         List<Product> dependentProductB = this.createDependentProducts(owner2, 1, "test_dep_prod_b",
-            reqProducts2.subList(0, 1));
+            reqProds.subList(0, 1));
 
-        Pool requiredPool1A = this.createPoolWithProducts(owner1, "reqPool1", reqProducts1.subList(0, 1));
-        Pool requiredPool2A = this.createPoolWithProducts(owner1, "reqPool2", reqProducts1.subList(1, 2));
-        Pool requiredPool1B = this.createPoolWithProducts(owner2, "reqPool1", reqProducts2.subList(0, 1));
-        Pool requiredPool2B = this.createPoolWithProducts(owner2, "reqPool2", reqProducts2.subList(1, 2));
+        Product skuProd1 = TestUtil.createProduct("reqPool1", "reqPool1")
+            .setProvidedProducts(reqProds.subList(0, 1));
+
+        Product skuProd2 = TestUtil.createProduct("reqPool2", "reqPool2")
+            .setProvidedProducts(reqProds.subList(1, 2));
+
+        this.createProduct(skuProd1, owner1, owner2);
+        this.createProduct(skuProd2, owner1, owner2);
+
+        Pool requiredPool1A = this.createPool(owner1, skuProd1, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool2A = this.createPool(owner1, skuProd2, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool1B = this.createPool(owner2, skuProd1, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool2B = this.createPool(owner2, skuProd2, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
         Pool dependentPoolA = this.createPoolWithProducts(owner1, "depPool1", dependentProductA);
         Pool dependentPoolB = this.createPoolWithProducts(owner2, "depPool2", dependentProductB);
 
@@ -915,23 +924,32 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         Consumer consumer1 = this.createConsumer(owner1);
         Consumer consumer2 = this.createConsumer(owner2);
 
-        List<Product> reqProds1 = Arrays.asList(
-            this.createProduct("req_prod_1", "req_prod_1", owner1),
-            this.createProduct("req_prod_2", "req_prod_2", owner1));
-
-        List<Product> reqProds2 = Arrays.asList(
-            this.createProduct("req_prod_1", "req_prod_1", owner2),
-            this.createProduct("req_prod_2", "req_prod_2", owner2));
+        List<Product> reqProds = Arrays.asList(
+            this.createProduct("req_prod_1", "req_prod_1", owner1, owner2),
+            this.createProduct("req_prod_2", "req_prod_2", owner1, owner2));
 
         List<Product> dependentProductA = this.createDependentProducts(owner1, 1, "test_dep_prod_a",
-            reqProds1.subList(0, 1));
+            reqProds.subList(0, 1));
         List<Product> dependentProductB = this.createDependentProducts(owner2, 1, "test_dep_prod_b",
-            reqProds2.subList(0, 1));
+            reqProds.subList(0, 1));
 
-        Pool requiredPool1A = this.createPoolWithProducts(owner1, "reqPool1", reqProds1.subList(0, 1));
-        Pool requiredPool2A = this.createPoolWithProducts(owner1, "reqPool2", reqProds1.subList(1, 2));
-        Pool requiredPool1B = this.createPoolWithProducts(owner2, "reqPool1", reqProds2.subList(0, 1));
-        Pool requiredPool2B = this.createPoolWithProducts(owner2, "reqPool2", reqProds2.subList(1, 2));
+        Product skuProd1 = TestUtil.createProduct("reqPool1", "reqPool1")
+            .setProvidedProducts(reqProds.subList(0, 1));
+
+        Product skuProd2 = TestUtil.createProduct("reqPool2", "reqPool2")
+            .setProvidedProducts(reqProds.subList(1, 2));
+
+        this.createProduct(skuProd1, owner1, owner2);
+        this.createProduct(skuProd2, owner1, owner2);
+
+        Pool requiredPool1A = this.createPool(owner1, skuProd1, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool2A = this.createPool(owner1, skuProd2, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool1B = this.createPool(owner2, skuProd1, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool2B = this.createPool(owner2, skuProd2, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
         Pool dependentPoolA = this.createPoolWithProducts(owner1, "depPool1", dependentProductA);
         Pool dependentPoolB = this.createPoolWithProducts(owner2, "depPool2", dependentProductB);
 

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -122,15 +122,13 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void nameRequired() {
-
-        Product prod = new Product("someproductlabel", null);
+    public void testProductNameRequired() {
+        Product prod = new Product("some product id", null);
         assertThrows(PersistenceException.class, () -> productCurator.create(prod, true));
-
     }
 
     @Test
-    public void labelRequired() {
+    public void testProductIdRequired() {
         Product prod = new Product(null, "My Product Name");
         assertThrows(ConstraintViolationException.class, () -> productCurator.create(prod, true));
     }
@@ -145,6 +143,22 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
         assertEquals(prod.getName(), prod2.getName());
         assertNotEquals(prod.getUuid(), prod2.getUuid());
+    }
+
+    @Test
+    public void testCannotPersistIdenticalProducts() {
+        Product p1 = new Product()
+            .setId("test-product")
+            .setName("test-product");
+
+        this.productCurator.create(p1, true);
+        this.productCurator.clear();
+
+        Product p2 = new Product()
+            .setId("test-product")
+            .setName("test-product");
+
+        assertThrows(PersistenceException.class, () -> this.productCurator.create(p2, true));
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/policy/EnforcerTest.java
+++ b/server/src/test/java/org/candlepin/policy/EnforcerTest.java
@@ -128,9 +128,7 @@ public class EnforcerTest extends DatabaseTestFixture {
 
         enforcer = new EntitlementRules(
             new DateSourceForTesting(2010, 1, 1), jsRules, i18n, config, consumerCurator, consumerTypeCurator,
-            mockProductCurator, new RulesObjectMapper(), mockOwnerCurator, mockOwnerProductCurator,
-            mockProductManager, mockEventSink, mockEventFactory, translator
-        );
+            mockProductCurator, new RulesObjectMapper(), mockEventSink, mockEventFactory, translator);
     }
 
     @Test

--- a/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
+++ b/server/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
@@ -138,9 +138,6 @@ public class EntitlementRulesTestFixture {
             consumerTypeCurator,
             productCurator,
             new RulesObjectMapper(),
-            ownerCurator,
-            ownerProductCuratorMock,
-            productManager,
             eventSink,
             eventFactory,
             translator

--- a/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/server/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -79,7 +79,9 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
     }
 
     @BeforeEach
-    public void setUp() {
+    public void init() throws Exception {
+        super.init(false);
+
         List<SubscriptionDTO> subscriptions = new ArrayList<>();
         subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
 
@@ -137,7 +139,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
      * Checking behavior when the physical pool has a numeric virt_limit
      */
     @Test
-    public void testLimitPool() throws JobException {
+    public void testLimitedPool() throws JobException {
         List<Pool> subscribedTo = new ArrayList<>();
         Consumer guestConsumer = TestUtil.createConsumer(systemType, owner);
         guestConsumer.setFact("virt.is_guest", "true");
@@ -194,7 +196,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testUnlimitPool() throws JobException {
+    public void testUnlimitedPool() throws JobException {
         List<Pool> subscribedTo = new ArrayList<>();
         Consumer guestConsumer = TestUtil.createConsumer(systemType, owner);
         guestConsumer.setFact("virt.is_guest", "true");

--- a/server/src/test/java/org/candlepin/resource/PoolResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/PoolResourceTest.java
@@ -86,15 +86,14 @@ public class PoolResourceTest extends DatabaseTestFixture {
         ownerCurator.create(owner1);
         ownerCurator.create(owner2);
 
-        product1 = this.createProduct(PRODUCT_CPULIMITED, PRODUCT_CPULIMITED, owner1);
-        product1Owner2 = this.createProduct(PRODUCT_CPULIMITED, PRODUCT_CPULIMITED, owner2);
+        product1 = this.createProduct(PRODUCT_CPULIMITED, PRODUCT_CPULIMITED, owner1, owner2);
         product2 = this.createProduct(owner1);
 
         pool1 = this.createPool(owner1, product1, 500L,
              TestUtil.createDate(START_YEAR, 1, 1), TestUtil.createDate(END_YEAR, 1, 1));
         pool2 = this.createPool(owner1, product2, 500L,
              TestUtil.createDate(START_YEAR, 1, 1), TestUtil.createDate(END_YEAR, 1, 1));
-        pool3 = this.createPool(owner2 , product1Owner2, 500L,
+        pool3 = this.createPool(owner2 , product1, 500L,
              TestUtil.createDate(START_YEAR, 1, 1), TestUtil.createDate(END_YEAR, 1, 1));
 
         poolResource = new PoolResource(consumerCurator, ownerCurator, i18n,

--- a/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/server/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -210,11 +210,9 @@ public class ProductResourceTest extends DatabaseTestFixture {
         Owner owner2 = this.ownerCurator.create(new Owner("TestCorp-02"));
         Owner owner3 = this.ownerCurator.create(new Owner("TestCorp-03"));
 
-        Product prod1 = this.createProduct("p1", "p1", owner1);
-        Product prod2 = this.createProduct("p1", "p1", owner2);
-        Product prod3 = this.createProduct("p2", "p2", owner2);
-        Product prod4 = this.createProduct("p2", "p2", owner3);
-        Product prod5 = this.createProduct("p3", "p3", owner3);
+        Product prod1 = this.createProduct("p1", "p1", owner1, owner2);
+        Product prod2 = this.createProduct("p2", "p2", owner2, owner3);
+        Product prod3 = this.createProduct("p3", "p3", owner3);
 
         Product poolProd1 = this.createProduct(owner1);
         Product poolProd2 = this.createProduct(owner2);
@@ -224,10 +222,10 @@ public class ProductResourceTest extends DatabaseTestFixture {
 
         // Set Provided Products
         poolProd1.setProvidedProducts(Arrays.asList(prod1));
-        poolProd2.setProvidedProducts(Arrays.asList(prod2));
-        poolProd3.setProvidedProducts(Arrays.asList(prod3));
-        poolProd4.setProvidedProducts(Arrays.asList(prod4));
-        poolProd5.setProvidedProducts(Arrays.asList(prod5));
+        poolProd2.setProvidedProducts(Arrays.asList(prod1));
+        poolProd3.setProvidedProducts(Arrays.asList(prod2));
+        poolProd4.setProvidedProducts(Arrays.asList(prod2));
+        poolProd5.setProvidedProducts(Arrays.asList(prod3));
 
         Pool pool1 = this.poolCurator.create(TestUtil.createPool(owner1, poolProd1, 5));
         Pool pool2 = this.poolCurator.create(TestUtil.createPool(owner2, poolProd2, 5));

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -58,7 +58,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.commons.io.FileUtils;
-import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.IOException;
@@ -678,7 +677,7 @@ public class TestUtil {
     }
 
     public static void mockTransactionalFunctionality(EntityManager mockEntityManager,
-        AbstractHibernateCurator mockCurator) {
+        AbstractHibernateCurator... mockCurators) {
 
         EntityTransaction transaction = new EntityTransaction() {
             private boolean active;
@@ -692,10 +691,15 @@ public class TestUtil {
             @Override
             public void commit() {
                 if (!this.active) {
-                    throw new IllegalStateException();
+                    throw new IllegalStateException("transaction is not active");
+                }
+
+                if (this.rollbackOnly) {
+                    throw new IllegalStateException("transaction is flagged rollback only");
                 }
 
                 this.active = false;
+                this.rollbackOnly = false;
             }
 
             @Override
@@ -711,10 +715,11 @@ public class TestUtil {
             @Override
             public void rollback() {
                 if (!this.active) {
-                    throw new IllegalStateException();
+                    throw new IllegalStateException("transaction is not active");
                 }
 
                 this.active = false;
+                this.rollbackOnly = false;
             }
 
             @Override
@@ -725,10 +730,16 @@ public class TestUtil {
 
         doReturn(transaction).when(mockEntityManager).getTransaction();
 
-        doAnswer((Answer<Transactional>) iom -> {
-            Transactional.Action action = (Transactional.Action) iom.getArguments()[0];
-            return new Transactional(mockEntityManager).wrap(action);
-        }).when(mockCurator).transactional(any());
+        for (AbstractHibernateCurator mockCurator : mockCurators) {
+            doReturn(mockEntityManager).when(mockCurator).getEntityManager();
+            doReturn(transaction).when(mockCurator).getTransaction();
+
+            doAnswer(iom -> new Transactional(mockEntityManager)).when(mockCurator).transactional();
+            doAnswer(iom -> {
+                return new Transactional(mockEntityManager)
+                    .run((Transactional.Action) iom.getArguments()[0]);
+            }).when(mockCurator).transactional(any(Transactional.Action.class));
+        }
     }
 
 }


### PR DESCRIPTION
- Versioned entities (products and content) must now be unique per
  (id, version) tuple
- Removed some obsoleted version lookup code
- RefreshPoolsJob now defaults to 3 retries, as the new unique
  restriction could cause parallel refreshes containing the same
  net-new product or content to fail on the first attempt