### PR TITLE
[F] Disallow consumer environment data when resource hidden [ENT-4182]

### DIFF
--- a/config/candlepin/candlepin.conf.template
+++ b/config/candlepin/candlepin.conf.template
@@ -39,10 +39,8 @@ candlepin.pretty_print=true
 
 candlepin.async.scheduler.enabled=<%= candlepin.async_scheduler_enabled %>
 
-<% if (candlepin.hidden_resources) { %>\
-candlepin.hidden_resources=<%= candlepin.hidden_resources %>
+candlepin.hidden_resources=
 
-<% } %>\
 <% if (candlepin.hidden_capabilities) { %>\
 candlepin.hidden_capabilities=<%= candlepin.hidden_capabilities %>
 

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -419,6 +419,7 @@ if [ "$DEPLOY" == "1" ]; then
         && [ "$CP_NEW_STRUCTURE" == true ] && ($PROJECT_DIR/bin/deployment/deploy '-?' | grep -q -- '-H'); then
         DEPLOY_FLAGS="$DEPLOY_FLAGS -H -a"
     else
+        DEPLOY_FLAGS="$DEPLOY_FLAGS -a"
         echo "This deployment is not for HOSTED."
     fi
 

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1622,41 +1622,45 @@ public class ConsumerResource implements ConsumersApi {
         if (environments == null) {
             return false;
         }
+
+        if (!environments.isEmpty() &&
+            this.config.getString(ConfigProperties.HIDDEN_RESOURCES).contains("environments")) {
+            throw new BadRequestException(i18n.tr("Server does not support environments."));
+        }
+
         boolean changesMade = false;
         List<String> validatedEnvIds = new ArrayList<>();
 
-        if (environments != null) {
-            for (EnvironmentDTO environment : environments) {
-                String environmentId = environment == null ? null : environment.getId();
-                String environmentName = environment == null ? null : environment.getName();
+        for (EnvironmentDTO environment : environments) {
+            String environmentId = environment == null ? null : environment.getId();
+            String environmentName = environment == null ? null : environment.getName();
 
-                if (environmentId != null) {
-                    if (!environmentCurator.exists(environmentId)) {
-                        throw new NotFoundException(i18n.tr(
-                            "Environment with ID \"{0}\" could not be found.", environmentId));
-                    }
+            if (environmentId != null) {
+                if (!environmentCurator.exists(environmentId)) {
+                    throw new NotFoundException(i18n.tr(
+                        "Environment with ID \"{0}\" could not be found.", environmentId));
                 }
-                else if (environmentName != null) {
-                    environmentId = this.environmentCurator
-                        .getEnvironmentIdByName(toUpdate.getOwnerId(), environmentName);
-
-                    if (environmentId == null) {
-                        throw new NotFoundException(i18n.tr(
-                            "Environment with name \"{0}\" could not be found.", environmentName));
-                    }
-                }
-                else {
-                    throw new NotFoundException(i18n.tr("Environment could not be" +
-                        " found using provided details."));
-                }
-
-                if (validatedEnvIds.contains(environmentId)) {
-                    throw new ConflictException(i18n.tr("Environment \"{0}\"" +
-                        " specified more than once." + environmentId));
-                }
-
-                validatedEnvIds.add(environmentId);
             }
+            else if (environmentName != null) {
+                environmentId = this.environmentCurator
+                    .getEnvironmentIdByName(toUpdate.getOwnerId(), environmentName);
+
+                if (environmentId == null) {
+                    throw new NotFoundException(i18n.tr(
+                        "Environment with name \"{0}\" could not be found.", environmentName));
+                }
+            }
+            else {
+                throw new NotFoundException(i18n.tr("Environment could not be" +
+                    " found using provided details."));
+            }
+
+            if (validatedEnvIds.contains(environmentId)) {
+                throw new ConflictException(i18n.tr("Environment \"{0}\"" +
+                    " specified more than once." + environmentId));
+            }
+
+            validatedEnvIds.add(environmentId);
         }
 
         if (validatedEnvIds.size() > 0) {

--- a/src/test/java/org/candlepin/config/CandlepinCommonTestConfig.java
+++ b/src/test/java/org/candlepin/config/CandlepinCommonTestConfig.java
@@ -39,6 +39,7 @@ public class CandlepinCommonTestConfig extends MapConfiguration {
             setProperty(ConfigProperties.CA_KEY_PASSWORD, "password");
             setProperty(ConfigProperties.SYNC_WORK_DIR, "/tmp");
             setProperty(ConfigProperties.ACTIVEMQ_LARGE_MSG_SIZE, "0");
+            setProperty(ConfigProperties.HIDDEN_RESOURCES, "");
 
             setProperty(DatabaseConfigFactory.IN_OPERATOR_BLOCK_SIZE, "10");
             setProperty(DatabaseConfigFactory.CASE_OPERATOR_BLOCK_SIZE, "10");

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -14,12 +14,15 @@
  */
 package org.candlepin.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,6 +49,7 @@ import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.StandardTranslator;
 import org.candlepin.dto.api.v1.ConsumerDTO;
 import org.candlepin.dto.api.v1.ConsumerTypeDTO;
+import org.candlepin.dto.api.v1.EnvironmentDTO;
 import org.candlepin.dto.api.v1.ReleaseVerDTO;
 import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.ForbiddenException;
@@ -60,6 +64,7 @@ import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.DeletedConsumerCurator;
 import org.candlepin.model.DistributorVersionCurator;
 import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestIdCurator;
 import org.candlepin.model.IdentityCertificate;
@@ -574,6 +579,81 @@ public class ConsumerResourceCreationTest {
         Principal p = new TrustedUserPrincipal("anyuser");
         when(this.principalProvider.get()).thenReturn(p);
         ConsumerDTO consumer = TestUtil.createConsumerDTO("consumerName", null, null, systemDto);
-        resource.createConsumer(consumer, USER, owner.getKey(), null, true);
+        consumer = resource.createConsumer(consumer, USER, owner.getKey(), null, true);
+        assertNull(consumer.getEnvironments());
+    }
+
+    @Test
+    public void registerWithEnvironmentUsingId() {
+        config.setProperty(ConfigProperties.HIDDEN_RESOURCES, "");
+
+        Principal p = new TrustedUserPrincipal("anyuser");
+        when(this.principalProvider.get()).thenReturn(p);
+        ConsumerDTO consumer = TestUtil.createConsumerDTO("consumerName", null, null, systemDto);
+        EnvironmentDTO environmentDTO = new EnvironmentDTO().id("env1");
+        consumer.addEnvironments(environmentDTO);
+        doReturn(true).when(environmentCurator).exists(environmentDTO.getId());
+        Environment environment = new Environment();
+        environment.setId("env1");
+        doReturn(List.of(environment)).when(this.environmentCurator).getConsumerEnvironments(any());
+
+        consumer = resource.createConsumer(consumer, USER, owner.getKey(), null, true);
+        assertEquals(1, consumer.getEnvironments().size());
+    }
+
+    @Test
+    public void registerWithEnvironmentUsingName() {
+        config.setProperty(ConfigProperties.HIDDEN_RESOURCES, "");
+
+        Principal p = new TrustedUserPrincipal("anyuser");
+        when(this.principalProvider.get()).thenReturn(p);
+        ConsumerDTO consumer = TestUtil.createConsumerDTO("consumerName", null, null, systemDto);
+        EnvironmentDTO environmentDTO = new EnvironmentDTO().name("envname1");
+        consumer.addEnvironments(environmentDTO);
+        doReturn("env1").when(environmentCurator).getEnvironmentIdByName(any(), any());
+        Environment environment = new Environment();
+        environment.setId("env1");
+        environment.setName("envname1");
+        doReturn(List.of(environment)).when(this.environmentCurator).getConsumerEnvironments(any());
+
+        consumer = resource.createConsumer(consumer, USER, owner.getKey(), null, true);
+        assertEquals(1, consumer.getEnvironments().size());
+    }
+
+    @Test
+    public void registerWithMultipleEnvironments() {
+        config.setProperty(ConfigProperties.HIDDEN_RESOURCES, "");
+
+        Principal p = new TrustedUserPrincipal("anyuser");
+        when(this.principalProvider.get()).thenReturn(p);
+        ConsumerDTO consumer = TestUtil.createConsumerDTO("consumerName", null, null, systemDto);
+        EnvironmentDTO environmentDTO1 = new EnvironmentDTO().id("env1");
+        EnvironmentDTO environmentDTO2 = new EnvironmentDTO().id("env2");
+        consumer.addEnvironments(environmentDTO1);
+        consumer.addEnvironments(environmentDTO2);
+        doReturn(true).when(environmentCurator).exists(any());
+        Environment environment1 = new Environment();
+        environment1.setId("env1");
+        Environment environment2 = new Environment();
+        environment2.setId("env2");
+        doReturn(List.of(environment1, environment2)).when(this.environmentCurator)
+            .getConsumerEnvironments(any());
+
+        consumer = resource.createConsumer(consumer, USER, owner.getKey(), null, true);
+        assertEquals(2, consumer.getEnvironments().size());
+    }
+
+    @Test
+    public void registerWithEnvironmentWhileEnvironmentResourceHiddenThrowsException() {
+        config.setProperty(ConfigProperties.HIDDEN_RESOURCES, "environments");
+
+        Principal p = new TrustedUserPrincipal("anyuser");
+        when(this.principalProvider.get()).thenReturn(p);
+        ConsumerDTO consumer = TestUtil.createConsumerDTO("consumerName", null, null, systemDto);
+        EnvironmentDTO environmentDTO = new EnvironmentDTO().id("env1");
+        consumer.addEnvironments(environmentDTO);
+
+        assertThrows(BadRequestException.class, () ->
+            resource.createConsumer(consumer, USER, owner.getKey(), null, true));
     }
 }


### PR DESCRIPTION
- Do not allow registering or updating a consumer with environment
  data when the environments resource is hidden.
- Do not hide the environments resource when autogenerating the
  config file, to make sure environment spec test can run properly.