### PR TITLE
[M] Improved error handling during async job execution (ENT-4636)

### DIFF
--- a/src/main/java/org/candlepin/async/JobManager.java
+++ b/src/main/java/org/candlepin/async/JobManager.java
@@ -1280,10 +1280,11 @@ public class JobManager implements ModeChangeListener {
 
                 throw e;
             }
-            catch (Exception e) {
-                boolean retry = status.getAttempts() < status.getMaxAttempts();
-                status = this.processJobFailure(status, eventSink, e, retry);
+            catch (Throwable e) {
+                boolean retry = !(e instanceof Error) &&
+                    status.getAttempts() < status.getMaxAttempts();
 
+                status = this.processJobFailure(status, eventSink, e, retry);
                 throw new JobExecutionException(e);
             }
 


### PR DESCRIPTION
- JobManager.executeJob now properly handles Errors and will
  cleanup and fail jobs when they occur