### PR TITLE
ENT-3901: SCA cert regeneration for multi-environment consumers

### DIFF
--- a/spec/content_access_spec.rb
+++ b/spec/content_access_spec.rb
@@ -307,6 +307,53 @@ describe 'Content Access' do
       end
   end
 
+  it "content access cert should handle multiple environments" do
+      env1 = @user.create_environment(@owner['key'], random_string('testenv'),
+        "My Test Env 1", "For test systems only.")
+      env2 = @user.create_environment(@owner['key'], random_string('testenv'),
+        "My Test Env 2", "For test systems only.")
+      content2 = @cp.create_content(
+        @owner['key'], "cname2", 'test-content2', random_string("clabel2"), "ctype", "cvendor",
+        {:content_url=> '/this/is/the/path2', :modified_products => [@modified_product["id"]], :arches => "x86_64"}, true)
+      @cp.add_content_to_product(@owner['key'], @product['id'], content2['id'])
+
+      promote_content_to_environment(@user, env1, @content, false)
+      promote_content_to_environment(@user, env2, content2, false)
+
+      consumer = @user.register(random_string('consumer'), :system, nil,
+          {'system.certificate_version' => '3.3'},nil, nil, [], [], [{'id' => env1['id']}, {'id' => env2['id']}])
+      expect(consumer['environments']).not_to eq([])
+      @consumer = Candlepin.new(nil, nil, consumer['idCert']['cert'], consumer['idCert']['key'])
+      certs = @consumer.list_certificates
+      certs.length.should == 1
+      json_body = extract_payload(certs[0]['cert'])
+
+      contents = json_body['products'][0]['content']
+      contents.length().should == 2
+      env_contents = { env1['name'] => @content,  env2['name'] => content2 }
+      content_envs = { @content['id'] => env1,  content2['id'] => env2 }
+
+      contents.each { |content|
+        content['enabled'].should == false
+        value = extension_from_cert(certs[0]['cert'], "1.3.6.1.4.1.2312.9.7")
+
+        env = content_envs[content['id']]
+        content_url = env_contents[env['name']].contentUrl
+
+        # Check that Standalone uses the owner key and environment name as prefix for content url, while Hosted does not
+        if is_standalone?
+          # We URL encode the environment name when generating the prefix, which replaces spaces with +
+          encoded_env_name = env['name'].gsub(' ', '+')
+
+          expect(content['path']).to eq('/' + @owner['key'] + '/' + encoded_env_name + content_url)
+          expect(are_content_urls_present(value, ['/' + @owner['key'] + '/' + encoded_env_name])).to eq(true)
+        else
+          expect(content['path']).to eq(content_url)
+          expect(are_content_urls_present(value, ['/sca/' + @owner['key']])).to eq(true)
+        end
+      }
+  end
+
   it "environment content changes show in content access cert" do
     @env = @user.create_environment(@owner['key'], random_string('testenv'),
       "My Test Env 1", "For test systems only.")

--- a/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -19,6 +19,7 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
 import org.candlepin.controller.util.ContentPrefix;
 import org.candlepin.controller.util.PromotedContent;
+import org.candlepin.controller.util.ScaContainerContentPrefix;
 import org.candlepin.controller.util.ScaContentPrefix;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.CertificateSerialCurator;
@@ -39,6 +40,7 @@ import org.candlepin.model.OwnerContentCurator;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
+import org.candlepin.model.dto.Content;
 import org.candlepin.pki.PKIUtility;
 import org.candlepin.pki.X509ByteExtensionWrapper;
 import org.candlepin.pki.X509ExtensionWrapper;
@@ -77,13 +79,13 @@ import javax.naming.ldap.Rdn;
  * content access modes.
  */
 public class ContentAccessManager {
-    private static Logger log = LoggerFactory.getLogger(ContentAccessManager.class);
+    private static final Logger log = LoggerFactory.getLogger(ContentAccessManager.class);
 
     /**
      * The ContentAccessMode enum specifies the supported content access modes, as well as some
      * utility methods for resolving, matching, and converting to database-compatible values.
      */
-    public static enum ContentAccessMode {
+    public enum ContentAccessMode {
         ENTITLEMENT,
         ORG_ENVIRONMENT;
 
@@ -188,21 +190,20 @@ public class ContentAccessManager {
             ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
     }
 
-    private Configuration config;
-    private PKIUtility pki;
-    private KeyPairCurator keyPairCurator;
-    private CertificateSerialCurator serialCurator;
-    private OwnerCurator ownerCurator;
-    private OwnerContentCurator ownerContentCurator;
-    private ContentAccessCertificateCurator contentAccessCertificateCurator;
-    private X509V3ExtensionUtil v3extensionUtil;
-    private ConsumerCurator consumerCurator;
-    private ConsumerTypeCurator consumerTypeCurator;
-    private EnvironmentCurator environmentCurator;
-    private ContentAccessCertificateCurator contentAccessCertCurator;
-    private EventSink eventSink;
-
-    private boolean standalone;
+    private final Configuration config;
+    private final PKIUtility pki;
+    private final KeyPairCurator keyPairCurator;
+    private final CertificateSerialCurator serialCurator;
+    private final OwnerCurator ownerCurator;
+    private final OwnerContentCurator ownerContentCurator;
+    private final ContentAccessCertificateCurator contentAccessCertificateCurator;
+    private final X509V3ExtensionUtil v3extensionUtil;
+    private final ConsumerCurator consumerCurator;
+    private final ConsumerTypeCurator consumerTypeCurator;
+    private final EnvironmentCurator environmentCurator;
+    private final ContentAccessCertificateCurator contentAccessCertCurator;
+    private final EventSink eventSink;
+    private final boolean standalone;
 
     @Inject
     public ContentAccessManager(
@@ -393,12 +394,18 @@ public class ContentAccessManager {
         log.info("Generating X509 certificate for consumer \"{}\"...", consumer.getUuid());
         // fake a product dto as a container for the org content
         org.candlepin.model.dto.Product container = new org.candlepin.model.dto.Product();
-        org.candlepin.model.dto.Content dContent = new org.candlepin.model.dto.Content();
         List<org.candlepin.model.dto.Content> dtoContents = new ArrayList<>();
-        dtoContents.add(dContent);
+        List<Environment> environments = this.environmentCurator.getConsumerEnvironments(consumer);
 
-        Environment environment = this.environmentCurator.getConsumerEnvironment(consumer);
-        dContent.setPath(this.getContainerContentPath(owner, environment));
+        ContentPrefix prefix = ScaContainerContentPrefix.from(owner, this.standalone, environments);
+
+        for (Environment environment : environments) {
+            dtoContents.add(getContent(prefix, environment.getId()));
+        }
+
+        if (dtoContents.isEmpty()) {
+            dtoContents.add(getContent(prefix, null));
+        }
 
         container.setContent(dtoContents);
 
@@ -412,12 +419,17 @@ public class ContentAccessManager {
         return new String(encodedCert);
     }
 
+    private Content getContent(ContentPrefix prefix, String environmentId) {
+        Content dContent = new Content();
+        dContent.setPath(prefix.get(environmentId));
+        return dContent;
+    }
+
     private String createPayloadAndSignature(Owner owner, Consumer consumer)
         throws IOException {
 
         log.info("Generating SCA payload for consumer \"{}\"...", consumer.getUuid());
-        Environment env = this.environmentCurator.getConsumerEnvironment(consumer);
-        byte[] payloadBytes = createContentAccessDataPayload(owner, env, consumer);
+        byte[] payloadBytes = createContentAccessDataPayload(owner, consumer);
 
         String payload = "-----BEGIN ENTITLEMENT DATA-----\n";
         payload += Util.toBase64(payloadBytes);
@@ -465,45 +477,8 @@ public class ContentAccessManager {
         return entitlementVersion != null && entitlementVersion.startsWith("3.");
     }
 
-    /**
-     * Fetches the path to use for content used to generate the ENTITLEMENT_DATA certificate
-     * extension
-     *
-     * @param owner
-     *  the owner of the entitlement for which the content path is being generated
-     *
-     * @param environment
-     *  the environment to which the consumer receiving the entitlement belongs
-     *
-     * @return
-     *  the container content path for the given owner and environment
-     */
-    private String getContainerContentPath(Owner owner, Environment environment) {
-        // Fix for BZ 1866525:
-        // - In hosted, SCA entitlement content path needs to use a dummy value to prevent existing
-        //   clients from breaking, while still being clear the path is present for SCA
-        // - In satellite (standalone), the path should simply be the content prefix
-
-        if (this.standalone) {
-            String envId = environment == null ? null : environment.getId();
-            List<Environment> envs = environment == null ? List.of() : List.of(environment);
-            return ScaContentPrefix.from(owner, this.standalone, envs).get(envId);
-        }
-        return "/sca/" + Util.encodeUrl(owner.getKey());
-    }
-
     private String createDN(Consumer consumer, Owner owner) {
-        StringBuilder sb = new StringBuilder("CN=")
-            .append(consumer.getUuid())
-            .append(", O=")
-            .append(Rdn.escapeValue(owner.getKey()));
-
-        if (consumer.getEnvironmentId() != null) {
-            Environment environment = this.environmentCurator.getConsumerEnvironment(consumer);
-            sb.append(", OU=").append(Rdn.escapeValue(environment.getName()));
-        }
-
-        return sb.toString();
+        return "CN=" + consumer.getUuid() + ", O=" + Rdn.escapeValue(owner.getKey());
     }
 
     private Set<X509ExtensionWrapper> prepareV3Extensions() {
@@ -522,7 +497,7 @@ public class ContentAccessManager {
         return v3extensionUtil.getByteExtensions(products);
     }
 
-    private byte[] createContentAccessDataPayload(Owner owner, Environment environment, Consumer consumer)
+    private byte[] createContentAccessDataPayload(Owner owner, Consumer consumer)
         throws IOException {
         Product container = new Product();
         container.setId("content_access");

--- a/src/main/java/org/candlepin/controller/util/ScaContainerContentPrefix.java
+++ b/src/main/java/org/candlepin/controller/util/ScaContainerContentPrefix.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2009 - 2021 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller.util;
+
+import org.candlepin.model.Environment;
+import org.candlepin.model.Owner;
+import org.candlepin.util.Util;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Content prefix implementation for simple content access certificate containers.
+ */
+public class ScaContainerContentPrefix implements ContentPrefix {
+
+    /**
+     * A factory method constructs an instance and prepares prefixes for the given environments.
+     *
+     * @param owner an owner to be used in construction of content prefixes
+     * @param standalone flag denoting whether we are in hosted or standalone deployment
+     * @param environments environments for which to prepare content prefixes
+     * @return content prefix instance
+     */
+    public static ContentPrefix from(Owner owner, boolean standalone, List<Environment> environments) {
+        if (standalone) {
+            return new ScaContainerContentPrefix(owner, standalone, environments);
+        }
+        else {
+            return new ScaContainerContentPrefix(owner, standalone, Collections.emptyList());
+        }
+    }
+
+    private final ContentPrefix prefixes;
+    private final String ownerKey;
+    private final boolean standalone;
+
+    private ScaContainerContentPrefix(Owner owner, boolean standalone, List<Environment> environments) {
+        this.prefixes = ScaContentPrefix.from(owner, standalone, environments);
+        this.ownerKey = owner.getKey();
+        this.standalone = standalone;
+    }
+
+    /**
+     * Returns a content prefix for the requested environment.
+     *
+     * In satellite (standalone), the prefix is created by appending the owner key and
+     * environment name if available. E.G. /some_org_key/an_env_name
+     *
+     * In hosted, SCA entitlement content paths should use just the owner key
+     * prefixed with 'sca'. E.G. /sca/some_org
+     *
+     * @param environmentId an id of environment for which to return a content prefix
+     * @return content prefix
+     */
+    @Override
+    public String get(String environmentId) {
+        // Fix for BZ 1866525:
+        // - In hosted, SCA entitlement content path needs to use a dummy value to prevent existing
+        //   clients from breaking, while still being clear the path is present for SCA
+        // - In satellite (standalone), the path should simply be the content prefix
+
+        if (this.standalone) {
+            return this.prefixes.get(environmentId);
+        }
+        return "/sca/" + Util.encodeUrl(ownerKey);
+    }
+
+}

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.audit.EventSink;
 import org.candlepin.config.CandlepinCommonTestConfig;
@@ -593,6 +594,10 @@ public class ContentAccessManagerTest {
 
         Owner owner = this.mockOwner();
         Consumer consumer = this.mockConsumer(owner);
+        Content content = this.mockContent(owner);
+        Environment environment = this.mockEnvironment(owner, consumer, content);
+        when(mockEnvironmentCurator.getConsumerEnvironments(any(Consumer.class)))
+            .thenReturn(List.of(environment));
 
         String expectedPath = "/sca/" + owner.getKey();
 
@@ -608,8 +613,12 @@ public class ContentAccessManagerTest {
 
         Owner owner = this.mockOwner();
         Consumer consumer = this.mockConsumer(owner);
+        Content content = this.mockContent(owner);
+        Environment environment = this.mockEnvironment(owner, consumer, content);
+        when(mockEnvironmentCurator.getConsumerEnvironments(any(Consumer.class)))
+            .thenReturn(List.of(environment));
 
-        String expectedPath = "/" + owner.getKey();
+        String expectedPath = "/" + owner.getKey() + "/" + environment.getName();
 
         ContentAccessManager manager = this.createManager();
         manager.getCertificate(consumer);
@@ -625,6 +634,8 @@ public class ContentAccessManagerTest {
         Consumer consumer = this.mockConsumer(owner);
         Content content = this.mockContent(owner);
         Environment environment = this.mockEnvironment(owner, consumer, content);
+        when(mockEnvironmentCurator.getConsumerEnvironments(any(Consumer.class)))
+            .thenReturn(List.of(environment));
 
         String expectedPrefix = "/" + owner.getKey() + "/" + environment.getName();
 

--- a/src/test/java/org/candlepin/controller/util/ScaContainerContentPrefixTest.java
+++ b/src/test/java/org/candlepin/controller/util/ScaContainerContentPrefixTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2009 - 2022 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.controller.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.model.Environment;
+import org.candlepin.model.Owner;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+class ScaContainerContentPrefixTest {
+
+    private static final boolean HOSTED = false;
+    private static final boolean STANDALONE = true;
+    private static final String ENV_ID = "env_id_1";
+    private static final String UNKNOWN_ENV_ID = "unknown_env_id_1";
+
+    @Test
+    void prefixShouldBePrefixedInHosted() {
+        Owner owner = ownerWithKey("owner_key_1");
+        List<Environment> environments = List.of(createEnv("AnAwesomeEnvironment1"));
+        ContentPrefix prefixes = ScaContainerContentPrefix.from(owner, HOSTED, environments);
+
+        String expected = "/sca/" + owner.getKey();
+
+        assertEquals(expected, prefixes.get(null));
+        assertEquals(expected, prefixes.get(ENV_ID));
+    }
+
+    @ParameterizedTest
+    @MethodSource("prefixEncodingSource2")
+    void shouldEncodePrefixInHosted(String ownerKey, String expectedPrefix) {
+        Owner owner = ownerWithKey(ownerKey);
+        ContentPrefix prefixes = ScaContainerContentPrefix.from(owner, HOSTED, List.of());
+
+        assertEquals(expectedPrefix, prefixes.get(ENV_ID));
+    }
+
+    public static Stream<Arguments> prefixEncodingSource2() {
+        return Stream.of(
+            Arguments.of("owner key #1", "/sca/owner+key+%231"),
+            Arguments.of(
+                "org! #$%&'()*+,/123:;=?@[]\"-.<>\\^_`{|}~£円",
+                "/sca/org%21+%23%24%25%26%27%28%29*%2B%2C%2F123%3A%3B%3D%3F%40%5B%5D%22" +
+                    "-.%3C%3E%5C%5E_%60%7B%7C%7D%7E%C2%A3%E5%86%86")
+        );
+    }
+
+    @Test
+    void shouldUseOwnerPrefixForNullEnvironments() {
+        Owner owner = ownerWithKey("owner_key_1");
+        ContentPrefix prefixes = ScaContainerContentPrefix.from(owner, STANDALONE, List.of());
+
+        assertEquals("/owner_key_1", prefixes.get(null));
+    }
+
+    @Test
+    void shouldUseOwnerPrefixForUnknownEnvironments() {
+        Owner owner = ownerWithKey("owner_key_1");
+        List<Environment> environments = List.of(createEnv("AnAwesomeEnvironment1"));
+        ContentPrefix prefixes = ScaContainerContentPrefix.from(owner, STANDALONE, environments);
+
+        assertEquals("/owner_key_1", prefixes.get(UNKNOWN_ENV_ID));
+    }
+
+    @Test
+    void prefixShouldAppendEnvIfAvailable() {
+        Owner owner = ownerWithKey("owner_key_1");
+        List<Environment> environments = List.of(createEnv("AnAwesomeEnvironment1"));
+        ContentPrefix prefixes = ScaContainerContentPrefix.from(owner, STANDALONE, environments);
+
+        assertEquals("/owner_key_1/AnAwesomeEnvironment1", prefixes.get(ENV_ID));
+    }
+
+    @ParameterizedTest
+    @MethodSource("prefixEncodingSource")
+    void prefixShouldBeEncoded(String ownerKey, String envName, String expectedPrefix) {
+        Owner owner = ownerWithKey(ownerKey);
+        List<Environment> environments = List.of(createEnv(envName));
+        ContentPrefix prefixes = ScaContainerContentPrefix.from(owner, STANDALONE, environments);
+
+        assertEquals(expectedPrefix, prefixes.get(ENV_ID));
+    }
+
+    public static Stream<Arguments> prefixEncodingSource() {
+        return Stream.of(
+            Arguments.of("owner key #1", "An/Awesome/Environment/#1",
+                "/owner+key+%231/An/Awesome/Environment/%231"),
+            Arguments.of(
+                "org! #$%&'()*+,/123:;=?@[]\"-.<>\\^_`{|}~£円",
+                "foo/test environment #1/bar",
+                "/org%21+%23%24%25%26%27%28%29*%2B%2C%2F123%3A%3B%3D%3F%40%5B%5D%22" +
+                    "-.%3C%3E%5C%5E_%60%7B%7C%7D%7E%C2%A3%E5%86%86/foo/test+environment+%231/bar")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"An/AwesomeEnvironment1", "An/Awesome/Environment1", "An/Awesome/Environment/1"})
+    void prefixShouldNotEncodeSlashesInEnvNames(String envName) {
+        Owner owner = ownerWithKey("owner_key_1");
+        List<Environment> environments = List.of(createEnv(envName));
+        ContentPrefix prefixes = ScaContainerContentPrefix.from(owner, STANDALONE, environments);
+
+        assertEquals("/owner_key_1/" + envName, prefixes.get(ENV_ID));
+    }
+
+    private Environment createEnv(String name) {
+        Environment environment = new Environment();
+        environment.setId(ENV_ID);
+        environment.setName(name);
+        return environment;
+    }
+
+    private Owner ownerWithKey(String key) {
+        return new Owner().setKey(key);
+    }
+
+}


### PR DESCRIPTION
- Handle content from multiple environments in content access certs
- Remove OU from SCA DN