### PR TITLE
[4.1] 2076658: Fixed attribute storage issue causing version collisions (ENT-4907)

### DIFF
--- a/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/src/main/java/org/candlepin/controller/ProductManager.java
@@ -247,7 +247,7 @@ public class ProductManager {
         Product entity = new Product()
             .setId(productData.getId());
 
-        applyProductChanges(entity, productData, productMap, contentMap);
+        entity = applyProductChanges(entity, productData, productMap, contentMap);
 
         // Check if we have an alternate version we can use instead.
         List<Product> alternateVersions = this.ownerProductCurator
@@ -773,21 +773,44 @@ public class ProductManager {
             entity.setMultiplier(update.getMultiplier());
         }
 
-        if (update.getAttributes() != null) {
-            entity.setAttributes(update.getAttributes());
-        }
-
         if (update.getDependentProductIds() != null) {
             entity.setDependentProductIds(update.getDependentProductIds());
         }
 
         // Complicated stuff
+        applyProductAttributeChanges(entity, update);
         applyProductContentChanges(entity, update, contentMap);
         applyDerivedProductChanges(entity, update, productMap);
         applyProvidedProductChanges(entity, update, productMap);
         applyBrandingChanges(entity, update);
 
         return entity;
+    }
+
+    /**
+     * Applies product attributes changes from the given ProductInfo instance to the specified
+     * Product entity. Attributes which have null values will be silently discarded from the
+     * updated attributes.
+     *
+     * @param entity
+     *  the Product entity to update
+     *
+     * @param update
+     *  the ProductInfo instance containing the data with which to update the entity
+     */
+    private static void applyProductAttributeChanges(Product entity, ProductInfo update) {
+        Map<String, String> incoming = update.getAttributes();
+        if (incoming != null) {
+            Map<String, String> filtered = new HashMap<>();
+
+            incoming.forEach((k, v) -> {
+                if (v != null) {
+                    filtered.put(k, v);
+                }
+            });
+
+            entity.setAttributes(filtered);
+        }
     }
 
     /**

--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -642,6 +642,10 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             throw new IllegalArgumentException("key is null");
         }
 
+        if (value == null) {
+            throw new IllegalArgumentException("value is null");
+        }
+
         // Impl note:
         // We can't standardize the value at all here; some attributes allow null, some expect
         // empty strings, and others have their own sential values. Unless we make a concerted
@@ -708,7 +712,11 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         this.entityVersion = null;
 
         if (attributes != null) {
-            this.attributes.putAll(attributes);
+            // Hibernate does not natively support null values in the map, so for the sake of
+            // consistency, reject any attributes that have a null value.
+            attributes.forEach((k, v) -> {
+                this.attributes.put(k, Objects.requireNonNull(v));
+            });
         }
 
         return this;

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -796,12 +796,7 @@ public class OwnerResource implements OwnersApi {
         }
 
         if (dto.getAttributes() != null) {
-            if (dto.getAttributes().isEmpty()) {
-                entity.setAttributes(Collections.emptyMap());
-            }
-            else {
-                entity.setAttributes(Util.toMap(dto.getAttributes()));
-            }
+            entity.setAttributes(Util.toMap(dto.getAttributes()));
         }
 
         // Impl note: derived product, provided products, and derived provided products are no longer

--- a/src/main/java/org/candlepin/resource/util/InfoAdapter.java
+++ b/src/main/java/org/candlepin/resource/util/InfoAdapter.java
@@ -369,9 +369,6 @@ public class InfoAdapter {
              */
             @Override
             public Map<String, String> getAttributes() {
-                if (source.getAttributes() == null) {
-                    return null;
-                }
                 return Util.toMap(source.getAttributes());
             }
 

--- a/src/main/java/org/candlepin/util/Util.java
+++ b/src/main/java/org/candlepin/util/Util.java
@@ -607,11 +607,12 @@ public class Util {
 
         // Impl note:
         // At the time of writing, there is a bug/oddity in the collector returned by
-        // Collectors.toMap which disallows null *values*. Since we allow null values, we must
-        // create our own collector here.
+        // Collectors.toMap which disallows null *values*. To retain the underlying
+        // Hibernate behavior, we'll just silently discard attributes with null values.
         return attributes.stream()
             .filter(Objects::nonNull)
             .filter(attr -> attr.getName() != null && !attr.getName().isEmpty())
+            .filter(attr -> attr.getValue() != null)
             .collect(HashMap::new, (map, attr)->map.put(attr.getName(), attr.getValue()), HashMap::putAll);
     }
 

--- a/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -313,8 +313,8 @@ public class AutobindRulesTest {
         //only enforce cores on pool 2:
         Product sku2 = mockStackingProduct("prod2", "Test Stack product", "1", "1");
         sku2.setAttribute(Product.Attributes.CORES, "6");
-        sku2.setAttribute(Product.Attributes.RAM, null);
-        sku2.setAttribute(Product.Attributes.SOCKETS, null);
+        sku2.removeAttribute(Product.Attributes.RAM);
+        sku2.removeAttribute(Product.Attributes.SOCKETS);
         sku2.addProvidedProduct(provided);
 
         Pool pool2 = TestUtil.createPool(owner, sku2)

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -56,6 +56,7 @@ import org.candlepin.dto.api.v1.OwnerDTO;
 import org.candlepin.dto.api.v1.PoolDTO;
 import org.candlepin.dto.api.v1.ProductCertificateDTO;
 import org.candlepin.dto.api.v1.ProductContentDTO;
+import org.candlepin.dto.api.v1.ProductDTO;
 import org.candlepin.dto.api.v1.ReleaseVerDTO;
 import org.candlepin.dto.api.v1.SystemPurposeAttributesDTO;
 import org.candlepin.dto.api.v1.UeberCertificateDTO;
@@ -274,21 +275,23 @@ public class OwnerResourceTest extends DatabaseTestFixture {
             this.principalProvider);
     }
 
-    private org.candlepin.dto.api.v1.ProductDTO buildTestProductDTO() {
-        org.candlepin.dto.api.v1.ProductDTO dto = TestUtil.createProductDTO("test_product");
-        dto.getAttributes().add(createAttribute(Product.Attributes.VERSION, "1.0"));
-        dto.getAttributes().add(createAttribute(Product.Attributes.VARIANT, "server"));
-        dto.getAttributes().add(createAttribute(Product.Attributes.TYPE, "SVC"));
-        dto.getAttributes().add(createAttribute(Product.Attributes.ARCHITECTURE, "ALL"));
+    private ProductDTO buildTestProductDTO() {
+        ProductDTO dto = TestUtil.createProductDTO("test_product");
+        dto.addAttributes(this.createAttribute(Product.Attributes.VERSION, "1.0"));
+        dto.addAttributes(this.createAttribute(Product.Attributes.VARIANT, "server"));
+        dto.addAttributes(this.createAttribute(Product.Attributes.TYPE, "SVC"));
+        dto.addAttributes(this.createAttribute(Product.Attributes.ARCHITECTURE, "ALL"));
 
         return dto;
     }
 
     private AttributeDTO createAttribute(String name, String value) {
-        return new AttributeDTO().name(name).value(value);
+        return new AttributeDTO()
+            .name(name)
+            .value(value);
     }
 
-    private void addContent(org.candlepin.dto.api.v1.ProductDTO product, ContentDTO dto) {
+    private void addContent(ProductDTO product, ContentDTO dto) {
         if (dto == null || dto.getId() == null) {
             throw new IllegalArgumentException("dto references incomplete content");
         }
@@ -2670,15 +2673,15 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     @Test
     public void testCreateProductResource() {
         Owner owner = this.createOwner("Example-Corporation");
-        org.candlepin.dto.api.v1.ProductDTO pdto = this.buildTestProductDTO();
+        ProductDTO pdto = this.buildTestProductDTO();
 
         assertNull(this.ownerProductCurator.getProductById(owner.getKey(), pdto.getId()));
 
-        org.candlepin.dto.api.v1.ProductDTO result = this.ownerResource
+        ProductDTO result = this.ownerResource
             .createProductByOwner(owner.getKey(), pdto);
         Product entity = this.ownerProductCurator.getProductById(owner, pdto.getId());
-        org.candlepin.dto.api.v1.ProductDTO expected = this.modelTranslator.translate(entity,
-            org.candlepin.dto.api.v1.ProductDTO.class);
+        ProductDTO expected = this.modelTranslator.translate(entity,
+            ProductDTO.class);
 
         assertNotNull(result);
         assertNotNull(entity);
@@ -2686,20 +2689,88 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testCreateProductWithAttributes() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attrib-1", "value-1");
+        attributes.put("attrib-2", "value-2");
+        attributes.put("attrib-3", "value-3");
+
+        Owner owner = this.createOwner("Test org");
+        ProductDTO pdto = new ProductDTO()
+            .id("test_prod-1")
+            .name("test product 1");
+
+        attributes.forEach((k, v) -> pdto.addAttributes(this.createAttribute(k, v)));
+
+        ProductDTO output = this.ownerResource.createProductByOwner(owner.getKey(), pdto);
+
+        assertNotNull(output);
+        assertEquals(pdto.getId(), output.getId());
+        assertEquals(pdto.getName(), output.getName());
+        assertNotNull(output.getAttributes());
+        assertEquals(attributes.size(), output.getAttributes().size());
+
+        for (AttributeDTO attrib : output.getAttributes()) {
+            assertTrue(attributes.containsKey(attrib.getName()));
+            assertEquals(attributes.get(attrib.getName()), attrib.getValue());
+        }
+    }
+
+    @Test
+    public void testCreateProductFiltersUnusableAttributes() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attrib-1", "value-1");
+        attributes.put("attrib-2", "value-2");
+        attributes.put("attrib-3", "value-3");
+        attributes.put("", "dropped");
+        attributes.put("dropped", null);
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("attrib-1", "value-1");
+        expected.put("attrib-2", "value-2");
+        expected.put("attrib-3", "value-3");
+
+        Owner owner = this.createOwner("Test org");
+        ProductDTO pdto = new ProductDTO()
+            .id("test_prod-1")
+            .name("test product 1");
+
+        attributes.forEach((k, v) -> pdto.addAttributes(this.createAttribute(k, v)));
+
+        // Add some dud attributes to ensure filtering is occurring for other types of malformed
+        // attribute data
+        pdto.addAttributes(null);
+        pdto.addAttributes(this.createAttribute(null, "dropped"));
+
+        ProductDTO output = this.ownerResource.createProductByOwner(owner.getKey(), pdto);
+
+        assertNotNull(output);
+        assertEquals(pdto.getId(), output.getId());
+        assertEquals(pdto.getName(), output.getName());
+        assertNotNull(output.getAttributes());
+        assertEquals(expected.size(), output.getAttributes().size());
+
+        for (AttributeDTO attrib : output.getAttributes()) {
+            assertTrue(expected.containsKey(attrib.getName()));
+            assertEquals(expected.get(attrib.getName()), attrib.getValue());
+        }
+    }
+
+    @Test
     public void testCreateProductWithContent() {
         Owner owner = this.createOwner("Example-Corporation");
         Content content = this.createContent("content-1", "content-1", owner);
-        org.candlepin.dto.api.v1.ProductDTO product = this.buildTestProductDTO();
+        ProductDTO product = this.buildTestProductDTO();
         ContentDTO contentDTO = this.modelTranslator.translate(content, ContentDTO.class);
         addContent(product, contentDTO);
 
         assertNull(this.ownerProductCurator.getProductById(owner.getKey(), product.getId()));
 
-        org.candlepin.dto.api.v1.ProductDTO result = this.ownerResource
+        ProductDTO result = this.ownerResource
             .createProductByOwner(owner.getKey(), product);
         Product entity = this.ownerProductCurator.getProductById(owner, product.getId());
-        org.candlepin.dto.api.v1.ProductDTO expected = this.modelTranslator.translate(entity,
-            org.candlepin.dto.api.v1.ProductDTO.class);
+        ProductDTO expected = this.modelTranslator.translate(entity,
+            ProductDTO.class);
 
         assertNotNull(result);
         assertNotNull(entity);
@@ -2711,16 +2782,92 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testUpdateProductWithAttributes() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attrib-1", "value-1");
+        attributes.put("attrib-2", "value-2");
+        attributes.put("attrib-3", "value-3");
+
+        Owner owner = this.createOwner("Test org");
+        Product existing = this.createProduct("test_prod-1", "test product 1", owner);
+
+        assertNotNull(existing);
+        assertTrue(existing.getAttributes().isEmpty());
+
+        ProductDTO pdto = new ProductDTO()
+            .id(existing.getId());
+
+        attributes.forEach((k, v) -> pdto.addAttributes(this.createAttribute(k, v)));
+
+        ProductDTO output = this.ownerResource.updateProductByOwner(owner.getKey(), existing.getId(), pdto);
+
+        assertNotNull(output);
+        assertEquals(existing.getId(), output.getId());
+        assertEquals(existing.getName(), output.getName());
+        assertNotNull(output.getAttributes());
+        assertEquals(attributes.size(), output.getAttributes().size());
+
+        for (AttributeDTO attrib : output.getAttributes()) {
+            assertTrue(attributes.containsKey(attrib.getName()));
+            assertEquals(attributes.get(attrib.getName()), attrib.getValue());
+        }
+    }
+
+    @Test
+    public void testUpdateProductFiltersUnusableAttributes() {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attrib-1", "value-1");
+        attributes.put("attrib-2", "value-2");
+        attributes.put("attrib-3", "value-3");
+        attributes.put("", "dropped");
+        attributes.put("dropped", null);
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("attrib-1", "value-1");
+        expected.put("attrib-2", "value-2");
+        expected.put("attrib-3", "value-3");
+
+        Owner owner = this.createOwner("Test org");
+        Product existing = this.createProduct("test_prod-1", "test product 1", owner);
+
+        assertNotNull(existing);
+        assertTrue(existing.getAttributes().isEmpty());
+
+        ProductDTO pdto = new ProductDTO()
+            .id(existing.getId());
+
+        attributes.forEach((k, v) -> pdto.addAttributes(this.createAttribute(k, v)));
+
+        // Add some dud attributes to ensure filtering is occurring for other types of malformed
+        // attribute data
+        pdto.addAttributes(null);
+        pdto.addAttributes(this.createAttribute(null, "dropped"));
+
+        ProductDTO output = this.ownerResource.updateProductByOwner(owner.getKey(), existing.getId(), pdto);
+
+        assertNotNull(output);
+        assertEquals(existing.getId(), output.getId());
+        assertEquals(existing.getName(), output.getName());
+        assertNotNull(output.getAttributes());
+        assertEquals(expected.size(), output.getAttributes().size());
+
+        for (AttributeDTO attrib : output.getAttributes()) {
+            assertTrue(expected.containsKey(attrib.getName()));
+            assertEquals(expected.get(attrib.getName()), attrib.getValue());
+        }
+    }
+
+    @Test
     public void testUpdateProductWithoutId() {
         Owner owner = this.createOwner("Update-Product-Owner");
-        org.candlepin.dto.api.v1.ProductDTO pdto = this.buildTestProductDTO();
+        ProductDTO pdto = this.buildTestProductDTO();
 
-        org.candlepin.dto.api.v1.ProductDTO product = this.ownerResource
+        ProductDTO product = this.ownerResource
             .createProductByOwner(owner.getKey(), pdto);
-        org.candlepin.dto.api.v1.ProductDTO update = TestUtil.createProductDTO(product.getId());
+        ProductDTO update = TestUtil.createProductDTO(product.getId());
         update.setName(product.getName());
         update.getAttributes().add(createAttribute("attri", "bute"));
-        org.candlepin.dto.api.v1.ProductDTO result = this.ownerResource
+        ProductDTO result = this.ownerResource
             .updateProductByOwner(owner.getKey(), product.getId(), update);
         assertEquals("bute", result.getAttributes().get(0).getValue());
     }
@@ -2728,10 +2875,10 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     @Test
     public void testUpdateProductIdMismatch() {
         Owner owner = this.createOwner("Update-Product-Owner");
-        org.candlepin.dto.api.v1.ProductDTO pdto = this.buildTestProductDTO();
-        org.candlepin.dto.api.v1.ProductDTO product = this.ownerResource
+        ProductDTO pdto = this.buildTestProductDTO();
+        ProductDTO product = this.ownerResource
             .createProductByOwner(owner.getKey(), pdto);
-        org.candlepin.dto.api.v1.ProductDTO update = this.buildTestProductDTO();
+        ProductDTO update = this.buildTestProductDTO();
         update.setId("TaylorSwift");
 
         assertThrows(BadRequestException.class, () ->
@@ -2773,7 +2920,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     public void testUpdateLockedProductFails() {
         Owner owner = this.createOwner("test_owner");
         Product product = this.createProduct("test_product", "test_product", owner);
-        org.candlepin.dto.api.v1.ProductDTO pdto = TestUtil.createProductDTO("test_product", "updated_name");
+        ProductDTO pdto = TestUtil.createProductDTO("test_product", "updated_name");
         product.setLocked(true);
         this.productCurator.merge(product);
 
@@ -2783,8 +2930,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
             this.ownerResource.updateProductByOwner(owner.getKey(), pdto.getId(), pdto)
         );
         Product entity = this.ownerProductCurator.getProductById(owner, pdto.getId());
-        org.candlepin.dto.api.v1.ProductDTO expected = this.modelTranslator.translate(entity,
-            org.candlepin.dto.api.v1.ProductDTO.class);
+        ProductDTO expected = this.modelTranslator.translate(entity,
+            ProductDTO.class);
 
         assertNotNull(entity);
         assertNotEquals(expected, pdto);
@@ -2811,10 +2958,10 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         Product entity = this.createProduct("test_product", "test_product", owner);
 
         securityInterceptor.enable();
-        org.candlepin.dto.api.v1.ProductDTO result = this.ownerResource.getProductByOwner(owner.getKey(),
+        ProductDTO result = this.ownerResource.getProductByOwner(owner.getKey(),
             entity.getId());
-        org.candlepin.dto.api.v1.ProductDTO expected = this.modelTranslator.translate(entity,
-            org.candlepin.dto.api.v1.ProductDTO.class);
+        ProductDTO expected = this.modelTranslator.translate(entity,
+            ProductDTO.class);
 
         assertNotNull(result);
         assertEquals(expected, result);

--- a/src/test/java/org/candlepin/util/UtilTest.java
+++ b/src/test/java/org/candlepin/util/UtilTest.java
@@ -395,8 +395,8 @@ public class UtilTest {
         public void testToMap() {
             List<AttributeDTO> attribList = List.of(
                 buildAttributeDTO("test_attrib-1", "test_value"),
-                buildAttributeDTO("test_attrib-2", ""),
-                buildAttributeDTO("test_attrib-3", null));
+                buildAttributeDTO("test_attrib-2", "test_value-2"),
+                buildAttributeDTO("test_attrib-3", ""));
 
             Map<String, String> attribMap = Util.toMap(attribList);
 
@@ -513,6 +513,31 @@ public class UtilTest {
 
                 assertTrue(attribMap.containsKey(attrib.getName()));
                 assertEquals(attrib.getValue(), attribMap.get(attrib.getName()));
+            }
+        }
+
+        @Test
+        public void testToMapDiscardsAttributesWithNullValues() {
+            List<AttributeDTO> attribList = List.of(
+                buildAttributeDTO("test_attrib-1", "value 1"),
+                buildAttributeDTO("test_attrib-2", null),
+                buildAttributeDTO("test_attrib-3", "value 3"),
+                buildAttributeDTO("test_attrib-4", null),
+                buildAttributeDTO("test_attrib-5", "value 5"));
+
+            Map<String, String> attribMap = Util.toMap(attribList);
+
+            assertNotNull(attribMap);
+            assertEquals(3, attribMap.size());
+
+            for (AttributeDTO attrib : attribList) {
+                if (attrib.getValue() != null) {
+                    assertTrue(attribMap.containsKey(attrib.getName()));
+                    assertEquals(attrib.getValue(), attribMap.get(attrib.getName()));
+                }
+                else {
+                    assertFalse(attribMap.containsKey(attrib.getName()));
+                }
             }
         }
     }

--- a/src/test/java/org/candlepin/util/UtilTest.java
+++ b/src/test/java/org/candlepin/util/UtilTest.java
@@ -18,9 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
+
+import org.candlepin.dto.api.v1.AttributeDTO;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -48,11 +51,15 @@ import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
 
 
 /**
@@ -376,4 +383,137 @@ public class UtilTest {
         }
     }
 
+    public static AttributeDTO buildAttributeDTO(String name, String value) {
+        return new AttributeDTO()
+            .name(name)
+            .value(value);
+    }
+
+    @Nested
+    class AttributesDTOToMapTests {
+        @Test
+        public void testToMap() {
+            List<AttributeDTO> attribList = List.of(
+                buildAttributeDTO("test_attrib-1", "test_value"),
+                buildAttributeDTO("test_attrib-2", ""),
+                buildAttributeDTO("test_attrib-3", null));
+
+            Map<String, String> attribMap = Util.toMap(attribList);
+
+            assertNotNull(attribMap);
+            assertEquals(attribList.size(), attribMap.size());
+
+            for (AttributeDTO attrib : attribList) {
+                assertTrue(attribMap.containsKey(attrib.getName()));
+                assertEquals(attrib.getValue(), attribMap.get(attrib.getName()));
+            }
+        }
+
+        @Test
+        public void testToMapHandlesNullCollections() {
+            Map<String, String> attribMap = Util.toMap(null);
+
+            assertNull(attribMap);
+        }
+
+        @Test
+        public void testToMapHandlesEmptyCollections() {
+            Map<String, String> attribMap = Util.toMap(Collections.emptyList());
+
+            assertNotNull(attribMap);
+            assertTrue(attribMap.isEmpty());
+        }
+
+        @Test
+        public void testToMapHandlesDuplicateKeys() {
+            String key = "test_attrib";
+            String valueA = "test_value-A";
+            String valueB = "test_value-B";
+
+            List<AttributeDTO> attribList = List.of(
+                buildAttributeDTO(key, valueA),
+                buildAttributeDTO("test_attrib-2", "some attribute"),
+                buildAttributeDTO(key, valueB));
+
+            Map<String, String> attribMap = Util.toMap(attribList);
+
+            assertNotNull(attribMap);
+            assertEquals(2, attribMap.size());
+
+            assertTrue(attribMap.containsKey(key));
+            assertEquals(valueB, attribMap.get(key));
+        }
+
+        @Test
+        public void testToMapDiscardsNullAttributes() {
+            List<AttributeDTO> attribList = new ArrayList<>();
+            attribList.add(null);
+            attribList.add(buildAttributeDTO("test_attrib-1", "test_value"));
+            attribList.add(null);
+            attribList.add(buildAttributeDTO("test_attrib-2", "another_value"));
+            attribList.add(null);
+
+            Map<String, String> attribMap = Util.toMap(attribList);
+
+            assertNotNull(attribMap);
+            assertEquals(2, attribMap.size());
+
+            for (AttributeDTO attrib : attribList) {
+                if (attrib == null) {
+                    continue;
+                }
+
+                assertTrue(attribMap.containsKey(attrib.getName()));
+                assertEquals(attrib.getValue(), attribMap.get(attrib.getName()));
+            }
+        }
+
+        @Test
+        public void testToMapDiscardsAttributesWithEmptyKeys() {
+            List<AttributeDTO> attribList = List.of(
+                buildAttributeDTO("", "test_value"),
+                buildAttributeDTO("test_attrib-2", "another_value"),
+                buildAttributeDTO("", "dead value"),
+                buildAttributeDTO("test_attrib-3", "a third value"),
+                buildAttributeDTO("", "also discarded"));
+
+            Map<String, String> attribMap = Util.toMap(attribList);
+
+            assertNotNull(attribMap);
+            assertEquals(2, attribMap.size());
+
+            for (AttributeDTO attrib : attribList) {
+                if (attrib.getName().isEmpty()) {
+                    continue;
+                }
+
+                assertTrue(attribMap.containsKey(attrib.getName()));
+                assertEquals(attrib.getValue(), attribMap.get(attrib.getName()));
+            }
+        }
+
+        @Test
+        public void testToMapDiscardsAttributesWithNullKeys() {
+            List<AttributeDTO> attribList = List.of(
+                buildAttributeDTO(null, "test_value"),
+                buildAttributeDTO("test_attrib-2", "another_value"),
+                buildAttributeDTO(null, "dead value"),
+                buildAttributeDTO("test_attrib-3", "a third value"),
+                buildAttributeDTO(null, "also discarded"));
+
+            Map<String, String> attribMap = Util.toMap(attribList);
+
+            assertNotNull(attribMap);
+            assertEquals(2, attribMap.size());
+
+            for (AttributeDTO attrib : attribList) {
+                if (attrib.getName() == null) {
+                    continue;
+                }
+
+                assertTrue(attribMap.containsKey(attrib.getName()));
+                assertEquals(attrib.getValue(), attribMap.get(attrib.getName()));
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Fixed a bug with null-versioned product attributes causing
  version collisions due to being used in the version calculation
  before being silently discarded during entity persistence
- Null-valued attributes are now silently discarded at the API
  layer to retain the current behavior
- Product entities will no longer accept null values for product
  attributes, as Hibernate throws them out anyway

This PR also includes the previous changes to Util.toMap that this update builds upon.