### PR TITLE
[M] Add openapi-generator 5.4.0 upgrade accompanying changes

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -5513,7 +5513,7 @@ paths:
         https://www.candlepinproject.org/docs/candlepin/pagination.html#paginating-results-from-candlepin
       tags:
         - Owner
-      operationId: listPools
+      operationId: listOwnerPools
       x-java-response:
         type: java.util.stream.Stream
         isContainer: true
@@ -6784,7 +6784,7 @@ paths:
         For more details please visit https://www.candlepinproject.org/docs/candlepin/pagination.html#paginating-results-from-candlepin.
       tags:
         - Pools
-      operationId: list
+      operationId: listPools
       parameters:
         - in: query
           name: owner

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import org.yaml.snakeyaml.Yaml
 
 buildscript {
     //openapi version has to be set manually in the plugins block as well.
-    ext.openapi_version = '5.2.1'
+    ext.openapi_version = '5.4.0'
 
     repositories {
         mavenCentral()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 dependencies {
     implementation(gradleApi())
-    implementation("org.openapitools:openapi-generator:5.0.0")
+    implementation("org.openapitools:openapi-generator:5.4.0")
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/buildSrc/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -49,7 +49,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
     protected boolean useBeanValidation = true;
     protected boolean useTags = false;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJavaJAXRSServerCodegen.class);
+    private final Logger LOGGER = LoggerFactory.getLogger(AbstractJavaJAXRSServerCodegen.class);
 
     public AbstractJavaJAXRSServerCodegen() {
         super();
@@ -61,16 +61,16 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         apiPackage = "org.openapitools.api";
         modelPackage = "org.openapitools.model";
 
-        // clioOptions default redifinition need to be updated
+        // clioOptions default redefinition need to be updated
         updateOption(CodegenConstants.INVOKER_PACKAGE, this.getInvokerPackage());
         updateOption(CodegenConstants.ARTIFACT_ID, this.getArtifactId());
         updateOption(CodegenConstants.API_PACKAGE, apiPackage);
         updateOption(CodegenConstants.MODEL_PACKAGE, modelPackage);
-        updateOption(this.DATE_LIBRARY, this.getDateLibrary());
+        updateOption(DATE_LIBRARY, this.getDateLibrary());
 
         additionalProperties.put("title", title);
         // java inflector uses the jackson lib
-        additionalProperties.put("jackson", "true");
+        additionalProperties.put(JACKSON, "true");
 
         cliOptions.add(new CliOption(CodegenConstants.IMPL_FOLDER, CodegenConstants.IMPL_FOLDER_DESC).defaultValue(implFolder));
         cliOptions.add(new CliOption("title", "a title describing the application").defaultValue(title));
@@ -142,8 +142,9 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         }
 
         if (openAPI.getPaths() != null) {
-            for (String pathname : openAPI.getPaths().keySet()) {
-                PathItem path = openAPI.getPaths().get(pathname);
+            for (Map.Entry<String, PathItem> openAPIGetPathsEntry : openAPI.getPaths().entrySet()) {
+                String pathname = openAPIGetPathsEntry.getKey();
+                PathItem path = openAPIGetPathsEntry.getValue();
                 if (path.readOperations() != null) {
                     for (Operation operation : path.readOperations()) {
                         if (operation.getTags() != null) {
@@ -305,6 +306,7 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
         return outputFolder + "/" + output + "/" + apiPackage().replace('.', '/');
     }
 
+    @Override
     public void setUseBeanValidation(boolean useBeanValidation) {
         this.useBeanValidation = useBeanValidation;
     }

--- a/buildSrc/src/main/resources/templates/api.mustache
+++ b/buildSrc/src/main/resources/templates/api.mustache
@@ -9,6 +9,10 @@ import javax.ws.rs.core.Response;
 {{#useSwaggerAnnotations}}
 import io.swagger.annotations.*;
 {{/useSwaggerAnnotations}}
+{{#supportAsync}}
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletableFuture;
+{{/supportAsync}}
 
 import org.jboss.resteasy.plugins.providers.multipart.MultipartInput;
 import java.util.Map;

--- a/buildSrc/src/main/resources/templates/pojo.mustache
+++ b/buildSrc/src/main/resources/templates/pojo.mustache
@@ -5,12 +5,14 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 
 {{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{#description}}/**
- * {{description}}
+ * {{.}}
  **/{{/description}}
-{{#useSwaggerAnnotations}}{{#description}}@ApiModel(description = "{{{description}}}"){{/description}}{{/useSwaggerAnnotations}}
-{{>generatedAnnotation}}{{>additionalModelTypeAnnotations}}public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+{{#useSwaggerAnnotations}}{{#description}}@ApiModel(description = "{{{.}}}"){{/description}}{{/useSwaggerAnnotations}}
+@JsonTypeName("{{name}}")
+{{>generatedAnnotation}}{{>additionalModelTypeAnnotations}}public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}
 
 {{>enumClass}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}
@@ -25,13 +27,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
   {{#vars}}/**
    {{#description}}
-   * {{description}}
+   * {{.}}
    {{/description}}
    {{#minimum}}
-   * minimum: {{minimum}}
+   * minimum: {{.}}
    {{/minimum}}
    {{#maximum}}
-   * maximum: {{maximum}}
+   * maximum: {{.}}
    {{/maximum}}
    **/
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
@@ -46,53 +48,54 @@ import com.fasterxml.jackson.annotation.JsonValue;
   }{{/generateBuilders}}
 
   {{#vendorExtensions.x-extra-annotation}}{{{vendorExtensions.x-extra-annotation}}}{{/vendorExtensions.x-extra-annotation}}{{#useSwaggerAnnotations}}
-  @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{/useSwaggerAnnotations}}
+  @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{/useSwaggerAnnotations}}
   @JsonProperty("{{baseName}}")
 {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }
 
-  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+  @JsonProperty("{{baseName}}")
+  {{#vendorExtensions.x-setter-extra-annotation}}{{{vendorExtensions.x-setter-extra-annotation}}}
+  {{/vendorExtensions.x-setter-extra-annotation}}public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
   }
 
   {{#isArray}}
-  public boolean add{{nameInCamelCase}}({{{items.datatypeWithEnum}}} {{name}}) {
+  public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
     if (this.{{name}} == null) {
       this.{{name}} = {{{defaultValue}}};
     }
 
-    return this.{{name}}.add({{name}});
-  }
-
-  public boolean remove{{nameInCamelCase}}({{{items.datatypeWithEnum}}} {{name}}) {
-    if ({{name}} != null && this.{{name}} != null) {
-      this.{{name}}.remove({{name}});
-    }
-
-    return false;
-  }
-  {{/isArray}}
-
-  {{#isMap}}
-  public {{classname}} put{{nameInCamelCase}}(String key, {{{items.datatypeWithEnum}}} {{name}}) {
-    if (this.{{name}} == null) {
-      this.{{name}} = {{{defaultValue}}};
-    }
-
-    this.{{name}}.put(key, {{name}});
+    this.{{name}}.add({{name}}Item);
     return this;
   }
 
-  public {{classname}} remove{{nameInCamelCase}}({{{items.datatypeWithEnum}}} {{name}}) {
-    if ({{name}} != null && this.{{name}} != null) {
-      this.{{name}}.remove({{name}});
+  public {{classname}} remove{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    if ({{name}}Item != null && this.{{name}} != null) {
+      this.{{name}}.remove({{name}}Item);
+    }
+
+    return this;
+  }
+  {{/isArray}}
+  {{#isMap}}
+  public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+    if (this.{{name}} == null) {
+      this.{{name}} = {{{defaultValue}}};
+    }
+
+    this.{{name}}.put(key, {{name}}Item);
+    return this;
+  }
+
+  public {{classname}} remove{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    if ({{name}}Item != null && this.{{name}} != null) {
+      this.{{name}}.remove({{name}}Item);
     }
 
     return this;
   }
   {{/isMap}}
-
   {{/vars}}
 
   @Override
@@ -149,13 +152,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
     {{#vars}}
     /**
       {{#description}}
-      * {{description}}
+      * {{.}}
       {{/description}}
       {{#minimum}}
-      * minimum: {{minimum}}
+      * minimum: {{.}}
       {{/minimum}}
       {{#maximum}}
-      * maximum: {{maximum}}
+      * maximum: {{.}}
       {{/maximum}}
       **/
     public Builder {{name}}({{{datatypeWithEnum}}} {{name}}) {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id("org.openapi.generator")
-    id 'java-library'
+    id "org.openapi.generator"
+    id "java-library"
 }
 
 description = "Candlepin Generated Client Library"
@@ -30,6 +30,6 @@ openApiGenerate {
     validateSpec = true
     skipValidateSpec = true
     configOptions = [
-        dateLibrary: "legacy"
+        dateLibrary: "java8"
     ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -418,7 +418,7 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>5.2.1</version>
+        <version>5.4.0</version>
         <executions>
           <execution>
             <goals>

--- a/src/main/java/org/candlepin/dto/api/v1/EntitlementTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/EntitlementTranslator.java
@@ -89,7 +89,7 @@ public class EntitlementTranslator implements ObjectTranslator<Entitlement, Enti
             if (certs != null && !certs.isEmpty()) {
                 for (Certificate cert : certs) {
                     if (cert != null) {
-                        dest.addCertificates(modelTranslator.translate(cert, CertificateDTO.class));
+                        dest.addCertificatesItem(modelTranslator.translate(cert, CertificateDTO.class));
                     }
                 }
             }

--- a/src/main/java/org/candlepin/model/OwnerInfoBuilder.java
+++ b/src/main/java/org/candlepin/model/OwnerInfoBuilder.java
@@ -33,13 +33,13 @@ public class OwnerInfoBuilder {
 
     public OwnerInfoBuilder() {
         ownerInfo = new OwnerInfo();
-        ownerInfo.putConsumerGuestCounts(GUEST, 0);
-        ownerInfo.putConsumerGuestCounts(PHYSICAL, 0);
+        ownerInfo.putConsumerGuestCountsItem(GUEST, 0);
+        ownerInfo.putConsumerGuestCountsItem(PHYSICAL, 0);
     }
 
     public void addTypeTotal(ConsumerType type, int consumers, int entitlements) {
-        ownerInfo.putConsumerCounts(type.getLabel(), consumers);
-        ownerInfo.putEntitlementsConsumedByType(type.getLabel(), entitlements);
+        ownerInfo.putConsumerCountsItem(type.getLabel(), consumers);
+        ownerInfo.putEntitlementsConsumedByTypeItem(type.getLabel(), entitlements);
     }
 
     public OwnerInfo build() {
@@ -51,7 +51,7 @@ public class OwnerInfoBuilder {
         if (count == null) {
             count = 0;
         }
-        ownerInfo.putConsumerTypeCountByPool(type.getLabel(), count + toAdd);
+        ownerInfo.putConsumerTypeCountByPoolItem(type.getLabel(), count + toAdd);
     }
 
     public void addToEnabledConsumerTypeCountByPool(ConsumerType type, int toAdd) {
@@ -59,12 +59,12 @@ public class OwnerInfoBuilder {
         if (count == null) {
             count = 0;
         }
-        ownerInfo.putEnabledConsumerTypeCountByPool(type.getLabel(), count + toAdd);
+        ownerInfo.putEnabledConsumerTypeCountByPoolItem(type.getLabel(), count + toAdd);
     }
 
     public void setConsumerTypesByPool(List<ConsumerType> consumerTypes) {
         for (ConsumerType c : consumerTypes) {
-            ownerInfo.putConsumerTypeCountByPool(c.getLabel(), 0);
+            ownerInfo.putConsumerTypeCountByPoolItem(c.getLabel(), 0);
         }
     }
 
@@ -73,7 +73,7 @@ public class OwnerInfoBuilder {
         ConsumptionTypeCountsDTO typeCounts;
         if (!ownerInfo.getEntitlementsConsumedByFamily().containsKey(family)) {
             typeCounts = new ConsumptionTypeCountsDTO().physical(0).guest(0);
-            ownerInfo.putEntitlementsConsumedByFamily(family, typeCounts);
+            ownerInfo.putEntitlementsConsumedByFamilyItem(family, typeCounts);
         }
         else {
             typeCounts = ownerInfo.getEntitlementsConsumedByFamily().get(family);
@@ -104,18 +104,18 @@ public class OwnerInfoBuilder {
             }
             activePools -= ownerInfo.getConsumerTypeCountByPool().get(key);
         }
-        ownerInfo.putConsumerTypeCountByPool("system", activePools);
+        ownerInfo.putConsumerTypeCountByPoolItem("system", activePools);
     }
 
     public void setGuestCount(Integer count) {
-        ownerInfo.putConsumerGuestCounts(GUEST, count);
+        ownerInfo.putConsumerGuestCountsItem(GUEST, count);
     }
 
     public void setPhysicalCount(Integer count) {
-        ownerInfo.putConsumerGuestCounts(PHYSICAL, count);
+        ownerInfo.putConsumerGuestCountsItem(PHYSICAL, count);
     }
 
     public void setConsumerCountByComplianceStatus(String status, Integer count) {
-        ownerInfo.putConsumerCountsByComplianceStatus(status, count);
+        ownerInfo.putConsumerCountsByComplianceStatusItem(status, count);
     }
 }

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1227,7 +1227,7 @@ public class OwnerResource implements OwnersApi {
 
     @Override
     @Transactional
-    public Stream<PoolDTO> listPools(
+    public Stream<PoolDTO> listOwnerPools(
         @Verify(value = Owner.class, subResource = SubResource.POOLS) String ownerKey,
         String consumerUuid,
         String activationKeyName,

--- a/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/src/main/java/org/candlepin/resource/PoolResource.java
@@ -90,7 +90,7 @@ public class PoolResource implements PoolsApi {
     @Override
     @Deprecated
     @SecurityHole
-    public List<PoolDTO> list(String ownerId, String consumerUuid, String productId,
+    public List<PoolDTO> listPools(String ownerId, String consumerUuid, String productId,
         Boolean listAll, String activeOn) {
 
         Principal principal = this.principalProvider.get();

--- a/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -149,7 +149,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         // Create a new consumer, can't re-use reference to the old:
         ConsumerDTO newConsumer = new ConsumerDTO();
         newConsumer.setUuid(consumer.getUuid());
-        newConsumer.putFacts("FACT", "FACT_VALUE");
+        newConsumer.putFactsItem("FACT", "FACT_VALUE");
 
         consumerResource.updateConsumer(consumer.getUuid(), newConsumer);
 

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -597,7 +597,7 @@ public class ConsumerResourceCreationTest {
         when(this.principalProvider.get()).thenReturn(p);
         ConsumerDTO consumer = TestUtil.createConsumerDTO("consumerName", null, null, systemDto);
         EnvironmentDTO environmentDTO = new EnvironmentDTO().id("env1");
-        consumer.addEnvironments(environmentDTO);
+        consumer.addEnvironmentsItem(environmentDTO);
         doReturn(true).when(environmentCurator).exists(environmentDTO.getId());
         Environment environment = new Environment();
         environment.setId("env1");
@@ -615,7 +615,7 @@ public class ConsumerResourceCreationTest {
         when(this.principalProvider.get()).thenReturn(p);
         ConsumerDTO consumer = TestUtil.createConsumerDTO("consumerName", null, null, systemDto);
         EnvironmentDTO environmentDTO = new EnvironmentDTO().name("envname1");
-        consumer.addEnvironments(environmentDTO);
+        consumer.addEnvironmentsItem(environmentDTO);
         doReturn("env1").when(environmentCurator).getEnvironmentIdByName(any(), any());
         Environment environment = new Environment();
         environment.setId("env1");
@@ -635,8 +635,8 @@ public class ConsumerResourceCreationTest {
         ConsumerDTO consumer = TestUtil.createConsumerDTO("consumerName", null, null, systemDto);
         EnvironmentDTO environmentDTO1 = new EnvironmentDTO().id("env1");
         EnvironmentDTO environmentDTO2 = new EnvironmentDTO().id("env2");
-        consumer.addEnvironments(environmentDTO1);
-        consumer.addEnvironments(environmentDTO2);
+        consumer.addEnvironmentsItem(environmentDTO1);
+        consumer.addEnvironmentsItem(environmentDTO2);
         doReturn(true).when(environmentCurator).exists(any());
         Environment environment1 = new Environment();
         environment1.setId("env1");
@@ -657,7 +657,7 @@ public class ConsumerResourceCreationTest {
         when(this.principalProvider.get()).thenReturn(p);
         ConsumerDTO consumer = TestUtil.createConsumerDTO("consumerName", null, null, systemDto);
         EnvironmentDTO environmentDTO = new EnvironmentDTO().id("env1");
-        consumer.addEnvironments(environmentDTO);
+        consumer.addEnvironmentsItem(environmentDTO);
 
         assertThrows(BadRequestException.class, () ->
             resource.createConsumer(consumer, USER, owner.getKey(), null, true));

--- a/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -212,7 +212,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     public void testCreateConsumer() {
         ConsumerDTO toSubmit = createConsumerDTO(CONSUMER_NAME, USER_NAME, null,
             standardSystemTypeDTO);
-        toSubmit.putFacts(METADATA_NAME, METADATA_VALUE);
+        toSubmit.putFactsItem(METADATA_NAME, METADATA_VALUE);
         ConsumerDTO submitted = consumerResource.createConsumer(
             toSubmit,
             someuser.getUsername(),
@@ -243,7 +243,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         ConsumerDTO toSubmit = createConsumerDTO(CONSUMER_NAME, USER_NAME, null, standardSystemTypeDTO);
         assertNull(toSubmit.getId());
         toSubmit.setUuid(uuid);
-        toSubmit.putFacts(METADATA_NAME, METADATA_VALUE);
+        toSubmit.putFactsItem(METADATA_NAME, METADATA_VALUE);
 
         ConsumerDTO submitted = consumerResource.createConsumer(toSubmit, null, owner.getKey(), null,
             true);
@@ -259,7 +259,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         ConsumerDTO anotherToSubmit = createConsumerDTO(CONSUMER_NAME, USER_NAME, null,
             standardSystemTypeDTO);
         anotherToSubmit.setUuid(uuid);
-        anotherToSubmit.putFacts(METADATA_NAME, METADATA_VALUE);
+        anotherToSubmit.putFactsItem(METADATA_NAME, METADATA_VALUE);
         anotherToSubmit.setId(null);
         assertThrows(BadRequestException.class, () ->
             consumerResource.createConsumer(anotherToSubmit, null, owner.getKey(), null, true));
@@ -425,7 +425,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
     public void testRegisterWithConsumerId() {
         ConsumerDTO toSubmit = createConsumerDTO(CONSUMER_NAME, USER_NAME, null, standardSystemTypeDTO);
         toSubmit.setUuid("1023131");
-        toSubmit.putFacts(METADATA_NAME, METADATA_VALUE);
+        toSubmit.putFactsItem(METADATA_NAME, METADATA_VALUE);
 
         ConsumerDTO submitted = consumerResource.createConsumer(
             toSubmit, null, null, null, true);
@@ -774,7 +774,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         Product prod = TestUtil.createProduct("Product One");
         ConsumerInstalledProductDTO updatedInstalledProduct = new ConsumerInstalledProductDTO()
             .productId(prod.getId()).productName(prod.getName());
-        consumer.addInstalledProducts(updatedInstalledProduct);
+        consumer.addInstalledProductsItem(updatedInstalledProduct);
         consumerResource.updateConsumer(consumer.getUuid(), consumer);
 
         Date afterUpdateTimestamp = consumerCurator.findByUuid(consumer.getUuid())
@@ -810,7 +810,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         Date modifiedDateOnCreate = consumerCurator.get(consumer.getId()).getRHCloudProfileModified();
 
         ConsumerDTO updatedConsumerDTO = new ConsumerDTO();
-        updatedConsumerDTO.putFacts("FACT", "FACT_VALUE");
+        updatedConsumerDTO.putFactsItem("FACT", "FACT_VALUE");
         consumerResource.updateConsumer(consumer.getUuid(), updatedConsumerDTO);
         Date modifiedTSOnUnnecessaryFactUpdate = consumerCurator.get(consumer.getId())
             .getRHCloudProfileModified();
@@ -818,7 +818,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         assertEquals(modifiedDateOnCreate, modifiedTSOnUnnecessaryFactUpdate);
 
         updatedConsumerDTO = new ConsumerDTO();
-        updatedConsumerDTO.putFacts(CloudProfileFacts.CPU_CORES_PERSOCKET.getFact(), "1");
+        updatedConsumerDTO.putFactsItem(CloudProfileFacts.CPU_CORES_PERSOCKET.getFact(), "1");
         consumerResource.updateConsumer(consumer.getUuid(), updatedConsumerDTO);
         Date modifiedTSOnNecessaryFactUpdate = consumerCurator.get(consumer.getId())
             .getRHCloudProfileModified();
@@ -836,7 +836,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         consumer.setAutoheal(true);
         consumer.setSystemPurposeStatus("test-status");
         consumer.setReleaseVer(new ReleaseVerDTO().releaseVer("test-release-version"));
-        consumer.putFacts("lscpu.model", "78");
+        consumer.putFactsItem("lscpu.model", "78");
         consumerResource.updateConsumer(consumer.getUuid(), consumer);
         Date profileModified = consumerCurator.get(consumer.getId()).getRHCloudProfileModified();
 
@@ -849,8 +849,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         consumer = consumerResource.createConsumer(consumer, null, null, null, true);
         Date profileCreated = consumerCurator.get(consumer.getId()).getRHCloudProfileModified();
 
-        consumer.putFacts("lscpu.model", "78");
-        consumer.putFacts("test-dmi.bios.vendor", "vendorA");
+        consumer.putFactsItem("lscpu.model", "78");
+        consumer.putFactsItem("test-dmi.bios.vendor", "vendorA");
         consumerResource.updateConsumer(consumer.getUuid(), consumer);
         Date profileModified = consumerCurator.get(consumer.getId()).getRHCloudProfileModified();
 

--- a/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -405,9 +405,9 @@ public class ConsumerResourceUpdateTest {
         consumer.addInstalledProduct(new ConsumerInstalledProduct(productB));
 
         ConsumerDTO incoming = new ConsumerDTO();
-        incoming.addInstalledProducts(new ConsumerInstalledProductDTO()
+        incoming.addInstalledProductsItem(new ConsumerInstalledProductDTO()
             .id(productB.getId()).productName(productB.getName()));
-        incoming.addInstalledProducts(new ConsumerInstalledProductDTO()
+        incoming.addInstalledProductsItem(new ConsumerInstalledProductDTO()
             .id(productC.getId()).productName(productC.getName()));
 
         this.resource.updateConsumer(consumer.getUuid(), incoming);
@@ -425,9 +425,9 @@ public class ConsumerResourceUpdateTest {
         consumer.addInstalledProduct(new ConsumerInstalledProduct(consumer, productB));
 
         ConsumerDTO incoming = new ConsumerDTO();
-        incoming.addInstalledProducts(new ConsumerInstalledProductDTO()
+        incoming.addInstalledProductsItem(new ConsumerInstalledProductDTO()
             .id(productB.getId()).productName(productB.getName()));
-        incoming.addInstalledProducts(new ConsumerInstalledProductDTO()
+        incoming.addInstalledProductsItem(new ConsumerInstalledProductDTO()
             .id(productC.getId()).productName(productC.getName()));
 
         this.resource.updateConsumer(consumer.getUuid(), incoming);
@@ -507,7 +507,7 @@ public class ConsumerResourceUpdateTest {
         updated.setUuid(uuid);
 
         GuestIdDTO expectedGuestId = TestUtil.createGuestIdDTO("Guest 2");
-        updated.addGuestIds(expectedGuestId);
+        updated.addGuestIdsItem(expectedGuestId);
 
         when(this.consumerCurator.getGuestConsumersMap(any(String.class), anySet())).
             thenReturn(new VirtConsumerMap());
@@ -812,13 +812,13 @@ public class ConsumerResourceUpdateTest {
 
         ConsumerDTO updated = new ConsumerDTO();
         updated.setUuid(uuid);
-        updated.putFacts(expectedFactName, expectedFactValue);
+        updated.putFactsItem(expectedFactName, expectedFactValue);
         Product prod = TestUtil.createProduct("Product One");
         ConsumerInstalledProductDTO expectedInstalledProduct =
             new ConsumerInstalledProductDTO().id(prod.getId()).productName(prod.getName());
 
-        updated.addInstalledProducts(expectedInstalledProduct);
-        updated.addGuestIds(expectedGuestId);
+        updated.addInstalledProductsItem(expectedInstalledProduct);
+        updated.addGuestIdsItem(expectedGuestId);
 
         when(this.consumerCurator.getGuestConsumersMap(any(String.class), anySet())).
             thenReturn(new VirtConsumerMap());
@@ -855,7 +855,7 @@ public class ConsumerResourceUpdateTest {
         Owner owner = createOwner();
         OwnerDTO ownerDTO = new OwnerDTO();
         ownerDTO.setId(owner.getId());
-        updated.addEnvironments(translator.translate(changedEnvironment, EnvironmentDTO.class));
+        updated.addEnvironmentsItem(translator.translate(changedEnvironment, EnvironmentDTO.class));
         updated.setOwner(new NestedOwnerDTO());
 
         when(environmentCurator.get(changedEnvironment.getId())).thenReturn(changedEnvironment);
@@ -877,7 +877,7 @@ public class ConsumerResourceUpdateTest {
 
         ConsumerDTO updated = new ConsumerDTO();
         updated.setUuid(uuid);
-        updated.addEnvironments(changedEnvironment);
+        updated.addEnvironmentsItem(changedEnvironment);
 
         Consumer existing = getFakeConsumer();
         existing.setUuid(updated.getUuid());
@@ -1098,7 +1098,7 @@ public class ConsumerResourceUpdateTest {
         OwnerDTO ownerDTO = new OwnerDTO();
         ownerDTO.setId(owner.getId());
 
-        updated.addEnvironments(translator.translate(changedEnvironment, EnvironmentDTO.class));
+        updated.addEnvironmentsItem(translator.translate(changedEnvironment, EnvironmentDTO.class));
         updated.setOwner(new NestedOwnerDTO());
 
         when(environmentCurator.get(changedEnvironment.getId())).thenReturn(changedEnvironment);
@@ -1321,7 +1321,7 @@ public class ConsumerResourceUpdateTest {
 
         EnvironmentDTO changedEnvironment = new EnvironmentDTO().id("42").name("environment");
         ConsumerDTO updated = new ConsumerDTO();
-        updated.addEnvironments(changedEnvironment);
+        updated.addEnvironmentsItem(changedEnvironment);
         Consumer existing = getFakeConsumer();
 
         assertThrows(BadRequestException.class,

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -370,7 +370,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         when(this.principalProvider.get()).thenReturn(principal);
         securityInterceptor.enable();
 
-        ownerResource.listPools(owner.getKey(), null, null, null, null, false, null,
+        ownerResource.listOwnerPools(owner.getKey(), null, null, null, null, false, null,
             null, new ArrayList<>(), false, false, null, null);
     }
 
@@ -404,8 +404,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         poolCurator.create(pool2);
 
         when(this.principalProvider.get()).thenReturn(principal);
-        Stream<PoolDTO> result = ownerResource.listPools(owner.getKey(), c.getUuid(), null, null, null, false,
-            Util.toDateTime(new Date()), null, new ArrayList<>(), false, false, null, null);
+        Stream<PoolDTO> result = ownerResource.listOwnerPools(owner.getKey(), c.getUuid(), null, null, null,
+            false, Util.toDateTime(new Date()), null, new ArrayList<>(), false, false, null, null);
 
         assertNotNull(result);
         List<PoolDTO> nowList = result.collect(Collectors.toList());
@@ -414,7 +414,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assert (nowList.get(0).getId().equals(pool1.getId()));
 
         Date activeOn = new Date(pool2.getStartDate().getTime() + 1000L * 60 * 60 * 24);
-        result = ownerResource.listPools(owner.getKey(), c.getUuid(), null, null, null, false,
+        result = ownerResource.listOwnerPools(owner.getKey(), c.getUuid(), null, null, null, false,
             Util.toDateTime(activeOn), null, new ArrayList<>(), false, false, null, null);
 
         assertNotNull(result);
@@ -436,7 +436,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         when(this.principalProvider.get()).thenReturn(principal);
 
-        Stream<PoolDTO> result = ownerResource.listPools(owner.getKey(), null, null, null, null, true,
+        Stream<PoolDTO> result = ownerResource.listOwnerPools(owner.getKey(), null, null, null, null, true,
             null, null, new ArrayList<>(), false, false, null, null);
 
         assertNotNull(result);
@@ -463,7 +463,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         params.add(createKeyValueParam("cores", "12"));
 
         when(this.principalProvider.get()).thenReturn(principal);
-        Stream<PoolDTO> result = ownerResource.listPools(owner.getKey(), null,
+        Stream<PoolDTO> result = ownerResource.listOwnerPools(owner.getKey(), null,
             null, null, null, true, null, null, params, false, false, null, null);
 
         assertNotNull(result);
@@ -475,7 +475,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         params.clear();
         params.add(createKeyValueParam("virt_only", "true"));
 
-        result = ownerResource.listPools(owner.getKey(), null, null,
+        result = ownerResource.listOwnerPools(owner.getKey(), null, null,
             null, null, true, null, null, params, false, false, null, null);
 
         assertNotNull(result);
@@ -502,7 +502,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         List<KeyValueParamDTO> params = new ArrayList<>();
 
         when(this.principalProvider.get()).thenReturn(principal);
-        Stream<PoolDTO> result = ownerResource.listPools(owner.getKey(), null, null, null, null, true,
+        Stream<PoolDTO> result = ownerResource.listOwnerPools(owner.getKey(), null, null, null, null, true,
             null, null, params, false, false, null, null);
 
         assertNotNull(result);
@@ -513,7 +513,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         params = new ArrayList<>();
         params.add(createKeyValueParam(Pool.Attributes.DEVELOPMENT_POOL, "!true"));
 
-        result = ownerResource.listPools(owner.getKey(), null, null, null, null,
+        result = ownerResource.listOwnerPools(owner.getKey(), null, null, null, null,
             true, null, null, params, false, false, null, null);
 
         assertNotNull(result);
@@ -549,7 +549,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         // Filtering should just cause this to return no results:
         assertThrows(NotFoundException.class, () ->
-            ownerResource.listPools(owner.getKey(), null, null, null, null, true, null,
+            ownerResource.listOwnerPools(owner.getKey(), null, null, null, null, true, null,
             null, new ArrayList<>(), false, false, null, null));
     }
 
@@ -1070,7 +1070,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         securityInterceptor.enable();
 
-        Stream<PoolDTO> poolStream = ownerResource.listPools(owner.getKey(), c.getUuid(), null,
+        Stream<PoolDTO> poolStream = ownerResource.listOwnerPools(owner.getKey(), c.getUuid(), null,
             p.getId(), null, true, null, null, new ArrayList<>(), false, false, null, null);
 
         assertNotNull(poolStream);
@@ -1097,7 +1097,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         Principal principal = setupPrincipal(owner2, Access.NONE);
         when(this.principalProvider.get()).thenReturn(principal);
 
-        assertThrows(NotFoundException.class, () -> ownerResource.listPools(
+        assertThrows(NotFoundException.class, () -> ownerResource.listOwnerPools(
             owner.getKey(), c.getUuid(), null, p.getUuid(),  null, true, null, null,
             new ArrayList<>(), false, false, null, null)
         );

--- a/src/test/java/org/candlepin/resource/PoolResourceTest.java
+++ b/src/test/java/org/candlepin/resource/PoolResourceTest.java
@@ -124,7 +124,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
 
         assertThrows(ForbiddenException.class, () ->
-            poolResource.list(null, null, null, false, null)
+            poolResource.listPools(null, null, null, false, null)
         );
     }
 
@@ -132,20 +132,20 @@ public class PoolResourceTest extends DatabaseTestFixture {
     public void testListAll() {
         when(this.principalProvider.get()).thenReturn(setupAdminPrincipal("superadmin"));
 
-        List<PoolDTO> pools = poolResource.list(null, null, null, false, null);
+        List<PoolDTO> pools = poolResource.listPools(null, null, null, false, null);
         assertEquals(3, pools.size());
     }
 
     @Test
     public void testListForOrg() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
-        List<PoolDTO> pools = poolResource.list(owner1.getId(), null, null,
+        List<PoolDTO> pools = poolResource.listPools(owner1.getId(), null, null,
             false, null);
         assertEquals(2, pools.size());
 
         when(this.principalProvider.get()).thenReturn(setupPrincipal(owner2, Access.ALL));
 
-        pools = poolResource.list(owner2.getId(), null, null, false, null);
+        pools = poolResource.listPools(owner2.getId(), null, null, false, null);
         assertEquals(1, pools.size());
     }
 
@@ -154,10 +154,10 @@ public class PoolResourceTest extends DatabaseTestFixture {
     public void testListForProduct() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
 
-        List<PoolDTO> pools = poolResource.list(null, null, product1.getId(),
+        List<PoolDTO> pools = poolResource.listPools(null, null, product1.getId(),
             false, null);
         assertEquals(2, pools.size());
-        pools = poolResource.list(null, null, product2.getId(), false, null);
+        pools = poolResource.listPools(null, null, product2.getId(), false, null);
         assertEquals(1, pools.size());
     }
 
@@ -165,7 +165,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
     public void testListForOrgAndProduct() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
 
-        List<PoolDTO> pools = poolResource.list(owner1.getId(), null, product1.getId(), false,
+        List<PoolDTO> pools = poolResource.listPools(owner1.getId(), null, product1.getId(), false,
             null);
         assertEquals(1, pools.size());
     }
@@ -175,7 +175,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
 
         assertThrows(NotFoundException.class, () ->
-            poolResource.list(owner2.getId(), null, product2.getId(), false, null)
+            poolResource.listPools(owner2.getId(), null, product2.getId(), false, null)
         );
     }
 
@@ -183,7 +183,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
     public void testListConsumerAndProductFiltering() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
 
-        List<PoolDTO> pools = poolResource.list(null, passConsumer.getUuid(),
+        List<PoolDTO> pools = poolResource.listPools(null, passConsumer.getUuid(),
             product1.getId(), false, null);
         assertEquals(1, pools.size());
 
@@ -194,7 +194,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
     @Test
     public void testCannotListPoolsForConsumerInAnotherOwner() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
-        assertThrows(NotFoundException.class, () -> poolResource.list(null, failConsumer.getUuid(),
+        assertThrows(NotFoundException.class, () -> poolResource.listPools(null, failConsumer.getUuid(),
             product1.getId(), false, null)
         );
     }
@@ -204,7 +204,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
     @Test
     public void testListBlocksConsumerOwnerFiltering() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
-        assertThrows(BadRequestException.class, () -> poolResource.list(owner1.getId(),
+        assertThrows(BadRequestException.class, () -> poolResource.listPools(owner1.getId(),
             passConsumer.getUuid(), product1.getId(), false, null)
         );
     }
@@ -213,7 +213,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
     public void testListConsumerFiltering() {
         when(this.principalProvider.get()).thenReturn(
             setupPrincipal(new ConsumerPrincipal(passConsumer, owner1)));
-        List<PoolDTO> pools = poolResource.list(
+        List<PoolDTO> pools = poolResource.listPools(
             null, passConsumer.getUuid(), null, false, null);
         assertEquals(2, pools.size());
 
@@ -225,7 +225,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
     public void testListNoSuchOwner() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
         assertThrows(NotFoundException.class, () ->
-            poolResource.list("-1", null, null, false, null)
+            poolResource.listPools("-1", null, null, false, null)
         );
     }
 
@@ -233,21 +233,21 @@ public class PoolResourceTest extends DatabaseTestFixture {
     public void testListNoSuchConsumer() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
         assertThrows(NotFoundException.class, () ->
-            poolResource.list(null, "blah", null, false, null)
+            poolResource.listPools(null, "blah", null, false, null)
         );
     }
 
     @Test
     public void testListNoSuchProduct() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
-        assertEquals(0, poolResource.list(owner1.getId(), null, "boogity", false,
+        assertEquals(0, poolResource.listPools(owner1.getId(), null, "boogity", false,
             null).size());
     }
 
     @Test
     public void ownerAdminCannotListAnotherOwnersPools() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
-        List<PoolDTO> pools = poolResource.list(owner1.getId(), null, null, false, null);
+        List<PoolDTO> pools = poolResource.listPools(owner1.getId(), null, null, false, null);
         assertEquals(2, pools.size());
 
         setupPrincipal(owner2, Access.ALL);
@@ -255,7 +255,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
 
         when(this.principalProvider.get()).thenReturn(setupPrincipal(owner2, Access.ALL));
         assertThrows(NotFoundException.class, () ->
-            poolResource.list(owner1.getId(), null, null, false, null)
+            poolResource.listPools(owner1.getId(), null, null, false, null)
         );
     }
 
@@ -265,7 +265,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
         when(this.principalProvider.get()).thenReturn(
             setupPrincipal(new ConsumerPrincipal(foreignConsumer, owner2)));
         assertThrows(NotFoundException.class, () ->
-            poolResource.list(null, passConsumer.getUuid(), null, false, null)
+            poolResource.listPools(null, passConsumer.getUuid(), null, false, null)
         );
     }
 
@@ -275,7 +275,7 @@ public class PoolResourceTest extends DatabaseTestFixture {
         when(this.principalProvider.get()).thenReturn(
             setupPrincipal(new ConsumerPrincipal(foreignConsumer, owner2)));
         assertThrows(NotFoundException.class, () ->
-            poolResource.list(owner1.getId(), null, null, false, null)
+            poolResource.listPools(owner1.getId(), null, null, false, null)
         );
     }
 
@@ -285,14 +285,14 @@ public class PoolResourceTest extends DatabaseTestFixture {
         when(this.principalProvider.get()).thenReturn(
             setupPrincipal(new ConsumerPrincipal(passConsumer, owner1)));
 
-        poolResource.list(owner1.getId(), null, null, false, null);
+        poolResource.listPools(owner1.getId(), null, null, false, null);
     }
 
     @Test
     public void testBadActiveOnDate() {
         when(this.principalProvider.get()).thenReturn(this.adminPrincipal);
         assertThrows(BadRequestException.class, () ->
-            poolResource.list(owner1.getId(), null, null, false, "bc")
+            poolResource.listPools(owner1.getId(), null, null, false, "bc")
         );
     }
 
@@ -303,11 +303,11 @@ public class PoolResourceTest extends DatabaseTestFixture {
 
         when(this.principalProvider.get()).thenReturn(setupAdminPrincipal("superadmin"));
 
-        List<PoolDTO> pools = poolResource.list(null, null, null, false, activeOn);
+        List<PoolDTO> pools = poolResource.listPools(null, null, null, false, activeOn);
         assertEquals(3, pools.size());
 
         activeOn = Integer.toString(START_YEAR - 1);
-        pools = poolResource.list(owner1.getId(), null, null, false, activeOn);
+        pools = poolResource.listPools(owner1.getId(), null, null, false, activeOn);
         assertEquals(0, pools.size());
     }
 


### PR DESCRIPTION
- Merge changes from upstream v5.4.0 to our local copies of:
    * AbstractJavaJAXRSServerCodegen.java
    * api.mustache
    * pojo.mustache
    * Keep our custom workarounds introduced in d6a9b9e7f, bfa2bc88f
      and 733fc0b8a
- Remove our custom workaround from 25c2c0d48 because the fix is in
  upstream and use the new method convention 'put/add*Item()'
- Fix issue with ambiguous operationId name generation
- Update the client openapi config to use the JDK8 date/time API