### PR TITLE
[M] 2075587: Fixed attribute storage issue causing version collisions (ENT-4907)

### DIFF
--- a/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/src/main/java/org/candlepin/controller/ProductManager.java
@@ -247,7 +247,7 @@ public class ProductManager {
         Product entity = new Product()
             .setId(productData.getId());
 
-        applyProductChanges(entity, productData, productMap, contentMap);
+        entity = applyProductChanges(entity, productData, productMap, contentMap);
 
         // Check if we have an alternate version we can use instead.
         List<Product> alternateVersions = this.ownerProductCurator
@@ -773,21 +773,44 @@ public class ProductManager {
             entity.setMultiplier(update.getMultiplier());
         }
 
-        if (update.getAttributes() != null) {
-            entity.setAttributes(update.getAttributes());
-        }
-
         if (update.getDependentProductIds() != null) {
             entity.setDependentProductIds(update.getDependentProductIds());
         }
 
         // Complicated stuff
+        applyProductAttributeChanges(entity, update);
         applyProductContentChanges(entity, update, contentMap);
         applyDerivedProductChanges(entity, update, productMap);
         applyProvidedProductChanges(entity, update, productMap);
         applyBrandingChanges(entity, update);
 
         return entity;
+    }
+
+    /**
+     * Applies product attributes changes from the given ProductInfo instance to the specified
+     * Product entity. Attributes which have null values will be silently discarded from the
+     * updated attributes.
+     *
+     * @param entity
+     *  the Product entity to update
+     *
+     * @param update
+     *  the ProductInfo instance containing the data with which to update the entity
+     */
+    private static void applyProductAttributeChanges(Product entity, ProductInfo update) {
+        Map<String, String> incoming = update.getAttributes();
+        if (incoming != null) {
+            Map<String, String> filtered = new HashMap<>();
+
+            incoming.forEach((k, v) -> {
+                if (v != null) {
+                    filtered.put(k, v);
+                }
+            });
+
+            entity.setAttributes(filtered);
+        }
     }
 
     /**

--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -642,6 +642,10 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             throw new IllegalArgumentException("key is null");
         }
 
+        if (value == null) {
+            throw new IllegalArgumentException("value is null");
+        }
+
         // Impl note:
         // We can't standardize the value at all here; some attributes allow null, some expect
         // empty strings, and others have their own sential values. Unless we make a concerted
@@ -708,7 +712,11 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         this.entityVersion = null;
 
         if (attributes != null) {
-            this.attributes.putAll(attributes);
+            // Hibernate does not natively support null values in the map, so for the sake of
+            // consistency, reject any attributes that have a null value.
+            attributes.forEach((k, v) -> {
+                this.attributes.put(k, Objects.requireNonNull(v));
+            });
         }
 
         return this;

--- a/src/main/java/org/candlepin/util/Util.java
+++ b/src/main/java/org/candlepin/util/Util.java
@@ -610,11 +610,12 @@ public class Util {
 
         // Impl note:
         // At the time of writing, there is a bug/oddity in the collector returned by
-        // Collectors.toMap which disallows null *values*. Since we allow null values, we must
-        // create our own collector here.
+        // Collectors.toMap which disallows null *values*. To retain the underlying
+        // Hibernate behavior, we'll just silently discard attributes with null values.
         return attributes.stream()
             .filter(Objects::nonNull)
             .filter(attr -> attr.getName() != null && !attr.getName().isEmpty())
+            .filter(attr -> attr.getValue() != null)
             .collect(HashMap::new, (map, attr)->map.put(attr.getName(), attr.getValue()), HashMap::putAll);
     }
 

--- a/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -43,7 +44,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 
 
@@ -122,7 +125,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         verifyNoInteractions(this.mockEntCertGenerator);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testUpdateProduct(boolean regenCerts) {
         Owner owner = this.createOwner("test-owner", "Test Owner");
@@ -151,7 +154,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testUpdateProductConvergeWithExisting(boolean regenCerts) {
         Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");
@@ -182,7 +185,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testUpdateProductDivergeFromExisting(boolean regenCerts) {
         Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");
@@ -279,7 +282,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         assertThrows(IllegalStateException.class, () -> this.productManager.removeProduct(owner, product));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testRemoveProductContent(boolean regenCerts) {
         Owner owner = this.createOwner("test-owner", "Test Owner");
@@ -316,7 +319,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         }
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testRemoveContentFromSharedProduct(boolean regenCerts) {
         Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");
@@ -394,7 +397,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         verifyNoInteractions(this.mockEntCertGenerator);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = {"false", "true"})
     public void testAddContentToSharedProduct(boolean regenCerts) {
         Owner owner1 = this.createOwner("test-owner-1", "Test Owner 1");
@@ -686,4 +689,74 @@ public class ProductManagerTest extends DatabaseTestFixture {
         assertEquals(2, output.getProvidedProducts().size());
     }
 
+    @Test
+    public void testCreateProductFiltersNullValuedAttributes() {
+        Owner owner = this.createOwner("test-owner", "Test Owner");
+        ProductInfo pinfo = mock(ProductInfo.class);
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attrib-1", "value 1");
+        attributes.put("attrib-2", null);
+        attributes.put("attrib-3", "value 3");
+
+        doReturn(attributes).when(pinfo).getAttributes();
+        doReturn("p1").when(pinfo).getId();
+        doReturn("prod1").when(pinfo).getName();
+
+        Product entity = this.productManager.createProduct(owner, pinfo);
+
+        assertNotNull(entity);
+        assertNotNull(entity.getAttributes());
+
+        for (Map.Entry<String, String> entry : attributes.entrySet()) {
+            if (entry.getValue() != null) {
+                assertTrue(entity.hasAttribute(entry.getKey()), "expected attribute is not present: " +
+                    entry.getKey());
+
+                assertEquals(entry.getValue(), entity.getAttributeValue(entry.getKey()));
+            }
+            else {
+                assertFalse(entity.hasAttribute(entry.getKey()), "unexpected attribute is present: " +
+                    entry.getKey());
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @ValueSource(strings = {"false", "true"})
+    public void testUpdateProductFiltersNullValuedAttributes(boolean regenCerts) {
+        Owner owner = this.createOwner("test-owner", "Test Owner");
+        Product base = TestUtil.createProduct("p1", "prod1");
+        base.setAttributes(Map.of("attrib-1", "original value"));
+        this.createProduct(base, owner);
+
+        ProductInfo pinfo = mock(ProductInfo.class);
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attrib-1", "value 1");
+        attributes.put("attrib-2", null);
+        attributes.put("attrib-3", "value 3");
+
+        doReturn(attributes).when(pinfo).getAttributes();
+        doReturn(base.getId()).when(pinfo).getId();
+        doReturn(base.getName()).when(pinfo).getName();
+
+        Product entity = this.productManager.updateProduct(owner, pinfo, regenCerts);
+
+        assertNotNull(entity);
+        assertNotNull(entity.getAttributes());
+
+        for (Map.Entry<String, String> entry : attributes.entrySet()) {
+            if (entry.getValue() != null) {
+                assertTrue(entity.hasAttribute(entry.getKey()), "expected attribute is not present: " +
+                    entry.getKey());
+
+                assertEquals(entry.getValue(), entity.getAttributeValue(entry.getKey()));
+            }
+            else {
+                assertFalse(entity.hasAttribute(entry.getKey()), "unexpected attribute is present: " +
+                    entry.getKey());
+            }
+        }
+    }
 }

--- a/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -327,8 +327,8 @@ public class AutobindRulesTest {
         //only enforce cores on pool 2:
         Product sku2 = mockStackingProduct("prod2", "Test Stack product", "1", "1");
         sku2.setAttribute(Product.Attributes.CORES, "6");
-        sku2.setAttribute(Product.Attributes.RAM, null);
-        sku2.setAttribute(Product.Attributes.SOCKETS, null);
+        sku2.removeAttribute(Product.Attributes.RAM);
+        sku2.removeAttribute(Product.Attributes.SOCKETS);
         sku2.addProvidedProduct(provided);
 
         Pool pool2 = TestUtil.createPool(owner, sku2)

--- a/src/test/java/org/candlepin/util/UtilTest.java
+++ b/src/test/java/org/candlepin/util/UtilTest.java
@@ -439,8 +439,8 @@ public class UtilTest {
         public void testToMap() {
             List<AttributeDTO> attribList = List.of(
                 buildAttributeDTO("test_attrib-1", "test_value"),
-                buildAttributeDTO("test_attrib-2", ""),
-                buildAttributeDTO("test_attrib-3", null));
+                buildAttributeDTO("test_attrib-2", "test_value-2"),
+                buildAttributeDTO("test_attrib-3", ""));
 
             Map<String, String> attribMap = Util.toMap(attribList);
 
@@ -557,6 +557,31 @@ public class UtilTest {
 
                 assertTrue(attribMap.containsKey(attrib.getName()));
                 assertEquals(attrib.getValue(), attribMap.get(attrib.getName()));
+            }
+        }
+
+        @Test
+        public void testToMapDiscardsAttributesWithNullValues() {
+            List<AttributeDTO> attribList = List.of(
+                buildAttributeDTO("test_attrib-1", "value 1"),
+                buildAttributeDTO("test_attrib-2", null),
+                buildAttributeDTO("test_attrib-3", "value 3"),
+                buildAttributeDTO("test_attrib-4", null),
+                buildAttributeDTO("test_attrib-5", "value 5"));
+
+            Map<String, String> attribMap = Util.toMap(attribList);
+
+            assertNotNull(attribMap);
+            assertEquals(3, attribMap.size());
+
+            for (AttributeDTO attrib : attribList) {
+                if (attrib.getValue() != null) {
+                    assertTrue(attribMap.containsKey(attrib.getName()));
+                    assertEquals(attrib.getValue(), attribMap.get(attrib.getName()));
+                }
+                else {
+                    assertFalse(attribMap.containsKey(attrib.getName()));
+                }
             }
         }
     }


### PR DESCRIPTION
- Fixed a bug with null-versioned product attributes causing
  version collisions due to being used in the version calculation
  before being silently discarded during entity persistence
- Null-valued attributes are now silently discarded at the API
  layer to retain the current behavior
- Product entities will no longer accept null values for product
  attributes, as Hibernate throws them out anyway