### PR TITLE
ENT-4804: Upgrade liquibase to 4.8.0

### DIFF
--- a/bin/deployment/deploy
+++ b/bin/deployment/deploy
@@ -44,13 +44,15 @@ gendb() {
     prepare_classpath
 
     info_msg "$MESSAGE"
-    LQCOMMAND="${PROJECT_DIR}/bin/deployment/liquibase.sh --driver=${JDBC_DRIVER} --classpath=$PROJECT_DIR/src/main/resources/:build/classes/java/main/:${JDBC_JAR} --changeLogFile=db/changelog/$CHANGELOG --url=${JDBC_URL} --username=candlepin"
+    LQCOMMAND="${PROJECT_DIR}/bin/deployment/liquibase.sh --driver=${JDBC_DRIVER} \
+      --classpath=build/classes/java/main/:${JDBC_JAR} --changelog-file=db/changelog/$CHANGELOG \
+      --url=${JDBC_URL} --username=candlepin --headless=true --hub-mode=OFF"
     if [ -n "$DBPASSWORD" ] ; then
         LQCOMMAND="$LQCOMMAND --password=$DBPASSWORD "
     fi
 
     if [ "$VERBOSE" == "1" ]; then
-        LQCOMMAND="$LQCOMMAND --logLevel=debug "
+        LQCOMMAND="$LQCOMMAND --log-level=debug "
     fi
 
     LQCOMMAND="$LQCOMMAND update -Dcommunity=True"

--- a/bin/deployment/liquibase.sh
+++ b/bin/deployment/liquibase.sh
@@ -15,7 +15,7 @@ if [ -f $HOME/.liquibaserc ] ; then
 fi
 
 # Configuration
-MAIN_CLASS=liquibase.integration.commandline.Main
+MAIN_CLASS=liquibase.integration.commandline.LiquibaseCommandLine
 BASE_FLAGS=""
 BASE_OPTIONS=""
 

--- a/bin/scripts/code/setup/cpdb
+++ b/bin/scripts/code/setup/cpdb
@@ -83,8 +83,8 @@ class DbSetup(object):
         # Figure out what to append to the classpath for liquibase:
         classpath = ":".join(glob.glob(JAR_PATH + "*postgresql*.jar"))
 
-        if os.path.exists('target/classes'):
-            classpath = "%s:%s" % (classpath, 'target/classes/')
+        if os.path.exists('build/classes'):
+            classpath = "%s:%s" % (classpath, 'build/classes')
 
         if os.path.exists(TOMCAT_CLASSPATH):
             classpath = "%s:%s" % (classpath, TOMCAT_CLASSPATH)
@@ -92,7 +92,8 @@ class DbSetup(object):
         if os.path.exists(JBOSS_CLASSPATH):
             classpath = "%s:%s" % (classpath, JBOSS_CLASSPATH)
 
-        liquibase_options = "--driver=%s --classpath=%s --changeLogFile=%s --url=\"%s\" --username=$DBUSERNAME" % (
+        liquibase_options = "--driver=%s --classpath=%s --changelog-file=%s --url=\"%s\" --username=$DBUSERNAME \
+            --headless=true --hub-mode=OFF" % (
             self.driver_class,
             classpath,
             changelog_path,
@@ -107,11 +108,11 @@ class DbSetup(object):
             liquibase_options += " --password=$DBPASSWORD"
 
         # Add in output level. By default, Liquibase defaults to "off"
-        liquibase_options += " --logLevel=%s" % ('debug' if self.verbose else 'severe')
+        liquibase_options += " --log-level=%s" % ('debug' if self.verbose else 'severe')
 
         print(liquibase_options)
 
-        output = run_command("/usr/share/candlepin/liquibase.sh %s migrate -Dcommunity=%s" % (liquibase_options, self.community))
+        output = run_command("/usr/share/candlepin/liquibase.sh %s update -Dcommunity=%s" % (liquibase_options, self.community))
         print(output)
 
 
@@ -185,7 +186,7 @@ if __name__ == "__main__":
 
     parser.add_option("--schema-only",
             dest="schema_only", action="store_true", default=False,
-            help="assumes database is already created by another tool and"
+            help="assumes database is already created by another tool and "
                  "applies schema to database; used with --create")
 
     parser.add_option("--validate",

--- a/build.gradle
+++ b/build.gradle
@@ -134,8 +134,9 @@ dependencies {
     implementation "javax.transaction:jta:1.1"
     implementation "javax.annotation:javax.annotation-api:1.3.2"
 
-    // Liqubase
-    implementation "org.liquibase:liquibase-core:3.1.0"
+    // Liquibase
+    implementation "org.liquibase:liquibase-core:4.8.0"
+    implementation 'info.picocli:picocli:4.6.3'
 
     // Logging
     implementation "ch.qos.logback:logback-classic:1.2.9"
@@ -214,7 +215,7 @@ dependencies {
 
     testImplementation "org.hamcrest:hamcrest-library:2.2"
     testImplementation "org.mockito:mockito-junit-jupiter:4.3.1"
-    testImplementation "com.mattbertolini:liquibase-slf4j:1.2.1"
+    testImplementation "com.mattbertolini:liquibase-slf4j:4.0.0"
 }
 
 // Copy the resources to the main classes directory so that the

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,13 @@
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
-      <version>3.1.0</version>
+      <version>4.8.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>4.6.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -359,7 +365,7 @@
     <dependency>
       <groupId>com.mattbertolini</groupId>
       <artifactId>liquibase-slf4j</artifactId>
-      <version>1.2.1</version>
+      <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskWrapper.java
+++ b/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskWrapper.java
@@ -66,7 +66,9 @@ public abstract class LiquibaseCustomTaskWrapper<T extends LiquibaseCustomTask> 
 
     @Override
     public String getConfirmationMessage() {
-        return null;
+        // We MUST return an empty string here instead of null, to avoid this issue:
+        // https://github.com/liquibase/liquibase/issues/1858
+        return "";
     }
 
     @Override


### PR DESCRIPTION
- Use the LiquibaseCommandLine class instead of the deprecated Main.
- Use dash-case cli arguments instead of deprecated camelCase.
- Apply workaround for a new liquibase bug.