### PR TITLE
[M] Updated Vagrantfile to support el8-ready Ansible role (ENT-4468)

### DIFF
--- a/bin/deployment/bash_functions
+++ b/bin/deployment/bash_functions
@@ -116,6 +116,18 @@ cert_from_pkcs12() {
     fi
 }
 
+select_jdbc_jar() {
+    for jar in "$@"
+    do
+        if [ -f "$jar" ]; then
+            JDBC_JAR="$jar"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 recreate_postgresql() {
     local db_name="$1"
     local db_user="${2:-$db_name}"
@@ -136,8 +148,11 @@ recreate_postgresql() {
 init_postgresql_jdbc() {
     local db_name="$1"
     local db_host="${DBHOSTNAME:-localhost}"
+
+    select_jdbc_jar "/usr/share/java/postgresql-jdbc.jar"
+    evalrc $? "No JDBC jar file available for PostgreSQL"
+
     JDBC_DRIVER="org.postgresql.Driver"
-    JDBC_JAR="/usr/share/java/postgresql-jdbc.jar"
     JDBC_URL="jdbc:postgresql://$db_host/$db_name"
 }
 
@@ -158,13 +173,17 @@ init_mysql_jdbc() {
     local db_host="${DBHOSTNAME:-localhost}"
     local password="$DBPASSWORD"
     [ -z "$password" ] && password=''
-    JDBC_DRIVER="com.mysql.jdbc.Driver"
-    JDBC_JAR="/usr/share/java/mysql-connector-java.jar"
+
+    select_jdbc_jar "/usr/lib/java/mariadb-java-client.jar" "/usr/share/java/mysql-connector-java.jar"
+    evalrc $? "No JDBC jar file available for MariaDB/MySQL"
+
+    JDBC_DRIVER="com.mysql.cj.jdbc.Driver"
     JDBC_URL="jdbc:mysql://$db_host/$db_name"
 
-    # Change once the mariadb-java-client RPM is available in EPEL
+    # FIXME:
+    # Use the mariadb driver and URL when the mariadb-java-client RPM is available in EL7 and the
+    # Liquibase errors are fully resolved with the newer drivers
     # JDBC_DRIVER="org.mariadb.jdbc.Driver"
-    # JDBC_JAR="/usr/lib/java/mariadb-java-client.jar"
     # JDBC_URL="jdbc:mariadb://$db_host/$db_name"
     local isolation_level=$(mysql -h $db_host $db_name  --user=$db_user --password="$password" -s -N -e 'select @@global.tx_isolation')
     echo "isolation_level : $isolation_level"

--- a/bin/deployment/deploy
+++ b/bin/deployment/deploy
@@ -270,9 +270,10 @@ TC_VERSION=6
 if ( [ -f /usr/sbin/tomcat ] && (! [ -f /usr/sbin/tomcat6 ] ) );
 then
     TC=tomcat
+    TC_PATH=/usr/sbin/tomcat
 
     # Determine which Tomcat version we're using
-    TC_VERSION=$(rpm -q tomcat | grep -oP "(?<=^tomcat-)[0-9]+\.[0-9]+")
+    TC_VERSION=$($TC_PATH version | grep -oP "(?<=Server number:  )([0-9]+\.[0-9]+)")
 fi
 
 if [ -z $TC_HOME ]; then

--- a/vagrant/candlepin.yml
+++ b/vagrant/candlepin.yml
@@ -1,16 +1,43 @@
-
 ---
-- hosts: dev
+- hosts: all
 
   environment:
-    JAVA_HOME: /usr/lib/jvm/java-1.8.0/
+    JAVA_HOME: /usr/lib/jvm/java
 
   roles:
     - role: candlepin
 
+  tasks:
+    # Run additional user-provided role if it exists. If it doesn't, this task will be skipped
+    # entirely. See the linked document below [1] for details on creating an Ansible role.
+    #
+    # [1] https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html
+    - name: "Run custom user role"
+      include_role:
+        name: "{{role}}"
+      when:
+        "path is directory"
+      vars:
+        role: candlepin_dev
+        path: "vagrant/roles/{{role}}"
+      tags:
+        - user_env
+        - custom
+        - system
+
   vars:
     ansible_user: vagrant
-    candlepin_git_pull: False
     candlepin_user: vagrant
-    candlepin_user_home: /home/vagrant
-    candlepin_checkout: /vagrant
+    candlepin_home: /vagrant
+
+    cp_configure_postgresql: true
+    cp_configure_mariadb: true
+    cp_configure_user_env: true
+    cp_configure_debugging: true
+
+    cp_git_checkout: false
+    cp_deploy: false
+
+    rvm1_rubies: ['ruby-2.4']
+    rvm1_user: "{{ candlepin_user }}"
+    rvm1_bundler_install: true

--- a/vagrant/requirements.yml
+++ b/vagrant/requirements.yml
@@ -1,2 +1,6 @@
+---
 - src: https://github.com/candlepin/ansible-role-candlepin.git
   name: candlepin
+  version: master
+
+- src: rvm.ruby


### PR DESCRIPTION
- Updated the Vagrant files to support the forthcoming Candlepin
  Ansible role for individual el7 and el8 support
- Updated bash_functions to support either the mysql or mariadb
  connector jars (el7/el8 support)
- Improved Tomcat version detection logic in the deploy script