### PR TITLE
[3.1] Add infrastructure related cherry-picks from candlepin-3.1-HOTFIX

### DIFF
--- a/bin/bash_functions
+++ b/bin/bash_functions
@@ -166,10 +166,9 @@ init_mysql_jdbc() {
     # JDBC_DRIVER="org.mariadb.jdbc.Driver"
     # JDBC_JAR="/usr/lib/java/mariadb-java-client.jar"
     # JDBC_URL="jdbc:mariadb://$db_host/$db_name"
-
-    local isolation_level=$(mysql -h $db_host $db_name  --user=$db_user --password="$password"  -e 'select @@global.tx_isolation')
-    local READ_COMMITTED="READ-COMMITTED"
-    if [[ $isolation_level != *$READ_COMMITTED* ]]; then
+    local isolation_level=$(mysql -h $db_host $db_name  --user=$db_user --password="$password" -s -N -e 'select @@global.tx_isolation')
+    echo "isolation_level : $isolation_level"
+    if [[ $isolation_level != "READ-COMMITTED" ]]; then
         err_msg "WARNING: candlepin requires READ-COMMITTED isolation level"
     fi
 }

--- a/buildSrc/src/main/groovy/Rspec.groovy
+++ b/buildSrc/src/main/groovy/Rspec.groovy
@@ -32,6 +32,9 @@ class Rspec extends DefaultTask {
     @Input
     String spec = ""
 
+    @Input
+    boolean fileOutput = true
+
     @Option(option = 'spec', description = 'The name of the spec file to search. Example: "core_and_ram"')
     void setSpec(final String specfile_name) {
         this.spec = specfile_name
@@ -40,6 +43,11 @@ class Rspec extends DefaultTask {
     @Option(option = 'test', description = 'Set the name of the spec test to run')
     void setTest(final String test_name) {
         this.test = test_name
+    }
+
+    @Option(option = 'no-file', description = 'Do not write output to an html file (the output is saved to a file by default)')
+    void setFileOutput(final boolean out) {
+        this.fileOutput = false
     }
 
     @TaskAction
@@ -51,6 +59,14 @@ class Rspec extends DefaultTask {
                 "--format", "ModifiedRSpec::FailuresFormatter",
                 "-I", "${project.getProjectDir()}/client/ruby"
         ]
+
+        if (fileOutput) {
+            rspec_args.add("--format")
+            rspec_args.add("h")
+            rspec_args.add("--force-color")
+            rspec_args.add("--out")
+            rspec_args.add("build/reports/tests/rspec/index.html")
+        }
 
         // Use --pattern to match the name of the spec file for the spec argument
         if (spec){

--- a/docker/candlepin-base/cp-test
+++ b/docker/candlepin-base/cp-test
@@ -55,10 +55,13 @@ build_rspec() {
     RSPEC_FILTER=$1
 
     BUILDR_ARGS="rspec"
+    GRADLE_ARGS=""
     if [ ! -z "$RSPEC_FILTER" ]; then
         BUILDR_ARGS="rspec:${RSPEC_FILTER}"
         GRADLE_ARGS="--spec ${RSPEC_FILTER}"
     fi
+
+    GRADLE_ARGS="${GRADLE_ARGS} --no-file"
 
     if [ -f ../gradlew ]; then
         ../gradlew rspec ${GRADLE_ARGS}

--- a/docker/mysql.cnf
+++ b/docker/mysql.cnf
@@ -6,7 +6,6 @@ default-character-set=utf8mb4
 
 [mysqld]
 symbolic-links=0
-transaction-isolation=READ-COMMITTED
 # MySQL/MariaDB "utf8" charset only supports characters up to three bytes wide
 # (i.e. no emojis).  To get full unicode support, we need to use "utf8mb4"
 # See https://mathiasbynens.be/notes/mysql-utf8mb4
@@ -14,3 +13,4 @@ init-connect='SET NAMES utf8mb4'
 collation-server=utf8mb4_unicode_ci
 character-set-server=utf8mb4
 character-set-client-handshake=FALSE
+transaction-isolation=READ-COMMITTED

--- a/docker/test
+++ b/docker/test
@@ -23,7 +23,8 @@ while getopts ":bc:dmn:opl" opt; do
   case $opt in
     c) TEST_CMD="$OPTARG";;
     m) COMPOSE_ARGS="-f $DIR/docker-compose-mysql.yml";
-       chcon -Rt svirt_sandbox_file_t $DIR/mysql.cnf;;
+       chcon -Rt svirt_sandbox_file_t $DIR/mysql.cnf;
+       sudo chown 999:999 $DIR/mysql.cnf;;
     n) PROJ_NAME="-p $OPTARG";;
     p) COMPOSE_ARGS="-f $DIR/docker-compose-postgres.yml";;
     l) USE_CACHE="1";;

--- a/docker/test
+++ b/docker/test
@@ -42,7 +42,7 @@ while getopts ":bc:dmn:opl" opt; do
 done
 
 # PROJ_NAME should be set in a jenkins environment. It allows multiple
-#  instaces of the compose to run without clobbering eachother.
+#  instances of the compose to run without clobbering each other.
 cd $DIR
 docker-compose $PROJ_NAME stop
 docker-compose $PROJ_NAME rm -f

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -29,6 +29,11 @@ pipeline {
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/unit-tests.sh'
                     }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
+                    }
                 }
                 stage('checkstyle') {
                     agent { label 'candlepin' }
@@ -37,6 +42,11 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/lint.sh'
+                    }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
                     }
                 }
                 stage('rspec-postgresql') {
@@ -51,6 +61,11 @@ pipeline {
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/rspec-tests.sh'
                     }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
+                    }
                 }
                 stage('rspec-mysql') {
                     agent { label 'candlepin' }
@@ -64,6 +79,11 @@ pipeline {
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/rspec-tests.sh'
                     }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
+                    }
                 }
                 stage('rspec-postgres-hosted') {
                     agent { label 'candlepin' }
@@ -76,6 +96,11 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/rspec-tests.sh'
+                    }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
                     }
                 }
                 stage('rspec-mysql-hosted') {
@@ -103,6 +128,11 @@ pipeline {
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/rspec-tests.sh'
                     }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
+                    }
                 }
                 stage('bugzilla-reference') {
                     environment {
@@ -122,6 +152,11 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/candlepin-validate-text.sh'
+                    }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
                     }
                 }
             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
     agent { label 'docker' }
     options {
         skipDefaultCheckout true
+        timeout(time: 16, unit: 'HOURS')
     }
     environment {
         CANDLEPIN_QUAY_BOT = credentials("candlepin-quay-bot")

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -28,7 +28,6 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/unit-tests.sh'
-                        sh 'docker logout quay.io'
                     }
                 }
                 stage('checkstyle') {
@@ -38,7 +37,6 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/lint.sh'
-                        sh 'docker logout quay.io'
                     }
                 }
                 stage('rspec-postgresql') {
@@ -52,7 +50,6 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/rspec-tests.sh'
-                        sh 'docker logout quay.io'
                     }
                 }
                 stage('rspec-mysql') {
@@ -66,7 +63,6 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/rspec-tests.sh'
-                        sh 'docker logout quay.io'
                     }
                 }
                 stage('rspec-postgres-hosted') {
@@ -80,7 +76,6 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/rspec-tests.sh'
-                        sh 'docker logout quay.io'
                     }
                 }
                 stage('rspec-mysql-hosted') {
@@ -94,7 +89,6 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/rspec-tests.sh'
-                        sh 'docker logout quay.io'
                     }
                 }
                 stage('rspec-qpid') {
@@ -108,7 +102,6 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/rspec-tests.sh'
-                        sh 'docker logout quay.io'
                     }
                 }
                 stage('bugzilla-reference') {
@@ -120,7 +113,6 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'python jenkins/check_pr_branch.py $CHANGE_ID'
-                        sh 'docker logout quay.io'
                     }
                 }
                 stage('validate-translation') {
@@ -130,7 +122,6 @@ pipeline {
                         checkout scm
                         sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'sh jenkins/candlepin-validate-text.sh'
-                        sh 'docker logout quay.io'
                     }
                 }
             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -4,7 +4,7 @@ library identifier: 'fh-pipeline-library@master', retriever: modernSCM(
    credentialsId: 'github-api-token-as-username-password'])
 
 pipeline {
-    agent { label 'docker' }
+    agent { label 'candlepin' }
     options {
         skipDefaultCheckout true
         timeout(time: 16, unit: 'HOURS')
@@ -22,7 +22,7 @@ pipeline {
             parallel {
                 stage('unit') {
                     // ensures that this stage will get assigned its own workspace
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
                         checkout scm
@@ -31,7 +31,7 @@ pipeline {
                     }
                 }
                 stage('checkstyle') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
                         checkout scm
@@ -40,7 +40,7 @@ pipeline {
                     }
                 }
                 stage('rspec-postgresql') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     environment {
                         CANDLEPIN_DATABASE = 'postgresql'
                         CP_TEST_ARGS = '-r'
@@ -53,7 +53,7 @@ pipeline {
                     }
                 }
                 stage('rspec-mysql') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     environment {
                         CANDLEPIN_DATABASE = 'mysql'
                         CP_TEST_ARGS = '-r'
@@ -66,7 +66,7 @@ pipeline {
                     }
                 }
                 stage('rspec-postgres-hosted') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     environment {
                         CANDLEPIN_DATABASE = 'postgresql'
                         CP_TEST_ARGS = '-H'
@@ -79,7 +79,7 @@ pipeline {
                     }
                 }
                 stage('rspec-mysql-hosted') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     environment {
                         CANDLEPIN_DATABASE = 'mysql'
                         CP_TEST_ARGS = '-H'
@@ -116,7 +116,7 @@ pipeline {
                     }
                 }
                 stage('validate-translation') {
-                    agent { label 'docker' }
+                    agent { label 'candlepin' }
                     steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
                         checkout scm

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -137,6 +137,7 @@ pipeline {
                 stage('bugzilla-reference') {
                     environment {
                         GITHUB_TOKEN = credentials('github-api-token-as-username-password')
+                        BUGZILLA_TOKEN = credentials('BUGZILLA_API_TOKEN')
                     }
                     steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'

--- a/jenkins/cleanup.sh
+++ b/jenkins/cleanup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+
+echo "Cleaning up workspace: ${WORKSPACE}"
+
+DIR="$(git rev-parse --show-toplevel)/docker/"
+cd $DIR
+
+# Run the cleanup
+PROJ_NAME="${STAGE_NAME}-${BUILD_TAG}"
+docker-compose -p $PROJ_NAME down
+RETVAL=$?
+
+cd -
+
+exit $RETVAL


### PR DESCRIPTION
Some explanation here: Satellite 6.9 is on 3.1.28, while candlepin-3.1-HOTFIX has too many unneeded commits (it is up to 3.1.31) that may destabilize it. Therefore we need a separate branch for 3.1 to be able to backport and release critical fixes only at this point (and to stop using candlepin-3.1-HOTFIX). This is what candlepin-3.1.28-4-HOTFIX will be.

This PR, is simply for only adding the needed infrastructure-related (jenkins/docker) commits to this branch, and to test that the pipeline works.