### PR TITLE
ENT-4183: DB Upgrade for environment data

### DIFF
--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -1010,26 +1010,26 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
             this.environmentIds.clear();
         }
 
-        // Creating a new map instance and assigning it to the environmentIds.
-        // This ensures that, we are deleting the existing entries and inserting the new entries.
-        // This is done to avoid constraint (cp_consumer_environments_pkey) violation exception.
-        // Whenever we try to update the existing data (changing priority), it actually updates
-        // the environment Id and not the priority.
-        LinkedHashMap<String, String> envMap = new LinkedHashMap<>();
         if (environmentIds != null) {
-
-            for (String environmentId : environmentIds) {
-                if (envMap.containsValue(environmentId)) {
-                    throw new DuplicateEntryException("Environment " + environmentId +
-                        " specified more than once.");
-                }
+            HashSet<String> deDuplicatedIds = new HashSet<>(environmentIds);
+            if (environmentIds.size() != deDuplicatedIds.size()) {
+                throw new DuplicateEntryException("One or more environments were specified more than once.");
             }
-            for (String environmentId : environmentIds) {
-                envMap.put(String.valueOf(envMap.size()), environmentId);
+
+            // Creating a new map instance and assigning it to the environmentIds.
+            // This ensures that, we are deleting the existing entries and inserting the new entries.
+            // This is done to avoid constraint (cp_consumer_environments_pkey) violation exception.
+            // Whenever we try to update the existing data (changing priority), it actually updates
+            // the environment Id and not the priority.
+            LinkedHashMap<String, String> envMap = new LinkedHashMap<>();
+
+            for (int i = 0; i < environmentIds.size(); i++) {
+                envMap.put(String.valueOf(i), environmentIds.get(i));
             }
 
             this.environmentIds = envMap;
         }
+
         return this;
     }
 

--- a/src/main/resources/db/changelog/20211123093750-migrate-environment-column.xml
+++ b/src/main/resources/db/changelog/20211123093750-migrate-environment-column.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20211123093750-1" author="ojanus">
+        <sql>
+            INSERT INTO cp_consumer_environments(cp_consumer_id, environment_id, priority)
+            SELECT id, environment_id, 0 FROM cp_consumer WHERE environment_id IS NOT NULL
+        </sql>
+
+        <dropForeignKeyConstraint baseTableName="cp_consumer" constraintName="fk_consumer_env"/>
+
+        <dropColumn tableName="cp_consumer" columnName="environment_id" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1256,4 +1256,5 @@
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20210817145050-add-consumer-environments.xml"/>
+    <include file="db/changelog/20211123093750-migrate-environment-column.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2348,4 +2348,5 @@
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20210817145050-add-consumer-environments.xml"/>
+    <include file="db/changelog/20211123093750-migrate-environment-column.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -165,4 +165,5 @@
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20210817145050-add-consumer-environments.xml"/>
+    <include file="db/changelog/20211123093750-migrate-environment-column.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- Migrate cp_consumer.environment_id to cp_consumer_environment table
- Delete cp_conusmer.environment_id column
- Remove redundant code from Consumer.setEnvironmentIds