### PR TITLE
[M] Use bugzilla API key instead of username/password

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -160,6 +160,7 @@ pipeline {
                 stage('bugzilla-reference') {
                     environment {
                         GITHUB_TOKEN = credentials('github-api-token-as-username-password')
+                        BUGZILLA_TOKEN = credentials('BUGZILLA_API_TOKEN')
                     }
                     steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'


### PR DESCRIPTION
- Recent changes to bugzilla require the use of API keys only
  from client applications