### PR TITLE
[M] Separate docker-compose responsibilities

### DIFF
--- a/docker/README.mkd
+++ b/docker/README.mkd
@@ -31,7 +31,10 @@ and bring up a database at hostname `db` on the running container
 
 By default the `test` script will run candlepin against a postgres database.  You can change this behavior with the
 `-m` or `-p` flags which will use mysql or postgres respectively. To change the default permanently,
-run the `switch-defaults` script.
+run the `switch-defaults` script. Additionally, you can use the `-x` flag which will use no database at all (useful
+for running tasks that do not require a running server and database, such as unit tests, checkstyle, translation
+validation). Finally, the `-q` flag does what the `-x` flag does already, plus requires a sonarqube server certificate
+(used for running the sonarqube analysis upload task).
 
 To run multiple candlepin containers simultaneously, give each invocation of `test` a unique name with the `-n` flag.
 
@@ -44,7 +47,7 @@ Some useful invocations of the `test` command:
 
 ```sh
 # run only unit tests
-./test -c '/usr/bin/cp-test -u'
+./test -x -c '/usr/bin/cp-test -u'
 
 # screw tests, give me a shell and a mysql db
 ./test -m -c '/bin/bash'

--- a/docker/docker-compose-no-db.yml
+++ b/docker/docker-compose-no-db.yml
@@ -1,0 +1,11 @@
+version: '3.3'
+services:
+  candlepin:
+    image: ${REGISTRY}/candlepin-base
+    ports:
+      - "8443:8443"
+      - "8080:8080"
+      - "22:22"
+    privileged: true
+    volumes:
+      - ../:/candlepin-dev

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -25,13 +25,6 @@ services:
       - ../:/candlepin-dev
     depends_on:
       - db
-    secrets:
-      - sonar_crt
-
-secrets:
-  sonar_crt:
-    file: /home/jenkins/sonar.crt
-
 
 networks:
   default:

--- a/docker/docker-compose-sonarqube.yml
+++ b/docker/docker-compose-sonarqube.yml
@@ -1,0 +1,17 @@
+version: '3.3'
+services:
+  candlepin:
+    image: ${REGISTRY}/candlepin-base
+    ports:
+      - "8443:8443"
+      - "8080:8080"
+      - "22:22"
+    privileged: true
+    volumes:
+      - ../:/candlepin-dev
+    secrets:
+      - sonar_crt
+
+secrets:
+  sonar_crt:
+    file: /home/jenkins/sonar.crt

--- a/docker/test
+++ b/docker/test
@@ -14,6 +14,11 @@ OPTIONS:
   -m        use mysql
   -n NAME   Sets the project name for the docker-compose run
   -p        use postgres
+  -x        use no database. only spin up the candlepin container
+              (useful for running things like unit tests, checkstyle,
+              that don't need a running server with db)
+  -q        use no database, but require the sonarqube certificate
+              (for running a sonarqube upload)
   -l        skip docker pull and use local images
   -d        run containers detached and do not
               automatically shut down & remove the
@@ -23,7 +28,7 @@ OPTIONS:
 USAGE
 }
 
-while getopts ":c:mn:plde" opt; do
+while getopts ":c:mn:pxqlde" opt; do
   case $opt in
     c) TEST_CMD="$OPTARG";;
     m) COMPOSE_ARGS="-f $DIR/docker-compose-mysql.yml";
@@ -31,6 +36,8 @@ while getopts ":c:mn:plde" opt; do
        sudo chown 999:999 $DIR/mysql.cnf;;
     n) PROJ_NAME="-p $OPTARG";;
     p) COMPOSE_ARGS="-f $DIR/docker-compose-postgres.yml";;
+    x) COMPOSE_ARGS="-f $DIR/docker-compose-no-db.yml";;
+    q) COMPOSE_ARGS="-f $DIR/docker-compose-sonarqube.yml";;
     l) USE_CACHE="1";;
     d) DETACHED="1";;
     e) EXPOSE_PORTS="1";;

--- a/jenkins/candlepin-validate-text.sh
+++ b/jenkins/candlepin-validate-text.sh
@@ -11,7 +11,7 @@ mkdir -p $WORKSPACE/artifacts/
 chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
 
 # Run the validation on translations
-./docker/test -p -c "cp-test -i -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
+./docker/test -x -c "cp-test -i -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
 RETVAL=$?
 sudo chown -R jenkins:jenkins $WORKSPACE/artifacts
 exit $RETVAL

--- a/jenkins/lint.sh
+++ b/jenkins/lint.sh
@@ -11,7 +11,7 @@ mkdir -p $WORKSPACE/artifacts/
 chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
 
 # Run the linter
-./docker/test -p -c "cp-test -l -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
+./docker/test -x -c "cp-test -l -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
 RETVAL=$?
 sudo chown -R jenkins:jenkins $WORKSPACE/artifacts
 exit $RETVAL

--- a/jenkins/unit-tests.sh
+++ b/jenkins/unit-tests.sh
@@ -11,7 +11,7 @@ mkdir -p $WORKSPACE/artifacts/
 chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
 
 # Run the Candlepin unit tests
-./docker/test -p -c "cp-test -u -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
+./docker/test -x -c "cp-test -u -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
 RETVAL=$?
 sudo chown -R jenkins:jenkins $WORKSPACE/artifacts
 exit $RETVAL

--- a/jenkins/upload-on-sonarqube.sh
+++ b/jenkins/upload-on-sonarqube.sh
@@ -12,10 +12,10 @@ chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
 
 if [ -z "$BRANCH_UPLOAD" ];  then
   # Uploading PR to SonarQube server
-  ./docker/test -c "cp-test -c ${CHANGE_BRANCH} -n ${SONAR_HOST_URL} ${BRANCH_NAME} ${CHANGE_ID} ${CHANGE_TARGET}" -n "${STAGE_NAME}-${BUILD_TAG}"
+  ./docker/test -q -c "cp-test -c ${CHANGE_BRANCH} -n ${SONAR_HOST_URL} ${BRANCH_NAME} ${CHANGE_ID} ${CHANGE_TARGET}" -n "${STAGE_NAME}-${BUILD_TAG}"
 else
   # Uploading branch to SonarQube server
-  ./docker/test -c "cp-test -c ${CHANGE_BRANCH} -n ${SONAR_HOST_URL} ${BRANCH_NAME}" -n "${STAGE_NAME}-${BUILD_TAG}"
+  ./docker/test -q -c "cp-test -c ${CHANGE_BRANCH} -n ${SONAR_HOST_URL} ${BRANCH_NAME}" -n "${STAGE_NAME}-${BUILD_TAG}"
 fi
 
 RETVAL=$?


### PR DESCRIPTION
- Add docker-compose option for only running the candlepin container
  when there is no need for a db (e.g. when running unit tests,
  checkstyle, translation validations), to avoid waisting resources.
- Move the requirement for a sonarqube certificate as docker secret
  to it's own docker-compose file, so that the default/postgres
  one can be run locally without it.