### PR TITLE
[M] Fix rpm build for Fedora 29 to 35

### DIFF
--- a/candlepin.spec.tmpl
+++ b/candlepin.spec.tmpl
@@ -75,7 +75,10 @@ Summary:        SELinux policy module supporting candlepin
 Group:          System Environment/Base
 BuildRequires:  checkpolicy
 BuildRequires:  selinux-policy-devel
+BuildRequires:  util-linux
+%if (0%{?rhel} && 0%{?rhel} < 9)
 BuildRequires:  hardlink
+%endif
 
 Requires:	selinux-policy >= %{_selinux_policy_version}
 Requires:       %{name} = %{version}-%{release}
@@ -160,7 +163,7 @@ do
 done
 #end raw
 cd -
-/usr/sbin/hardlink -cv %{buildroot}/%{_datadir}/selinux
+hardlink -cv %{buildroot}/%{_datadir}/selinux
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
- In recent Fedora releases, and also RHEL9, the hardlink command
  has changed location (from /usr/sbin/ to /usr/bin/) and is
  provided by a different package (from hardlink to util-linux,
  to eventually util-linux-core). These spec changes fix building
  the candlepin rpm with that regard.