### PR TITLE
[4.0] Enforce locale when parsing Date from String [ENT-4536]

### DIFF
--- a/server/client/ruby/candlepin_api.rb
+++ b/server/client/ruby/candlepin_api.rb
@@ -1318,10 +1318,10 @@ class Candlepin
       else
         uuid = @uuid
       end
-      since = params[:since] if params[:since]
+      headers = {:accept => :json}
+      headers[:if_modified_since] = params[:since] if params[:since]
       path = "/consumers/#{uuid}/accessible_content"
-      response = get_client(path, Net::HTTP::Get, :get)[URI.escape(path)].get \
-        ({:accept => :json, :if_modified_since => since})
+      response = get_client(path, Net::HTTP::Get, :get)[URI.escape(path)].get(headers)
       return JSON.parse(response.body)
   end
 

--- a/server/src/main/java/org/candlepin/resteasy/DateFormatter.java
+++ b/server/src/main/java/org/candlepin/resteasy/DateFormatter.java
@@ -22,9 +22,12 @@ import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.lang.annotation.Annotation;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
+import java.util.Locale;
 
 import javax.xml.bind.DatatypeConverter;
 
@@ -58,10 +61,11 @@ public class DateFormatter implements StringParameterUnmarshaller<Date> {
                     log.debug("Attempting to parse date \"{}\" using format: {}", value, format);
 
                     try {
-                        SimpleDateFormat formatter = new SimpleDateFormat(format);
-                        return formatter.parse(value);
+                        DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(format)
+                            .toFormatter(Locale.US);
+                        return Date.from(Instant.from(formatter.parse(value)));
                     }
-                    catch (ParseException exception) {
+                    catch (DateTimeParseException exception) {
                         // Whoops. Hopefully we have more formats to try...
                         log.debug("Unable to parse date \"{}\" with format {}", value, format, exception);
                     }

--- a/server/src/test/java/org/candlepin/resteasy/DateFormatterTest.java
+++ b/server/src/test/java/org/candlepin/resteasy/DateFormatterTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resteasy;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.time.Instant;
+import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Locale;
+
+
+public class DateFormatterTest {
+
+    @AfterEach
+    public void cleanup() {
+        Locale.setDefault(Locale.US);
+    }
+
+    @Test
+    public void testFromStringParseWithAustralianEnglishAsSystemLocale() {
+        Locale.setDefault(new Locale("en", "AU"));
+        DateFormatter formatter = new DateFormatter();
+        Annotation[] annotations = new Annotation[] {Annotated.class.getAnnotations()[0]};
+        formatter.setAnnotations(annotations);
+
+        assertDoesNotThrow(() -> formatter.fromString("Thu, 01 Jan 1970 00:00:00 GMT"));
+    }
+
+    @Test
+    public void testFromString() {
+        DateFormatter formatter = new DateFormatter();
+        Annotation[] annotations = new Annotation[] {Annotated.class.getAnnotations()[0]};
+        formatter.setAnnotations(annotations);
+
+        OffsetDateTime offsetDateTime =
+            OffsetDateTime.of(2021, Month.NOVEMBER.getValue(), 26, 5, 0, 0, 0, ZoneOffset.UTC);
+
+        Date parsedDate = formatter.fromString("Fri, 26 Nov 2021 05:00:00 UTC");
+
+        assertEquals(offsetDateTime.toInstant(), parsedDate.toInstant());
+    }
+
+    @Test
+    public void testFromStringParseWithSpecialValueNow() {
+        DateFormatter formatter = new DateFormatter();
+        Annotation[] annotations = new Annotation[] {Annotated.class.getAnnotations()[0]};
+        formatter.setAnnotations(annotations);
+
+        Date parsedDate = formatter.fromString("now");
+
+        // Check that the returned date is more or less similar to the current time (rounded to minutes for
+        // convenience)
+        Instant currentDateRoundedDownToMinutes = new Date().toInstant().truncatedTo(ChronoUnit.MINUTES);
+        Instant parsedDateRoundedDownToMinutes = parsedDate.toInstant().truncatedTo(ChronoUnit.MINUTES);
+        assertEquals(currentDateRoundedDownToMinutes, parsedDateRoundedDownToMinutes);
+    }
+
+    // For the HTTP-date format, see https://httpwg.org/specs/rfc7231.html#http.date
+    @Test
+    public void testFromStringParseHTTPDateWithoutSpecifyingFormatThrowsException() {
+        DateFormatter formatter = new DateFormatter();
+
+        assertThrows(RuntimeException.class,
+            () -> formatter.fromString("Thu, 01 Jan 1970 00:00:00 GMT"));
+    }
+
+    @Test
+    public void testFromStringShouldParseISO8601DateWithoutSpecifyingFormat() {
+        DateFormatter formatter = new DateFormatter();
+
+        OffsetDateTime offsetDateTime =
+            OffsetDateTime.of(2021, Month.NOVEMBER.getValue(), 26, 11, 32, 43, 0, ZoneOffset.UTC);
+
+        Date parsedDate = formatter.fromString("2021-11-26T11:32:43+00:00");
+        assertEquals(offsetDateTime.toInstant(), parsedDate.toInstant());
+    }
+
+    @Test
+    public void testFromStringParseNullReturnsNull() {
+        DateFormatter formatter = new DateFormatter();
+
+        assertNull(formatter.fromString(null));
+    }
+
+    @Test
+    public void testFromStringParseEmptyReturnsNull() {
+        DateFormatter formatter = new DateFormatter();
+
+        assertNull(formatter.fromString(""));
+    }
+
+    @Test
+    public void testFromStringParseInvalidDateThrowsException() {
+        DateFormatter formatter = new DateFormatter();
+        Annotation[] annotations = new Annotation[] {Annotated.class.getAnnotations()[0]};
+        formatter.setAnnotations(annotations);
+
+        // use wrong format as input (missing timezone code)
+        assertThrows(RuntimeException.class, () -> formatter.fromString("Thu, 01 Jan 1970 00:00:00"));
+    }
+
+    /*
+     * Mock class with annotation that we need to test with
+     */
+    @DateFormat("EEE, dd MMM yyyy HH:mm:ss z")
+    private static class Annotated {}
+}


### PR DESCRIPTION
- Starting with Java 9, the CLDR is used as the default locale
provider, which has an effect on how java.text and java.time utils
format/parse certain date formats. Specifically, the format used
by the If-Modified-Since header value is affected when the server
is run with system locale set to some locales such as en_AU or
en_CA, which results in a parsing error to be thrown. Enforcing
the locale used when parsing dates to en_US solves this.