### PR TITLE
ENT-3756: Implementation of SCA-by-default for newly created Owners

### DIFF
--- a/spec/content_access_spec.rb
+++ b/spec/content_access_spec.rb
@@ -126,7 +126,7 @@ describe 'Content Access' do
     owner = @cp.create_owner random_string("test_owner")
 
     expect(owner['contentAccessModeList']).to eq("entitlement,org_environment")
-    expect(owner['contentAccessMode']).to eq("entitlement")
+    expect(owner['contentAccessMode']).to eq("org_environment")
   end
 
   it "will assign the default mode and list when empty strings are specified" do
@@ -134,9 +134,8 @@ describe 'Content Access' do
       'contentAccessModeList' => '',
       'contentAccessMode' => ''
     })
-
     expect(owner['contentAccessModeList']).to eq("entitlement,org_environment")
-    expect(owner['contentAccessMode']).to eq("entitlement")
+    expect(owner['contentAccessMode']).to eq("org_environment")
   end
 
   it "leave mode and list unchanged when nil is specified" do

--- a/spec/refresh_pools_spec.rb
+++ b/spec/refresh_pools_spec.rb
@@ -43,6 +43,20 @@ describe 'Refresh Pools' do
     end
   end
 
+  it 'contains the proper return value when owner is auto generated' do
+    result = @cp.refresh_pools("auto-generated-owner", false, true)
+
+    if !is_hosted?
+      expect(result).to be_nil
+    else
+      expect(result).to eq("Pools refreshed for owner: auto-generated-owner")
+
+      owner = @cp.get_owner("auto-generated-owner")
+      expect(owner['displayName']).to eq("auto-generated-owner")
+      expect(owner['contentAccessMode']).to eq("org_environment")
+    end
+  end
+
   it 'creates the correct number of pools' do
     owner = create_owner random_string('some-owner')
 
@@ -1688,5 +1702,4 @@ describe 'Refresh Pools' do
     expect(product_uuids.size).to eq(owners.size)
     expect(product_uuids).to all(eq(product_uuids.first))
   end
-
 end

--- a/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -122,7 +122,7 @@ public class ContentAccessManager {
          *  the default ContentAccessMode instance
          */
         public static ContentAccessMode getDefault() {
-            return ENTITLEMENT;
+            return ORG_ENVIRONMENT;
         }
 
         /**

--- a/src/test/java/org/candlepin/async/tasks/ActiveEntitlementJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/ActiveEntitlementJobTest.java
@@ -54,6 +54,7 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
     public void setUp() {
         owner = new Owner("test-owner", "Test Owner");
         owner = ownerCurator.create(owner);
+        owner.setContentAccessMode("entitlement");
 
         prod = this.createProduct("1", "2", owner);
 

--- a/src/test/java/org/candlepin/async/tasks/HealEntireOrgJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/HealEntireOrgJobTest.java
@@ -80,6 +80,7 @@ public class HealEntireOrgJobTest {
     @Test
     public void testHealEntireOrgJob() throws JobExecutionException {
         Owner owner = this.createTestOwner(HealEntireOrgJob.OWNER_KEY, "log_level");
+        owner.setContentAccessMode("entitlement");
         doReturn(owner).when(ownerCurator).getByKey(owner.getKey());
 
         Consumer consumer1 = TestUtil.createConsumer(owner);
@@ -131,7 +132,7 @@ public class HealEntireOrgJobTest {
     @Test
     public void testGetConsumerException() throws JobExecutionException {
         Owner owner = this.createTestOwner(HealEntireOrgJob.OWNER_KEY, "log_level");
-        // owner.setContentAccessMode("org_environment");
+        owner.setContentAccessMode("entitlement");
         // owner.setAutobindDisabled(false);
         doReturn(owner).when(ownerCurator).getByKey(owner.getKey());
 

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -331,9 +331,9 @@ public class ContentAccessManagerTest {
     }
 
     @Test
-    public void testContentAccessModeDefaultIsEntitlement() {
+    public void testContentAccessModeDefaultIsOrgEntitlement() {
         ContentAccessMode output = ContentAccessMode.getDefault();
-        assertSame(ContentAccessMode.ENTITLEMENT, output);
+        assertSame(ContentAccessMode.ORG_ENVIRONMENT, output);
     }
 
     @Test
@@ -515,7 +515,7 @@ public class ContentAccessManagerTest {
             .setContentAccessModeList(initialAccessModeList)
             .setContentAccessMode(initialAccessMode);
 
-        String updatedAccessModeList = orgEnvironmentMode;
+        String updatedAccessModeList = entitlementMode;
         String updatedAccessMode = "";
 
         // We should convert the requested access mode to the default value, which is still invalid

--- a/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -200,6 +200,7 @@ public class EntitlerTest {
     @Test
     public void bindByProductsString() throws Exception {
         Owner owner = new Owner("o1");
+        owner.setContentAccessMode("entitlement");
         owner.setId(TestUtil.randomString());
         String[] pids = {"prod1", "prod2", "prod3"};
         when(cc.findByUuid(eq("abcd1234"))).thenReturn(consumer);
@@ -394,6 +395,7 @@ public class EntitlerTest {
     @Test
     public void testRevokesLapsedUnmappedGuestEntitlementsOnAutoHeal() throws Exception {
         Owner owner1 = new Owner("o1");
+        owner1.setContentAccessMode("entitlement");
         owner1.setId(TestUtil.randomString());
         when(ownerCurator.findOwnerById(eq(owner1.getId()))).thenReturn(owner1);
         Product product = TestUtil.createProduct();

--- a/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -357,7 +357,7 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void fetchesOwnerContentAccess() {
-        String expectedContentAccessMode = "entitlement";
+        String expectedContentAccessMode = "org_environment";
         String expectedContentAccessModeList = "entitlement,org_environment";
         Owner owner = this.createOwner("test_key");
         this.ownerCurator.flush();

--- a/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -784,6 +784,7 @@ public class ConsumerResourceTest {
     @Test
     public void testNoDryBindWhenAutobindDisabledForOwner() {
         Owner owner = createOwner();
+        owner.setContentAccessMode("entitlement");
         owner.setId(TestUtil.randomString());
         Consumer consumer = createConsumer(owner);
         owner.setAutobindDisabled(true);

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -2109,8 +2109,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testCreateOwnerSetContentAccessListAndMode() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "false");
-
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
@@ -2130,8 +2128,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testCreateOwnerSetContentAccessList() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "false");
-
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
@@ -2143,17 +2139,13 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerDTO output = this.ownerResource.createOwner(changes);
 
         assertNotNull(output);
-
         assertEquals(entitlementMode + "," + orgEnvMode, output.getContentAccessModeList());
-        assertEquals(entitlementMode, output.getContentAccessMode());
+        assertEquals(orgEnvMode, output.getContentAccessMode());
     }
 
     @Test
     public void testCreateOwnerSetContentAccessModeCannotUseInvalidModeInList() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "false");
-
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
-        String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
         OwnerDTO changes = new OwnerDTO()
             .key("test_owner")
@@ -2165,8 +2157,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testCreateOwnerSetContentAccessModeCannotUseInvalidMode() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "false");
-
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
@@ -2181,15 +2171,13 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testCreateOwnerSetContentAccessModeCannotUseImpliedDefault() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "false");
-
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
         OwnerDTO changes = new OwnerDTO()
             .key("test_owner")
             .displayName("test_owner")
-            .contentAccessModeList(orgEnvMode);
+            .contentAccessModeList(entitlementMode);
 
         // This should fail since creation requires that we specify the values, even if those
         // values are defaults. As such, the default value of entitlement should not be allowed
@@ -2199,25 +2187,21 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testCreateOwnerCanUseNonDefaultContentAccessModeInStandalone() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "true");
-
+    public void testCreateOwnerCanUseNonDefaultContentAccessMode() {
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
-        String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
         OwnerDTO changes = new OwnerDTO()
             .key("test_owner")
             .displayName("test_owner")
-            .contentAccessModeList(orgEnvMode)
-            .contentAccessMode(orgEnvMode);
+            .contentAccessModeList(entitlementMode)
+            .contentAccessMode(entitlementMode);
 
-        ownerResource.createOwner(changes);
+        OwnerDTO output = ownerResource.createOwner(changes);
+        assertNotNull(output);
     }
 
     @Test
-    public void testCreateOwnerCanSetNonDefaultContentAccessModeListInStandalone() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "true");
-
+    public void testCreateOwnerCanSetNonDefaultContentAccessModeList() {
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
@@ -2231,13 +2215,11 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertNotNull(output);
 
         assertEquals(entitlementMode + "," + orgEnvMode, output.getContentAccessModeList());
-        assertEquals(entitlementMode, output.getContentAccessMode());
+        assertEquals(orgEnvMode, output.getContentAccessMode());
     }
 
     @Test
     public void testSetContentAccessModeList() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "false");
-
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
@@ -2258,8 +2240,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testSetContentAccessMode() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "false");
-
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
@@ -2280,8 +2260,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testSetContentAccessModeListAndMode() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "false");
-
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
@@ -2303,8 +2281,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testSetContentAccessModeCannotUseInvalidModeInList() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "false");
-
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
@@ -2320,8 +2296,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testSetContentAccessModeCannotUseInvalidMode() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "false");
-
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
@@ -2336,9 +2310,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testUpdateCannotChangeContentAccessModeInStandalone() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "true");
-
+    public void testUpdateCannotChangeContentAccessModeIfNotPresentInContentAccessList() {
         String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
         String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
 
@@ -2350,23 +2322,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
             .contentAccessMode(orgEnvMode);
 
         assertThrows(BadRequestException.class, () -> ownerResource.updateOwner(owner.getKey(), changes));
-    }
-
-    @Test
-    public void testUpdateCanChangeContentAccessModeListInStandalone() {
-        this.config.setProperty(ConfigProperties.STANDALONE, "true");
-
-        String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
-        String orgEnvMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
-
-        Owner owner = this.ownerCurator.create(new Owner("test_owner", "test_owner")
-            .setContentAccessModeList(entitlementMode)
-            .setContentAccessMode(entitlementMode));
-
-        OwnerDTO changes = new OwnerDTO()
-            .contentAccessModeList(orgEnvMode);
-
-        ownerResource.updateOwner(owner.getKey(), changes);
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -80,6 +80,7 @@ public class ConsumerBindUtilTest {
         this.systemConsumerType.setId("test-ctype-" + TestUtil.randomInt());
         this.owner = TestUtil.createOwner();
         this.owner.setId(TestUtil.randomString());
+        this.owner.setContentAccessMode("entitlement");
     }
 
     private ConsumerBindUtil buildConsumerBindUtil() {

--- a/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
+++ b/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
@@ -130,6 +130,7 @@ public class InstalledProductStatusCalculatorTest {
     @Test
     public void validRangeForSingleValidEnitlement() {
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
 
@@ -152,6 +153,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -177,6 +179,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -201,6 +204,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -286,6 +290,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -310,6 +315,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -334,6 +340,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -357,6 +364,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -380,6 +388,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -403,6 +412,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -469,6 +479,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -491,6 +502,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -517,6 +529,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -542,6 +555,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -569,6 +583,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -598,6 +613,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Product product2 = TestUtil.createProduct("p2", "product2");
         Consumer consumer = this.mockConsumer(owner, product);
@@ -624,6 +640,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -656,6 +673,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -681,6 +699,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Consumer consumer = this.mockConsumer(owner, product);
         consumer.setCreated(now);
@@ -709,6 +728,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Product stacked = TestUtil.createProduct("p1_stack", "product1-stacked");
         Consumer consumer = this.mockConsumer(owner, product);
@@ -737,6 +757,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         Product sockets = TestUtil.createProduct("socketed", "socketed_product");
         sockets.setAttribute(Product.Attributes.SOCKETS, "2");
@@ -763,6 +784,7 @@ public class InstalledProductStatusCalculatorTest {
         Date now = new Date();
 
         Owner owner = TestUtil.createOwner();
+        owner.setContentAccessMode("entitlement");
         Product product = TestUtil.createProduct("p1", "product1");
         product.setAttribute(Product.Attributes.GUEST_LIMIT, "2");
 


### PR DESCRIPTION
Changed the default content access mode to ORG_ENVIRONMENT for newly created orgs.