### PR TITLE
[M] Update MySQL connector to use org.mariadb connector (ENT-4387)

### DIFF
--- a/bin/deployment/bash_functions
+++ b/bin/deployment/bash_functions
@@ -177,14 +177,8 @@ init_mysql_jdbc() {
     select_jdbc_jar "/usr/lib/java/mariadb-java-client.jar" "/usr/share/java/mysql-connector-java.jar"
     evalrc $? "No JDBC jar file available for MariaDB/MySQL"
 
-    JDBC_DRIVER="com.mysql.cj.jdbc.Driver"
-    JDBC_URL="jdbc:mysql://$db_host/$db_name"
-
-    # FIXME:
-    # Use the mariadb driver and URL when the mariadb-java-client RPM is available in EL7 and the
-    # Liquibase errors are fully resolved with the newer drivers
-    # JDBC_DRIVER="org.mariadb.jdbc.Driver"
-    # JDBC_URL="jdbc:mariadb://$db_host/$db_name"
+    JDBC_DRIVER="org.mariadb.jdbc.Driver"
+    JDBC_URL="jdbc:mariadb://$db_host/$db_name"
     local isolation_level=$(mysql -h $db_host $db_name  --user=$db_user --password="$password" -s -N -e 'select @@global.tx_isolation')
     echo "isolation_level : $isolation_level"
     if [[ $isolation_level != "READ-COMMITTED" ]]; then

--- a/build.gradle
+++ b/build.gradle
@@ -68,10 +68,10 @@ ext {
 
     // If MYSQL set up the mysql stuff else set up postgres (default)
     if (project.findProperty("database_server") == "mysql") {
-        jdbc_driver_class = "com.mysql.jdbc.Driver"
+        jdbc_driver_class = "org.mariadb.jdbc.Driver"
         jdbc_dialect = "org.hibernate.dialect.MySQL5InnoDBDialect"
         jdbc_quartz_driver_class = "org.quartz.impl.jdbcjobstore.StdJDBCDelegate"
-        jdbc_url = "jdbc:mysql://${db_host}/${db_name}"
+        jdbc_url = "jdbc:mariadb://${db_host}/${db_name}"
     } else {
         jdbc_driver_class = "org.postgresql.Driver"
         jdbc_dialect = "org.hibernate.dialect.PostgreSQL92Dialect"


### PR DESCRIPTION
- Update deploy script config generation and build.gradle to use
  MariaDB Java connector rather than the MySQL java connector