### PR TITLE
[M] 2045066: Changed default identity certificate duration to 5 years (ENT-4676)

### DIFF
--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -406,7 +406,7 @@ public class ConfigProperties {
 
             this.put(SUSPEND_MODE_ENABLED, "true");
 
-            this.put(IDENTITY_CERT_YEAR_ADDENDUM, "16");
+            this.put(IDENTITY_CERT_YEAR_ADDENDUM, "5");
             this.put(IDENTITY_CERT_EXPIRY_THRESHOLD, "90");
             this.put(SHARD_WEBAPP, "candlepin");
 

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2729,8 +2729,7 @@ public class ConsumerResource implements ConsumersApi {
         }
 
         if (errored) {
-            throw new BadRequestException(i18n.tr(
-                "Problem regenerating ID cert for unit {0}", c));
+            throw new BadRequestException(i18n.tr("Problem regenerating ID cert for unit {0}", c));
         }
 
         log.debug("Generated identity cert: {}", idCert.getSerial());

--- a/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
@@ -83,8 +83,7 @@ public class DefaultIdentityCertServiceAdapter implements
         throws GeneralSecurityException, IOException {
 
         if (log.isDebugEnabled()) {
-            log.debug("Generating identity cert for consumer: " +
-                consumer.getUuid());
+            log.debug("Generating identity cert for consumer: {}", consumer.getUuid());
         }
 
         IdentityCertificate certificate = null;


### PR DESCRIPTION
- Lowered the default identity certificate duration from 16 years
  to 5 years