### PR TITLE
[M] 2010251: SCA 'lastUpdated' & If-Modified-Since date fixes [ENT-4428]

### DIFF
--- a/src/main/java/org/candlepin/util/Util.java
+++ b/src/main/java/org/candlepin/util/Util.java
@@ -44,6 +44,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -141,6 +142,10 @@ public class Util {
             return null;
         }
         return Date.from(dt.toInstant());
+    }
+
+    public static Date roundDownToSeconds(Date date) {
+        return Date.from(date.toInstant().truncatedTo(ChronoUnit.SECONDS));
     }
 
     public static boolean equals(String str, String str1) {

--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -60,7 +60,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.mockito.stubbing.Answer;
 
@@ -491,19 +490,6 @@ public class TestUtil {
     public static Date createDateOffset(int years, int months, int days) {
         LocalDate now = LocalDate.now();
         return createDate(now.getYear() + years, now.getMonthValue() + months, now.getDayOfMonth() + days);
-    }
-
-    public static String xmlToBase64String(String xml) {
-        // byte[] bytes = Base64.encode(xml);
-        Base64 encoder = new Base64();
-        byte[] bytes = encoder.encode(xml.getBytes());
-
-        StringBuilder buf = new StringBuilder();
-        for (byte b : bytes) {
-            buf.append((char) Integer.parseInt(Integer.toHexString(b), 16));
-        }
-
-        return buf.toString();
     }
 
     public static User createUser(String username, String password,


### PR DESCRIPTION
- Now we only wrap the SCA cert into a fresh ContentAccessCertificate
  copy after the db changes are flushed (to make sure the 'updated'
  date that is marked with @PreUpdate annotation has been changed) to
  avoid sending a stale 'lastUpdated' date to the client.
- The date sent in the If-Modified-Since header does not have
  millisecond accuracy, so make sure to round down the server-side
  certificate dates we compare it with to the second.