### PR TITLE
Update cache jars [ENT-4860]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,11 +167,11 @@ dependencies {
     implementation "org.hibernate.validator:hibernate-validator-annotation-processor:6.2.3.Final"
 
     // Hibernate
-    implementation 'org.hibernate:hibernate-c3p0:5.4.6.Final'
+    implementation 'org.hibernate:hibernate-c3p0:5.6.7.Final'
     // Ehcache (for use with hibernate primarily)
-    implementation "org.hibernate:hibernate-jcache:5.4.6.Final"
-    implementation "org.ehcache:ehcache:3.8.0"
-    implementation "javax.cache:cache-api:1.0.0"
+    implementation "org.hibernate:hibernate-jcache:5.6.7.Final"
+    implementation "org.ehcache:ehcache:3.10.0"
+    implementation "javax.cache:cache-api:1.1.1"
 
     // Artemis server & client
     implementation "org.apache.activemq:artemis-server:2.21.0"

--- a/pom.xml
+++ b/pom.xml
@@ -245,25 +245,25 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-c3p0</artifactId>
-      <version>5.4.6.Final</version>
+      <version>5.6.7.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-jcache</artifactId>
-      <version>5.4.6.Final</version>
+      <version>5.6.7.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
-      <version>3.8.0</version>
+      <version>3.10.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>javax.cache</groupId>
       <artifactId>cache-api</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -29,6 +29,7 @@
             <property name="hibernate.c3p0.idle_test_period" value="300" />
             <!-- max_statements should always be 0 -->
             <property name="hibernate.c3p0.max_statements" value="0" />
+            <property name="hibernate.connection.release_mode" value="on_close"/>
         </properties>
     </persistence-unit>
 

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -4,8 +4,8 @@
     xmlns='http://www.ehcache.org/v3'
     xmlns:jsr107='http://www.ehcache.org/v3/jsr107'
     xsi:schemaLocation="
-        http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.8.xsd
-        http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.8.xsd">
+        http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.10.xsd
+        http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.10.xsd">
 
 
     <service>


### PR DESCRIPTION
The issue we had with empty collections was because this was fixed in hibernate 5.5.3:
https://hibernate.atlassian.net/browse/HHH-4808

We were relying on the connection remaining open when the CandlepinQuery is passed to the interceptor.
The setting "hibernate.connection.release_mode" allows it to behave the way it did before the bug was fixed.