### PR TITLE
[M] Added support for skipping pool creation while processing test data (ENT-4849)

### DIFF
--- a/bin/deployment/test_data_importer.py
+++ b/bin/deployment/test_data_importer.py
@@ -643,6 +643,9 @@ def create_subscriptions(cp, options, owners, data):
 
         for product in products:
             if 'type' in product and product['type'] == 'MKT':
+                if 'skip_pools' in product and product['skip_pools']:
+                    continue
+
                 if 'quantity' in product:
                     small_quantity = int(product['quantity'])
                     large_quantity = small_quantity * 10 if small_quantity > 0 else 10


### PR DESCRIPTION
- Marketing products tagged with the "skip_pools" attribute will
  now be skipped during subscription/pool creation