### PR TITLE
[M] Enforce locale when parsing Date from String [ENT-4536]

### DIFF
--- a/client/ruby/candlepin_api.rb
+++ b/client/ruby/candlepin_api.rb
@@ -1319,10 +1319,10 @@ class Candlepin
       else
         uuid = @uuid
       end
-      since = params[:since] if params[:since]
+      headers = {:accept => :json}
+      headers[:if_modified_since] = params[:since] if params[:since]
       path = "/consumers/#{uuid}/accessible_content"
-      response = get_client(path, Net::HTTP::Get, :get)[URI.escape(path)].get \
-        ({:accept => :json, :if_modified_since => since})
+      response = get_client(path, Net::HTTP::Get, :get)[URI.escape(path)].get(headers)
       return JSON.parse(response.body)
   end
 

--- a/src/main/java/org/candlepin/resteasy/converter/OffsetDateTimeParamConverterProvider.java
+++ b/src/main/java/org/candlepin/resteasy/converter/OffsetDateTimeParamConverterProvider.java
@@ -28,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 
 import javax.validation.constraints.Pattern;
 import javax.ws.rs.ext.ParamConverter;
@@ -79,7 +80,7 @@ public class OffsetDateTimeParamConverterProvider implements ParamConverterProvi
             try {
                 if (this.pattern != null && !this.pattern.isBlank()) {
                     DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(pattern)
-                        .toFormatter();
+                        .toFormatter(Locale.US);
                     return Util.parseOffsetDateTime(formatter, value);
                 }
                 else {

--- a/src/test/java/org/candlepin/resteasy/converter/OffsetDateTimeParamConverterProviderTest.java
+++ b/src/test/java/org/candlepin/resteasy/converter/OffsetDateTimeParamConverterProviderTest.java
@@ -14,82 +14,112 @@
  */
 package org.candlepin.resteasy.converter;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
 import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.Locale;
 
-import javax.validation.Payload;
 import javax.validation.constraints.Pattern;
 import javax.ws.rs.ext.ParamConverter;
 
 
 public class OffsetDateTimeParamConverterProviderTest {
 
+    @AfterEach
+    public void tearDown() {
+        Locale.setDefault(Locale.US);
+    }
+
     @Test
     public void testNowValueParse() {
-        OffsetDateTimeParamConverterProvider offsetDateTimeParamConverterProvider
-            = new OffsetDateTimeParamConverterProvider();
-        ParamConverter<OffsetDateTime> offsetDateTimeParamConverter = offsetDateTimeParamConverterProvider
-            .getConverter(OffsetDateTime.class, OffsetDateTime.class, null);
-        OffsetDateTime dateTime = offsetDateTimeParamConverter.fromString("now");
+        ParamConverter<OffsetDateTime> converter = this.createConverter(null);
+        OffsetDateTime dateTime = converter.fromString("now");
         assertNotNull(dateTime);
     }
 
     @Test
     public void testDateStringConverterWithPattern() {
-        OffsetDateTimeParamConverterProvider offsetDateTimeParamConverterProvider
-            = new OffsetDateTimeParamConverterProvider();
-        Annotation[] annotations = new Annotation[1];
-        annotations[0] = new Pattern() {
-
-            @Override
-            public String regexp() {
-                return "EEE, dd MMM yyyy HH:mm:ss Z";
-            }
-
-            @Override
-            public Flag[] flags() {
-                return new Flag[0];
-            }
-
-            @Override
-            public String message() {
-                return null;
-            }
-
-            @Override
-            public Class<?>[] groups() {
-                return new Class[0];
-            }
-
-            @Override
-            public Class<? extends Payload>[] payload() {
-                return new Class[0];
-            }
-
-            @Override
-            public Class<? extends Annotation> annotationType() {
-                return Pattern.class;
-            }
-        };
-        ParamConverter<OffsetDateTime> offsetDateTimeParamConverter = offsetDateTimeParamConverterProvider
-            .getConverter(OffsetDateTime.class, OffsetDateTime.class, annotations);
-        OffsetDateTime dateTime = offsetDateTimeParamConverter.fromString("Fri, 13 Mar 2020 13:30:30 +0530");
-        assertEquals("2020-03-13T13:30:30+05:30", dateTime.toString());
-
+        Annotation[] annotations = new Annotation[] {Annotated.class.getAnnotations()[0]};
+        ParamConverter<OffsetDateTime> converter = this.createConverter(annotations);
+        OffsetDateTime dateTime = converter.fromString("Fri, 13 Mar 2020 13:30:30 EST");
+        assertEquals("2020-03-13T13:30:30-04:00", dateTime.toString());
     }
 
     @Test
     public void testDateStringConverterWithoutPattern() {
-        OffsetDateTimeParamConverterProvider offsetDateTimeParamConverterProvider
-            = new OffsetDateTimeParamConverterProvider();
-        ParamConverter<OffsetDateTime> offsetDateTimeParamConverter = offsetDateTimeParamConverterProvider
-            .getConverter(OffsetDateTime.class, OffsetDateTime.class, null);
-        OffsetDateTime dateTime = offsetDateTimeParamConverter.fromString("2021-01-24T13:30:30.382+01:00");
+        ParamConverter<OffsetDateTime> converter = this.createConverter(null);
+        OffsetDateTime dateTime = converter.fromString("2021-01-24T13:30:30.382+01:00");
         assertEquals("2021-01-24T13:30:30.382+01:00", dateTime.toString());
     }
+
+    @Test
+    public void testDateStringConverterWithAustralianEnglishAsSystemLocale() {
+        Locale.setDefault(new Locale("en", "AU"));
+
+        Annotation[] annotations = new Annotation[] {Annotated.class.getAnnotations()[0]};
+        ParamConverter<OffsetDateTime> converter = this.createConverter(annotations);
+
+        assertDoesNotThrow(() -> converter.fromString("Mon, 11 Jan 2021 15:30:05 EST"));
+    }
+
+    @Test
+    public void testDateStringConverterWithNullInputReturnsNull() {
+        ParamConverter<OffsetDateTime> converter = this.createConverter(null);
+        assertNull(converter.fromString(null));
+    }
+
+    @Test
+    public void testDateStringConverterWithEmptyInputReturnsNull() {
+        ParamConverter<OffsetDateTime> converter = this.createConverter(null);
+        assertNull(converter.fromString(""));
+    }
+
+    @Test
+    public void testDateStringConverterWithInvalidDateThrowsException() {
+        ParamConverter<OffsetDateTime> converter = this.createConverter(null);
+        // invalid date (does not specify timezone code)
+        assertThrows(RuntimeException.class,
+            () -> converter.fromString("Mon, 11 Jan 2021 15:30:05"));
+    }
+
+    @Test
+    public void testGetConverterWithNonOffsetDateTimeTypeReturnsNull() {
+        OffsetDateTimeParamConverterProvider provider = new OffsetDateTimeParamConverterProvider();
+        ParamConverter<Date> converter = provider
+            .getConverter(Date.class, OffsetDateTime.class, null);
+        assertNull(converter);
+    }
+
+    @Test
+    public void testToStringWithNullInputReturnsNull() {
+        ParamConverter<OffsetDateTime> converter = this.createConverter(null);
+        assertNull(converter.toString(null));
+    }
+
+    @Test
+    public void testToString() {
+        ParamConverter<OffsetDateTime> converter = this.createConverter(null);
+        OffsetDateTime dateTime = OffsetDateTime.now();
+        assertEquals(dateTime.toString(), converter.toString(dateTime));
+    }
+
+    private ParamConverter<OffsetDateTime> createConverter(Annotation[] annotations) {
+        OffsetDateTimeParamConverterProvider provider = new OffsetDateTimeParamConverterProvider();
+        return provider.getConverter(OffsetDateTime.class, OffsetDateTime.class, annotations);
+    }
+
+    /*
+     * Mock class with annotation that we need to test with
+     */
+    @Pattern(regexp = "EEE, dd MMM yyyy HH:mm:ss z")
+    private static class Annotated {}
 }


### PR DESCRIPTION
- Starting with Java 9, the CLDR is used as the default locale
  provider, which has an effect on how java.text and java.time utils
  format/parse certain date formats. Specifically, the format used
  by the If-Modified-Since header value is affected when the server
  is run with system locale set to some locales such as en_AU or
  en_CA, which results in a parsing error to be thrown. Enforcing
  the locale used when parsing dates to en_US solves this.