### PR TITLE
Added support for Fedora 35 to Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,10 +18,37 @@ ANSIBLE_VARS = {
   :cp_deploy => false
 }
 
+def configure_ansible_provisioning(vm_config)
+  vm_config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "ansible/candlepin.yml"
+    ansible.galaxy_role_file = "ansible/requirements.yml"
+    # ansible.verbose = "v"
+    ansible.extra_vars = ANSIBLE_VARS.clone
+
+    # Pass through ansible variables and tags from the environment variables
+    ENV.each do |key, value|
+      # Pass through anything starting with the "cp_" prefix
+      if key.downcase.start_with?(ANSIBLE_VAR_PREFIX)
+        ansible.extra_vars[key.downcase] = value
+      end
+
+      # Pass through ansible tags
+      if key.downcase == ANSIBLE_TAGS_VAR
+        ansible.tags = value
+      end
+
+      # Pass through ansible tags to skip
+      if key.downcase == ANSIBLE_SKIP_TAGS_VAR
+        ansible.skip_tags = value
+      end
+    end
+  end
+end
+
 
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.synced_folder ".", "/vagrant", type: "sshfs", sshfs_opts_append: "-o nonempty"
+  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
   config.vm.host_name = "candlepin.example.com"
   config.ssh.forward_agent = true
 
@@ -49,30 +76,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # vm_config.vm.networking "forwarded_port", protocol: "tcp", guest: 8443, host: 8443
 
     vm_config.vm.provision "shell", inline: "yum update -y yum python ca-certificates"
-    vm_config.vm.provision "ansible" do |ansible|
-      ansible.playbook = "ansible/candlepin.yml"
-      ansible.galaxy_role_file = "ansible/requirements.yml"
-      # ansible.verbose = "v"
-      ansible.extra_vars = ANSIBLE_VARS.clone
-
-      # Pass through ansible variables and tags from the environment variables
-      ENV.each do |key, value|
-        # Pass through anything starting with the "cp_" prefix
-        if key.downcase.start_with?(ANSIBLE_VAR_PREFIX)
-          ansible.extra_vars[key.downcase] = value
-        end
-
-        # Pass through ansible tags
-        if key.downcase == ANSIBLE_TAGS_VAR
-          ansible.tags = value
-        end
-
-        # Pass through ansible tags to skip
-        if key.downcase == ANSIBLE_SKIP_TAGS_VAR
-          ansible.skip_tags = value
-        end
-      end
-    end
+    configure_ansible_provisioning(vm_config)
   end
 
   config.vm.define("el8", primary: true) do |vm_config|
@@ -85,30 +89,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # vm_config.vm.networking "forwarded_port", protocol: "tcp", guest: 8443, host: 8443
 
     vm_config.vm.provision "shell", inline: "dnf update -y dnf ca-certificates"
-    vm_config.vm.provision "ansible" do |ansible|
-      ansible.playbook = "ansible/candlepin.yml"
-      ansible.galaxy_role_file = "ansible/requirements.yml"
-      # ansible.verbose = "v"
-      ansible.extra_vars = ANSIBLE_VARS.clone
+    configure_ansible_provisioning(vm_config)
+  end
 
-      # Pass through ansible variables and tags from the environment variables
-      ENV.each do |key, value|
-        # Pass through anything starting with the "cp_" prefix
-        if key.downcase.start_with?(ANSIBLE_VAR_PREFIX)
-          ansible.extra_vars[key.downcase] = value
-        end
+  config.vm.define("f35", autostart: false) do |vm_config|
+    vm_config.vm.box = "fedora/35-cloud-base"
+    vm_config.vm.host_name = "candlepin-f35.example.com"
 
-        # Pass through ansible tags
-        if key.downcase == ANSIBLE_TAGS_VAR
-          ansible.tags = value
-        end
+    # Uncomment these lines for forward the Candlepin standard dev ports to this guest
+    # vm_config.vm.networking "forwarded_port", protocol: "tcp", guest: 8080, host: 8080
+    # vm_config.vm.networking "forwarded_port", protocol: "tcp", guest: 8443, host: 8443
 
-        # Pass through ansible tags to skip
-        if key.downcase == ANSIBLE_SKIP_TAGS_VAR
-          ansible.skip_tags = value
-        end
-      end
-    end
+    vm_config.vm.provision "shell", inline: "dnf update -y dnf python ca-certificates"
+    configure_ansible_provisioning(vm_config)
   end
 
 end

--- a/ansible/candlepin.yml
+++ b/ansible/candlepin.yml
@@ -33,9 +33,10 @@
         - name: "Include custom role if present"
           include_role:
             name: "{{cp_custom_role}}"
+            apply:
+              tags:
+                - custom
           when:
             - "cp_custom_role is defined"
       tags:
-        - user_env
         - custom
-        - system


### PR DESCRIPTION
- Added Fedora 35 support in the Candlepin Vagrantfile
- Abstracted out Ansible provisioning logic in the Vagrantfile
- Improved tagging on the custom user role