### PR TITLE
Add the Owner key to the consumer identity certificate

### DIFF
--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -32,8 +32,9 @@ describe 'Identity Certificate' do
     @identity_cert.should_not be_nil
   end
 
-  it 'should have the same CN as the consumer\'s UUID' do
+  it 'should have the same CN and O as the consumer UUID & Owner Key' do
     @identity_cert.subject.to_s.should include("CN=#{@consumer.uuid}")
+    @identity_cert.subject.to_s.should include("O=#{@consumer.owner['key']}")
   end
 
   it 'should contain the consumer\'s name' do

--- a/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
@@ -148,7 +148,8 @@ public class DefaultIdentityCertServiceAdapter implements
     private String createDN(Consumer consumer) {
         StringBuilder sb = new StringBuilder("CN=");
         sb.append(consumer.getUuid());
-
+        sb.append(", O=");
+        sb.append(consumer.getOwner().getKey());
         return sb.toString();
     }
 }

--- a/src/test/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapterTest.java
@@ -30,7 +30,9 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.IdentityCertificate;
 import org.candlepin.model.IdentityCertificateCurator;
 import org.candlepin.model.KeyPairCurator;
+import org.candlepin.model.Owner;
 import org.candlepin.pki.PKIUtility;
+import org.candlepin.test.TestUtil;
 import org.candlepin.util.ExpiryDateFunction;
 import org.candlepin.util.Util;
 
@@ -86,6 +88,9 @@ public class DefaultIdentityCertServiceAdapterTest {
         Consumer consumer = mock(Consumer.class);
         when(consumer.getId()).thenReturn("42");
         when(consumer.getUuid()).thenReturn(Util.generateUUID());
+        Owner owner = mock(Owner.class);
+        when(owner.getKey()).thenReturn(TestUtil.randomString());
+        when(consumer.getOwner()).thenReturn(owner);
         KeyPair kp = createKeyPair();
         when(kpc.getConsumerKeyPair(consumer)).thenReturn(kp);
         when(idcur.get(consumer.getId())).thenReturn(null);
@@ -147,6 +152,9 @@ public class DefaultIdentityCertServiceAdapterTest {
         Consumer consumer = mock(Consumer.class);
         IdentityCertificate mockic = mock(IdentityCertificate.class);
         when(consumer.getIdCert()).thenReturn(mockic);
+        Owner owner = mock(Owner.class);
+        when(owner.getKey()).thenReturn(TestUtil.randomString());
+        when(consumer.getOwner()).thenReturn(owner);
         when(mockic.getId()).thenReturn("43");
         when(idcur.get(mockic.getId())).thenReturn(mockic);
 
@@ -199,6 +207,10 @@ public class DefaultIdentityCertServiceAdapterTest {
         Consumer consumer = mock(Consumer.class);
         when(consumer.getId()).thenReturn("42L");
         when(consumer.getUuid()).thenReturn(Util.generateUUID());
+        Owner owner = mock(Owner.class);
+        when(owner.getKey()).thenReturn(TestUtil.randomString());
+        when(consumer.getOwner()).thenReturn(owner);
+
         when(idcur.get(consumer.getId())).thenReturn(null);
 
 


### PR DESCRIPTION
This brings the identity certificate in line with what we are already doing in entitlement certificates