### PR TITLE
test data: explicitly set entitlement mode for admin & donaldduck owners

### DIFF
--- a/bin/deployment/test_data.json
+++ b/bin/deployment/test_data.json
@@ -425,6 +425,8 @@
         {
             "name": "admin",
             "displayName": "Admin Owner",
+            "contentAccessModeList": "entitlement",
+            "contentAccessMode": "entitlement",
             "content": [
                 {
                     "name": "admin-content",
@@ -646,7 +648,9 @@
         },
         {
             "name": "donaldduck",
-            "displayName": "Donald Duck"
+            "displayName": "Donald Duck",
+            "contentAccessModeList": "entitlement,org_environment",
+            "contentAccessMode": "org_environment"
         }
     ],
     "users": [


### PR DESCRIPTION
After the switch to SCA by default [1], new owners are created with
content access mode set to org_environment. Since the test data did not
explicitly set the access mode for the "admin" & "donaldduck" owners,
they are now created in org_environment mode, breaking test cases that
use the test data. Since the "snowwhite" owner already has
org_environment, explicitly set the entitlement mode for the other
owners.

[1] https://github.com/candlepin/candlepin/pull/3239