### PR TITLE
[M] Restored write lock on orphan product UUID query

### DIFF
--- a/spec/content_versioning_spec.rb
+++ b/spec/content_versioning_spec.rb
@@ -222,7 +222,7 @@ describe 'Content Versioning' do
     length = 100
 
     # Repeat this test a few(ish) times to hopefully catch any synchronization error
-    (1..5).each do
+    (1..10).each do
       o1_uuids = []
       o2_uuids = []
 
@@ -253,10 +253,15 @@ describe 'Content Versioning' do
       end
 
       sleep 1
-      @cp.trigger_job("OrphanCleanupJob");
+      job = @cp.trigger_job("OrphanCleanupJob")
 
       updater.join
       generator.join
+      job_status = wait_for_job(job['id'])
+
+      # Verify the orphan cleanup job completed successfully
+      expect(job_status).to_not be_nil
+      expect(job_status['state'].upcase).to eq('FINISHED')
 
       # Verify the contents created/updated still exist
       o1_uuids.each do |uuid|

--- a/spec/product_versioning_spec.rb
+++ b/spec/product_versioning_spec.rb
@@ -405,7 +405,7 @@ describe 'Product Versioning' do
     length = 100
 
     # Repeat this test a few(ish) times to hopefully catch any synchronization error
-    (1..5).each do
+    (1..10).each do
       o1_uuids = []
       o2_uuids = []
 
@@ -436,10 +436,15 @@ describe 'Product Versioning' do
       end
 
       sleep 1
-      @cp.trigger_job("OrphanCleanupJob")
+      job = @cp.trigger_job("OrphanCleanupJob")
 
       updater.join
       generator.join
+      job_status = wait_for_job(job['id'])
+
+      # Verify the orphan cleanup job completed successfully
+      expect(job_status).to_not be_nil
+      expect(job_status['state'].upcase).to eq('FINISHED')
 
       # Verify the products created/updated still exist
       o1_uuids.each do |uuid|

--- a/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/src/main/java/org/candlepin/controller/ProductManager.java
@@ -45,6 +45,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import javax.persistence.LockModeType;
+
 
 
 /**
@@ -57,6 +59,9 @@ import java.util.stream.Collectors;
  */
 public class ProductManager {
     private static final Logger log = LoggerFactory.getLogger(ProductManager.class);
+
+    /** Name of the system lock used by various product operations */
+    public static final String SYSTEM_LOCK = "products";
 
     private final ContentAccessManager contentAccessManager;
 
@@ -232,6 +237,8 @@ public class ProductManager {
             throw new IllegalStateException("product has already been created: " + productData.getId());
         }
 
+        this.ownerProductCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_READ);
+
         Map<String, Product> productMap = this.resolveProductRefs(owner, productData);
         Map<String, Content> contentMap = this.resolveContentRefs(owner, productData);
 
@@ -244,7 +251,7 @@ public class ProductManager {
 
         // Check if we have an alternate version we can use instead.
         List<Product> alternateVersions = this.ownerProductCurator
-            .getProductsByVersions(Collections.singleton(entity.getEntityVersion()))
+            .getProductsByVersions(Set.of(entity.getEntityVersion()))
             .get(entity.getId());
 
         if (alternateVersions != null) {
@@ -323,6 +330,8 @@ public class ProductManager {
             return entity;
         }
 
+        this.ownerProductCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_READ);
+
         Map<String, Product> productMap = this.resolveProductRefs(owner, productData);
         Map<String, Content> contentMap = this.resolveContentRefs(owner, productData);
 
@@ -342,7 +351,7 @@ public class ProductManager {
         // their own version.
         // This is probably going to be a very expensive operation, though.
         List<Product> alternateVersions = this.ownerProductCurator
-            .getProductsByVersions(Collections.singleton(updated.getEntityVersion()))
+            .getProductsByVersions(Set.of(updated.getEntityVersion()))
             .get(updated.getId());
 
         if (alternateVersions != null) {
@@ -437,6 +446,8 @@ public class ProductManager {
             throw new IllegalArgumentException("entity is null");
         }
 
+        this.ownerProductCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_READ);
+
         Map<String, Product> productMap = this.resolveProductRefs(owner, entity);
         Map<String, Content> contentMap = this.resolveContentRefs(owner, entity);
 
@@ -461,7 +472,7 @@ public class ProductManager {
         // their own version.
         // This is probably going to be a very expensive operation, though.
         List<Product> alternateVersions = this.ownerProductCurator
-            .getProductsByVersions(Collections.singleton(updated.getEntityVersion()))
+            .getProductsByVersions(Set.of(updated.getEntityVersion()))
             .get(updated.getId());
 
         if (alternateVersions != null) {

--- a/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
+++ b/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.controller.refresher;
 
+import org.candlepin.controller.ContentManager;
+import org.candlepin.controller.ProductManager;
 import org.candlepin.controller.refresher.builders.ContentNodeBuilder;
 import org.candlepin.controller.refresher.builders.NodeFactory;
 import org.candlepin.controller.refresher.builders.PoolNodeBuilder;
@@ -51,6 +53,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import javax.persistence.EntityTransaction;
+import javax.persistence.LockModeType;
 
 
 
@@ -444,6 +447,11 @@ public class RefreshWorker {
                 .addVisitor(new PoolNodeVisitor(this.poolCurator))
                 .addVisitor(new ProductNodeVisitor(this.productCurator, this.ownerProductCurator))
                 .addVisitor(new ContentNodeVisitor(this.contentCurator, this.ownerContentCurator));
+
+            // Obtain system locks on products and content so we don't need to worry about
+            // orphan cleanup deleting stuff out from under us
+            this.ownerProductCurator.getSystemLock(ProductManager.SYSTEM_LOCK, LockModeType.PESSIMISTIC_READ);
+            this.ownerContentCurator.getSystemLock(ContentManager.SYSTEM_LOCK, LockModeType.PESSIMISTIC_READ);
 
             // Clear existing entities in the event this isn't the first run of this refresher
             this.poolMapper.clearExistingEntities();

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -621,9 +621,9 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     public void heartbeatUpdate(final String reporterId, final Date checkIn, final String ownerKey)
         throws PersistenceException {
         final String query;
-        final String db = ((String) this.currentSession().getSessionFactory().getProperties()
-            .get("hibernate.dialect")).toLowerCase();
-        if (db.contains("mysql") || db.contains("maria")) {
+        final String dialect = this.getDatabaseDialect();
+
+        if (dialect.contains("mysql") || dialect.contains("maria")) {
             query = "" +
                 "UPDATE cp_consumer consumer" +
                 " JOIN cp_consumer_hypervisor hypervisor on consumer.id = hypervisor.consumer_id " +
@@ -632,7 +632,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
                 " WHERE hypervisor.reporter_id = :reporter" +
                 " AND owner.account = :ownerKey";
         }
-        else if (db.contains("postgresql")) {
+        else if (dialect.contains("postgresql")) {
             query = "" +
                 "UPDATE cp_consumer consumer" +
                 " SET lastcheckin = :checkin" +

--- a/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -547,6 +547,7 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
      *  a map containing the products found, keyed by product ID
      */
     public Map<String, List<Product>> getProductsByVersions(Collection<Integer> versions) {
+
         Map<String, List<Product>> result = new HashMap<>();
 
         if (versions != null && !versions.isEmpty()) {

--- a/src/main/java/org/candlepin/model/SystemLock.java
+++ b/src/main/java/org/candlepin/model/SystemLock.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2009 - 2022 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+
+
+/**
+ * The SystemLock entity is used to simplify queries surrounding the system lock.
+ */
+@Entity
+@Table(name = SystemLock.DB_TABLE)
+public class SystemLock {
+
+    /** Name of the table backing this object in the database */
+    public static final String DB_TABLE = "cp_system_locks";
+
+    @Id
+    private String id;
+
+    public SystemLock() {
+
+    }
+
+    public SystemLock setId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+}

--- a/src/main/resources/db/changelog/20220117152105-add_system_lock_table.xml
+++ b/src/main/resources/db/changelog/20220117152105-add_system_lock_table.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20220117152105-1" author="crog">
+        <comment>
+            Add the cp_system_locks table
+        </comment>
+
+        <createTable tableName="cp_system_locks">
+            <column name="id" type="VARCHAR(32)">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="cp_system_locks_pkey"/>
+            </column>
+        </createTable>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1256,4 +1256,5 @@
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
+    <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2348,4 +2348,5 @@
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
+    <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -165,4 +165,5 @@
     <include file="db/changelog/20210503150950-add-consumer-service_type-column.xml"/>
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
+    <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- Restored the write lock which was erroneously removed when
  updating the orphan product lookup
- Updated the conflict spec test to ensure the orphan cleanup
  job actually completes successfully