### PR TITLE
1964379: Fix to include products from new entitlements selected via auto-attach or bulk-pool attach operations

### DIFF
--- a/spec/conditional_content_spec.rb
+++ b/spec/conditional_content_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'candlepin_scenarios'
+include CertificateMethods
 
 describe 'Conditional Content and Dependent Entitlements' do
 
@@ -239,6 +240,179 @@ describe 'Conditional Content and Dependent Entitlements' do
     expect(content_repo_type(dependent_cert, @conditional_content_3.id)).to be_nil
   end
 
+  it 'v3 cert includes conditional content after auto attach that also entitles the required product' do
+    owner = create_owner random_string('owner')
+    user = user_client(owner, random_string('user'))
+
+    rh00271_eng_product = create_product("204", "Red Hat Enterprise Linux Server - Extended Life Cycle Support", {:owner => owner['key']})
+    rh00271_product = create_product("RH00271", "Extended Life Cycle Support (Unlimited Guests)", {
+      :owner => owner['key'],
+      :providedProducts => [rh00271_eng_product.id],
+      :multiplier => 1,
+      :attributes => {
+        :stacking_id => "RH00271"
+      }
+    })
+
+    rh00051_eng_product = create_product("69", "Red Hat Enterprise Linux Server", {:owner => owner['key']})
+    rh00051_product = create_product("RH00051", "Red Hat Enterprise Linux for Virtual Datacenters with Smart Management, Standard", {
+      :owner => owner['key'],
+      :providedProducts => [rh00051_eng_product.id],
+      :multiplier => 1,
+      :attributes => {
+        :stacking_id => "RH00051"
+      }
+    })
+
+    rh00051_content = @cp.create_content(
+      owner['key'], "cname-c1", 'test-content-c1', random_string("clabel"), "ctype", "cvendor",
+      {:content_url=> '/this/is/the/path'}, true)
+
+    # Content that has a required/modified product 'rh00051_eng_product' (this eng product needs to be entitled to the
+    # consumer already, or otherwise this content will get filtered out during entitlement cert generation)
+    rh00271_content = @cp.create_content(
+      owner['key'], "cname-c2", 'test-content-c2', random_string("clabel"), "ctype", "cvendor",
+      {:content_url=> '/this/is/the/path', :modified_products => [rh00051_eng_product["id"]]}, true)
+
+    @cp.add_content_to_product(owner['key'], rh00051_eng_product['id'], rh00051_content['id'], true)
+    @cp.add_content_to_product(owner['key'], rh00271_eng_product['id'], rh00271_content['id'], true)
+
+    # creating master pool for the RH00051 product
+    rh00051_pool = @cp.create_pool(owner['key'], rh00051_product['id'], {:quantity => 10,
+      :subscription_id => "random",
+      :upstream_pool_id => "random",
+      :provided_products => [rh00051_eng_product.id],
+      :locked => "true"})
+
+    #creating master pool for the RH00271 product
+    rh00271_pool = @cp.create_pool(owner['key'], rh00271_product['id'], {:quantity => 10,
+      :subscription_id => "random",
+      :upstream_pool_id => "random",
+      :provided_products => [rh00271_eng_product.id],
+      :locked => "true"})
+
+    # Create system with V3 certificate version
+    installed_prods = [{'productId' => rh00271_eng_product['id'], 'productName' => rh00271_eng_product['name']},
+      {'productId' => rh00051_eng_product['id'], 'productName' => rh00051_eng_product['name']}]
+    system1 = user.register(random_string('system55'), :system, nil, {"system.certificate_version" => "3.2" },
+       nil, owner['key'], [], installed_prods)
+    system1_client = Candlepin.new(nil, nil, system1['idCert']['cert'], system1['idCert']['key'])
+
+    # Auto-attach the system
+    ents = system1_client.consume_product
+    expect(ents.length).to eq(2)
+
+    # Verify each entitlement cert contains the appropriate content set
+    rh00271_cert_json_body = nil
+    rh00051_cert_json_body = nil
+    ents.each { |ent|
+      if ent.pool.id == rh00051_pool.id
+        rh00051_cert_json_body = extract_payload(ent['certificates'][0]['cert'])
+      end
+
+      if ent.pool.id == rh00271_pool.id
+        rh00271_cert_json_body = extract_payload(ent['certificates'][0]['cert'])
+      end
+    }
+    expect(rh00051_cert_json_body).to_not be_nil
+    expect(rh00271_cert_json_body).to_not be_nil
+
+    expect(rh00051_cert_json_body['products'][0]['content'].size).to eq(1)
+    expect(rh00051_cert_json_body['products'][0]['content'][0].id).to eq(rh00051_content.id)
+
+    # rh00271_content (which depends on modified product id 69) should not have been filtered out, because the
+    # engineering product 69 should already be covered by entitlement rh00051:
+    expect(rh00271_cert_json_body['products'][0]['content'].size).to eq(1)
+    expect(rh00271_cert_json_body['products'][0]['content'][0].id).to eq(rh00271_content.id)
+  end
+
+  it 'v1 cert includes conditional content after auto attach that also entitles the required product' do
+    owner = create_owner random_string('owner')
+    user = user_client(owner, random_string('user'))
+
+    rh00271_eng_product = create_product("204", "Red Hat Enterprise Linux Server - Extended Life Cycle Support", {:owner => owner['key']})
+    rh00271_product = create_product("RH00271", "Extended Life Cycle Support (Unlimited Guests)", {
+      :owner => owner['key'],
+      :providedProducts => [rh00271_eng_product.id],
+      :multiplier => 1,
+      :attributes => {
+        :stacking_id => "RH00271"
+      }
+    })
+
+    rh00051_eng_product = create_product("69", "Red Hat Enterprise Linux Server", {:owner => owner['key']})
+    rh00051_product = create_product("RH00051", "Red Hat Enterprise Linux for Virtual Datacenters with Smart Management, Standard", {
+      :owner => owner['key'],
+      :providedProducts => [rh00051_eng_product.id],
+      :multiplier => 1,
+      :attributes => {
+        :stacking_id => "RH00051"
+      }
+    })
+
+    # Note: for v1 certificates, we only support certain types of content type, like 'yum', so we must set the type
+    # to yum here, and also only numeric ids
+    rh00051_content = @cp.create_content(
+      owner['key'], "cname-c1", '111555', random_string("clabel"), "yum", "cvendor",
+      {:content_url=> '/this/is/the/path'}, true)
+
+    # Content that has a required/modified product 'rh00051_eng_product' (this eng product needs to be entitled to the
+    # consumer already, or otherwise this content will get filtered out during entitlement cert generation)
+    rh00271_content = @cp.create_content(
+      owner['key'], "cname-c2", '222333', random_string("clabel"), "yum", "cvendor",
+      {:content_url=> '/this/is/the/path', :modified_products => [rh00051_eng_product["id"]]}, true)
+
+    @cp.add_content_to_product(owner['key'], rh00051_eng_product['id'], rh00051_content['id'], true)
+    @cp.add_content_to_product(owner['key'], rh00271_eng_product['id'], rh00271_content['id'], true)
+
+    # creating master pool for the RH00051 product
+    rh00051_pool = @cp.create_pool(owner['key'], rh00051_product['id'], {:quantity => 10,
+      :subscription_id => "random",
+      :upstream_pool_id => "random",
+      :provided_products => [rh00051_eng_product.id],
+      :locked => "true"})
+
+    #creating master pool for the RH00271 product
+    rh00271_pool = @cp.create_pool(owner['key'], rh00271_product['id'], {:quantity => 10,
+      :subscription_id => "random",
+      :upstream_pool_id => "random",
+      :provided_products => [rh00271_eng_product.id],
+      :locked => "true"})
+
+    # creating system with V1 certificate version
+    installed_prods = [{'productId' => rh00271_eng_product['id'], 'productName' => rh00271_eng_product['name']},
+      {'productId' => rh00051_eng_product['id'], 'productName' => rh00051_eng_product['name']}]
+    system1 = user.register(random_string('system55'), :system, nil, {"system.certificate_version" => "1.0" },
+       nil, owner['key'], [], installed_prods)
+    system1_client = Candlepin.new(nil, nil, system1['idCert']['cert'], system1['idCert']['key'])
+
+    # Auto-attach the system
+    ents = system1_client.consume_product
+    expect(ents.length).to eq(2)
+
+    # Verify each entitlement cert contains the appropriate content set
+    rh00271_cert = nil
+    rh00051_cert = nil
+    ents.each { |ent|
+      if ent.pool.id == rh00051_pool.id
+        rh00051_cert = entitlement_cert(ent)
+      end
+
+      if ent.pool.id == rh00271_pool.id
+        rh00271_cert = entitlement_cert(ent)
+      end
+    }
+    expect(rh00271_cert).to_not be_nil
+    expect(rh00051_cert).to_not be_nil
+
+    expect(content_repo_type(rh00051_cert, rh00051_content.id)).to eq(rh00051_content.type)
+    expect(content_name(rh00051_cert, rh00051_content.id)).to eq(rh00051_content.name)
+
+    # rh00271_content (which depends on modified product id 69) should not have been filtered out, because the
+    # engineering product 69 should already be covered by entitlement rh00051:
+    expect(content_repo_type(rh00271_cert, rh00271_content.id)).to eq(rh00271_content.type)
+    expect(content_name(rh00271_cert, rh00271_content.id)).to eq(rh00271_content.name)
+  end
 
   private
 
@@ -252,5 +426,9 @@ describe 'Conditional Content and Dependent Entitlements' do
 
   def content_repo_type(cert, content_id)
     extension_from_cert(cert, "1.3.6.1.4.1.2312.9.2.#{content_id}.1")
+  end
+
+  def content_name(cert, content_id)
+    extension_from_cert(cert, "1.3.6.1.4.1.2312.9.2.#{content_id}.1.1")
   end
 end

--- a/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -660,21 +660,26 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
     }
 
     /**
-     * List all entitled product IDs from entitlements which overlap the given date range.
+     * Returns the set of all entitled product IDs from consumer's entitlements, current pool &
+     * set of all pools about to be entitled (selected via auto attach or bulk pool attach) which overlap
+     * the given date range.
      *
-     * i.e. given start date must be within the entitlements start/end dates, or
+     * i.e. Given start date must be within the entitlements start/end dates, or
      * the given end date must be within the entitlements start/end dates,
      * or the given start date must be before the entitlement *and* the given end date
      * must be after entitlement. (i.e. we are looking for *any* overlap)
      *
-     * also assumes the consumer is about to create an entitlement with the pool provided
-     * as an argument, so includes the products from that pool
-     *
      * @param consumer
+     *  Entitled consumer
      * @param pool
-     * @return entitled product IDs
+     *  Pool under consideration to test for date overlap
+     * @param poolsToBeEntitled
+     *  Set of pools about to be entitled
+     *
+     * @return
+     *  Set of entitled product IDs
      */
-    public Set<String> listEntitledProductIds(Consumer consumer, Pool pool) {
+    public Set<String> listEntitledProductIds(Consumer consumer, Pool pool, Set<Pool> poolsToBeEntitled) {
         // FIXME Either address the TODO below, or move this method out of the curator.
         // TODO: Swap this to a db query if we're worried about memory:
         Set<String> entitledProductIds = new HashSet<>();
@@ -686,6 +691,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         ConsumerType ctype = this.consumerTypeCurator.getConsumerType(consumer);
 
         pools.add(pool);
+        pools.addAll(poolsToBeEntitled);
         for (Pool p : pools) {
             if (!poolOverlapsRange(p, pool.getStartDate(), pool.getEndDate())) {
                 // Skip this entitlement:

--- a/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -268,12 +268,11 @@ public class X509V3ExtensionUtil extends X509Util {
 
     public List<org.candlepin.model.dto.Product> createProducts(Product sku,
         Set<Product> products, String contentPrefix, Map<String, EnvironmentContent> promotedContent,
-        Consumer consumer, Pool pool) {
+        Consumer consumer, Pool pool, Set<Pool> entitledPools) {
 
         List<org.candlepin.model.dto.Product> toReturn = new ArrayList<>();
 
-        Set<String> entitledProductIds = entCurator.listEntitledProductIds(consumer,
-            pool);
+        Set<String> entitledProductIds = entCurator.listEntitledProductIds(consumer, pool, entitledPools);
 
         for (Product p : Collections2.filter(products, PROD_FILTER_PREDICATE)) {
             toReturn.add(mapProduct(p, sku, contentPrefix, promotedContent, consumer, pool,

--- a/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -27,6 +27,7 @@ import org.candlepin.paging.PageRequest;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.hamcrest.Matchers;
 import org.hibernate.Hibernate;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +41,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -215,7 +217,7 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     @Test
     public void listEntitledProductIds() {
         Pool pool = setupListProvidingEntitlement().getPool();
-        Set<String> results = entitlementCurator.listEntitledProductIds(consumer, pool);
+        Set<String> results = entitlementCurator.listEntitledProductIds(consumer, pool, new HashSet<>());
         assertEquals(3, results.size());
         assertTrue(results.contains(providedProduct1.getId()));
         assertTrue(results.contains(providedProduct2.getId()));
@@ -235,7 +237,8 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         Pool anotherPool = newPoolUsingProducts(existingEntPool,
             createDate(2002, 1, 1),
             createDate(2006, 1, 1));
-        Set<String> results = entitlementCurator.listEntitledProductIds(consumer, anotherPool);
+        Set<String> results = entitlementCurator.listEntitledProductIds(consumer,
+            anotherPool, new HashSet<>());
         assertEquals(3, results.size());
         assertTrue(results.contains(existingEntPool.getProductId()));
     }
@@ -245,7 +248,8 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
         Pool existingEntPool = setupListProvidingEntitlement().getPool();
         Pool anotherPool = newPoolUsingProducts(existingEntPool, pastDate, createDate(2002, 1, 1));
 
-        Set<String> results = entitlementCurator.listEntitledProductIds(consumer, anotherPool);
+        Set<String> results = entitlementCurator.listEntitledProductIds(consumer,
+            anotherPool, new HashSet<>());
         assertEquals(3, results.size());
         assertTrue(results.contains(existingEntPool.getProductId()));
     }
@@ -254,7 +258,8 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     public void listEntitledProductIdsTotalOverlap() {
         Pool existingEntPool = setupListProvidingEntitlement().getPool();
         Pool anotherPool = newPoolUsingProducts(existingEntPool, pastDate, futureDate);
-        Set<String> results = entitlementCurator.listEntitledProductIds(consumer, anotherPool);
+        Set<String> results = entitlementCurator.listEntitledProductIds(consumer,
+            anotherPool, new HashSet<>());
         // Picks up suite pools as well:
         assertEquals(5, results.size());
         assertTrue(results.contains(existingEntPool.getProductId()));
@@ -264,9 +269,36 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
     public void listEntitledProductIdsNoOverlap() {
         Pool existingEntPool = setupListProvidingEntitlement().getPool();
         Pool anotherPool = setupListProvidingEntitlement(parentProduct2, pastDate, pastDate).getPool();
-        Set<String> results = entitlementCurator.listEntitledProductIds(consumer, anotherPool);
+        Set<String> results = entitlementCurator.listEntitledProductIds(consumer,
+            anotherPool, new HashSet<>());
         assertEquals(3, results.size());
         assertFalse(results.contains(existingEntPool.getProductId()));
+    }
+
+    @Test
+    public void testListEntitledProductIdsWhenEntitledPoolsArePresent() {
+        Product providedProduct = TestUtil.createProduct();
+        providedProduct = this.createProduct(providedProduct, owner);
+        Product product = TestUtil.createProduct();
+        product.addProvidedProduct(providedProduct);
+        product = this.createProduct(product, owner);
+
+        Pool entitlePool = this.poolCurator.create(new Pool()
+            .setOwner(owner).setProduct(product).setQuantity(16L)
+            .setStartDate(pastDate).setEndDate(futureDate));
+        Pool anotherPool = setupListProvidingEntitlement(parentProduct2, pastDate, pastDate).getPool();
+        Set<String> results = entitlementCurator.listEntitledProductIds(consumer,
+            anotherPool, Set.of(entitlePool));
+
+        assertEquals(5, results.size());
+
+        Set<String> providedProductIds = anotherPool.getProduct().getProvidedProducts().stream()
+            .map(prod -> prod.getId()).collect(Collectors.toSet());
+        providedProductIds.add(product.getId());
+        providedProductIds.add(providedProduct.getId());
+        providedProductIds.add(anotherPool.getProduct().getId());
+
+        assertTrue(CollectionUtils.isEqualCollection(results, providedProductIds));
     }
 
     @Test
@@ -1266,5 +1298,4 @@ public class EntitlementCuratorTest extends DatabaseTestFixture {
 
         assertEquals(entitlementCount, deleted);
     }
-
 }

--- a/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -401,7 +401,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         X509Certificate result = certServiceAdapter.createX509Certificate(consumer, owner, pool,
             entitlement, product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         // unmapped guest pools expire in 7 days, 7 * 24 = 168
         Date oneHourAfterSevenDays = new Date(now.getTime() + 169 * 60 * 60 * 1000);
@@ -430,7 +430,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         X509Certificate result = certServiceAdapter.createX509Certificate(consumer, owner, pool,
             entitlement, product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
         // cert does not capture the milliseconds. truncating.
         assertEquals(result.getNotBefore().getTime(), pool.getStartDate().getTime() / 1000 * 1000);
         // pool start date is less than an hour ago, so an hour gets used
@@ -438,7 +438,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         pool.setStartDate(cal.getTime());
         result = certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(), getProductModels(product,
-            new HashSet<>(), "prefix", entitlement), new BigInteger("1234"), keyPair, true);
+            new HashSet<>(), "prefix", entitlement), new BigInteger("1234"),
+            keyPair, true, new HashSet<>());
         assertTrue(result.getNotBefore().getTime() < pool.getStartDate().getTime() / 1000 * 1000);
     }
 
@@ -466,7 +467,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
             "prefix", entitlement);
         assertThrows(CertificateSizeException.class, () ->  certServiceAdapter.createX509Certificate(consumer,
             owner, pool, entitlement, product, providedProducts, productModels,
-            new BigInteger("1234"), keyPair, true)
+            new BigInteger("1234"), keyPair, true, new HashSet<>())
         );
     }
 
@@ -495,7 +496,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
         }
         assertThrows(CertificateSizeException.class, () -> certServiceAdapter.createX509Certificate(consumer,
             owner, pool, entitlement, product, new HashSet<>(), getProductModels(product, new HashSet<>(),
-            "prefix", entitlement), new BigInteger("1234"), keyPair, true)
+            "prefix", entitlement), new BigInteger("1234"),
+            keyPair, true, new HashSet<>())
         );
     }
 
@@ -572,7 +574,8 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(), getProductModels(product, new HashSet<>(),
-            "prefix", entitlement), new BigInteger("1234"), keyPair, true);
+            "prefix", entitlement), new BigInteger("1234"),
+            keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsContentUrl("/somePrefix" + CONTENT_URL, CONTENT_ID)),
@@ -593,7 +596,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class), argThat(
             new ListContainsContentUrl("/someorg/Awesome+Environment+%231" + CONTENT_URL, CONTENT_ID)),
@@ -614,7 +617,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class), argThat(
             new ListContainsContentUrl("/some+org/Awesome+Environment+%231" + CONTENT_URL, CONTENT_ID)),
@@ -629,7 +632,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsContentUrl("/someorg/$env" + CONTENT_URL, CONTENT_ID)),
@@ -644,7 +647,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, false);
+            new BigInteger("1234"), keyPair, false, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsContentUrl(CONTENT_URL, CONTENT_ID)),
@@ -658,7 +661,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsContentUrl(CONTENT_URL, CONTENT_ID)),
@@ -673,7 +676,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsContentUrl(CONTENT_URL, CONTENT_ID)), any(Set.class), any(Date.class),
@@ -737,7 +740,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsContentExtensions()), any(Set.class), any(Date.class),
@@ -752,7 +755,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsEntitlementExtensions()), any(Set.class),
@@ -765,7 +768,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsProvidesManagement("0")), any(Set.class),
@@ -780,7 +783,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsProvidesManagement("1")), any(Set.class),
@@ -795,7 +798,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsStackingId("3456")), any(Set.class), any(Date.class),
@@ -810,7 +813,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsVirtOnlyKey("1")), any(Set.class), any(Date.class),
@@ -825,7 +828,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsOrderNumberKey("this_order")), any(Set.class),
@@ -842,7 +845,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListContainsSupportLevel("Premium")), any(Set.class),
@@ -876,7 +879,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         entAdapter.createX509Certificate(consumer, owner, pool, entitlement, product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
     }
 
     @Test
@@ -886,7 +889,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         certServiceAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         verify(mockedPKI).createX509Certificate(any(String.class),
             argThat(new ListDoesNotContainSupportLevel()), any(Set.class), any(Date.class),
@@ -908,7 +911,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         entAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
         verify(mockV3extensionUtil).getExtensions();
         verify(mockV3extensionUtil).getByteExtensions(eq(product), any(List.class),
             nullable(String.class), any(Map.class));
@@ -934,7 +937,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         entAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
         verify(mockV3extensionUtil).getExtensions();
         verify(mockV3extensionUtil).getByteExtensions(eq(product), any(List.class), nullable(String.class),
             any(Map.class));
@@ -957,7 +960,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         entAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
 
         // Verify v1
         verify(mockExtensionUtil).consumerExtensions(eq(consumer));
@@ -979,7 +982,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
         entAdapter.createX509Certificate(consumer, owner, pool, entitlement,
             product, new HashSet<>(),
             getProductModels(product, new HashSet<>(), "prefix", entitlement),
-            new BigInteger("1234"), keyPair, true);
+            new BigInteger("1234"), keyPair, true, new HashSet<>());
         verify(mockV3extensionUtil).getExtensions();
         verify(mockV3extensionUtil).getByteExtensions(eq(product), any(List.class),
             nullable(String.class), any(Map.class));
@@ -1028,7 +1031,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         Set<X509ExtensionWrapper> extensions =
             certServiceAdapter.prepareV1Extensions(products, pool, consumer,
-            entitlement.getQuantity(), "", null);
+            entitlement.getQuantity(), "", null, new HashSet<>());
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1050,7 +1053,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         Set<X509ExtensionWrapper> extensions =
             certServiceAdapter.prepareV1Extensions(products, pool, consumer,
-            entitlement.getQuantity(), "", null);
+            entitlement.getQuantity(), "", null, new HashSet<>());
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1082,7 +1085,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         Set<X509ExtensionWrapper> extensions =
             certServiceAdapter.prepareV1Extensions(products, pool, consumer,
-            entitlement.getQuantity(), "", null);
+            entitlement.getQuantity(), "", null, new HashSet<>());
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1110,7 +1113,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         Set<X509ExtensionWrapper> extensions =
             certServiceAdapter.prepareV1Extensions(products, pool, consumer,
-            entitlement.getQuantity(), "", null);
+            entitlement.getQuantity(), "", null, new HashSet<>());
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1143,7 +1146,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         Set<X509ExtensionWrapper> extensions =
             certServiceAdapter.prepareV1Extensions(products, pool, consumer,
-            entitlement.getQuantity(), "", null);
+            entitlement.getQuantity(), "", null, new HashSet<>());
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1177,7 +1180,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         Set<X509ExtensionWrapper> extensions =
             certServiceAdapter.prepareV1Extensions(products, pool, consumer,
-            entitlement.getQuantity(), "", null);
+            entitlement.getQuantity(), "", null, new HashSet<>());
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1215,7 +1218,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         Set<X509ExtensionWrapper> extensions =
             certServiceAdapter.prepareV1Extensions(products, pool, consumer, entitlement.getQuantity(),
-            "", null);
+            "", null, new HashSet<>());
         Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
         Map<String, String> extMap = getEncodedContentMap(extensions);
 
@@ -1249,7 +1252,7 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         return v3extensionUtil.createProducts(
             sku, providedProducts, prefix, new HashMap<>(),
-            e.getConsumer(), e.getPool());
+            e.getConsumer(), e.getPool(), new HashSet<>());
     }
 
     @Test

--- a/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
+++ b/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
@@ -162,7 +162,7 @@ public class X509V3ExtensionUtilTest {
         consumer.setOwner(owner);
 
         List<org.candlepin.model.dto.Product> certProds = util.createProducts(mktProd,
-            prods, "", new HashMap<>(), consumer, pool);
+            prods, "", new HashMap<>(), consumer, pool, new HashSet<>());
 
         assertEquals(1, certProds.size());
         assertEquals(brandedName, certProds.get(0).getBrandName());
@@ -270,7 +270,7 @@ public class X509V3ExtensionUtilTest {
         consumer.setOwner(owner);
 
         List<org.candlepin.model.dto.Product> certProds = util.createProducts(mktProd,
-            prods, "", new HashMap<>(), consumer, pool);
+            prods, "", new HashMap<>(), consumer, pool, new HashSet<>());
 
         assertEquals(1, certProds.size());
         // Should get the first name we encountered


### PR DESCRIPTION
While generating entitlement certificates, products from existing entitlements on a consumer are included as entitled products, and not from new entitlements selected as a result of an auto-attach or bulk-pool attach.
This fix is to include products from new entitlements selected via auto-attach or bulk-pool attach operations as well.