### PR TITLE
[M] Removed mysql-connector-java from gradle dependencies. (ENT-4783)

### DIFF
--- a/bin/deployment/bash_functions
+++ b/bin/deployment/bash_functions
@@ -174,7 +174,8 @@ init_mysql_jdbc() {
     local password="$DBPASSWORD"
     [ -z "$password" ] && password=''
 
-    select_jdbc_jar "/usr/lib/java/mariadb-java-client.jar" "/usr/share/java/mysql-connector-java.jar"
+    local maria_client_jar=$(find $CP_EXTRACT_CLASSPATH -type f -name "mariadb-java-client*.jar")
+    select_jdbc_jar $maria_client_jar
     evalrc $? "No JDBC jar file available for MariaDB/MySQL"
 
     JDBC_DRIVER="org.mariadb.jdbc.Driver"

--- a/bin/deployment/deploy
+++ b/bin/deployment/deploy
@@ -12,10 +12,12 @@ prepare_classpath() {
     jar xf $(find ${PROJECT_DIR}/build -name 'candlepin*.war' | head -n 1)
     chmod -R 744 ${CP_EXTRACT_DIR}
     cd -
-    export CP_LIQUIBASE_CLASSPATH="${CP_EXTRACT_DIR}/WEB-INF/lib"
+    export CP_EXTRACT_CLASSPATH="${CP_EXTRACT_DIR}/WEB-INF/lib"
 }
 
 gendb() {
+    prepare_classpath
+
     if [ "$USE_MYSQL" == "1" ]; then
         init_mysql_jdbc $APP_DB_NAME
     else
@@ -40,8 +42,6 @@ gendb() {
         MESSAGE="Updating Database"
         CHANGELOG="changelog-update.xml"
     fi
-
-    prepare_classpath
 
     info_msg "$MESSAGE"
     LQCOMMAND="${PROJECT_DIR}/bin/deployment/liquibase.sh --driver=${JDBC_DRIVER} \

--- a/bin/deployment/liquibase.sh
+++ b/bin/deployment/liquibase.sh
@@ -19,7 +19,7 @@ MAIN_CLASS=liquibase.integration.commandline.LiquibaseCommandLine
 BASE_FLAGS=""
 BASE_OPTIONS=""
 
-CP_CLASSPATH=${CP_LIQUIBASE_CLASSPATH:-/var/lib/tomcat/webapps/candlepin/WEB-INF/lib}
+CP_CLASSPATH=${CP_EXTRACT_CLASSPATH:-/var/lib/tomcat/webapps/candlepin/WEB-INF/lib}
 CLASSPATH=$(JARS=("$CP_CLASSPATH"/*.jar); IFS=:; echo "${JARS[*]}")
 
 # Set parameters

--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,6 @@ dependencies {
 
     // DB Drivers
     runtimeOnly "org.postgresql:postgresql:42.3.3"
-    runtimeOnly "mysql:mysql-connector-java:8.0.28"
     runtimeOnly "org.mariadb.jdbc:mariadb-java-client:3.0.4"
 
     testRuntime "org.hsqldb:hsqldb:2.6.1"

--- a/pom.xml
+++ b/pom.xml
@@ -309,12 +309,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.28</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
       <version>3.0.4</version>


### PR DESCRIPTION
We are also making a change to use the mariadb-java-client jar from the classpath so that we always use the same version that is defined by gradle. I was able to verify the changes be deploying candle pin in a Vagrant vm for el7, el8, and f35.