### PR TITLE
[4.0] Changed entity versions to a 64bit value (ENT-4831)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
@@ -48,7 +48,7 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
     private Set<OwnerContent> ownerContentEntities;
     private Map<Owner, Map<String, String>> ownerContentUuidMap;
     private Map<Owner, Set<String>> deletedContentUuids;
-    private Map<Owner, Set<Integer>> ownerEntityVersions;
+    private Map<Owner, Set<Long>> ownerEntityVersions;
     private Map<Owner, Map<String, List<Content>>> ownerVersionedEntityMap;
 
 
@@ -220,10 +220,10 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
     private Content resolveEntityVersion(EntityNode<Content, ContentInfo> node) {
         Owner owner = node.getOwner();
         Content entity = node.getMergedEntity();
-        int entityVersion = entity.getEntityVersion();
+        long entityVersion = entity.getEntityVersion();
 
         Map<String, List<Content>> entityMap = this.ownerVersionedEntityMap.computeIfAbsent(owner, key -> {
-            Set<Integer> versions = this.ownerEntityVersions.remove(key);
+            Set<Long> versions = this.ownerEntityVersions.remove(key);
 
             return versions != null ?
                 this.ownerContentCurator.getContentByVersions(versions) :

--- a/server/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
@@ -55,7 +55,7 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
     private Set<OwnerProduct> ownerProductEntities;
     private Map<Owner, Map<String, String>> ownerProductUuidMap;
     private Map<Owner, Set<String>> deletedProductUuids;
-    private Map<Owner, Set<Integer>> ownerEntityVersions;
+    private Map<Owner, Set<Long>> ownerEntityVersions;
     private Map<Owner, Map<String, List<Product>>> ownerVersionedEntityMap;
 
 
@@ -229,10 +229,10 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
     private Product resolveEntityVersion(EntityNode<Product, ProductInfo> node) {
         Owner owner = node.getOwner();
         Product entity = node.getMergedEntity();
-        int entityVersion = entity.getEntityVersion();
+        long entityVersion = entity.getEntityVersion();
 
         Map<String, List<Product>> entityMap = this.ownerVersionedEntityMap.computeIfAbsent(owner, key -> {
-            Set<Integer> versions = this.ownerEntityVersions.remove(key);
+            Set<Long> versions = this.ownerEntityVersions.remove(key);
 
             return versions != null ?
                 this.ownerProductCurator.getProductsByVersions(versions) :

--- a/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -342,7 +342,7 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
      * @return
      *  a map containing the contents found, keyed by content ID
      */
-    public Map<String, List<Content>> getContentByVersions(Collection<Integer> versions) {
+    public Map<String, List<Content>> getContentByVersions(Collection<Long> versions) {
         Map<String, List<Content>> result = new HashMap<>();
 
         if (versions != null && !versions.isEmpty()) {
@@ -351,7 +351,7 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
             TypedQuery<Content> query = this.getEntityManager()
                 .createQuery(jpql, Content.class);
 
-            for (Collection<Integer> block : this.partition(versions)) {
+            for (Collection<Long> block : this.partition(versions)) {
                 for (Content element : query.setParameter("vblock", block).getResultList()) {
                     result.computeIfAbsent(element.getId(), k -> new LinkedList<>())
                         .add(element);

--- a/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -546,7 +546,7 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
      * @return
      *  a map containing the products found, keyed by product ID
      */
-    public Map<String, List<Product>> getProductsByVersions(Collection<Integer> versions) {
+    public Map<String, List<Product>> getProductsByVersions(Collection<Long> versions) {
         Map<String, List<Product>> result = new HashMap<>();
 
         if (versions != null && !versions.isEmpty()) {
@@ -555,7 +555,7 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
             TypedQuery<Product> query = this.getEntityManager()
                 .createQuery(jpql, Product.class);
 
-            for (Collection<Integer> block : this.partition(versions)) {
+            for (Collection<Long> block : this.partition(versions)) {
                 for (Product element : query.setParameter("vblock", block).getResultList()) {
                     result.computeIfAbsent(element.getId(), k -> new LinkedList<>())
                         .add(element);

--- a/server/src/main/java/org/candlepin/model/ProductContent.java
+++ b/server/src/main/java/org/candlepin/model/ProductContent.java
@@ -16,6 +16,7 @@ package org.candlepin.model;
 
 import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.service.model.ProductContentInfo;
+import org.candlepin.util.LongHashCodeBuilder;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -175,9 +176,11 @@ public class ProductContent extends AbstractHibernateObject implements ProductCo
      * @return
      *  a version hash for this entity
      */
-    public int getEntityVersion() {
-        return new HashCodeBuilder(7, 19)
-            .append(this.getContent() != null ? this.getContent().getEntityVersion() : 0)
+    public long getEntityVersion() {
+        // initialValue and multiplier choosen fairly arbitrarily from a list of prime numbers
+        // These should be unique per versioned entity.
+        return new LongHashCodeBuilder(307, 317)
+            .append(this.getContent() != null ? this.getContent().getEntityVersion() : null)
             .append(this.isEnabled())
             .toHashCode();
     }

--- a/server/src/main/java/org/candlepin/util/LongHashCodeBuilder.java
+++ b/server/src/main/java/org/candlepin/util/LongHashCodeBuilder.java
@@ -1,0 +1,449 @@
+/**
+ * Copyright (c) 2009 - 2022 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+
+
+/**
+ * A version/hash builder based on the design and principles of the Apache HashCodeBuilder (which
+ * itself is based on principles outlined in Joshua Bloch's Effective Java). However, unlike the
+ * HashCodeBuilder, this class provides no reflection or object-introspection functionality.
+ *
+ * The functionality is very similar, if not identical to the aforementioned HashCodeBuilder, except
+ * the output is a 64-bit long instead of a 32-bit integer. This should, in theory, cut down on the
+ * number of collisions.
+ */
+public class LongHashCodeBuilder {
+
+    public static final long DEFAULT_INITIAL_VALUE = 97L;
+    public static final long DEFAULT_MULTIPLIER = 757L;
+
+    private final long multiplier;
+    private long accumulator = 0;
+
+    /**
+     * Creates a new LongHashCodeBuilder with the default initial value and multiplier.
+     */
+    public LongHashCodeBuilder() {
+        this(DEFAULT_INITIAL_VALUE, DEFAULT_MULTIPLIER);
+    }
+
+    /**
+     * Creates a new LongHashCodeBuilder with the specified initial value and multiplier; both of
+     * which must be odd numbers, and, preferably, prime numbers. While not strictly necessary, the
+     * pair should also be unique on a per-class basis.
+     *
+     * @param initialValue
+     *  the initial value for the entity version; must be an odd number
+     *
+     * @param multiplier
+     *  the per-field multiplier; must be an odd number
+     *
+     * @throws IllegalArgumentException
+     *  if either initialValue or multiplier are even numbers
+     */
+    public LongHashCodeBuilder(long initialValue, long multiplier) {
+        if (initialValue % 2 == 0) {
+            throw new IllegalArgumentException("initialValue is an even number");
+        }
+
+        if (multiplier % 2 == 0) {
+            throw new IllegalArgumentException("multiplier is an even number");
+        }
+
+        this.accumulator = initialValue;
+        this.multiplier = multiplier;
+    }
+
+    /**
+     * Appends a boolean value to this hash code builder.
+     *
+     * @param value
+     *  the value to add to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(boolean value) {
+        this.accumulator = this.accumulator * this.multiplier + (value ? 0 : 1);
+        return this;
+    }
+
+    /**
+     * Appends an array of boolean values to this hash code builder.
+     *
+     * @param array
+     *  the array of values to append to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(boolean[] array) {
+        if (array != null) {
+            for (boolean element : array) {
+                this.append(element);
+            }
+        }
+        else {
+            this.append((Object) null);
+        }
+
+        return this;
+    }
+
+    /**
+     * Appends a byte value to this hash code builder.
+     *
+     * @param value
+     *  the value to add to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(byte value) {
+        this.accumulator = this.accumulator * this.multiplier + value;
+        return this;
+    }
+
+    /**
+     * Appends an array of byte values to this hash code builder.
+     *
+     * @param array
+     *  the array of values to append to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(byte[] array) {
+        if (array != null) {
+            for (byte element : array) {
+                this.append(element);
+            }
+        }
+        else {
+            this.append((Object) null);
+        }
+
+        return this;
+    }
+
+    /**
+     * Appends a char value to this hash code builder.
+     *
+     * @param value
+     *  the value to add to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(char value) {
+        this.accumulator = this.accumulator * this.multiplier + value;
+        return this;
+    }
+
+    /**
+     * Appends an array of char values to this hash code builder.
+     *
+     * @param array
+     *  the array of values to append to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(char[] array) {
+        if (array != null) {
+            for (char element : array) {
+                this.append(element);
+            }
+        }
+        else {
+            this.append((Object) null);
+        }
+
+        return this;
+    }
+
+    /**
+     * Appends a short value to this hash code builder.
+     *
+     * @param value
+     *  the value to add to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(short value) {
+        this.accumulator = this.accumulator * this.multiplier + value;
+        return this;
+    }
+
+    /**
+     * Appends an array of short values to this hash code builder.
+     *
+     * @param array
+     *  the array of values to append to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(short[] array) {
+        if (array != null) {
+            for (short element : array) {
+                this.append(element);
+            }
+        }
+        else {
+            this.append((Object) null);
+        }
+
+        return this;
+    }
+
+    /**
+     * Appends an integer value to this hash code builder.
+     *
+     * @param value
+     *  the value to add to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(int value) {
+        this.accumulator = this.accumulator * this.multiplier + value;
+        return this;
+    }
+
+    /**
+     * Appends an array of integer values to this hash code builder.
+     *
+     * @param array
+     *  the array of values to append to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(int[] array) {
+        if (array != null) {
+            for (int element : array) {
+                this.append(element);
+            }
+        }
+        else {
+            this.append((Object) null);
+        }
+
+        return this;
+    }
+
+    /**
+     * Appends a long value to this hash code builder.
+     *
+     * @param value
+     *  the value to add to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(long value) {
+        this.accumulator = this.accumulator * this.multiplier + value;
+        return this;
+    }
+
+    /**
+     * Appends an array of long values to this hash code builder.
+     *
+     * @param array
+     *  the array of values to append to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(long[] array) {
+        if (array != null) {
+            for (long element : array) {
+                this.append(element);
+            }
+        }
+        else {
+            this.append((Object) null);
+        }
+
+        return this;
+    }
+
+    /**
+     * Appends a float value to this hash code builder.
+     *
+     * @param value
+     *  the value to add to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(float value) {
+        return this.append(Float.floatToIntBits(value));
+    }
+
+    /**
+     * Appends an array of float values to this hash code builder.
+     *
+     * @param array
+     *  the array of values to append to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(float[] array) {
+        if (array != null) {
+            for (float element : array) {
+                this.append(element);
+            }
+        }
+        else {
+            this.append((Object) null);
+        }
+
+        return this;
+    }
+
+    /**
+     * Appends a double value to this hash code builder.
+     *
+     * @param value
+     *  the value to add to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(double value) {
+        return this.append(Double.doubleToLongBits(value));
+    }
+
+    /**
+     * Appends an array of double values to this hash code builder.
+     *
+     * @param array
+     *  the array of values to append to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(double[] array) {
+        if (array != null) {
+            for (double element : array) {
+                this.append(element);
+            }
+        }
+        else {
+            this.append((Object) null);
+        }
+
+        return this;
+    }
+
+    /**
+     * Appends an object to this hash code builder.
+     *
+     * @param value
+     *  the object to add to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(Object value) {
+        if (value == null) {
+            this.accumulator *= this.multiplier;
+        }
+        else if (value.getClass().isArray()) {
+            this.processObjectArray((Object[]) value);
+        }
+        else {
+            this.accumulator = this.accumulator * this.multiplier + value.hashCode();
+        }
+
+        return this;
+    }
+
+    /**
+     * Appends an array of objects to this hash code builder.
+     *
+     * @param array
+     *  the array of values to append to the hash code
+     *
+     * @return
+     *  a reference to this hash code builder
+     */
+    public LongHashCodeBuilder append(Object[] array) {
+        if (array != null) {
+            for (Object element : array) {
+                this.append(element);
+            }
+        }
+        else {
+            this.append((Object) null);
+        }
+
+        return this;
+    }
+
+    /**
+     * Determines the type of array we have, and directs the call to the proper handler. Acts like
+     * a scuffed jump table.
+     *
+     * @param array
+     *  the array to process
+     */
+    private void processObjectArray(Object array) {
+        if (array instanceof byte[]) {
+            this.append((byte[]) array);
+        }
+        else if (array instanceof int[]) {
+            this.append((int[]) array);
+        }
+        else if (array instanceof long[]) {
+            this.append((long[]) array);
+        }
+        else if (array instanceof double[]) {
+            this.append((double[]) array);
+        }
+        else if (array instanceof char[]) {
+            this.append((char[]) array);
+        }
+        else if (array instanceof float[]) {
+            this.append((float[]) array);
+        }
+        else if (array instanceof short[]) {
+            this.append((short[]) array);
+        }
+        else if (array instanceof boolean[]) {
+            this.append((boolean[]) array);
+        }
+        else {
+            this.append((Object[]) array);
+        }
+    }
+
+    /**
+     * Fetches the current hash code based on the values provided to this builder thus far.
+     * Further calls to <tt>append</tt> will change the output of this method.
+     *
+     * @return
+     *  the current entity version
+     */
+    public long toHashCode() {
+        return this.accumulator;
+    }
+
+}

--- a/server/src/main/resources/db/changelog/20220314130000-64bit_entity_versions.xml
+++ b/server/src/main/resources/db/changelog/20220314130000-64bit_entity_versions.xml
@@ -7,13 +7,28 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20220314130000-1" author="crog">
+        <modifyDataType
+            columnName="entity_version"
+            newDataType="bigint"
+            tableName="cp2_products"/>
+    </changeSet>
+
+    <changeSet id="20220314130000-2" author="crog">
+        <modifyDataType
+            columnName="entity_version"
+            newDataType="bigint"
+            tableName="cp2_content"/>
+    </changeSet>
+
+    <changeSet id="20220314130000-3" author="crog">
         <comment>
-            Clear existing product entity versions to prevent accidental collisions due to the
+            Clear existing entity versions to prevent accidental collisions due to the
             algorithm change
         </comment>
 
         <sql>
             UPDATE cp2_products SET entity_version = NULL;
+            UPDATE cp2_content SET entity_version = NULL;
         </sql>
     </changeSet>
 

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1256,5 +1256,5 @@
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
-    <include file="db/changelog/20220314130000-clear_product_entity_versions.xml"/>
+    <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2348,5 +2348,5 @@
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
-    <include file="db/changelog/20220314130000-clear_product_entity_versions.xml"/>
+    <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -165,5 +165,5 @@
     <include file="db/changelog/20210622100950-cert_serials_drop_collected_column.xml"/>
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
-    <include file="db/changelog/20220314130000-clear_product_entity_versions.xml"/>
+    <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -694,8 +694,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         Owner owner = this.createOwner();
 
         int seed = 13579;
-        List<Integer> versions = new Random(seed)
-            .ints()
+        List<Long> versions = new Random(seed)
+            .longs()
             .boxed()
             .limit(100000)
             .collect(Collectors.toList());

--- a/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -688,8 +688,8 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         Owner owner = this.createOwner();
 
         int seed = 13579;
-        List<Integer> versions = new Random(seed)
-            .ints()
+        List<Long> versions = new Random(seed)
+            .longs()
             .boxed()
             .limit(100000)
             .collect(Collectors.toList());

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -406,15 +406,19 @@ public class ProductTest {
         Product p3 = spy(new Product())
             .setId("p3");
 
-        doReturn(1).when(p1).getEntityVersion();
-        doReturn(2).when(p2).getEntityVersion();
-        doReturn(3).when(p3).getEntityVersion();
+        // Explictly set the entity version such that we can get into a case where the sum
+        // of a subset equals the sum of a different subset
+        doReturn(1L).when(p1).getEntityVersion();
+        doReturn(2L).when(p2).getEntityVersion();
+        doReturn(3L).when(p3).getEntityVersion();
 
         return List.of(p1, p2, p3);
     }
 
     @Test
     public void testEntityVersionChangesWithProvidedProducts() {
+        // The products here must be generated such that the sum of the entity versions of the first
+        // two children is equal to the entity version of the third.
         List<Product> children = this.buildTestProducts();
 
         Product p1 = new Product();
@@ -492,15 +496,17 @@ public class ProductTest {
 
         // Explictly set the entity version such that we can get into a case where the sum
         // of a subset equals the sum of a different subset
-        doReturn(1).when(pc1).getEntityVersion();
-        doReturn(2).when(pc2).getEntityVersion();
-        doReturn(3).when(pc3).getEntityVersion();
+        doReturn(1L).when(pc1).getEntityVersion();
+        doReturn(2L).when(pc2).getEntityVersion();
+        doReturn(3L).when(pc3).getEntityVersion();
 
         return List.of(pc1, pc2, pc3);
     }
 
     @Test
     public void testEntityVersionChangesWithContent() {
+        // The ProductContent instances here must be generated such that the sum of the entity
+        // versions of the first two children is equal to the entity version of the third.
         List<ProductContent> children = this.buildTestContent();
 
         Product p1 = new Product();
@@ -601,6 +607,8 @@ public class ProductTest {
 
     @Test
     public void testEntityVersionChangesWithBranding() {
+        // The branding here must be generated such that the sum of the hashcodes of the first two
+        // children is equal to the hash code of the third.
         List<Branding> children = this.buildTestBranding();
 
         Product p1 = new Product();
@@ -676,9 +684,9 @@ public class ProductTest {
         ProductContent pcontent = spy(new ProductContent())
             .setContent(new Content().setId("content"));
 
-        doReturn(1).when(derived).getEntityVersion();
-        doReturn(1).when(provided).getEntityVersion();
-        doReturn(1).when(pcontent).getEntityVersion();
+        doReturn(1L).when(derived).getEntityVersion();
+        doReturn(1L).when(provided).getEntityVersion();
+        doReturn(1L).when(pcontent).getEntityVersion();
 
         Branding branding = new Branding() {
             @Override

--- a/server/src/test/java/org/candlepin/util/LongHashCodeBuilderTest.java
+++ b/server/src/test/java/org/candlepin/util/LongHashCodeBuilderTest.java
@@ -1,0 +1,903 @@
+/**
+ * Copyright (c) 2009 - 2022 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+
+
+/**
+ * Test suite for the LongHashCodeBuilder class
+ */
+public class LongHashCodeBuilderTest {
+
+    // A safe initial value that can be used in tests where we aren't testing the initial value
+    private static final long SAFE_INITIAL_VALUE = 7L;
+
+    // A safe multiplier that can be used in tests where aren't testing the multiplier
+    private static final long SAFE_MULTIPLIER = 37L;
+
+
+    @Test
+    public void testDefaultInitialValue() {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+
+        // With no constructor arguments, the initial value should be the default initial value
+        assertEquals(LongHashCodeBuilder.DEFAULT_INITIAL_VALUE, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(longs = { Long.MIN_VALUE + 1, -15001L, 1, 15001L, Long.MAX_VALUE })
+    public void testProvidedInitialValue(long initialValue) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder(initialValue, SAFE_MULTIPLIER);
+
+        assertEquals(initialValue, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(longs = { Long.MIN_VALUE, -2, 0, 2, Long.MAX_VALUE - 1 })
+    public void testProvidedInitialValueMustBeOdd(long initialValue) {
+        assertThrows(IllegalArgumentException.class, () ->
+            new LongHashCodeBuilder(initialValue, SAFE_MULTIPLIER));
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(booleans = { true, false })
+    public void testAppendBooleanChangesResult(boolean input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(booleans = { true, false })
+    public void testRepeatedAppendBooleanChangesResult(boolean input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(booleans = { true, false })
+    public void testAppendBooleanIsDeterministic(boolean input) {
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @Test
+    public void testAppendBooleanArrayChangesResult() {
+        boolean[] input = new boolean[] { true, false };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testRepeatedAppendBooleanArrayChangesResult() {
+        boolean[] input = new boolean[] { true, false };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testAppendBooleanArrayIsDeterministic() {
+        boolean[] input = new boolean[] { true, false };
+
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(bytes = { Byte.MIN_VALUE, -0x10, 0, 0x10, Byte.MAX_VALUE })
+    public void testAppendByteChangesResult(byte input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(bytes = { Byte.MIN_VALUE, -0x10, 0, 0x10, Byte.MAX_VALUE })
+    public void testRepeatedAppendByteChangesResult(byte input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(bytes = { Byte.MIN_VALUE, -0x10, 0, 0x10, Byte.MAX_VALUE })
+    public void testAppendByteIsDeterministic(byte input) {
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @Test
+    public void testAppendByteArrayChangesResult() {
+        byte[] input = new byte[] { Byte.MIN_VALUE, -0x10, 0, 0x10, Byte.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testRepeatedAppendByteArrayChangesResult() {
+        byte[] input = new byte[] { Byte.MIN_VALUE, -0x10, 0, 0x10, Byte.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testAppendByteArrayIsDeterministic() {
+        byte[] input = new byte[] { Byte.MIN_VALUE, -0x10, 0, 0x10, Byte.MAX_VALUE };
+
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(chars = { Character.MIN_VALUE, 'a', 0, 'z', Character.MAX_VALUE })
+    public void testAppendCharChangesResult(char input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(chars = { Character.MIN_VALUE, 'a', 0, 'z', Character.MAX_VALUE })
+    public void testRepeatedAppendCharChangesResult(char input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(chars = { Character.MIN_VALUE, 'a', 0, 'z', Character.MAX_VALUE })
+    public void testAppendCharIsDeterministic(char input) {
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @Test
+    public void testAppendCharArrayChangesResult() {
+        char[] input = new char[] { Character.MIN_VALUE, 'a', 0, 'z', Character.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testRepeatedAppendCharArrayChangesResult() {
+        char[] input = new char[] { Character.MIN_VALUE, 'a', 0, 'z', Character.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testAppendCharArrayIsDeterministic() {
+        char[] input = new char[] { Character.MIN_VALUE, 'a', 0, 'z', Character.MAX_VALUE };
+
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(shorts = { Short.MIN_VALUE, -0x10, 0, 0x10, Short.MAX_VALUE })
+    public void testAppendShortChangesResult(short input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(shorts = { Short.MIN_VALUE, -0x10, 0, 0x10, Short.MAX_VALUE })
+    public void testRepeatedAppendShortChangesResult(short input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(shorts = { Short.MIN_VALUE, -0x10, 0, 0x10, Short.MAX_VALUE })
+    public void testAppendShortIsDeterministic(short input) {
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @Test
+    public void testAppendShortArrayChangesResult() {
+        short[] input = new short[] { Short.MIN_VALUE, -0x10, 0, 0x10, Short.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testRepeatedAppendShortArrayChangesResult() {
+        short[] input = new short[] { Short.MIN_VALUE, -0x10, 0, 0x10, Short.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testAppendShortArrayIsDeterministic() {
+        short[] input = new short[] { Short.MIN_VALUE, -0x10, 0, 0x10, Short.MAX_VALUE };
+
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(ints = { Integer.MIN_VALUE, -0x10, 0, 0x10, Integer.MAX_VALUE })
+    public void testAppendIntChangesResult(int input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(ints = { Integer.MIN_VALUE, -0x10, 0, 0x10, Integer.MAX_VALUE })
+    public void testRepeatedAppendIntChangesResult(int input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(ints = { Integer.MIN_VALUE, -0x10, 0, 0x10, Integer.MAX_VALUE })
+    public void testAppendIntIsDeterministic(int input) {
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @Test
+    public void testAppendIntArrayChangesResult() {
+        int[] input = new int[] { Integer.MIN_VALUE, -0x10, 0, 0x10, Integer.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testRepeatedAppendIntArrayChangesResult() {
+        int[] input = new int[] { Integer.MIN_VALUE, -0x10, 0, 0x10, Integer.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testAppendIntArrayIsDeterministic() {
+        int[] input = new int[] { Integer.MIN_VALUE, -0x10, 0, 0x10, Integer.MAX_VALUE };
+
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(longs = { Long.MIN_VALUE, -0x10, 0, 0x10, Long.MAX_VALUE })
+    public void testAppendLongChangesResult(long input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(longs = { Long.MIN_VALUE, -0x10, 0, 0x10, Long.MAX_VALUE })
+    public void testRepeatedAppendLongChangesResult(long input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(longs = { Long.MIN_VALUE, -0x10, 0, 0x10, Long.MAX_VALUE })
+    public void testAppendLongIsDeterministic(long input) {
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @Test
+    public void testAppendLongArrayChangesResult() {
+        long[] input = new long[] { Long.MIN_VALUE, -0x10, 0, 0x10, Long.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testRepeatedAppendLongArrayChangesResult() {
+        long[] input = new long[] { Long.MIN_VALUE, -0x10, 0, 0x10, Long.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testAppendLongArrayIsDeterministic() {
+        long[] input = new long[] { Long.MIN_VALUE, -0x10, 0, 0x10, Long.MAX_VALUE };
+
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(floats = { Float.MIN_VALUE, -10.20F, 0, 10.20F, Float.MAX_VALUE })
+    public void testAppendFloatChangesResult(float input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(floats = { Float.MIN_VALUE, -10.20F, 0, 10.20F, Float.MAX_VALUE })
+    public void testRepeatedAppendFloatChangesResult(float input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(floats = { Float.MIN_VALUE, -10.20F, 0, 10.20F, Float.MAX_VALUE })
+    public void testAppendFloatIsDeterministic(float input) {
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @Test
+    public void testAppendFloatArrayChangesResult() {
+        float[] input = new float[] { Float.MIN_VALUE, -10.20F, 0, 10.20F, Float.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testRepeatedAppendFloatArrayChangesResult() {
+        float[] input = new float[] { Float.MIN_VALUE, -10.20F, 0, 10.20F, Float.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testAppendFloatArrayIsDeterministic() {
+        float[] input = new float[] { Float.MIN_VALUE, -10.20F, 0, 10.20F, Float.MAX_VALUE };
+
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(doubles = { Double.MIN_VALUE, -10.20, 0, 10.20, Double.MAX_VALUE })
+    public void testAppendDoubleChangesResult(double input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(doubles = { Double.MIN_VALUE, -10.20, 0, 10.20, Double.MAX_VALUE })
+    public void testRepeatedAppendDoubleChangesResult(double input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @ValueSource(doubles = { Double.MIN_VALUE, -10.20, 0, 10.20, Double.MAX_VALUE })
+    public void testAppendDoubleIsDeterministic(double input) {
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @Test
+    public void testAppendDoubleArrayChangesResult() {
+        double[] input = new double[] { Double.MIN_VALUE, -10.20, 0, 10.20, Double.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testRepeatedAppendDoubleArrayChangesResult() {
+        double[] input = new double[] { Double.MIN_VALUE, -10.20, 0, 10.20, Double.MAX_VALUE };
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testAppendDoubleArrayIsDeterministic() {
+        double[] input = new double[] { Double.MIN_VALUE, -10.20, 0, 10.20, Double.MAX_VALUE };
+
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    public static Stream<Arguments> buildTestObjects() {
+        Object myObject = new Object() {
+            @Override
+            @SuppressWarnings("EqualsHashCode")
+            public int hashCode() {
+                return 42;
+            }
+        };
+
+        return Stream.of(
+            Arguments.of((Object) null),
+            Arguments.of(new Object()),
+            Arguments.of("test_string"),
+            Arguments.of(myObject)
+        );
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @MethodSource("buildTestObjects")
+    public void testAppendObjectChangesResult(Object input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @MethodSource("buildTestObjects")
+    public void testRepeatedAppendObjectChangesResult(Object input) {
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}]: {0}")
+    @MethodSource("buildTestObjects")
+    public void testAppendObjectIsDeterministic(Object input) {
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+    @Test
+    public void testAppendObjectArrayChangesResult() {
+        Object[] input = buildTestObjects().toArray();
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long initialHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(initialHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testRepeatedAppendObjectArrayChangesResult() {
+        Object[] input = buildTestObjects().toArray();
+
+        LongHashCodeBuilder builder = new LongHashCodeBuilder();
+        long previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+        previousHash = builder.toHashCode();
+
+        builder.append(input);
+
+        assertNotEquals(previousHash, builder.toHashCode());
+    }
+
+    @Test
+    public void testAppendObjectArrayIsDeterministic() {
+        Object[] input = buildTestObjects().toArray();
+
+        LongHashCodeBuilder builder1 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+        LongHashCodeBuilder builder2 = new LongHashCodeBuilder(SAFE_INITIAL_VALUE, SAFE_MULTIPLIER);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        long initialHash = builder1.toHashCode();
+
+        builder1.append(input);
+        builder2.append(input);
+
+        assertEquals(builder1.toHashCode(), builder2.toHashCode());
+        assertNotEquals(initialHash, builder1.toHashCode());
+        assertNotEquals(initialHash, builder2.toHashCode());
+    }
+
+}


### PR DESCRIPTION
- Entity versions on Product, ProductContent, and Content are now
  64 bits instead of 32bits
- Rewrote the version calculation *again*, ensuring that even
  null and empty collections are represented in the final version
  hash
- The initial value and multipliers have been made unique between
  all versioned entities