### PR TITLE
adding milestones to abort previous builds

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -4,13 +4,26 @@ library identifier: 'fh-pipeline-library@master', retriever: modernSCM(
    credentialsId: 'github-api-token-as-username-password'])
 
 pipeline {
-    agent { label 'candlepin' }
+    agent none
     options {
         skipDefaultCheckout true
         timeout(time: 16, unit: 'HOURS')
     }
     stages {
+        stage('Stop Old Builds') {
+            // purely a jenkins step; no env needed
+            agent none
+            steps {
+                script {
+                    // stops all previous running builds
+                    for (int i = 1; i <= (env.BUILD_NUMBER as int); i++) {
+                       milestone ordinal: i
+                    }
+                }
+            }
+        }
         stage('Trust') {
+            agent none
             steps {
                 enforceTrustedApproval("candlepin","rhsm-jenkins-github-app")
             }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -8,20 +8,9 @@ pipeline {
     options {
         skipDefaultCheckout true
         timeout(time: 16, unit: 'HOURS')
+        disableConcurrentBuilds(abortPrevious: true)
     }
     stages {
-        stage('Stop Old Builds') {
-            // purely a jenkins step; no env needed
-            agent none
-            steps {
-                script {
-                    // stops all previous running builds
-                    for (int i = 1; i <= (env.BUILD_NUMBER as int); i++) {
-                       milestone ordinal: i
-                    }
-                }
-            }
-        }
         stage('Trust') {
             agent none
             steps {
@@ -160,6 +149,7 @@ pipeline {
                     }
                 }
                 stage('bugzilla-reference') {
+                    agent { label 'candlepin' }
                     environment {
                         GITHUB_TOKEN = credentials('github-api-token-as-username-password')
                         BUGZILLA_TOKEN = credentials('BUGZILLA_API_TOKEN')


### PR DESCRIPTION
This PR uses the built in milestones plugin https://www.jenkins.io/doc/pipeline/steps/pipeline-milestone-step/  to stop previous builds.  Instead of manually tracking milestone steps as in the docs of this plugin we're setting them to the build number so that the latest milestone is always the latest job.  We are also setting the previous milestone in case it wasn't set.  (see https://issues.jenkins.io/browse/JENKINS-43353 ).   Some implementations of this do this in a for loop to ensure that all previous builds have a milestone set  (for example: https://github.com/RedHatInsights/insights-tag-service/blob/44abadea01427601e8962f35f099f870d4b2e754/Jenkinsfile#L27 ), however this does take time and it slows down the system for PRs with a large number of builds (hundreds?).  If we see any slowing down I can only do the last N of the loop or something.

Any reviewer can test this by going to the job for this PR in jenkins and clicking "build now" many times.  As they queue they will all be halted except the last one.
