### PR TITLE
[M] Duplicate entity versions are now disallowed per-ID (ENT-4509)

### DIFF
--- a/spec/content_versioning_spec.rb
+++ b/spec/content_versioning_spec.rb
@@ -204,32 +204,6 @@ describe 'Content Versioning' do
     content[0]["uuid"].should eq(content2["uuid"])
   end
 
-  it "should not converge with an orphaned content" do
-    # NOTE:
-    # This test should be removed/disabled if in-place updating/converging is reenabled, as orphans
-    # will not be created in such a case
-
-    owner1 = create_owner random_string('test_owner')
-    owner2 = create_owner random_string('test_owner')
-
-    id = random_string('test_content')
-    label = "shared content"
-    type = "shared_content_type"
-    vendor = "generous vendor"
-
-    orphan = @cp.create_content(owner1["key"], id, id, label, type, vendor)
-    content1 = @cp.update_content(owner1["key"], id, { :name => "#{id}-update" })
-    content2 = @cp.create_content(owner2["key"], id, id, label, type, vendor)
-
-    expect(orphan['uuid']).to_not eq(content1['uuid'])
-    expect(orphan['uuid']).to_not eq(content2['uuid'])
-    expect(content1['uuid']).to_not eq(content2['uuid'])
-
-    expect(@cp.get_content_by_uuid(orphan['uuid'])).to_not be_nil
-    expect(@cp.get_content_by_uuid(content1['uuid'])).to_not be_nil
-    expect(@cp.get_content_by_uuid(content2['uuid'])).to_not be_nil
-  end
-
   it 'should cleanup orphans without interfering with normal actions' do
     # NOTE:
     # This test takes advantage of the immutable nature of contents with the in-place update branch

--- a/spec/product_versioning_spec.rb
+++ b/spec/product_versioning_spec.rb
@@ -391,29 +391,6 @@ describe 'Product Versioning' do
     prod6["uuid"].should eq(prod5["uuid"])
   end
 
-  it "should not converge with an orphaned product" do
-    # NOTE:
-    # This test should be removed/disabled if in-place updating/converging is reenabled, as orphans
-    # will not be created in such a case
-
-    owner1 = create_owner random_string('test_owner')
-    owner2 = create_owner random_string('test_owner')
-
-    id = random_string('test_product')
-
-    orphan = @cp.create_product(owner1["key"], id, id)
-    product1 = @cp.update_product(owner1["key"], id, { :name => "#{id}-update" })
-    product2 = @cp.create_product(owner2["key"], id, id)
-
-    expect(orphan['uuid']).to_not eq(product1['uuid'])
-    expect(orphan['uuid']).to_not eq(product2['uuid'])
-    expect(product1['uuid']).to_not eq(product2['uuid'])
-
-    expect(@cp.get_product_by_uuid(orphan['uuid'])).to_not be_nil
-    expect(@cp.get_product_by_uuid(product1['uuid'])).to_not be_nil
-    expect(@cp.get_product_by_uuid(product2['uuid'])).to_not be_nil
-  end
-
   it 'should cleanup orphans without interfering with normal actions' do
     # NOTE:
     # This test takes advantage of the immutable nature of products with the in-place update branch

--- a/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
+++ b/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
@@ -57,7 +57,8 @@ public class RefreshPoolsJob implements AsyncJob {
         public RefreshPoolsJobConfig() {
             this.setJobKey(JOB_KEY)
                 .setJobName(JOB_NAME)
-                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY));
+                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY))
+                .setRetryCount(3);
         }
 
         /**

--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -134,10 +134,8 @@ public class CandlepinPoolManager implements PoolManager {
     private final ComplianceRules complianceRules;
     private final SystemPurposeComplianceRules systemPurposeComplianceRules;
     private final ProductCurator productCurator;
-    private final ProductManager productManager;
     private final AutobindRules autobindRules;
     private final ActivationKeyRules activationKeyRules;
-    private final ContentManager contentManager;
     private final OwnerCurator ownerCurator;
     private final OwnerProductCurator ownerProductCurator;
     private final CdnCurator cdnCurator;
@@ -170,8 +168,6 @@ public class CandlepinPoolManager implements PoolManager {
         AutobindRules autobindRules,
         ActivationKeyRules activationKeyRules,
         ProductCurator productCurator,
-        ProductManager productManager,
-        ContentManager contentManager,
         OwnerCurator ownerCurator,
         OwnerProductCurator ownerProductCurator,
         OwnerManager ownerManager,
@@ -197,8 +193,6 @@ public class CandlepinPoolManager implements PoolManager {
         this.productCurator = Objects.requireNonNull(productCurator);
         this.autobindRules = Objects.requireNonNull(autobindRules);
         this.activationKeyRules = Objects.requireNonNull(activationKeyRules);
-        this.productManager = Objects.requireNonNull(productManager);
-        this.contentManager = Objects.requireNonNull(contentManager);
         this.ownerCurator = Objects.requireNonNull(ownerCurator);
         this.ownerProductCurator = Objects.requireNonNull(ownerProductCurator);
         this.ownerManager = Objects.requireNonNull(ownerManager);
@@ -213,7 +207,6 @@ public class CandlepinPoolManager implements PoolManager {
      * We need to update/regen entitlements in the same transaction we update pools
      * so we don't miss anything
      */
-    @Transactional
     @SuppressWarnings("checkstyle:methodlength")
     @Traceable
     void refreshPoolsWithRegeneration(SubscriptionServiceAdapter subAdapter,
@@ -221,14 +214,14 @@ public class CandlepinPoolManager implements PoolManager {
         @TraceableParam("owner") Owner owner, boolean lazy) {
 
         Date now = new Date();
-        owner = this.resolveOwner(owner);
-        log.info("Refreshing pools for owner: {}", owner);
+        Owner resolvedOwner = this.resolveOwner(owner);
+        log.info("Refreshing pools for owner: {}", resolvedOwner);
 
         RefreshWorker refresher = this.refreshWorkerProvider.get();
 
         log.debug("Fetching subscriptions from adapter...");
-        refresher.addSubscriptions(subAdapter.getSubscriptions(owner.getKey()));
-        Map<String, ? extends SubscriptionInfo> subscriptionMap = refresher.getSubscriptions();
+        refresher.addSubscriptions(subAdapter.getSubscriptions(resolvedOwner.getKey()));
+        Map<String, ? extends SubscriptionInfo> subMap = refresher.getSubscriptions();
 
         // If trace output is enabled, dump some JSON representing the subscriptions we received so
         // we can simulate this in a testing environment.
@@ -237,8 +230,8 @@ public class CandlepinPoolManager implements PoolManager {
                 ObjectMapper mapper = this.jsonProvider
                     .locateMapper(Object.class, MediaType.APPLICATION_JSON_TYPE);
 
-                log.trace("Received {} subscriptions from upstream:", subscriptionMap.size());
-                log.trace(mapper.writeValueAsString(subscriptionMap.values()));
+                log.trace("Received {} subscriptions from upstream:", subMap.size());
+                log.trace(mapper.writeValueAsString(subMap.values()));
                 log.trace("Finished outputting upstream subscriptions");
             }
             catch (Exception e) {
@@ -247,12 +240,13 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         // Check if there are any dev pools (products) that need refreshing
-        List<String> devProdIds = this.ownerProductCurator.getDevProductIds(owner.getId());
+        List<String> devProdIds = this.ownerProductCurator.getDevProductIds(resolvedOwner.getId());
         if (devProdIds != null && !devProdIds.isEmpty()) {
-            log.info("Refreshing {} development products for owner: {}", devProdIds.size(), owner.getKey());
+            log.info("Refreshing {} development products for owner: {}", devProdIds.size(),
+                resolvedOwner.getKey());
 
             Collection<? extends ProductInfo> devProducts = prodAdapter
-                .getProductsByIds(owner.getKey(), devProdIds);
+                .getProductsByIds(resolvedOwner.getKey(), devProdIds);
 
             // Dump JSON representing dev products for simulation
             if (log.isTraceEnabled()) {
@@ -273,7 +267,7 @@ public class CandlepinPoolManager implements PoolManager {
         }
 
         // Execute refresh!
-        RefreshResult refreshResult = refresher.execute(owner);
+        RefreshResult refreshResult = refresher.execute(resolvedOwner);
 
         List<EntityState> existingStates = List.of(
             EntityState.CREATED, EntityState.UPDATED, EntityState.UNCHANGED);
@@ -285,87 +279,92 @@ public class CandlepinPoolManager implements PoolManager {
         Map<String, Product> updatedProducts = refreshResult.getEntities(Product.class, EntityState.UPDATED);
 
         // TODO: Move everything below this line to the refresher
-        boolean poolsModified = false;
+        this.poolCurator.transactional((args) -> {
+            boolean poolsModified = false;
 
-        Map<String, List<Pool>> subscriptionPools = this.poolCurator
-            .mapPoolsBySubscriptionIds(subscriptionMap.keySet());
+            Map<String, List<Pool>> subscriptionPools = this.poolCurator
+                .mapPoolsBySubscriptionIds(subMap.keySet());
 
-        log.debug("Refreshing {} pool(s)...", subscriptionMap.size());
-        for (Iterator<? extends SubscriptionInfo> si = subscriptionMap.values().iterator(); si.hasNext();) {
-            SubscriptionInfo sub = si.next();
+            log.debug("Refreshing {} pool(s)...", subMap.size());
+            for (Iterator<? extends SubscriptionInfo> si = subMap.values().iterator(); si.hasNext();) {
+                SubscriptionInfo sub = si.next();
 
-            if (now.after(sub.getEndDate())) {
-                log.info("Skipping expired subscription: {}", sub);
+                if (now.after(sub.getEndDate())) {
+                    log.info("Skipping expired subscription: {}", sub);
 
-                si.remove();
-                continue;
-            }
+                    si.remove();
+                    continue;
+                }
 
-            log.debug("Processing subscription: {}", sub);
-            Pool pool = this.convertToMasterPoolImpl(sub, owner, existingProducts);
-            pool.setLocked(true);
+                log.debug("Processing subscription: {}", sub);
+                Pool pool = this.convertToMasterPoolImpl(sub, resolvedOwner, existingProducts);
+                pool.setLocked(true);
 
-            List<Pool> subPools = subscriptionPools.getOrDefault(sub.getId(), Collections.emptyList());
-            this.refreshPoolsForMasterPool(pool, false, lazy, updatedProducts, subPools);
-            poolsModified = true;
-        }
-
-        // Flush our newly created pools
-        this.poolCurator.flush();
-
-        // delete pools whose subscription disappeared:
-        log.debug("Deleting pools for absent subscriptions...");
-        List<Pool> poolsToDelete = new ArrayList<>();
-
-        for (Pool pool : poolCurator.getPoolsFromBadSubs(owner, subscriptionMap.keySet())) {
-            if (this.isManaged(pool)) {
-                poolsToDelete.add(pool);
+                List<Pool> subPools = subscriptionPools.getOrDefault(sub.getId(), Collections.emptyList());
+                this.refreshPoolsForMasterPool(pool, false, lazy, updatedProducts, subPools);
                 poolsModified = true;
             }
-        }
 
-        deletePools(poolsToDelete);
+            // Flush our newly created pools
+            this.poolCurator.flush();
 
-        // TODO: break this call into smaller pieces. There may be lots of floating pools
-        log.debug("Updating floating pools...");
-        List<Pool> floatingPools = poolCurator.getOwnersFloatingPools(owner);
-        updateFloatingPools(floatingPools, lazy, updatedProducts);
+            // delete pools whose subscription disappeared:
+            log.debug("Deleting pools for absent subscriptions...");
+            List<Pool> poolsToDelete = new ArrayList<>();
 
-        // Check if we've put any pools into a state in which they're referencing a product which no
-        // longer belongs to the organization
-        List<String> pids = this.poolCurator.getPoolsUsingOrphanedProducts(owner.getId());
-        if (pids != null && pids.size() > 0) {
-            log.error("One or more pools references a product which no longer belongs to its " +
-                "organization: {}", pids);
+            for (Pool pool : poolCurator.getPoolsFromBadSubs(resolvedOwner, subMap.keySet())) {
+                if (this.isManaged(pool)) {
+                    poolsToDelete.add(pool);
+                    poolsModified = true;
+                }
+            }
 
-            throw new IllegalStateException("One or more pools was left in an undefined state: " + pids);
-        }
+            deletePools(poolsToDelete);
 
-        // If we've updated or deleted a pool and we have product/content changes, our content view has
-        // likely changed.
-        //
-        // Impl note:
-        // We're abusing some facts about how this whole process works *at the time of writing* to make
-        // a fairly accurate guess as to whether or not the content view changed. That is:
-        //
-        // - We only receive product and content info from subscriptions provided upstream
-        // - We only call refreshPoolsForMasterPool or deletePools based on matches with the
-        //   received subscriptions
-        //
-        // By checking both of these, we can estimate that if we have changed products/content AND
-        // have refreshed or deleted a pool, we likely have a content view update. Note that this
-        // does fall apart in a handful of cases (deletion of an expired pool + modification of that
-        // pool's product/content), but barring a major refactor of this code to make the evaluation
-        // on a per-pool basis, there's not a whole lot more we can do here.
-        if (poolsModified && refreshResult.hasEntity(Product.class, mutatedStates)) {
-            // TODO: Should we also mark any existing SCA certs as dirty/revoked here?
+            // TODO: break this call into smaller pieces. There may be lots of floating pools
+            log.debug("Updating floating pools...");
+            List<Pool> floatingPools = poolCurator.getOwnersFloatingPools(resolvedOwner);
+            updateFloatingPools(floatingPools, lazy, updatedProducts);
 
-            owner.setLastContentUpdate(now);
-            this.ownerCurator.merge(owner);
-        }
+            // Check if we've put any pools into a state in which they're referencing a product which no
+            // longer belongs to the organization
+            List<String> pids = this.poolCurator.getPoolsUsingOrphanedProducts(resolvedOwner.getId());
+            if (pids != null && pids.size() > 0) {
+                log.error("One or more pools references a product which no longer belongs to its " +
+                    "organization: {}", pids);
 
-        log.info("Refresh pools for owner: {} completed in: {}ms", owner.getKey(),
-            System.currentTimeMillis() - now.getTime());
+                throw new IllegalStateException("One or more pools was left in an undefined state: " + pids);
+            }
+
+            // If we've updated or deleted a pool and we have product/content changes, our content view has
+            // likely changed.
+            //
+            // Impl note:
+            // We're abusing some facts about how this whole process works *at the time of writing* to make
+            // a fairly accurate guess as to whether or not the content view changed. That is:
+            //
+            // - We only receive product and content info from subscriptions provided upstream
+            // - We only call refreshPoolsForMasterPool or deletePools based on matches with the
+            //   received subscriptions
+            //
+            // By checking both of these, we can estimate that if we have changed products/content AND
+            // have refreshed or deleted a pool, we likely have a content view update. Note that this
+            // does fall apart in a handful of cases (deletion of an expired pool + modification of that
+            // pool's product/content), but barring a major refactor of this code to make the evaluation
+            // on a per-pool basis, there's not a whole lot more we can do here.
+            if (poolsModified && refreshResult.hasEntity(Product.class, mutatedStates)) {
+                // TODO: Should we also mark any existing SCA certs as dirty/revoked here?
+
+                resolvedOwner.setLastContentUpdate(now);
+                this.ownerCurator.merge(resolvedOwner);
+            }
+
+            log.info("Refresh pools for owner: {} completed in: {}ms", resolvedOwner.getKey(),
+                System.currentTimeMillis() - now.getTime());
+
+            return null;
+        }).allowExistingTransactions()
+        .execute();
     }
 
     private Owner resolveOwner(Owner owner) {

--- a/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/src/main/java/org/candlepin/controller/ContentManager.java
@@ -144,7 +144,7 @@ public class ContentManager {
 
         // Check if we have an alternate version we can use instead.
         List<Content> alternateVersions = this.ownerContentCurator
-            .getContentByVersions(owner, Collections.singleton(entity.getEntityVersion()))
+            .getContentByVersions(Collections.singleton(entity.getEntityVersion()))
             .get(entity.getId());
 
         if (alternateVersions != null) {
@@ -240,7 +240,7 @@ public class ContentManager {
         // their own version.
         // This is probably going to be a very expensive operation, though.
         List<Content> alternateVersions = this.ownerContentCurator
-            .getContentByVersions(owner, Collections.singleton(updated.getEntityVersion()))
+            .getContentByVersions(Collections.singleton(updated.getEntityVersion()))
             .get(updated.getId());
 
         if (alternateVersions != null) {

--- a/src/main/java/org/candlepin/controller/Entitler.java
+++ b/src/main/java/org/candlepin/controller/Entitler.java
@@ -82,7 +82,6 @@ public class Entitler {
     private Configuration config;
     private ConsumerCurator consumerCurator;
     private ConsumerTypeCurator consumerTypeCurator;
-    private ContentManager contentManager;
     private EventFactory evtFactory;
     private EventSink sink;
     private EntitlementRulesTranslator messageTranslator;
@@ -91,7 +90,6 @@ public class Entitler {
     private OwnerCurator ownerCurator;
     private PoolCurator poolCurator;
     private PoolManager poolManager;
-    private ProductManager productManager;
     private ProductServiceAdapter productAdapter;
     private Provider<RefreshWorker> refreshWorkerProvider;
 
@@ -99,8 +97,7 @@ public class Entitler {
     public Entitler(PoolManager pm, ConsumerCurator cc, I18n i18n, EventFactory evtFactory,
         EventSink sink, EntitlementRulesTranslator messageTranslator,
         EntitlementCurator entitlementCurator, Configuration config,
-        OwnerCurator ownerCurator, PoolCurator poolCurator,
-        ProductManager productManager, ProductServiceAdapter productAdapter, ContentManager contentManager,
+        OwnerCurator ownerCurator, PoolCurator poolCurator, ProductServiceAdapter productAdapter,
         ConsumerTypeCurator ctc, Provider<RefreshWorker> refreshWorkerProvider) {
 
         this.poolManager = pm;
@@ -113,9 +110,7 @@ public class Entitler {
         this.config = config;
         this.ownerCurator = ownerCurator;
         this.poolCurator = poolCurator;
-        this.productManager = productManager;
         this.productAdapter = productAdapter;
-        this.contentManager = contentManager;
         this.consumerTypeCurator = ctc;
         this.refreshWorkerProvider = refreshWorkerProvider;
     }
@@ -378,8 +373,6 @@ public class Entitler {
             .setStartDate(startDate)
             .setEndDate(endDate);
 
-        // FIXME: We may need to do something explicit with the provided products!
-
         log.info("Created development pool with SKU {}", skuProduct.getId());
         pool.setAttribute(Pool.Attributes.DEVELOPMENT_POOL, "true");
         pool.setAttribute(Pool.Attributes.REQUIRES_CONSUMER, consumer.getUuid());
@@ -419,10 +412,9 @@ public class Entitler {
             // Do a refresh so we're all up to date here
             log.debug("Importing products for dev pool resolution...");
 
-            RefreshWorker refresher = this.refreshWorkerProvider.get()
-                .addProducts(this.productAdapter.getProductsByIds(owner.getKey(), devProductIds));
-
-            RefreshResult refreshResult = refresher.execute(owner);
+            RefreshResult refreshResult = this.refreshWorkerProvider.get()
+                .addProducts(this.productAdapter.getProductsByIds(owner.getKey(), devProductIds))
+                .execute(owner);
 
             // Step through the items we refreshed and add the resulting products to our map
             List<EntityState> states = Arrays.asList(

--- a/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/src/main/java/org/candlepin/controller/ProductManager.java
@@ -244,7 +244,7 @@ public class ProductManager {
 
         // Check if we have an alternate version we can use instead.
         List<Product> alternateVersions = this.ownerProductCurator
-            .getProductsByVersions(owner, Collections.singleton(entity.getEntityVersion()))
+            .getProductsByVersions(Collections.singleton(entity.getEntityVersion()))
             .get(entity.getId());
 
         if (alternateVersions != null) {
@@ -342,7 +342,7 @@ public class ProductManager {
         // their own version.
         // This is probably going to be a very expensive operation, though.
         List<Product> alternateVersions = this.ownerProductCurator
-            .getProductsByVersions(owner, Collections.singleton(updated.getEntityVersion()))
+            .getProductsByVersions(Collections.singleton(updated.getEntityVersion()))
             .get(updated.getId());
 
         if (alternateVersions != null) {
@@ -461,7 +461,7 @@ public class ProductManager {
         // their own version.
         // This is probably going to be a very expensive operation, though.
         List<Product> alternateVersions = this.ownerProductCurator
-            .getProductsByVersions(owner, Collections.singleton(updated.getEntityVersion()))
+            .getProductsByVersions(Collections.singleton(updated.getEntityVersion()))
             .get(updated.getId());
 
         if (alternateVersions != null) {

--- a/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
+++ b/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
@@ -26,6 +26,7 @@ import org.candlepin.controller.refresher.visitors.ContentNodeVisitor;
 import org.candlepin.controller.refresher.visitors.NodeProcessor;
 import org.candlepin.controller.refresher.visitors.PoolNodeVisitor;
 import org.candlepin.controller.refresher.visitors.ProductNodeVisitor;
+import org.candlepin.controller.util.EntityVersioningRetryWrapper;
 import org.candlepin.model.ContentCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerContentCurator;
@@ -37,9 +38,9 @@ import org.candlepin.service.model.ContentInfo;
 import org.candlepin.service.model.ProductContentInfo;
 import org.candlepin.service.model.ProductInfo;
 import org.candlepin.service.model.SubscriptionInfo;
+import org.candlepin.util.Transactional;
 
 import com.google.inject.Inject;
-import com.google.inject.persist.Transactional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.persistence.EntityTransaction;
+
 
 
 /**
@@ -57,6 +60,13 @@ import java.util.Objects;
  */
 public class RefreshWorker {
     private static Logger log = LoggerFactory.getLogger(RefreshWorker.class);
+
+    /**
+     * The number of times to retry certain CRUD operations which may fail as a result of
+     * entity versioning constraints
+     */
+    private static final int VERSIONING_CONSTRAINT_VIOLATION_RETRIES = 4;
+
 
     private PoolCurator poolCurator;
     private ContentCurator contentCurator;
@@ -416,38 +426,59 @@ public class RefreshWorker {
      * @return
      *  the result of this refresh operation
      */
-    @Transactional
     public RefreshResult execute(Owner owner) {
-        NodeMapper nodeMapper = new NodeMapper();
+        Transactional<RefreshResult> block = this.poolCurator.transactional((args) -> {
+            NodeMapper nodeMapper = new NodeMapper();
 
-        NodeFactory nodeFactory = new NodeFactory()
-            .setNodeMapper(nodeMapper)
-            .addMapper(this.poolMapper)
-            .addMapper(this.productMapper)
-            .addMapper(this.contentMapper)
-            .addBuilder(new PoolNodeBuilder())
-            .addBuilder(new ProductNodeBuilder())
-            .addBuilder(new ContentNodeBuilder());
+            NodeFactory nodeFactory = new NodeFactory()
+                .setNodeMapper(nodeMapper)
+                .addMapper(this.poolMapper)
+                .addMapper(this.productMapper)
+                .addMapper(this.contentMapper)
+                .addBuilder(new PoolNodeBuilder())
+                .addBuilder(new ProductNodeBuilder())
+                .addBuilder(new ContentNodeBuilder());
 
-        NodeProcessor nodeProcessor = new NodeProcessor()
-            .setNodeMapper(nodeMapper)
-            .addVisitor(new PoolNodeVisitor(this.poolCurator))
-            .addVisitor(new ProductNodeVisitor(this.productCurator, this.ownerProductCurator))
-            .addVisitor(new ContentNodeVisitor(this.contentCurator, this.ownerContentCurator));
+            NodeProcessor nodeProcessor = new NodeProcessor()
+                .setNodeMapper(nodeMapper)
+                .addVisitor(new PoolNodeVisitor(this.poolCurator))
+                .addVisitor(new ProductNodeVisitor(this.productCurator, this.ownerProductCurator))
+                .addVisitor(new ContentNodeVisitor(this.contentCurator, this.ownerContentCurator));
 
-        // Add in our existing entities
-        this.poolMapper.addExistingEntities(
-            this.poolCurator.listByOwnerAndTypes(owner.getId(), PoolType.NORMAL, PoolType.DEVELOPMENT));
+            // Clear existing entities in the event this isn't the first run of this refresher
+            this.poolMapper.clearExistingEntities();
+            this.productMapper.clearExistingEntities();
+            this.contentMapper.clearExistingEntities();
 
-        this.productMapper.addExistingEntities(this.ownerProductCurator.getProductsByOwner(owner).list());
-        this.contentMapper.addExistingEntities(this.ownerContentCurator.getContentByOwner(owner).list());
+            // Add in our existing entities
+            this.poolMapper.addExistingEntities(
+                this.poolCurator.listByOwnerAndTypes(owner.getId(), PoolType.NORMAL, PoolType.DEVELOPMENT));
 
-        // Have our node factory build the node trees
-        nodeFactory.buildNodes(owner);
+            this.productMapper.addExistingEntities(this.ownerProductCurator.getProductsByOwner(owner).list());
+            this.contentMapper.addExistingEntities(this.ownerContentCurator.getContentByOwner(owner).list());
 
-        // Process our nodes, starting at the roots, letting the processors build up any persistence
-        // state necessary to finalize everything
-        return nodeProcessor.processNodes();
+            // Have our node factory build the node trees
+            nodeFactory.buildNodes(owner);
+
+            // Process our nodes, starting at the roots, letting the processors build up any persistence
+            // state necessary to finalize everything
+            return nodeProcessor.processNodes();
+        });
+
+        // Attempt to retry if we're not already in a transaction
+        // Impl note: at the time of writing, nested transactions are not supported in Hibernate
+        EntityTransaction transaction = this.poolCurator.getTransaction();
+        if (transaction == null || !transaction.isActive()) {
+            // Retry this operation if we hit a constraint violation on the entity version constraint
+            return new EntityVersioningRetryWrapper()
+                .retries(VERSIONING_CONSTRAINT_VIOLATION_RETRIES)
+                .execute(() -> block.execute());
+        }
+        else {
+            // A transaction is already active, just run the block as-is
+            return block.allowExistingTransactions()
+                .execute();
+        }
     }
 
 }

--- a/src/main/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapper.java
@@ -175,7 +175,23 @@ public abstract class AbstractEntityMapper<E extends AbstractHibernateObject, I 
      */
     @Override
     public void clear() {
+        this.clearExistingEntities();
+        this.clearImportedEntities();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clearExistingEntities() {
         this.existingEntities.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clearImportedEntities() {
         this.importedEntities.clear();
     }
 }

--- a/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
@@ -223,8 +223,17 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
     int addImportedEntities(Collection<I> entities);
 
     /**
-     * Clears this entity mapper, removing all known existing and imported entities, and clearing any
-     * provided candidate entities map.
+     * Clears this entity mapper, removing all known existing and imported entities
      */
     void clear();
+
+    /**
+     * Clears any existing entities from this mapper
+     */
+    void clearExistingEntities();
+
+    /**
+     * Clears any imported entities from this mapper
+     */
+    void clearImportedEntities();
 }

--- a/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
@@ -226,12 +226,20 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
             Set<Integer> versions = this.ownerEntityVersions.remove(key);
 
             return versions != null ?
-                this.ownerContentCurator.getContentByVersions(key, versions) :
+                this.ownerContentCurator.getContentByVersions(versions) :
                 Collections.emptyMap();
         });
 
         for (Content candidate : entityMap.getOrDefault(entity.getId(), Collections.emptyList())) {
-            if (entityVersion == candidate.getEntityVersion() && entity.equals(candidate)) {
+            if (entityVersion == candidate.getEntityVersion()) {
+                if (!entity.equals(candidate)) {
+                    String errmsg = String.format("Entity version collision detected: %s != %s",
+                        entity, candidate);
+
+                    log.error(errmsg);
+                    throw new IllegalStateException(errmsg);
+                }
+
                 return candidate;
             }
         }

--- a/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
@@ -235,12 +235,20 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
             Set<Integer> versions = this.ownerEntityVersions.remove(key);
 
             return versions != null ?
-                this.ownerProductCurator.getProductsByVersions(key, versions) :
+                this.ownerProductCurator.getProductsByVersions(versions) :
                 Collections.emptyMap();
         });
 
         for (Product candidate : entityMap.getOrDefault(entity.getId(), Collections.emptyList())) {
-            if (entityVersion == candidate.getEntityVersion() && entity.equals(candidate)) {
+            if (entityVersion == candidate.getEntityVersion()) {
+                if (!entity.equals(candidate)) {
+                    String errmsg = String.format("Entity version collision detected: %s != %s",
+                        entity, candidate);
+
+                    log.error(errmsg);
+                    throw new IllegalStateException(errmsg);
+                }
+
                 return candidate;
             }
         }

--- a/src/main/java/org/candlepin/controller/util/EntityVersioningRetryWrapper.java
+++ b/src/main/java/org/candlepin/controller/util/EntityVersioningRetryWrapper.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller.util;
+
+import org.hibernate.exception.ConstraintViolationException;
+
+import java.util.function.Supplier;
+
+
+
+/**
+ * Wrapper class providing retry logic to handle ConstraintViolationExceptions occuring as a result
+ * of parallel requests attempting to create the same versioned entities at the same time. In many
+ * cases, only a single retry is needed; but for operations which create many entities (such as
+ * refresh), several retries may be necessary to avoid complete failure.
+ */
+public class EntityVersioningRetryWrapper {
+
+    /** The name of the constraint that will trigger a retry when violated */
+    public static final String CONSTRAINT_STRING = "entity_version";
+
+    private int maxRetries;
+
+    /**
+     * Creates a new retry wrapper with the default max retry value of 2.
+     */
+    public EntityVersioningRetryWrapper() {
+        this.maxRetries = 2;
+    }
+
+    /**
+     * Sets the number of times to retry execution of this wrapper if a failure occurs. If a
+     * negative value is provided, this method throws an exception.
+     *
+     * @param attempts
+     *  the maximum number of times to retry execution of this wrapper upon failure
+     *
+     * @throws IllegalArgumentException
+     *  if attempts is negative
+     *
+     * @return
+     *  this retry wrapper
+     */
+    public EntityVersioningRetryWrapper retries(int attempts) {
+        if (attempts < 0) {
+            throw new IllegalArgumentException("max attempts is less than zero");
+        }
+
+        this.maxRetries = attempts;
+        return this;
+    }
+
+    /**
+     * Executes this retry wrapper with the provided action. The action will always be executed at
+     * least once, and will retry the action if a specific constraint violation exception occurs.
+     * <p></p>
+     * If the action fails with a versioning-related constraint violation, it will be retried
+     * up to the maximum number of retries specified with the <tt>retries</tt> method. Any other
+     * exceptions are immediately rethrown without any attempts to process them or retry the action.
+     * <p></p>
+     * If the action fails with a versioning-related constraint violation, but is at the retry
+     * limit, this method throws the constraint violation exception.
+     *
+     * @param action
+     *  the action to retry until successful completion
+     *
+     * @return
+     *  the result of the provided action
+     */
+    public <O> O execute(Supplier<O> action) {
+        // Retry this operation if we hit a constraint violation on the entity version constraint
+        int retries = 0;
+
+        while (true) {
+            try {
+                return action.get();
+            }
+            catch (Exception e) {
+                if (retries++ < this.maxRetries && isEntityVersioningConstraintViolation(e)) {
+                    continue;
+                }
+
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Checks if the given exception is one originating from a constraint violation related to
+     * entity versioning.
+     *
+     * @param exception
+     *  the exception to check
+     *
+     * @return
+     *  true if the exception originates from an entity versioning constraint violation; false
+     *  otherwise
+     */
+    public static boolean isEntityVersioningConstraintViolation(Exception exception) {
+        for (Throwable cause = exception; cause != null; cause = cause.getCause()) {
+            if (cause instanceof ConstraintViolationException) {
+                ConstraintViolationException cve = (ConstraintViolationException) cause;
+                String cname = cve.getConstraintName();
+
+                if (cname != null && cname.contains(CONSTRAINT_STRING)) {
+                    return true;
+                }
+
+                break;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -20,7 +20,6 @@ import org.candlepin.bind.PoolOperationCallback;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
 import org.candlepin.controller.PoolManager;
-import org.candlepin.controller.ProductManager;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.rules.v1.ConsumerDTO;
 import org.candlepin.dto.rules.v1.EntitlementDTO;
@@ -32,8 +31,6 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerTypeCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
-import org.candlepin.model.OwnerCurator;
-import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolQuantity;
 import org.candlepin.model.Product;
@@ -71,6 +68,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+
+
 /**
  * Enforces entitlement rules for normal (non-manifest) consumers.
  */
@@ -86,9 +85,6 @@ public class EntitlementRules implements Enforcer {
     private ConsumerTypeCurator consumerTypeCurator;
     private ProductCurator productCurator;
     private RulesObjectMapper objectMapper;
-    private OwnerCurator ownerCurator;
-    private OwnerProductCurator ownerProductCurator;
-    private ProductManager productManager;
     private EventSink eventSink;
     private EventFactory eventFactory;
     private ModelTranslator translator;
@@ -100,9 +96,7 @@ public class EntitlementRules implements Enforcer {
     public EntitlementRules(DateSource dateSource,
         JsRunner jsRules, I18n i18n, Configuration config, ConsumerCurator consumerCurator,
         ConsumerTypeCurator consumerTypeCurator, ProductCurator productCurator, RulesObjectMapper mapper,
-        OwnerCurator ownerCurator, OwnerProductCurator ownerProductCurator,
-        ProductManager productManager, EventSink eventSink,
-        EventFactory eventFactory, ModelTranslator translator) {
+        EventSink eventSink, EventFactory eventFactory, ModelTranslator translator) {
 
         this.jsRules = jsRules;
         this.dateSource = dateSource;
@@ -112,9 +106,6 @@ public class EntitlementRules implements Enforcer {
         this.consumerTypeCurator = consumerTypeCurator;
         this.productCurator = productCurator;
         this.objectMapper = mapper;
-        this.ownerCurator = ownerCurator;
-        this.ownerProductCurator = ownerProductCurator;
-        this.productManager = productManager;
         this.eventSink = eventSink;
         this.eventFactory = eventFactory;
         this.translator = translator;

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2029,14 +2029,9 @@ public class ConsumerResource implements ConsumersApi {
         }
 
         // we want to insert the content access cert to this list if appropriate
-        try {
-            Certificate cert = this.contentAccessManager.getCertificate(consumer);
-            if (cert != null) {
-                returnCerts.add(translator.translate(cert, CertificateDTO.class));
-            }
-        }
-        catch (IOException | GeneralSecurityException e) {
-            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), e);
+        Certificate cert = this.contentAccessManager.getCertificate(consumer);
+        if (cert != null) {
+            returnCerts.add(translator.translate(cert, CertificateDTO.class));
         }
 
         return returnCerts;
@@ -2060,29 +2055,24 @@ public class ConsumerResource implements ConsumersApi {
                 .build();
         }
 
-        ContentAccessListing result = new ContentAccessListing();
-
-        try {
-            ContentAccessCertificate cac = this.contentAccessManager.getCertificate(consumer);
-            if (cac == null) {
-                throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"));
-            }
-
-            String cert = cac.getCert();
-            String certificate = cert.substring(0, cert.indexOf("-----BEGIN ENTITLEMENT DATA-----\n"));
-            String json = cert.substring(cert.indexOf("-----BEGIN ENTITLEMENT DATA-----\n"));
-            List<String> pieces = new ArrayList<>();
-            pieces.add(certificate);
-            pieces.add(json);
-            result.setContentListing(cac.getSerial().getId(), pieces);
-            result.setLastUpdate(cac.getUpdated());
-
-            return Response.ok(result, MediaType.APPLICATION_JSON)
-                .build();
+        ContentAccessCertificate cac = this.contentAccessManager.getCertificate(consumer);
+        if (cac == null) {
+            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"));
         }
-        catch (IOException | GeneralSecurityException e) {
-            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), e);
-        }
+
+        String cert = cac.getCert();
+        String certificate = cert.substring(0, cert.indexOf("-----BEGIN ENTITLEMENT DATA-----\n"));
+        String json = cert.substring(cert.indexOf("-----BEGIN ENTITLEMENT DATA-----\n"));
+        List<String> pieces = new ArrayList<>();
+        pieces.add(certificate);
+        pieces.add(json);
+
+        ContentAccessListing result = new ContentAccessListing()
+            .setContentListing(cac.getSerial().getId(), pieces)
+            .setLastUpdate(cac.getUpdated());
+
+        return Response.ok(result, MediaType.APPLICATION_JSON)
+            .build();
     }
 
     @Override
@@ -2155,14 +2145,9 @@ public class ConsumerResource implements ConsumersApi {
         }
 
         // add content access cert if needed
-        try {
-            ContentAccessCertificate cac = this.contentAccessManager.getCertificate(consumer);
-            if (cac != null) {
-                allCerts.add(new CertificateSerialDTO().serial(cac.getSerial().getId()));
-            }
-        }
-        catch (IOException | GeneralSecurityException e) {
-            throw new BadRequestException(i18n.tr("Cannot retrieve content access certificate"), e);
+        ContentAccessCertificate cac = this.contentAccessManager.getCertificate(consumer);
+        if (cac != null) {
+            allCerts.add(new CertificateSerialDTO().serial(cac.getSerial().getId()));
         }
 
         return allCerts;

--- a/src/main/java/org/candlepin/resource/dto/ContentAccessListing.java
+++ b/src/main/java/org/candlepin/resource/dto/ContentAccessListing.java
@@ -26,16 +26,18 @@ public class ContentAccessListing {
     private Date lastUpdate;
     private Map<Long, List<String>> content = new HashMap<>();
 
-    public void setLastUpdate(Date lastUpdate) {
+    public ContentAccessListing setLastUpdate(Date lastUpdate) {
         this.lastUpdate = lastUpdate;
+        return this;
     }
 
     public Date getLastUpdate() {
         return this.lastUpdate;
     }
 
-    public void setContentListing(Long serial, List<String> contentListing) {
+    public ContentAccessListing setContentListing(Long serial, List<String> contentListing) {
         this.content.put(serial, contentListing);
+        return this;
     }
 
     public Map<Long, List<String>> getContentListing() {

--- a/src/main/java/org/candlepin/sync/Exporter.java
+++ b/src/main/java/org/candlepin/sync/Exporter.java
@@ -59,7 +59,6 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -68,6 +67,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+
 
 /**
  * Exporter
@@ -399,8 +400,8 @@ public class Exporter {
             if ((serials == null) || (serials.contains(cert.getSerial().getId()))) {
                 log.debug("Exporting entitlement certificate: {}", cert.getSerial());
                 File file = new File(entCertDir.getCanonicalPath(), cert.getSerial().getId() + ".pem");
-                CertificateExporter crt = new CertificateExporter();
-                crt.exportCertificate(cert, file);
+
+                new CertificateExporter().exportCertificate(cert, file);
             }
         }
     }
@@ -419,24 +420,17 @@ public class Exporter {
      *  Throws IO exception if unable to export content access certs for the consumer.
      */
     private void exportContentAccessCerts(File baseDir, Consumer consumer) throws IOException {
-        ContentAccessCertificate contentAccessCert = null;
-
-        try {
-            contentAccessCert = this.contentAccessManager.getCertificate(consumer);
-        }
-        catch (GeneralSecurityException gse) {
-            throw new IOException("Cannot retrieve content access certificate", gse);
-        }
+        ContentAccessCertificate contentAccessCert = this.contentAccessManager.getCertificate(consumer);
 
         if (contentAccessCert != null) {
-            File contentAccessCertDir = new File(baseDir.getCanonicalPath(),
-                "content_access_certificates");
+            File contentAccessCertDir = new File(baseDir.getCanonicalPath(), "content_access_certificates");
             contentAccessCertDir.mkdir();
-            log.debug("Exporting content access certificate: " + contentAccessCert.getSerial());
+
+            log.debug("Exporting content access certificate: {}", contentAccessCert.getSerial());
             File file = new File(contentAccessCertDir.getCanonicalPath(),
                 contentAccessCert.getSerial().getId() + ".pem");
-            CertificateExporter crt = new CertificateExporter();
-            crt.exportCertificate(contentAccessCert, file);
+
+            new CertificateExporter().exportCertificate(contentAccessCert, file);
         }
     }
 

--- a/src/main/java/org/candlepin/util/TransactionExecutionException.java
+++ b/src/main/java/org/candlepin/util/TransactionExecutionException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+
+
+/**
+ * The TransactionExecutionException is thrown when an exception occurs during execution of a
+ * transactional block.
+ */
+public class TransactionExecutionException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with the specified cause.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public TransactionExecutionException(Throwable cause) {
+        super("Unexpected exception occured while executing transactional block", cause);
+    }
+}

--- a/src/main/resources/db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml
+++ b/src/main/resources/db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20211110083000-1" author="crog">
+        <comment>
+            Removes existing entity versions to avoid conflicts with any existing duplicates, and
+            resets entity versioning to allow a rebuild of the versioning without a migration.
+        </comment>
+
+        <sql>
+            UPDATE cp2_products SET entity_version = NULL;
+            UPDATE cp2_content SET entity_version = NULL;
+        </sql>
+    </changeSet>
+
+    <changeSet id="20211110083000-2" author="crog">
+        <addUniqueConstraint tableName="cp2_products"
+            columnNames="product_id, entity_version"
+            constraintName="cp2_product_entity_version"
+            deferrable="true"
+            initiallyDeferred="false"/>
+    </changeSet>
+
+    <changeSet id="20211110083000-3" author="crog">
+        <addUniqueConstraint tableName="cp2_content"
+            columnNames="content_id, entity_version"
+            constraintName="cp2_content_entity_version"
+            deferrable="true"
+            initiallyDeferred="false"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1255,4 +1255,5 @@
     <include file="db/changelog/20210412145432-drop_content_cache.xml"/>
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
+    <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2347,4 +2347,5 @@
     <include file="db/changelog/20210412145432-drop_content_cache.xml"/>
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
+    <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -164,4 +164,5 @@
     <include file="db/changelog/20210412145432-drop_content_cache.xml"/>
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
+    <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -89,11 +89,9 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.security.KeyPair;
-import java.security.PrivateKey;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -101,6 +99,8 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
+
+
 
 /**
  * Test suite for the ContentAccessManager class
@@ -721,22 +721,7 @@ public class ContentAccessManagerTest {
     }
 
     @Test
-    public void testGetCertificateThrowsIOException() throws Exception {
-        Owner owner = this.mockOwner();
-        Consumer consumer = this.mockConsumer(owner);
-        Content content = this.mockContent(owner);
-        Product product = this.mockProduct(owner, content);
-        Pool pool = this.mockPool(product);
-
-        PKIUtility mockPkiUtility = mock(PKIUtility.class);
-        doThrow(IOException.class).when(mockPkiUtility).getPemEncoded(any(PrivateKey.class));
-        ContentAccessManager manager = this.createManager(mockPkiUtility);
-
-        assertThrows(IOException.class, () -> manager.getCertificate(consumer));
-    }
-
-    @Test
-    public void testGetCertificateReturnsNullOnUnknownException() throws Exception {
+    public void testGetCertificateReturnsNullOnException() throws Exception {
         Owner owner = this.mockOwner();
         Consumer consumer = this.mockConsumer(owner);
         Content content = this.mockContent(owner);

--- a/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -139,8 +139,7 @@ public class EntitlerTest {
         this.refreshWorkerProvider = () -> refreshWorker;
 
         entitler = new Entitler(pm, cc, i18n, ef, sink, translator, entitlementCurator, config,
-            ownerCurator, poolCurator, productManager, productAdapter,
-            contentManager, consumerTypeCurator, this.refreshWorkerProvider);
+            ownerCurator, poolCurator, productAdapter, consumerTypeCurator, this.refreshWorkerProvider);
     }
 
     private void mockRefresh(Owner owner, Collection<Product> products, Collection<Content> contents) {

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -128,6 +128,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import javax.inject.Provider;
+import javax.persistence.EntityManager;
 
 
 
@@ -191,6 +192,11 @@ public class PoolManagerTest {
         product = TestUtil.createProduct();
         pool = TestUtil.createPool(owner, product);
 
+        TestUtil.mockTransactionalFunctionality(mock(EntityManager.class), mockPoolCurator,
+            mockProductCurator, entitlementCurator, certCuratorMock, consumerCuratorMock,
+            consumerTypeCuratorMock, mockOwnerCurator, mockOwnerContentCurator, mockOwnerProductCurator,
+            mockCdnCurator, mockContentCurator);
+
         when(mockOwnerCurator.getByKey(eq(owner.getKey()))).thenReturn(owner);
 
         when(mockConfig.getInt(eq(ConfigProperties.PRODUCT_CACHE_MAX))).thenReturn(100);
@@ -209,9 +215,9 @@ public class PoolManagerTest {
             mockPoolCurator, mockEventSink, eventFactory, mockConfig, enforcerMock, poolRulesMock,
             entitlementCurator, consumerCuratorMock, consumerTypeCuratorMock, certCuratorMock,
             mockECGenerator, complianceRules, systemPurposeComplianceRules, autobindRules,
-            activationKeyRules, mockProductCurator, mockProductManager, mockContentManager,
-            mockOwnerCurator, mockOwnerProductCurator, mockOwnerManager,
-            mockCdnCurator, i18n, mockBindChainFactory, jsonProvider, refreshWorkerProvider));
+            activationKeyRules, mockProductCurator, mockOwnerCurator, mockOwnerProductCurator,
+            mockOwnerManager, mockCdnCurator, i18n, mockBindChainFactory, jsonProvider,
+            refreshWorkerProvider));
 
         setupBindChain();
 

--- a/src/test/java/org/candlepin/controller/refresher/RefreshWorkerVersioningTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/RefreshWorkerVersioningTest.java
@@ -44,7 +44,7 @@ public class RefreshWorkerVersioningTest extends DatabaseTestFixture {
 
     @BeforeEach
     public void init() throws Exception {
-        super.init();
+        super.init(false);
     }
 
     private RefreshWorker buildRefreshWorker() {

--- a/src/test/java/org/candlepin/controller/util/EntityVersioningRetryWrapperTest.java
+++ b/src/test/java/org/candlepin/controller/util/EntityVersioningRetryWrapperTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.controller.util;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+
+
+public class EntityVersioningRetryWrapperTest {
+
+    private Exception buildConstraintViolation(String constraintName) {
+        return new ConstraintViolationException("test exception", new SQLException(), constraintName);
+    }
+
+    @Test
+    public void testCorrectExceptionCorrectConstraintDetection() {
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+        boolean result = EntityVersioningRetryWrapper.isEntityVersioningConstraintViolation(exception);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testCorrectExceptionIncorrectConstraintDetection() {
+        Exception exception = this.buildConstraintViolation("some other constraint");
+        boolean result = EntityVersioningRetryWrapper.isEntityVersioningConstraintViolation(exception);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIncorrectExceptionDetection() {
+        Exception exception = new SQLException();
+
+        boolean result = EntityVersioningRetryWrapper.isEntityVersioningConstraintViolation(exception);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testNegativeRetriesValuesDisallowed() {
+        assertThrows(IllegalArgumentException.class, () -> new EntityVersioningRetryWrapper().retries(-5));
+    }
+
+    @Test
+    public void testExecuteSucceedsWithoutRetries() {
+        String expected = "success";
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+
+        Supplier<String> supplier = mock(Supplier.class);
+        doReturn(expected).doThrow(new RuntimeException("fail")).when(supplier).get();
+
+        String output = new EntityVersioningRetryWrapper()
+            .retries(0)
+            .execute(supplier);
+
+        verify(supplier, times(1)).get();
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testExecuteWontRetryWithoutRetries() {
+        String expected = "success";
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+
+        Supplier<String> supplier = mock(Supplier.class);
+        doThrow(exception).doReturn(expected).doThrow(new RuntimeException("fail")).when(supplier).get();
+
+        Exception actual = assertThrows(ConstraintViolationException.class, () -> {
+            new EntityVersioningRetryWrapper()
+                .retries(0)
+                .execute(supplier);
+        });
+
+        verify(supplier, times(1)).get();
+        assertEquals(exception, actual);
+    }
+
+    @Test
+    public void testExecuteReturnsUponSuccess() {
+        String expected = "success";
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+
+        Supplier<String> supplier = mock(Supplier.class);
+        doReturn(expected).doThrow(new RuntimeException("fail")).when(supplier).get();
+
+        String output = new EntityVersioningRetryWrapper()
+            .retries(2)
+            .execute(supplier);
+
+        verify(supplier, times(1)).get();
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testExecuteRetriesOnVersioningConstraintViolation() {
+        String expected = "success";
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+
+        Supplier<String> supplier = mock(Supplier.class);
+        doThrow(exception).doReturn(expected).doThrow(new RuntimeException("fail")).when(supplier).get();
+
+        String output = new EntityVersioningRetryWrapper()
+            .retries(2)
+            .execute(supplier);
+
+        verify(supplier, times(2)).get();
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testExecuteLimitsRetriesOnVersioningConstraintViolation() {
+        String expected = "success";
+        Exception exception = this.buildConstraintViolation(EntityVersioningRetryWrapper.CONSTRAINT_STRING);
+
+        Supplier<String> supplier = mock(Supplier.class);
+        doThrow(exception).doThrow(exception).doThrow(exception).doReturn(expected).when(supplier).get();
+
+        Exception actual = assertThrows(ConstraintViolationException.class, () -> {
+            new EntityVersioningRetryWrapper()
+                .retries(2)
+                .execute(supplier);
+        });
+
+        verify(supplier, times(3)).get();
+        assertEquals(exception, actual);
+    }
+
+}

--- a/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -14,21 +14,24 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 
-import javax.inject.Inject;
+import javax.persistence.PersistenceException;
+
+
 
 /**
  * ContentCuratorTest
  */
 public class ContentCuratorTest extends DatabaseTestFixture {
-    @Inject private ContentCurator contentCurator;
-    @Inject private OwnerCurator ownerCurator;
 
     private Content updates;
     private Owner owner;
@@ -53,5 +56,27 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         updates.setReleaseVersion("releaseVer");
         updates.setMetadataExpiration(new Long(1));
         updates.setModifiedProductIds(new HashSet<String>() { { add("productIdOne"); } });
+    }
+
+    @Test
+    public void testCannotPersistIdenticalProducts() {
+        Content c1 = new Content()
+            .setId("test-content")
+            .setName("test-content")
+            .setType("content-type")
+            .setLabel("content-label")
+            .setVendor("content-vendor");
+
+        this.contentCurator.create(c1, true);
+        this.contentCurator.clear();
+
+        Content c2 = new Content()
+            .setId("test-content")
+            .setName("test-content")
+            .setType("content-type")
+            .setLabel("content-label")
+            .setVendor("content-vendor");
+
+        assertThrows(PersistenceException.class, () -> this.contentCurator.create(c2, true));
     }
 }

--- a/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -866,23 +866,32 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         Consumer consumer1 = this.createConsumer(owner1);
         Consumer consumer2 = this.createConsumer(owner2);
 
-        List<Product> reqProducts1 = Arrays.asList(
-            this.createProduct("req_prod_1", "req_prod_1", owner1),
-            this.createProduct("req_prod_2", "req_prod_2", owner1));
-
-        List<Product> reqProducts2 = Arrays.asList(
-            this.createProduct("req_prod_1", "req_prod_1", owner2),
-            this.createProduct("req_prod_2", "req_prod_2", owner2));
+        List<Product> reqProds = Arrays.asList(
+            this.createProduct("req_prod_1", "req_prod_1", owner1, owner2),
+            this.createProduct("req_prod_2", "req_prod_2", owner1, owner2));
 
         List<Product> dependentProductA = this.createDependentProducts(owner1, 1, "test_dep_prod_a",
-            reqProducts1.subList(0, 1));
+            reqProds.subList(0, 1));
         List<Product> dependentProductB = this.createDependentProducts(owner2, 1, "test_dep_prod_b",
-            reqProducts2.subList(0, 1));
+            reqProds.subList(0, 1));
 
-        Pool requiredPool1A = this.createPoolWithProducts(owner1, "reqPool1", reqProducts1.subList(0, 1));
-        Pool requiredPool2A = this.createPoolWithProducts(owner1, "reqPool2", reqProducts1.subList(1, 2));
-        Pool requiredPool1B = this.createPoolWithProducts(owner2, "reqPool1", reqProducts2.subList(0, 1));
-        Pool requiredPool2B = this.createPoolWithProducts(owner2, "reqPool2", reqProducts2.subList(1, 2));
+        Product skuProd1 = TestUtil.createProduct("reqPool1", "reqPool1")
+            .setProvidedProducts(reqProds.subList(0, 1));
+
+        Product skuProd2 = TestUtil.createProduct("reqPool2", "reqPool2")
+            .setProvidedProducts(reqProds.subList(1, 2));
+
+        this.createProduct(skuProd1, owner1, owner2);
+        this.createProduct(skuProd2, owner1, owner2);
+
+        Pool requiredPool1A = this.createPool(owner1, skuProd1, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool2A = this.createPool(owner1, skuProd2, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool1B = this.createPool(owner2, skuProd1, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool2B = this.createPool(owner2, skuProd2, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
         Pool dependentPoolA = this.createPoolWithProducts(owner1, "depPool1", dependentProductA);
         Pool dependentPoolB = this.createPoolWithProducts(owner2, "depPool2", dependentProductB);
 
@@ -915,23 +924,32 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         Consumer consumer1 = this.createConsumer(owner1);
         Consumer consumer2 = this.createConsumer(owner2);
 
-        List<Product> reqProds1 = Arrays.asList(
-            this.createProduct("req_prod_1", "req_prod_1", owner1),
-            this.createProduct("req_prod_2", "req_prod_2", owner1));
-
-        List<Product> reqProds2 = Arrays.asList(
-            this.createProduct("req_prod_1", "req_prod_1", owner2),
-            this.createProduct("req_prod_2", "req_prod_2", owner2));
+        List<Product> reqProds = Arrays.asList(
+            this.createProduct("req_prod_1", "req_prod_1", owner1, owner2),
+            this.createProduct("req_prod_2", "req_prod_2", owner1, owner2));
 
         List<Product> dependentProductA = this.createDependentProducts(owner1, 1, "test_dep_prod_a",
-            reqProds1.subList(0, 1));
+            reqProds.subList(0, 1));
         List<Product> dependentProductB = this.createDependentProducts(owner2, 1, "test_dep_prod_b",
-            reqProds2.subList(0, 1));
+            reqProds.subList(0, 1));
 
-        Pool requiredPool1A = this.createPoolWithProducts(owner1, "reqPool1", reqProds1.subList(0, 1));
-        Pool requiredPool2A = this.createPoolWithProducts(owner1, "reqPool2", reqProds1.subList(1, 2));
-        Pool requiredPool1B = this.createPoolWithProducts(owner2, "reqPool1", reqProds2.subList(0, 1));
-        Pool requiredPool2B = this.createPoolWithProducts(owner2, "reqPool2", reqProds2.subList(1, 2));
+        Product skuProd1 = TestUtil.createProduct("reqPool1", "reqPool1")
+            .setProvidedProducts(reqProds.subList(0, 1));
+
+        Product skuProd2 = TestUtil.createProduct("reqPool2", "reqPool2")
+            .setProvidedProducts(reqProds.subList(1, 2));
+
+        this.createProduct(skuProd1, owner1, owner2);
+        this.createProduct(skuProd2, owner1, owner2);
+
+        Pool requiredPool1A = this.createPool(owner1, skuProd1, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool2A = this.createPool(owner1, skuProd2, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool1B = this.createPool(owner2, skuProd1, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
+        Pool requiredPool2B = this.createPool(owner2, skuProd2, 1000L, TestUtil.createDate(2000, 1, 1),
+            TestUtil.createDate(2100, 1, 1));
         Pool dependentPoolA = this.createPoolWithProducts(owner1, "depPool1", dependentProductA);
         Pool dependentPoolB = this.createPoolWithProducts(owner2, "depPool2", dependentProductB);
 

--- a/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -122,15 +122,13 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void nameRequired() {
-
-        Product prod = new Product("someproductlabel", null);
+    public void testProductNameRequired() {
+        Product prod = new Product("some product id", null);
         assertThrows(PersistenceException.class, () -> productCurator.create(prod, true));
-
     }
 
     @Test
-    public void labelRequired() {
+    public void testProductIdRequired() {
         Product prod = new Product(null, "My Product Name");
         assertThrows(ConstraintViolationException.class, () -> productCurator.create(prod, true));
     }
@@ -145,6 +143,22 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
         assertEquals(prod.getName(), prod2.getName());
         assertNotEquals(prod.getUuid(), prod2.getUuid());
+    }
+
+    @Test
+    public void testCannotPersistIdenticalProducts() {
+        Product p1 = new Product()
+            .setId("test-product")
+            .setName("test-product");
+
+        this.productCurator.create(p1, true);
+        this.productCurator.clear();
+
+        Product p2 = new Product()
+            .setId("test-product")
+            .setName("test-product");
+
+        assertThrows(PersistenceException.class, () -> this.productCurator.create(p2, true));
     }
 
     @Test

--- a/src/test/java/org/candlepin/policy/EnforcerTest.java
+++ b/src/test/java/org/candlepin/policy/EnforcerTest.java
@@ -126,9 +126,7 @@ public class EnforcerTest extends DatabaseTestFixture {
 
         enforcer = new EntitlementRules(
             new DateSourceForTesting(2010, 1, 1), jsRules, i18n, config, consumerCurator, consumerTypeCurator,
-            mockProductCurator, new RulesObjectMapper(), mockOwnerCurator, mockOwnerProductCurator,
-            mockProductManager, mockEventSink, mockEventFactory, translator
-        );
+            mockProductCurator, new RulesObjectMapper(), mockEventSink, mockEventFactory, translator);
     }
 
     @Test

--- a/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
@@ -138,9 +138,6 @@ public class EntitlementRulesTestFixture {
             consumerTypeCurator,
             productCurator,
             new RulesObjectMapper(),
-            ownerCurator,
-            ownerProductCuratorMock,
-            productManager,
             eventSink,
             eventFactory,
             translator

--- a/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -79,7 +79,9 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
     }
 
     @BeforeEach
-    public void setUp() {
+    public void init() throws Exception {
+        super.init(false);
+
         List<SubscriptionDTO> subscriptions = new ArrayList<>();
         subAdapter = new ImportSubscriptionServiceAdapter(subscriptions);
 
@@ -137,7 +139,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
      * Checking behavior when the physical pool has a numeric virt_limit
      */
     @Test
-    public void testLimitPool() throws JobException {
+    public void testLimitedPool() throws JobException {
         List<Pool> subscribedTo = new ArrayList<>();
         Consumer guestConsumer = TestUtil.createConsumer(systemType, owner);
         guestConsumer.setFact("virt.is_guest", "true");
@@ -194,7 +196,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testUnlimitPool() throws JobException {
+    public void testUnlimitedPool() throws JobException {
         List<Pool> subscribedTo = new ArrayList<>();
         Consumer guestConsumer = TestUtil.createConsumer(systemType, owner);
         guestConsumer.setFact("virt.is_guest", "true");

--- a/src/test/java/org/candlepin/resource/PoolResourceTest.java
+++ b/src/test/java/org/candlepin/resource/PoolResourceTest.java
@@ -88,15 +88,14 @@ public class PoolResourceTest extends DatabaseTestFixture {
         ownerCurator.create(owner1);
         ownerCurator.create(owner2);
 
-        product1 = this.createProduct(PRODUCT_CPULIMITED, PRODUCT_CPULIMITED, owner1);
-        product1Owner2 = this.createProduct(PRODUCT_CPULIMITED, PRODUCT_CPULIMITED, owner2);
+        product1 = this.createProduct(PRODUCT_CPULIMITED, PRODUCT_CPULIMITED, owner1, owner2);
         product2 = this.createProduct(owner1);
 
         pool1 = this.createPool(owner1, product1, 500L,
              TestUtil.createDate(START_YEAR, 1, 1), TestUtil.createDate(END_YEAR, 1, 1));
         pool2 = this.createPool(owner1, product2, 500L,
              TestUtil.createDate(START_YEAR, 1, 1), TestUtil.createDate(END_YEAR, 1, 1));
-        pool3 = this.createPool(owner2 , product1Owner2, 500L,
+        pool3 = this.createPool(owner2 , product1, 500L,
              TestUtil.createDate(START_YEAR, 1, 1), TestUtil.createDate(END_YEAR, 1, 1));
 
         // Run most of these tests as an owner admin:

--- a/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -134,11 +134,9 @@ public class ProductResourceTest extends DatabaseTestFixture {
         Owner owner2 = this.ownerCurator.create(new Owner("TestCorp-02"));
         Owner owner3 = this.ownerCurator.create(new Owner("TestCorp-03"));
 
-        Product prod1 = this.createProduct("p1", "p1", owner1);
-        Product prod2 = this.createProduct("p1", "p1", owner2);
-        Product prod3 = this.createProduct("p2", "p2", owner2);
-        Product prod4 = this.createProduct("p2", "p2", owner3);
-        Product prod5 = this.createProduct("p3", "p3", owner3);
+        Product prod1 = this.createProduct("p1", "p1", owner1, owner2);
+        Product prod2 = this.createProduct("p2", "p2", owner2, owner3);
+        Product prod3 = this.createProduct("p3", "p3", owner3);
 
         Product poolProd1 = this.createProduct(owner1);
         Product poolProd2 = this.createProduct(owner2);
@@ -148,10 +146,10 @@ public class ProductResourceTest extends DatabaseTestFixture {
 
         // Set Provided Products
         poolProd1.setProvidedProducts(Arrays.asList(prod1));
-        poolProd2.setProvidedProducts(Arrays.asList(prod2));
-        poolProd3.setProvidedProducts(Arrays.asList(prod3));
-        poolProd4.setProvidedProducts(Arrays.asList(prod4));
-        poolProd5.setProvidedProducts(Arrays.asList(prod5));
+        poolProd2.setProvidedProducts(Arrays.asList(prod1));
+        poolProd3.setProvidedProducts(Arrays.asList(prod2));
+        poolProd4.setProvidedProducts(Arrays.asList(prod2));
+        poolProd5.setProvidedProducts(Arrays.asList(prod3));
 
         this.poolCurator.create(TestUtil.createPool(owner1, poolProd1, 5));
         this.poolCurator.create(TestUtil.createPool(owner2, poolProd2, 5));


### PR DESCRIPTION
- Versioned entities (products and content) must now be unique per
  (id, version) tuple
- Removed some obsoleted version lookup code
- RefreshPoolsJob now defaults to 3 retries, as the new unique
  restriction could cause parallel refreshes containing the same
  net-new product or content to fail on the first attempt
- The product/content mapping operation of the RefreshWorker will
  now attempt to retry if a constraint violation occurs on the
  new entity versioning constraint and if the RefreshWorker has
  control over the current transaction
- ContentAccessManager.getCertificate no longer throws checked
  exceptions
- Several improvements to the Transactional wrapper