### PR TITLE
[4.0] Use new maven mead target [ENT-4392]

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -36,5 +36,5 @@ autobuild_tags = candlepin-nightly-rhel6 candlepin-nightly-rhel7
 releaser = tito.release.DistGitMeadReleaser
 branches = candlepin-mead-rhel-6
 mead_scm = git://git.app.eng.bos.redhat.com/candlepin.git
-target = candlepin-1-jdk11-maven-candidate
+target = candlepin-1-jdk11-rhel-9-maven-candidate
 mead_push_url = git+ssh://MEAD_SCM_USERNAME@code.engineering.redhat.com/candlepin.git


### PR DESCRIPTION
- This avoids a bug in gettext, which has been fixed in RHEL9,
  which resulted in no translation classes being compiled.