### PR TITLE
[M] ENT-3930: Compile against jss from the file system

### DIFF
--- a/bin/deployment/deploy
+++ b/bin/deployment/deploy
@@ -384,6 +384,12 @@ if (( MAJOR_TC_VERSION >= 8 )); then
     printf "\nTomcat version is 8 or newer. Updating context.xml...\n\n"
     $SUDO unzip -q $DEPLOY -d $DEPLOY_DIR
     $SUDO mv $DEPLOY_DIR/META-INF/context_tomcat8.xml $DEPLOY_DIR/META-INF/context.xml
+
+    # Starting with jss 5, the jar is called 'jss.jar' instead of 'jss4.jar'
+    if [ -f "/usr/lib64/jss/jss.jar" ]; then
+      $SUDO sed -i 's/jss4.jar/jss.jar/g' $DEPLOY_DIR/META-INF/context.xml
+    fi
+
     $SUDO chown -R tomcat:tomcat $DEPLOY_DIR
 fi
 

--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,9 @@ dependencies {
     checkstyle "com.puppycrawl.tools:checkstyle:8.29"
     checkstyle "com.github.sevntu-checkstyle:sevntu-checks:1.36.0"
 
-    providedCompile "org.mozilla:jss:4.4.6"
+    // Use wildcard because this could be called jss4.jar or jss.jar
+    // (depending on if we are before Fedora35/RHEL9 or after)
+    providedCompile fileTree(dir: '/usr/lib64/jss', include: '*.jar')
     providedCompile "javax.servlet:servlet-api:2.5"
 
     // DB Drivers
@@ -267,7 +269,6 @@ repositories {
     maven { url "https://oauth.googlecode.com/svn/code/maven/" }
     // For LogDriver
     maven { url "https://awood.fedorapeople.org/ivy/candlepin/" }
-    // Temporary repo, which stores jss 4.4.6
     maven { url "https://barnabycourt.fedorapeople.org/repo/candlepin/" }
 }
 
@@ -334,7 +335,11 @@ test {
 
     // Sometimes causes out of memory on vagrant
     maxHeapSize = "2g"
-    jvmArgs "-XX:+HeapDumpOnOutOfMemoryError"
+    jvmArgs = [
+            // We need to load the native jss lib (either libjss4.so or libjss.so) from this directory
+            '-Djava.library.path=/usr/lib64/jss',
+            '-XX:+HeapDumpOnOutOfMemoryError'
+    ]
 
     testLogging {
         // set options for log level LIFECYCLE
@@ -519,9 +524,41 @@ task pom {
                     connection = 'scm:git:git://github.com/candlepin/candlepin.git'
                     developerConnection = 'scm:git:git@github.com:candlepin/candlepin.git'
                 }
+                dependencies {
+                    dependency {
+                        groupId 'org.mozilla'
+                        artifactId 'jss'
+                        version '${jssVersion}'
+                        scope 'system'
+                        systemPath '${jssLocation}'
+                    }
+                }
+                // Choose which jss library to use by activating the appropriate profile
+                // based on which version of the jss jar exists on the file system.
                 profiles {
                     profile {
-                        id 'build'
+                        id 'build-with-jss4'
+                        activation {
+                            file {
+                                exists '/usr/lib64/jss/jss4.jar'
+                            }
+                        }
+                        properties {
+                            jssVersion '4.9.1'
+                            jssLocation '/usr/lib64/jss/jss4.jar'
+                        }
+                    }
+                    profile {
+                        id 'build-with-jss5-plus'
+                        activation {
+                            file {
+                                exists '/usr/lib64/jss/jss.jar'
+                            }
+                        }
+                        properties {
+                            jssVersion '5.0.0'
+                            jssLocation '/usr/lib64/jss/jss.jar'
+                        }
                     }
                 }
                 repositories {
@@ -720,6 +757,22 @@ task pom {
                                         includes {
                                             include 'candlepin-api-spec.yaml'
                                         }
+                                    }
+                                }
+                            }
+                        }
+                        // This helps debugging by printing out which profiles
+                        // are active during the compilation phase
+                        plugin {
+                            groupId 'org.apache.maven.plugins'
+                            artifactId 'maven-help-plugin'
+                            version '3.2.0'
+                            executions {
+                                execution {
+                                    id 'show-profiles'
+                                    phase 'compile'
+                                    goals {
+                                        goal 'active-profiles'
                                     }
                                 }
                             }

--- a/candlepin.spec.tmpl
+++ b/candlepin.spec.tmpl
@@ -143,6 +143,11 @@ mv %{buildroot}/%{_sharedstatedir}/tomcat/webapps/%{name}/META-INF/context_tomca
 %{buildroot}/%{_sharedstatedir}/tomcat/webapps/%{name}/META-INF/context.xml
 %endif
 
+## If we're running with jss 5+ (RHEL9+/Fedora35+) use the appropriate jar file name
+%if (0%{?rhel} && 0%{?rhel} >= 9) || (0%{?fedora} && 0%{?fedora} >= 35)
+sed -i 's/jss4.jar/jss.jar/g' %{buildroot}/%{_sharedstatedir}/tomcat/webapps/%{name}/META-INF/context.xml
+%endif
+
 %{__ln_s} /etc/candlepin/certs/keystore %{buildroot}/%{_sysconfdir}/tomcat/keystore
 
 ## /var/lib dir for hornetq state

--- a/mead.chain
+++ b/mead.chain
@@ -1,4 +1,4 @@
 [org.candlepin-candlepin]
 scmurl=${mead_scm}#${git_ref}
 maven_options=-N ${maven_options}
-packages=gettext
+packages=gettext jss

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,13 @@
   </scm>
   <dependencies>
     <dependency>
+      <groupId>org.mozilla</groupId>
+      <artifactId>jss</artifactId>
+      <version>${jssVersion}</version>
+      <scope>system</scope>
+      <systemPath>${jssLocation}</systemPath>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-jpamodelgen</artifactId>
       <version>5.4.18.Final</version>
@@ -302,12 +309,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.mozilla</groupId>
-      <artifactId>jss</artifactId>
-      <version>4.4.6</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
       <version>2.5</version>
@@ -581,11 +582,45 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>show-profiles</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>active-profiles</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>
     <profile>
-      <id>build</id>
+      <id>build-with-jss4</id>
+      <activation>
+        <file>
+          <exists>/usr/lib64/jss/jss4.jar</exists>
+        </file>
+      </activation>
+      <properties>
+        <jssVersion>4.9.1</jssVersion>
+        <jssLocation>/usr/lib64/jss/jss4.jar</jssLocation>
+      </properties>
+    </profile>
+    <profile>
+      <id>build-with-jss5-plus</id>
+      <activation>
+        <file>
+          <exists>/usr/lib64/jss/jss.jar</exists>
+        </file>
+      </activation>
+      <properties>
+        <jssVersion>5.0.0</jssVersion>
+        <jssLocation>/usr/lib64/jss/jss.jar</jssLocation>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/src/main/java/org/candlepin/pki/impl/JSSProviderLoader.java
+++ b/src/main/java/org/candlepin/pki/impl/JSSProviderLoader.java
@@ -38,12 +38,6 @@ public class JSSProviderLoader {
     private static final String NSS_DB_LOCATION = "/etc/pki/nssdb";
     private static final Logger log = LoggerFactory.getLogger(JSSProviderLoader.class);
 
-    static {
-        // Satellite 6 is only supported on 64 bit architectures
-        addLibraryPath("/usr/lib64/jss");
-        System.loadLibrary("jss4");
-    }
-
     /**
      * Code from http://fahdshariff.blogspot.jp/2011/08/changing-java-library-path-at-runtime.html so that we
      * can add the JSS directory to the load path without having to require it as a JVM option on startup.


### PR DESCRIPTION
- Candlepin is already loading jss (both the .jar and the .so) as a
  library from the file system when deployed in Tomcat.
  For compilation purposes though a fixed jss jar was used as a
  maven/gradle dependency in a fedorapeople repo. Also, for unit
  testing, the .so was loaded on startup using a hack in Java code.
  Now in gradle, load them both (.jar and .so) directly from
  the file system for compilation/unit testing purposes, and in maven
  use the jar (only) from the file system for compilation.
- Starting with Fedora 35 and RHEL9, the jss library has upgraded
  to major version 5, and the file names have now changed from
  'jss4.jar' to 'jss.jar', and from 'libjss4.so' to 'libjss.so'.
  Now they are loaded regardless of their name.