### PR TITLE
[4.0] Fixed a potential collision with product entity versioning (ENT-4805)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/server/src/main/java/org/candlepin/controller/ContentManager.java
@@ -158,14 +158,17 @@ public class ContentManager {
             log.debug("Checking {} alternate content versions", alternateVersions.size());
 
             for (Content alt : alternateVersions) {
-                if (alt.equals(entity)) {
-                    log.debug("Converging content with existing version: {} => {}", entity, alt);
-
-                    // If we're "creating" a content, we shouldn't have any other object references to
-                    // update for this content. Instead, we'll just add the new owner to the content.
-                    this.ownerContentCurator.mapContentToOwner(alt, owner);
-                    return alt;
+                if (!alt.equals(entity)) {
+                    String errmsg = String.format("Entity version collision detected: %s != %s", alt, entity);
+                    throw new IllegalStateException(errmsg);
                 }
+
+                log.debug("Converging content with existing version: {} => {}", entity, alt);
+
+                // If we're "creating" a content, we shouldn't have any other object references to
+                // update for this content. Instead, we'll just add the new owner to the content.
+                this.ownerContentCurator.mapContentToOwner(alt, owner);
+                return alt;
             }
         }
 
@@ -256,14 +259,19 @@ public class ContentManager {
             log.debug("Checking {} alternate content versions", alternateVersions.size());
 
             for (Content alt : alternateVersions) {
-                if (alt.equals(updated)) {
-                    log.debug("Converging content with existing version: {} => {}", updated, alt);
+                if (!alt.equals(updated)) {
+                    String errmsg = String.format("Entity version collision detected: %s != %s",
+                        alt, updated);
 
-                    this.ownerContentCurator.updateOwnerContentReferences(owner,
-                        Collections.singletonMap(entity.getUuid(), alt.getUuid()));
-
-                    updated = alt;
+                    throw new IllegalStateException(errmsg);
                 }
+
+                log.debug("Converging content with existing version: {} => {}", updated, alt);
+
+                this.ownerContentCurator.updateOwnerContentReferences(owner,
+                    Collections.singletonMap(entity.getUuid(), alt.getUuid()));
+
+                updated = alt;
             }
         }
 

--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -258,14 +258,17 @@ public class ProductManager {
             log.debug("Checking {} alternate product versions", alternateVersions.size());
 
             for (Product alt : alternateVersions) {
-                if (alt.equals(entity)) {
-                    log.debug("Converging with existing product version: {} => {}", entity, alt);
-
-                    // If we're "creating" a product, we shouldn't have any other object references to
-                    // update for this product. Instead, we'll just add the new owner to the product.
-                    this.ownerProductCurator.mapProductToOwner(alt, owner);
-                    return alt;
+                if (!alt.equals(entity)) {
+                    String errmsg = String.format("Entity version collision detected: %s != %s", alt, entity);
+                    throw new IllegalStateException(errmsg);
                 }
+
+                log.debug("Converging with existing product version: {} => {}", entity, alt);
+
+                // If we're "creating" a product, we shouldn't have any other object references to
+                // update for this product. Instead, we'll just add the new owner to the product.
+                this.ownerProductCurator.mapProductToOwner(alt, owner);
+                return alt;
             }
         }
 
@@ -358,14 +361,19 @@ public class ProductManager {
             log.debug("Checking {} alternate product versions", alternateVersions.size());
 
             for (Product alt : alternateVersions) {
-                if (alt.equals(updated)) {
-                    log.debug("Converging with existing product version: {} => {}", updated, alt);
+                if (!alt.equals(updated)) {
+                    String errmsg = String.format("Entity version collision detected: %s != %s",
+                        alt, updated);
 
-                    this.ownerProductCurator.updateOwnerProductReferences(owner,
-                        Collections.singletonMap(entity.getUuid(), alt.getUuid()));
-
-                    updated = alt;
+                    throw new IllegalStateException(errmsg);
                 }
+
+                log.debug("Converging with existing product version: {} => {}", updated, alt);
+
+                this.ownerProductCurator.updateOwnerProductReferences(owner,
+                    Collections.singletonMap(entity.getUuid(), alt.getUuid()));
+
+                updated = alt;
             }
         }
 
@@ -479,14 +487,19 @@ public class ProductManager {
             log.debug("Checking {} alternate product versions", alternateVersions.size());
 
             for (Product alt : alternateVersions) {
-                if (alt.equals(updated)) {
-                    log.debug("Converging with existing product: {} => {}", updated, alt);
+                if (!alt.equals(updated)) {
+                    String errmsg = String.format("Entity version collision detected: %s != %s",
+                        alt, updated);
 
-                    this.ownerProductCurator.updateOwnerProductReferences(owner,
-                        Collections.singletonMap(entity.getUuid(), alt.getUuid()));
-
-                    updated = alt;
+                    throw new IllegalStateException(errmsg);
                 }
+
+                log.debug("Converging with existing product: {} => {}", updated, alt);
+
+                this.ownerProductCurator.updateOwnerProductReferences(owner,
+                    Collections.singletonMap(entity.getUuid(), alt.getUuid()));
+
+                updated = alt;
             }
         }
 

--- a/server/src/main/java/org/candlepin/model/Branding.java
+++ b/server/src/main/java/org/candlepin/model/Branding.java
@@ -93,8 +93,9 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
         return id;
     }
 
-    public void setId(String id) {
+    public Branding setId(String id) {
         this.id = id;
+        return this;
     }
 
     /**
@@ -109,8 +110,9 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
         return productId;
     }
 
-    public void setProductId(String productId) {
+    public Branding setProductId(String productId) {
         this.productId = productId;
+        return this;
     }
 
     /**
@@ -121,8 +123,9 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
         return name;
     }
 
-    public void setName(String name) {
+    public Branding setName(String name) {
         this.name = name;
+        return this;
     }
 
     /**
@@ -135,8 +138,9 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
         return type;
     }
 
-    public void setType(String type) {
+    public Branding setType(String type) {
         this.type = type;
+        return this;
     }
 
     /**
@@ -150,9 +154,13 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
 
     /**
      * Sets the parent marketing product that this branding belongs to.
+     *
+     * @return
+     *  a reference to this Branding instance
      */
-    public void setProduct(Product product) {
+    public Branding setProduct(Product product) {
         this.product = product;
+        return this;
     }
 
     @Override

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -1300,6 +1300,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
                 .append(this.attributes);
 
             if (this.derivedProduct != null) {
+                builder.append("derived_product");
                 builder.append(this.derivedProduct.getEntityVersion());
             }
 
@@ -1308,42 +1309,46 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             // again, doesn't implement .hashCode reliably on the proxy collections. So, we have to
             // manually step through these and add the elements to ensure the hash code is
             // generated properly.
-            int accumulator;
+            // Additionally, the algorithm used by HashCodeBuilder is order dependent, so we must be
+            // sure to add our children entities into it in a consistent manner.
 
             if (!this.providedProducts.isEmpty()) {
-                accumulator = 0;
-                for (Product product : this.providedProducts) {
-                    accumulator += (product != null ? product.getEntityVersion() : 0);
-                }
+                builder.append("provided_products");
 
-                builder.append(accumulator);
+                this.providedProducts.stream()
+                    .filter(Objects::nonNull)
+                    .map(Product::getEntityVersion)
+                    .sorted()
+                    .forEach(builder::append);
             }
 
             if (!this.dependentProductIds.isEmpty()) {
-                accumulator = 0;
-                for (String pid : this.dependentProductIds) {
-                    accumulator += (pid != null ? pid.hashCode() : 0);
-                }
+                builder.append("dependent_product_ids");
 
-                builder.append(accumulator);
+                this.dependentProductIds.stream()
+                    .filter(Objects::nonNull)
+                    .sorted()
+                    .forEach(builder::append);
             }
 
             if (!this.productContent.isEmpty()) {
-                accumulator = 0;
-                for (ProductContent pc : this.productContent) {
-                    accumulator += (pc != null ? pc.getEntityVersion() : 0);
-                }
+                builder.append("product_content");
 
-                builder.append(accumulator);
+                this.productContent.stream()
+                    .filter(Objects::nonNull)
+                    .map(ProductContent::getEntityVersion)
+                    .sorted()
+                    .forEach(builder::append);
             }
 
             if (!this.branding.isEmpty()) {
-                accumulator = 0;
-                for (Branding branding : this.branding) {
-                    accumulator += (branding != null ? branding.hashCode() : 0);
-                }
+                builder.append("branding");
 
-                builder.append(accumulator);
+                this.branding.stream()
+                    .filter(Objects::nonNull)
+                    .map(Branding::hashCode)
+                    .sorted()
+                    .forEach(builder::append);
             }
 
             this.entityVersion = builder.toHashCode();

--- a/server/src/main/java/org/candlepin/model/ProductContent.java
+++ b/server/src/main/java/org/candlepin/model/ProductContent.java
@@ -88,9 +88,13 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
 
     /**
      * @param content the content to set
+     *
+     * @return
+     *  a reference to this ProductContent instance
      */
-    public void setContent(Content content) {
+    public ProductContent setContent(Content content) {
         this.content = content;
+        return this;
     }
 
     /**
@@ -103,9 +107,13 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
 
     /**
      * @param product the product to set
+     *
+     * @return
+     *  a reference to this ProductContent instance
      */
-    public void setProduct(Product product) {
+    public ProductContent setProduct(Product product) {
         this.product = product;
+        return this;
     }
 
     /**
@@ -118,9 +126,13 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
 
     /**
      * @param enabled the enabled to set
+     *
+     * @return
+     *  a reference to this ProductContent instance
      */
-    public void setEnabled(boolean enabled) {
+    public ProductContent setEnabled(boolean enabled) {
         this.enabled = enabled;
+        return this;
     }
 
     /**

--- a/server/src/main/resources/db/changelog/20220314130000-clear_product_entity_versions.xml
+++ b/server/src/main/resources/db/changelog/20220314130000-clear_product_entity_versions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20220314130000-1" author="crog">
+        <comment>
+            Clear existing product entity versions to prevent accidental collisions due to the
+            algorithm change
+        </comment>
+
+        <sql>
+            UPDATE cp2_products SET entity_version = NULL;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1256,4 +1256,5 @@
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
+    <include file="db/changelog/20220314130000-clear_product_entity_versions.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2348,4 +2348,5 @@
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
+    <include file="db/changelog/20220314130000-clear_product_entity_versions.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -165,4 +165,5 @@
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
+    <include file="db/changelog/20220314130000-clear_product_entity_versions.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -135,7 +135,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         verifyZeroInteractions(this.mockEntCertGenerator);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testUpdateContent(boolean regenCerts) {
         Owner owner = this.createOwner("test-owner", "Test Owner");
@@ -170,7 +170,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testUpdateContentConvergeWithExisting(boolean regenCerts) {
         Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");
@@ -204,7 +204,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testUpdateContentDivergeFromExisting(boolean regenCerts) {
         Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");
@@ -247,7 +247,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
             () -> this.contentManager.updateContent(owner, update, false));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testRemoveContent(boolean regenCerts) {
         Owner owner = this.createOwner("test-owner-1", "Test Owner 1");
@@ -276,7 +276,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testRemoveContentDivergeFromExisting(boolean regenCerts) {
         Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 import org.candlepin.util.Util;
 
@@ -175,7 +177,7 @@ public class ProductTest {
         assertTrue(rhs.equals(lhs));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0} => {1}, {2}")
     @MethodSource("getValuesForEqualityAndReplication")
     public void testEquality(String valueName, Object value1, Object value2) throws Exception {
         Method[] methods = this.getAccessorAndMutator(valueName, value1.getClass());
@@ -212,7 +214,7 @@ public class ProductTest {
         assertEquals(lhs.getEntityVersion(), rhs.getEntityVersion());
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0} => {1}, {2}")
     @MethodSource("getValuesForEqualityAndReplication")
     public void testEntityVersion(String valueName, Object value1, Object value2) throws Exception {
         Method[] methods = this.getAccessorAndMutator(valueName, value1.getClass());
@@ -234,7 +236,7 @@ public class ProductTest {
         assertNotEquals(lhs.getEntityVersion(), rhs.getEntityVersion());
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @MethodSource("getValuesForEqualityAndReplication")
     public void testClone(String valueName, Object value1, Object value2) throws Exception {
         Method[] methods = this.getAccessorAndMutator(valueName, value1.getClass());
@@ -260,7 +262,7 @@ public class ProductTest {
         assertEquals(base.hashCode(), clone.hashCode());
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = { "1", "3", "5" })
     public void testSetDerivedProductChecksForCyclesOnDerivedProducts(int depth) {
         Product parent = new Product();
@@ -279,7 +281,7 @@ public class ProductTest {
         assertThrows(IllegalStateException.class, () -> parent.setDerivedProduct(chain));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = { "1", "3", "5" })
     public void testSetDerivedProductChecksForCyclesOnProvidedProducts(int depth) {
         Product parent = new Product();
@@ -304,7 +306,7 @@ public class ProductTest {
         assertThrows(IllegalStateException.class, () -> parent.setDerivedProduct(chain));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = { "1", "3", "5" })
     public void testAddProvidedProductChecksForCyclesOnDerivedProducts(int depth) {
         Product parent = new Product();
@@ -323,7 +325,7 @@ public class ProductTest {
         assertThrows(IllegalStateException.class, () -> parent.addProvidedProduct(chain));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = { "1", "3", "5" })
     public void testAddProvidedProductChecksForCyclesOnProvidedProducts(int depth) {
         Product parent = new Product();
@@ -348,7 +350,7 @@ public class ProductTest {
         assertThrows(IllegalStateException.class, () -> parent.addProvidedProduct(chain));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = { "1", "3", "5" })
     public void testSetProvidedProductsChecksForCyclesOnDerivedProducts(int depth) {
         Product parent = new Product();
@@ -368,7 +370,7 @@ public class ProductTest {
         assertThrows(IllegalStateException.class, () -> parent.setProvidedProducts(children));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = { "1", "3", "5" })
     public void testSetProvidedProductsChecksForCyclesOnProvidedProducts(int depth) {
         Product parent = new Product();
@@ -392,5 +394,321 @@ public class ProductTest {
 
         List<Product> children = List.of(new Product(), new Product(), chain);
         assertThrows(IllegalStateException.class, () -> parent.setProvidedProducts(children));
+    }
+
+    private List<Product> buildTestProducts() {
+        Product p1 = spy(new Product())
+            .setId("p1");
+
+        Product p2 = spy(new Product())
+            .setId("p2");
+
+        Product p3 = spy(new Product())
+            .setId("p3");
+
+        doReturn(1).when(p1).getEntityVersion();
+        doReturn(2).when(p2).getEntityVersion();
+        doReturn(3).when(p3).getEntityVersion();
+
+        return List.of(p1, p2, p3);
+    }
+
+    @Test
+    public void testEntityVersionChangesWithProvidedProducts() {
+        List<Product> children = this.buildTestProducts();
+
+        Product p1 = new Product();
+
+        Product p2 = new Product();
+        p2.addProvidedProduct(children.get(0));
+
+        Product p3 = new Product();
+        p3.addProvidedProduct(children.get(0));
+        p3.addProvidedProduct(children.get(1));
+
+        Product p4 = new Product();
+        p4.addProvidedProduct(children.get(2));
+
+        assertNotEquals(p1.getEntityVersion(), p2.getEntityVersion());
+        assertNotEquals(p1.getEntityVersion(), p3.getEntityVersion());
+        assertNotEquals(p1.getEntityVersion(), p4.getEntityVersion());
+
+        assertNotEquals(p2.getEntityVersion(), p3.getEntityVersion());
+        assertNotEquals(p2.getEntityVersion(), p4.getEntityVersion());
+
+        assertNotEquals(p3.getEntityVersion(), p4.getEntityVersion());
+    }
+
+    @Test
+    public void testEntityVersionIgnoresProvidedProductOrder() {
+        List<Product> children = this.buildTestProducts();
+
+        Product p1 = new Product();
+        p1.addProvidedProduct(children.get(0));
+        p1.addProvidedProduct(children.get(1));
+        p1.addProvidedProduct(children.get(2));
+
+        Product p2 = new Product();
+        p2.addProvidedProduct(children.get(0));
+        p2.addProvidedProduct(children.get(2));
+        p2.addProvidedProduct(children.get(1));
+
+        Product p3 = new Product();
+        p3.addProvidedProduct(children.get(1));
+        p3.addProvidedProduct(children.get(0));
+        p3.addProvidedProduct(children.get(2));
+
+        Product p4 = new Product();
+        p4.addProvidedProduct(children.get(1));
+        p4.addProvidedProduct(children.get(2));
+        p4.addProvidedProduct(children.get(0));
+
+        Product p5 = new Product();
+        p5.addProvidedProduct(children.get(2));
+        p5.addProvidedProduct(children.get(0));
+        p5.addProvidedProduct(children.get(1));
+
+        Product p6 = new Product();
+        p6.addProvidedProduct(children.get(2));
+        p6.addProvidedProduct(children.get(1));
+        p6.addProvidedProduct(children.get(0));
+
+        assertEquals(p1.getEntityVersion(), p2.getEntityVersion());
+        assertEquals(p2.getEntityVersion(), p3.getEntityVersion());
+        assertEquals(p3.getEntityVersion(), p4.getEntityVersion());
+        assertEquals(p4.getEntityVersion(), p5.getEntityVersion());
+        assertEquals(p5.getEntityVersion(), p6.getEntityVersion());
+    }
+
+    private List<ProductContent> buildTestContent() {
+        ProductContent pc1 = spy(new ProductContent())
+            .setContent(new Content().setId("c1"));
+
+        ProductContent pc2 = spy(new ProductContent())
+            .setContent(new Content().setId("c2"));
+
+        ProductContent pc3 = spy(new ProductContent())
+            .setContent(new Content().setId("c3"));
+
+        // Explictly set the entity version such that we can get into a case where the sum
+        // of a subset equals the sum of a different subset
+        doReturn(1).when(pc1).getEntityVersion();
+        doReturn(2).when(pc2).getEntityVersion();
+        doReturn(3).when(pc3).getEntityVersion();
+
+        return List.of(pc1, pc2, pc3);
+    }
+
+    @Test
+    public void testEntityVersionChangesWithContent() {
+        List<ProductContent> children = this.buildTestContent();
+
+        Product p1 = new Product();
+
+        Product p2 = new Product();
+        p2.addProductContent(children.get(0));
+
+        Product p3 = new Product();
+        p3.addProductContent(children.get(0));
+        p3.addProductContent(children.get(1));
+
+        Product p4 = new Product();
+        p4.addProductContent(children.get(2));
+
+        assertNotEquals(p1.getEntityVersion(), p2.getEntityVersion());
+        assertNotEquals(p1.getEntityVersion(), p3.getEntityVersion());
+        assertNotEquals(p1.getEntityVersion(), p4.getEntityVersion());
+
+        assertNotEquals(p2.getEntityVersion(), p3.getEntityVersion());
+        assertNotEquals(p2.getEntityVersion(), p4.getEntityVersion());
+
+        assertNotEquals(p3.getEntityVersion(), p4.getEntityVersion());
+    }
+
+    @Test
+    public void testEntityVersionIgnoresContentOrder() {
+        List<ProductContent> children = this.buildTestContent();
+
+        Product p1 = new Product();
+        p1.addProductContent(children.get(0));
+        p1.addProductContent(children.get(1));
+        p1.addProductContent(children.get(2));
+
+        Product p2 = new Product();
+        p2.addProductContent(children.get(0));
+        p2.addProductContent(children.get(2));
+        p2.addProductContent(children.get(1));
+
+        Product p3 = new Product();
+        p3.addProductContent(children.get(1));
+        p3.addProductContent(children.get(0));
+        p3.addProductContent(children.get(2));
+
+        Product p4 = new Product();
+        p4.addProductContent(children.get(1));
+        p4.addProductContent(children.get(2));
+        p4.addProductContent(children.get(0));
+
+        Product p5 = new Product();
+        p5.addProductContent(children.get(2));
+        p5.addProductContent(children.get(0));
+        p5.addProductContent(children.get(1));
+
+        Product p6 = new Product();
+        p6.addProductContent(children.get(2));
+        p6.addProductContent(children.get(1));
+        p6.addProductContent(children.get(0));
+
+        assertEquals(p1.getEntityVersion(), p2.getEntityVersion());
+        assertEquals(p2.getEntityVersion(), p3.getEntityVersion());
+        assertEquals(p3.getEntityVersion(), p4.getEntityVersion());
+        assertEquals(p4.getEntityVersion(), p5.getEntityVersion());
+        assertEquals(p5.getEntityVersion(), p6.getEntityVersion());
+    }
+
+    private List<Branding> buildTestBranding() {
+        // Explictly set the hashcode such that we can get into a case where the sum
+        // of a subset equals the sum of a different subset
+        Branding b1 = new Branding() {
+            @Override
+            @SuppressWarnings("EqualsHashCode")
+            public int hashCode() {
+                return 1;
+            }
+        };
+        b1.setId("b1");
+
+        Branding b2 = new Branding() {
+            @Override
+            @SuppressWarnings("EqualsHashCode")
+            public int hashCode() {
+                return 2;
+            }
+        };
+        b2.setId("b2");
+
+        Branding b3 = new Branding() {
+            @Override
+            @SuppressWarnings("EqualsHashCode")
+            public int hashCode() {
+                return 3;
+            }
+        };
+        b3.setId("b3");
+
+        return List.of(b1, b2, b3);
+    }
+
+    @Test
+    public void testEntityVersionChangesWithBranding() {
+        List<Branding> children = this.buildTestBranding();
+
+        Product p1 = new Product();
+
+        Product p2 = new Product();
+        p2.addBranding(children.get(0));
+
+        Product p3 = new Product();
+        p3.addBranding(children.get(0));
+        p3.addBranding(children.get(1));
+
+        Product p4 = new Product();
+        p4.addBranding(children.get(2));
+
+        assertNotEquals(p1.getEntityVersion(), p2.getEntityVersion());
+        assertNotEquals(p1.getEntityVersion(), p3.getEntityVersion());
+        assertNotEquals(p1.getEntityVersion(), p4.getEntityVersion());
+
+        assertNotEquals(p2.getEntityVersion(), p3.getEntityVersion());
+        assertNotEquals(p2.getEntityVersion(), p4.getEntityVersion());
+
+        assertNotEquals(p3.getEntityVersion(), p4.getEntityVersion());
+    }
+
+    @Test
+    public void testEntityVersionIgnoresBrandingOrder() {
+        List<Branding> children = this.buildTestBranding();
+
+        Product p1 = new Product();
+        p1.addBranding(children.get(0));
+        p1.addBranding(children.get(1));
+        p1.addBranding(children.get(2));
+
+        Product p2 = new Product();
+        p2.addBranding(children.get(0));
+        p2.addBranding(children.get(2));
+        p2.addBranding(children.get(1));
+
+        Product p3 = new Product();
+        p3.addBranding(children.get(1));
+        p3.addBranding(children.get(0));
+        p3.addBranding(children.get(2));
+
+        Product p4 = new Product();
+        p4.addBranding(children.get(1));
+        p4.addBranding(children.get(2));
+        p4.addBranding(children.get(0));
+
+        Product p5 = new Product();
+        p5.addBranding(children.get(2));
+        p5.addBranding(children.get(0));
+        p5.addBranding(children.get(1));
+
+        Product p6 = new Product();
+        p6.addBranding(children.get(2));
+        p6.addBranding(children.get(1));
+        p6.addBranding(children.get(0));
+
+        assertEquals(p1.getEntityVersion(), p2.getEntityVersion());
+        assertEquals(p2.getEntityVersion(), p3.getEntityVersion());
+        assertEquals(p3.getEntityVersion(), p4.getEntityVersion());
+        assertEquals(p4.getEntityVersion(), p5.getEntityVersion());
+        assertEquals(p5.getEntityVersion(), p6.getEntityVersion());
+    }
+
+    @Test
+    public void testEntityVersioningAvoidsCollidingOnDifferentChildren() {
+        // Create a set of children which all have the same version or hashcode
+        Product derived = spy(new Product())
+            .setId("derived");
+        Product provided = spy(new Product())
+            .setId("provided");
+        ProductContent pcontent = spy(new ProductContent())
+            .setContent(new Content().setId("content"));
+
+        doReturn(1).when(derived).getEntityVersion();
+        doReturn(1).when(provided).getEntityVersion();
+        doReturn(1).when(pcontent).getEntityVersion();
+
+        Branding branding = new Branding() {
+            @Override
+            @SuppressWarnings("EqualsHashCode")
+            public int hashCode() {
+                return 1;
+            }
+        };
+        branding.setId("b1");
+
+
+        Product p1 = new Product();
+        p1.setDerivedProduct(derived);
+
+        Product p2 = new Product();
+        p2.addProvidedProduct(provided);
+
+        Product p3 = new Product();
+        p3.addProductContent(pcontent);
+
+        Product p4 = new Product();
+        p4.addBranding(branding);
+
+        assertNotEquals(p1.getEntityVersion(), p2.getEntityVersion());
+        assertNotEquals(p1.getEntityVersion(), p3.getEntityVersion());
+        assertNotEquals(p1.getEntityVersion(), p4.getEntityVersion());
+
+        assertNotEquals(p2.getEntityVersion(), p3.getEntityVersion());
+        assertNotEquals(p2.getEntityVersion(), p4.getEntityVersion());
+
+        assertNotEquals(p3.getEntityVersion(), p4.getEntityVersion());
     }
 }


### PR DESCRIPTION
- Fixed a bug that could cause a versioning collision in some cases
- Added an additional exception when a version collision is detected
  during product and content management
- Added method chaining to mutators in ProductContent and Branding
- Existing product entity versions will be cleared to rebuild database
  and avoid collisions with existing versions