### PR TITLE
[4.0] 2023725: SCA 'lastUpdated' & If-Modified-Since date fixes [ENT-4428]

### DIFF
--- a/server/spec/content_access_spec.rb
+++ b/server/spec/content_access_spec.rb
@@ -461,16 +461,22 @@ describe 'Content Access' do
     old_cert = content_body.contentListing.values[0]
     old_x509 = old_cert[0]
     old_content = old_cert[1]
+    old_last_update = content_body.lastUpdate
 
     @cp.update_content(@owner["key"], @content_id, { :name => "new content name" })
+
+    # Sleep a bit to make sure the 'lastUpdate' has more than a second change
+    sleep 1
 
     content_body = @consumer.get_content_access_body()
     cert = content_body.contentListing.values[0]
     x509 = cert[0]
     content = cert[1]
+    last_update = content_body.lastUpdate
 
     expect(x509).to eq(old_x509)
     expect(content).to_not eq(old_content)
+    expect(last_update).to_not eq(old_last_update)
   end
 
   it "change in content only regenerates content part of the content access certificate (with environment)" do
@@ -484,26 +490,31 @@ describe 'Content Access' do
     old_cert = content_body.contentListing.values[0]
     old_x509 = old_cert[0]
     old_content = old_cert[1]
+    old_last_update = content_body.lastUpdate
 
     @cp.update_content(@owner["key"], @content_id, { :name => "new content name" })
+
+    # Sleep a bit to make sure the 'lastUpdate' has more than a second change
+    sleep 1
 
     content_body = @consumer.get_content_access_body()
     cert = content_body.contentListing.values[0]
     x509 = cert[0]
     content = cert[1]
+    last_update = content_body.lastUpdate
 
     expect(x509).to eq(old_x509)
     expect(content).to_not eq(old_content)
+    expect(last_update).to_not eq(old_last_update)
   end
 
   it "does return a not modified return code when the data has not been updated since date" do
     @consumer = consumer_client(@user, @consumername, type=:system, username=nil, facts= {'system.certificate_version' => '3.3'})
-    certs = @consumer.list_certificates
-    certs.length.should == 1
-    sleep 1
-    date = Time.now
+    content_body = @consumer.get_content_access_body()
+    last_update = Time.parse(content_body.lastUpdate).httpdate
+
     lambda do
-      listing = @consumer.get_content_access_body({:since => date.httpdate})
+      listing = @consumer.get_content_access_body({:since => last_update})
     end.should raise_exception(RestClient::NotModified)
   end
 

--- a/server/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -239,14 +239,14 @@ public class ContentAccessManager {
     }
 
     /**
-     * Generate an entitlement certificate, used to grant access to some content.
-     * End date specified explicitly to allow for flexible termination policies.
+     * Fetch and potentially regenerate a Simple Content Access certificate, used to grant access to
+     * some content. The certificate will be regenerated if it is missing, or new content has been made
+     * available. Otherwise, it will be simply fetched.
      *
      * @return Client entitlement certificates.
      * @throws IOException thrown if there's a problem reading the cert.
      * @throws GeneralSecurityException thrown security problem
      */
-    @Transactional
     public ContentAccessCertificate getCertificate(Consumer consumer)
         throws GeneralSecurityException, IOException {
 
@@ -260,13 +260,28 @@ public class ContentAccessManager {
             return null;
         }
 
-        ContentAccessCertificate existing = consumer.getContentAccessCert();
+        org.candlepin.util.Transactional<ContentAccessCertificate> transaction =
+            this.consumerCurator.transactional(args -> {
+                ContentAccessCertificate existing = consumer.getContentAccessCert();
+                return existing == null ?
+                    createNewScaCertificate(consumer, owner) :
+                    updateScaCertificate(consumer, owner, existing);
+            });
+
         ContentAccessCertificate result;
-        if (existing == null) {
-            result = createNewScaCertificate(consumer, owner);
+        try {
+            result = transaction.allowExistingTransactions()
+                .onRollback(status -> log.error("Rolling back SCA cert (re)generation transaction"))
+                .execute();
         }
-        else {
-            result = updateScaCertificate(consumer, owner, existing);
+        catch (IOException | GeneralSecurityException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            // Something went horribly wrong...
+            log.error("Could not fetch or (re)generate SCA certificate for consumer {}",
+                consumer.getUuid(), e);
+            return null;
         }
 
         return wrap(result);
@@ -291,6 +306,7 @@ public class ContentAccessManager {
         ContentAccessCertificate savedCert = this.contentAccessCertificateCurator.create(existing);
         consumer.setContentAccessCert(savedCert);
         this.consumerCurator.merge(consumer);
+
         return savedCert;
     }
 
@@ -654,9 +670,16 @@ public class ContentAccessManager {
 
             // Check cert properties
             ContentAccessCertificate cert = consumer.getContentAccessCert();
-            return cert == null ||
-                date.before(cert.getUpdated()) ||
-                date.after(cert.getSerial().getExpiration());
+            if (cert == null) {
+                return true;
+            }
+
+            // The date provided by the client does not preserve milliseconds, so we need to round down
+            // the dates preserved on the server by removing milliseconds for a proper date comparison
+            Date certUpdatedDate = Util.roundDownToSeconds(cert.getUpdated());
+            Date certExpirationDate = Util.roundDownToSeconds(cert.getSerial().getExpiration());
+            return date.before(certUpdatedDate) ||
+                date.after(certExpirationDate);
         }
 
         return false;

--- a/server/src/main/java/org/candlepin/util/Util.java
+++ b/server/src/main/java/org/candlepin/util/Util.java
@@ -37,6 +37,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.text.SimpleDateFormat;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
@@ -126,6 +127,10 @@ public class Util {
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.MINUTE, minuteField);
         return calendar.getTime();
+    }
+
+    public static Date roundDownToSeconds(Date date) {
+        return Date.from(date.toInstant().truncatedTo(ChronoUnit.SECONDS));
     }
 
     public static <T> T assertNotNull(T value, String message) {

--- a/server/src/test/java/org/candlepin/test/TestUtil.java
+++ b/server/src/test/java/org/candlepin/test/TestUtil.java
@@ -57,7 +57,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.mockito.stubbing.Answer;
 
@@ -456,19 +455,6 @@ public class TestUtil {
     public static Date createDateOffset(int years, int months, int days) {
         LocalDate now = LocalDate.now();
         return createDate(now.getYear() + years, now.getMonthValue() + months, now.getDayOfMonth() + days);
-    }
-
-    public static String xmlToBase64String(String xml) {
-        // byte[] bytes = Base64.encode(xml);
-        Base64 encoder = new Base64();
-        byte[] bytes = encoder.encode(xml.getBytes());
-
-        StringBuilder buf = new StringBuilder();
-        for (byte b : bytes) {
-            buf.append((char) Integer.parseInt(Integer.toHexString(b), 16));
-        }
-
-        return buf.toString();
     }
 
     public static User createUser(String username, String password,


### PR DESCRIPTION
- Now we only wrap the SCA cert into a fresh ContentAccessCertificate
  copy after the db changes are flushed (to make sure the 'updated'
  date that is marked with @PreUpdate annotation has been changed) to
  avoid sending a stale 'lastUpdated' date to the client.
- The date sent in the If-Modified-Since header does not have
  millisecond accuracy, so make sure to round down the server-side
  certificate dates we compare it with to the second.