### PR TITLE
[M] Added principal name for system generated jobs (ENT-4855)

### DIFF
--- a/src/main/java/org/candlepin/async/JobManager.java
+++ b/src/main/java/org/candlepin/async/JobManager.java
@@ -89,7 +89,7 @@ import javax.transaction.Synchronization;
 
 // FIXME: The transaction management here is getting out of hand. The annotations should probably
 // be removed entirely and replaced with explicit transaction management, and the protected methods
-// using them should be reverted to their propery visibility (private).
+// using them should be reverted to their proper visibility (private).
 
 
 /**
@@ -164,9 +164,11 @@ public class JobManager implements ModeChangeListener {
         @Override
         public void execute(org.quartz.JobExecutionContext context) throws org.quartz.JobExecutionException {
             String jobKey = context.getJobDetail().getKey().getName();
+            Principal principal = new JobPrincipal(SystemPrincipal.NAME + "." + jobKey);
+            ResteasyContext.pushContext(Principal.class, principal);
 
             try {
-                log.trace("Queuing job: {}", jobKey);
+                log.trace("Queuing scheduled job: {}", jobKey);
                 this.manager.queueJob(JobConfig.forJob(jobKey));
             }
             catch (JobException e) {
@@ -209,7 +211,7 @@ public class JobManager implements ModeChangeListener {
 
     /**
      * The JobMessageSynchronizer commits or rolls back a messenger transaction upon the completion
-     * of a database tranaction.
+     * of a database transaction.
      */
     private static class JobMessageSynchronizer implements Synchronization {
         /** An array of states that are valid to synchronize against */

--- a/src/main/java/org/candlepin/auth/Principal.java
+++ b/src/main/java/org/candlepin/auth/Principal.java
@@ -130,5 +130,4 @@ public abstract class Principal implements Serializable, java.security.Principal
             return "";
         }
     }
-
 }

--- a/src/main/java/org/candlepin/auth/SystemPrincipal.java
+++ b/src/main/java/org/candlepin/auth/SystemPrincipal.java
@@ -25,6 +25,8 @@ public class SystemPrincipal extends Principal {
      */
     private static final long serialVersionUID = -2122749997316786617L;
 
+    public static final String NAME = "System";
+
     @Override
     public String getType() {
         return "system";
@@ -32,7 +34,7 @@ public class SystemPrincipal extends Principal {
 
     @Override
     public String getName() {
-        return "System";
+        return NAME;
     }
 
     @Override


### PR DESCRIPTION
Setting the principal name for system generated job instead of it just being null. I included some output from the cp_async_jobs table from testing the code.

```
candlepin=> Select id, name, job_key, principal from cp_async_jobs;
                id                |          name          |        job_key         |           principal           
----------------------------------+------------------------+------------------------+-------------------------------
 ff808181801e769a01801e80d0380b21 | ActiveEntitlementJob   | ActiveEntitlementJob   | System_ActiveEntitlementJob
 ff808181801e769a01801e80d04d0b22 | ExpiredPoolsCleanupJob | ExpiredPoolsCleanupJob | System_ExpiredPoolsCleanupJob
 ff808181801e769a01801e817aaa0b23 | ManifestCleanerJob     | ManifestCleanerJob     | admin
(3 rows)
```

