### PR TITLE
[M] Added consumer name to cp_deleted_consumer table (ENT-4570)

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -8798,6 +8798,8 @@ components:
               type: string
             consumerUuid:
               type: string
+            consumerName:
+              type: string
             ownerId:
               type: string
             ownerKey:

--- a/spec/deleted_consumer_spec.rb
+++ b/spec/deleted_consumer_spec.rb
@@ -18,7 +18,10 @@ describe 'Deleted Consumer Resource' do
     consumer1.unregister(consumer1.uuid)
 
     deleted_consumers = @cp.get_deleted_consumers(date=date)
-    deleted_consumers.map { |i| i['consumerUuid'] }.should include(uuid)
+    deleted_consumer = deleted_consumers.find { |item| item['consumerUuid'].include?(uuid) }
+    expect(deleted_consumer['consumerUuid']).to eq(uuid)
+    expect(deleted_consumer['consumerName']).to eq(consumername1)
+
   end
 
 end

--- a/src/main/java/org/candlepin/dto/api/v1/DeletedConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/DeletedConsumerTranslator.java
@@ -65,6 +65,7 @@ public class DeletedConsumerTranslator implements ObjectTranslator<DeletedConsum
 
         dest.id(source.getId())
             .consumerUuid(source.getConsumerUuid())
+            .consumerName(source.getConsumerName())
             .ownerId(source.getOwnerId())
             .ownerKey(source.getOwnerKey())
             .ownerDisplayName(source.getOwnerDisplayName())

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -216,6 +216,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         deletedConsumer.setConsumerUuid(entity.getUuid())
             .setOwnerId(entity.getOwnerId())
             .setOwnerKey(owner.getKey())
+            .setConsumerName(entity.getName())
             .setOwnerDisplayName(owner.getDisplayName())
             .setPrincipalName(principal != null ? principal.getName() : null);
 

--- a/src/main/java/org/candlepin/model/DeletedConsumer.java
+++ b/src/main/java/org/candlepin/model/DeletedConsumer.java
@@ -55,6 +55,11 @@ public class DeletedConsumer extends AbstractHibernateObject {
     @NotNull
     private String consumerUuid;
 
+    @Column(name = "consumer_name", length = 255)
+    @Size(max = 255)
+    @NotNull
+    private String consumerName;
+
     /**
      * using the id instead of actual Owner because the owner could be deleted
      * and we still want to keep this record around.
@@ -108,6 +113,15 @@ public class DeletedConsumer extends AbstractHibernateObject {
     public DeletedConsumer setOwnerId(String oid) {
         ownerId = oid;
         return this;
+    }
+
+    public DeletedConsumer setConsumerName(String consumerName) {
+        this.consumerName = consumerName;
+        return this;
+    }
+
+    public String getConsumerName() {
+        return consumerName;
     }
 
     public String getOwnerId() {

--- a/src/main/resources/db/changelog/20220329140000-add_consumer_name_to_cp_deleted_consumers.xml
+++ b/src/main/resources/db/changelog/20220329140000-add_consumer_name_to_cp_deleted_consumers.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20220329140000-1" author="JoshAlbrecht23">
+        <comment>
+            Add consumer name to the cp_deleted_consumers table.
+        </comment>
+
+        <addColumn tableName="cp_deleted_consumers">
+            <column name="consumer_name" type="VARCHAR(255)"/>
+        </addColumn>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1261,4 +1261,5 @@
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
     <include file="db/changelog/20220328090000-accommodate_large_overrides.xml"/>
+    <include file="db/changelog/20220329140000-add_consumer_name_to_cp_deleted_consumers.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2353,4 +2353,5 @@
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
     <include file="db/changelog/20220328090000-accommodate_large_overrides.xml"/>
+    <include file="db/changelog/20220329140000-add_consumer_name_to_cp_deleted_consumers.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -170,4 +170,5 @@
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
     <include file="db/changelog/20220328090000-accommodate_large_overrides.xml"/>
+    <include file="db/changelog/20220329140000-add_consumer_name_to_cp_deleted_consumers.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/dto/api/v1/DeletedConsumerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/DeletedConsumerTranslatorTest.java
@@ -44,6 +44,7 @@ public class DeletedConsumerTranslatorTest extends
         DeletedConsumer source = new DeletedConsumer();
         source.setId("deleted-consumer-id");
         source.setConsumerUuid("deleted-consumer-uuid");
+        source.setConsumerName("deleted-consumer-name");
         source.setOwnerId("deleted-consumer-owner-id");
         source.setOwnerKey("deleted-consumer-owner-key");
         source.setOwnerDisplayName("deleted-consumer-owner-display-name");
@@ -62,6 +63,7 @@ public class DeletedConsumerTranslatorTest extends
         if (source != null) {
             assertEquals(source.getId(), dest.getId());
             assertEquals(source.getConsumerUuid(), dest.getConsumerUuid());
+            assertEquals(source.getConsumerName(), dest.getConsumerName());
             assertEquals(source.getOwnerId(), dest.getOwnerId());
             assertEquals(source.getOwnerKey(), dest.getOwnerKey());
         }

--- a/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -842,6 +842,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         DeletedConsumer dc = dcc.findByConsumerUuid(cid);
 
         assertEquals(cid, dc.getConsumerUuid());
+        assertEquals(consumer.getName(), dc.getConsumerName());
         assertEquals(owner.getId(), dc.getOwnerId());
     }
 

--- a/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
@@ -44,6 +44,7 @@ public class DeletedConsumerCuratorTest extends DatabaseTestFixture {
         super.init();
 
         DeletedConsumer dc = new DeletedConsumer("abcde", "10", "key", "name");
+        dc.setConsumerName("consumerName");
         dcc.create(dc);
         try {
             Thread.sleep(5);
@@ -58,6 +59,7 @@ public class DeletedConsumerCuratorTest extends DatabaseTestFixture {
         // a created timestamp after this time
         twoResultsDate = new Date();
         dc = new DeletedConsumer("fghij", "10", "key", "name");
+        dc.setConsumerName("consumerName");
         dcc.create(dc);
         try {
             Thread.sleep(5);
@@ -69,6 +71,7 @@ public class DeletedConsumerCuratorTest extends DatabaseTestFixture {
 
         oneResultDate = new Date();
         dc = new DeletedConsumer("klmno", "20", "key", "name");
+        dc.setConsumerName("consumerName");
         dcc.create(dc);
     }
 

--- a/src/test/java/org/candlepin/model/DeletedConsumerTest.java
+++ b/src/test/java/org/candlepin/model/DeletedConsumerTest.java
@@ -15,42 +15,138 @@
 package org.candlepin.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
 
 public class DeletedConsumerTest {
 
-    private DeletedConsumer dc = new DeletedConsumer("abcde", "10", "key", "displayname");
-
     @Test
-    public void consumerId() {
-        assertEquals("abcde", dc.getConsumerUuid());
-        dc.setConsumerUuid("changed");
-        assertEquals("changed", dc.getConsumerUuid());
+    public void testConstructors() {
+        DeletedConsumer deletedConsumer = new DeletedConsumer();
+        assertNull(deletedConsumer.getConsumerUuid());
+        assertNull(deletedConsumer.getConsumerName());
+        assertNull(deletedConsumer.getOwnerId());
+        assertNull(deletedConsumer.getOwnerKey());
+        assertNull(deletedConsumer.getOwnerDisplayName());
+        assertNull(deletedConsumer.getPrincipalName());
+
+        String expectedConsumerUuid = UUID.randomUUID().toString();
+        String expectedConsumerName = "test-consumer-name";
+        String expectedOwnerId = "test-owner-id";
+        String expectedOwnerKey = "test-owner-key";
+        String expectedOwnerDisplayName = "test-owner-display-name";
+        deletedConsumer = new DeletedConsumer(expectedConsumerUuid, expectedOwnerId,
+            expectedOwnerKey, expectedOwnerDisplayName);
+
+        assertEquals(expectedConsumerUuid, deletedConsumer.getConsumerUuid());
+        assertEquals(expectedOwnerId, deletedConsumer.getOwnerId());
+        assertEquals(expectedOwnerKey, deletedConsumer.getOwnerKey());
+        assertEquals(expectedOwnerDisplayName, deletedConsumer.getOwnerDisplayName());
     }
 
     @Test
-    public void ownerId() {
-        assertEquals("10", dc.getOwnerId());
-        dc.setOwnerId("11");
-        assertEquals("11", dc.getOwnerId());
+    public void testGetSetConsumerUuid() {
+        DeletedConsumer deletedConsumer = new DeletedConsumer();
+
+        // Verify initial state is as we expect
+        assertNull(deletedConsumer.getConsumerUuid());
+
+        String expectedConsumerUuid = UUID.randomUUID().toString();
+
+        // Update the field, and ensure we're returning a self-ref
+        DeletedConsumer out = deletedConsumer.setConsumerUuid(expectedConsumerUuid);
+        assertSame(out, deletedConsumer);
+
+        //Verify final state is as expected
+        assertEquals(expectedConsumerUuid, deletedConsumer.getConsumerUuid());
     }
 
     @Test
-    public void displayName() {
-        assertEquals("displayname", dc.getOwnerDisplayName());
-        dc.setOwnerDisplayName("dn2");
-        assertEquals("dn2", dc.getOwnerDisplayName());
+    public void testGetSetConsumerName() {
+        DeletedConsumer deletedConsumer = new DeletedConsumer();
+
+        // Verify initial state is as we expect
+        assertNull(deletedConsumer.getConsumerName());
+
+        String expectedConsumerName = "test-consumer-name";
+
+        // Update the field, and ensure we're returning a self-ref
+        DeletedConsumer out = deletedConsumer.setConsumerName(expectedConsumerName);
+        assertSame(out, deletedConsumer);
+
+        //Verify final state is as expected
+        assertEquals(expectedConsumerName, deletedConsumer.getConsumerName());
     }
 
     @Test
-    public void key() {
-        assertEquals("key", dc.getOwnerKey());
-        dc.setOwnerKey("key2");
-        assertEquals("key2", dc.getOwnerKey());
+    public void testGetSetOwnerId() {
+        DeletedConsumer deletedConsumer = new DeletedConsumer();
+
+        // Verify initial state is as we expect
+        assertNull(deletedConsumer.getOwnerId());
+
+        String expectedOwnerId = "test-owner-id";
+
+        // Update the field, and ensure we're returning a self-ref
+        DeletedConsumer out = deletedConsumer.setOwnerId(expectedOwnerId);
+        assertSame(out, deletedConsumer);
+
+        //Verify final state is as expected
+        assertEquals(expectedOwnerId, deletedConsumer.getOwnerId());
     }
 
+    @Test
+    public void testGetSetOwnerKey() {
+        DeletedConsumer deletedConsumer = new DeletedConsumer();
 
+        // Verify initial state is as we expect
+        assertNull(deletedConsumer.getOwnerKey());
 
+        String expectedOwnerKey = "test-owner-key";
+
+        // Update the field, and ensure we're returning a self-ref
+        DeletedConsumer out = deletedConsumer.setOwnerKey(expectedOwnerKey);
+        assertSame(out, deletedConsumer);
+
+        //Verify final state is as expected
+        assertEquals(expectedOwnerKey, deletedConsumer.getOwnerKey());
+    }
+
+    @Test
+    public void testGetSetOwnerDisplayName() {
+        DeletedConsumer deletedConsumer = new DeletedConsumer();
+
+        // Verify initial state is as we expect
+        assertNull(deletedConsumer.getOwnerDisplayName());
+
+        String expectedOwnerDisplayName = "test-owner-display-name";
+
+        // Update the field, and ensure we're returning a self-ref
+        DeletedConsumer out = deletedConsumer.setOwnerDisplayName(expectedOwnerDisplayName);
+        assertSame(out, deletedConsumer);
+
+        //Verify final state is as expected
+        assertEquals(expectedOwnerDisplayName, deletedConsumer.getOwnerDisplayName());
+    }
+
+    @Test
+    public void testGetSetPrincipalName() {
+        DeletedConsumer deletedConsumer = new DeletedConsumer();
+
+        // Verify initial state is as we expect
+        assertNull(deletedConsumer.getPrincipalName());
+
+        String expectedPrincipalName = "test-principal-name";
+
+        // Update the field, and ensure we're returning a self-ref
+        DeletedConsumer out = deletedConsumer.setPrincipalName(expectedPrincipalName);
+        assertSame(out, deletedConsumer);
+
+        //Verify final state is as expected
+        assertEquals(expectedPrincipalName, deletedConsumer.getPrincipalName());
+    }
 }


### PR DESCRIPTION
We are wanting to add the consumer name to the cp_deleted_consumer table so that you get back more information than the uuid of the consumer when you use the deleted_consumers endpoint.

I included a screen shot and the steps of the workflow I used to test:
1. I registered using subscription-manager, and checked cp_consumer table to get uuid and name of the consumer.
2. I unregistered and checked the cp_deleted_consumers table and verified that the correct consumer name was inserted.
3. I then verified the correct deleted consumers  information was returned from the deleted_consumers endpoint.

![workflow](https://user-images.githubusercontent.com/12454178/161064376-92149652-1972-45b0-9c55-72d1bd715c82.png)

