### PR TITLE
[4.0] 2076659: Fixed attribute storage issue causing version collisions (ENT-4907)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/server/src/main/java/org/candlepin/controller/ProductManager.java
@@ -773,21 +773,44 @@ public class ProductManager {
             entity.setMultiplier(update.getMultiplier());
         }
 
-        if (update.getAttributes() != null) {
-            entity.setAttributes(update.getAttributes());
-        }
-
         if (update.getDependentProductIds() != null) {
             entity.setDependentProductIds(update.getDependentProductIds());
         }
 
         // Complicated stuff
+        applyProductAttributeChanges(entity, update);
         applyProductContentChanges(entity, update, contentMap);
         applyDerivedProductChanges(entity, update, productMap);
         applyProvidedProductChanges(entity, update, productMap);
         applyBrandingChanges(entity, update);
 
         return entity;
+    }
+
+    /**
+     * Applies product attributes changes from the given ProductInfo instance to the specified
+     * Product entity. Attributes which have null values will be silently discarded from the
+     * updated attributes.
+     *
+     * @param entity
+     *  the Product entity to update
+     *
+     * @param update
+     *  the ProductInfo instance containing the data with which to update the entity
+     */
+    private static void applyProductAttributeChanges(Product entity, ProductInfo update) {
+        Map<String, String> incoming = update.getAttributes();
+        if (incoming != null) {
+            Map<String, String> filtered = new HashMap<>();
+
+            incoming.forEach((k, v) -> {
+                if (v != null) {
+                    filtered.put(k, v);
+                }
+            });
+
+            entity.setAttributes(filtered);
+        }
     }
 
     /**

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -642,6 +642,10 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             throw new IllegalArgumentException("key is null");
         }
 
+        if (value == null) {
+            throw new IllegalArgumentException("value is null");
+        }
+
         // Impl note:
         // We can't standardize the value at all here; some attributes allow null, some expect
         // empty strings, and others have their own sential values. Unless we make a concerted
@@ -708,7 +712,11 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         this.entityVersion = null;
 
         if (attributes != null) {
-            this.attributes.putAll(attributes);
+            // Hibernate does not natively support null values in the map, so for the sake of
+            // consistency, reject any attributes that have a null value.
+            attributes.forEach((k, v) -> {
+                this.attributes.put(Objects.requireNonNull(k), Objects.requireNonNull(v));
+            });
         }
 
         return this;

--- a/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/server/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -36,6 +37,7 @@ import org.candlepin.model.Content;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
+import org.candlepin.service.model.ProductInfo;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
@@ -45,6 +47,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 
 
@@ -687,4 +691,74 @@ public class ProductManagerTest extends DatabaseTestFixture {
         assertEquals(2, output.getProvidedProducts().size());
     }
 
+    @Test
+    public void testCreateProductFiltersNullValuedAttributes() {
+        Owner owner = this.createOwner("test-owner", "Test Owner");
+        ProductInfo pinfo = mock(ProductInfo.class);
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attrib-1", "value 1");
+        attributes.put("attrib-2", null);
+        attributes.put("attrib-3", "value 3");
+
+        doReturn(attributes).when(pinfo).getAttributes();
+        doReturn("p1").when(pinfo).getId();
+        doReturn("prod1").when(pinfo).getName();
+
+        Product entity = this.productManager.createProduct(owner, pinfo);
+
+        assertNotNull(entity);
+        assertNotNull(entity.getAttributes());
+
+        for (Map.Entry<String, String> entry : attributes.entrySet()) {
+            if (entry.getValue() != null) {
+                assertTrue(entity.hasAttribute(entry.getKey()), "expected attribute is not present: " +
+                    entry.getKey());
+
+                assertEquals(entry.getValue(), entity.getAttributeValue(entry.getKey()));
+            }
+            else {
+                assertFalse(entity.hasAttribute(entry.getKey()), "unexpected attribute is present: " +
+                    entry.getKey());
+            }
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @ValueSource(strings = {"false", "true"})
+    public void testUpdateProductFiltersNullValuedAttributes(boolean regenCerts) {
+        Owner owner = this.createOwner("test-owner", "Test Owner");
+        Product base = TestUtil.createProduct("p1", "prod1");
+        base.setAttributes(Map.of("attrib-1", "original value"));
+        this.createProduct(base, owner);
+
+        ProductInfo pinfo = mock(ProductInfo.class);
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("attrib-1", "value 1");
+        attributes.put("attrib-2", null);
+        attributes.put("attrib-3", "value 3");
+
+        doReturn(attributes).when(pinfo).getAttributes();
+        doReturn(base.getId()).when(pinfo).getId();
+        doReturn(base.getName()).when(pinfo).getName();
+
+        Product entity = this.productManager.updateProduct(owner, pinfo, regenCerts);
+
+        assertNotNull(entity);
+        assertNotNull(entity.getAttributes());
+
+        for (Map.Entry<String, String> entry : attributes.entrySet()) {
+            if (entry.getValue() != null) {
+                assertTrue(entity.hasAttribute(entry.getKey()), "expected attribute is not present: " +
+                    entry.getKey());
+
+                assertEquals(entry.getValue(), entity.getAttributeValue(entry.getKey()));
+            }
+            else {
+                assertFalse(entity.hasAttribute(entry.getKey()), "unexpected attribute is present: " +
+                    entry.getKey());
+            }
+        }
+    }
 }

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -17,6 +17,7 @@ package org.candlepin.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
@@ -718,5 +719,94 @@ public class ProductTest {
         assertNotEquals(p2.getEntityVersion(), p4.getEntityVersion());
 
         assertNotEquals(p3.getEntityVersion(), p4.getEntityVersion());
+    }
+
+    @Test
+    public void testSetAttribute() {
+        Product prod = new Product();
+
+        Map<String, String> attributes = prod.getAttributes();
+        assertNotNull(attributes);
+        assertTrue(attributes.isEmpty());
+
+        prod.setAttribute("key", "value");
+
+        attributes = prod.getAttributes();
+        assertNotNull(attributes);
+        assertEquals(1, attributes.size());
+        assertEquals("value", attributes.get("key"));
+    }
+
+    @Test
+    public void testSetAttributeAllowsEmptyValues() {
+        Product prod = new Product();
+
+        Map<String, String> attributes = prod.getAttributes();
+        assertNotNull(attributes);
+        assertTrue(attributes.isEmpty());
+
+        prod.setAttribute("key", "");
+
+        attributes = prod.getAttributes();
+        assertNotNull(attributes);
+        assertEquals(1, attributes.size());
+        assertEquals("", attributes.get("key"));
+    }
+
+    @Test
+    public void testSetAttributeDisallowsNullKeys() {
+        Product prod = new Product();
+        assertThrows(IllegalArgumentException.class, () -> prod.setAttribute(null, "value"));
+    }
+
+    @Test
+    public void testSetAttributeDisallowsNullValues() {
+        Product prod = new Product();
+        assertThrows(IllegalArgumentException.class, () -> prod.setAttribute("key", null));
+    }
+
+    @Test
+    public void testSetAttributes() {
+        Product prod = new Product();
+
+        Map<String, String> incoming = Map.of(
+            "attrib-1", "value-1",
+            "attrib-2", "value-2",
+            "attrib-3", "");
+
+        Map<String, String> existing = prod.getAttributes();
+        assertNotNull(existing);
+        assertTrue(existing.isEmpty());
+
+        prod.setAttributes(incoming);
+
+        existing = prod.getAttributes();
+        assertNotNull(existing);
+        assertEquals(incoming.size(), existing.size());
+
+        for (Map.Entry<String, String> attrib : existing.entrySet()) {
+            assertTrue(incoming.containsKey(attrib.getKey()));
+            assertEquals(attrib.getValue(), incoming.get(attrib.getKey()));
+        }
+    }
+
+    @Test
+    public void testSetAttributesDisallowsNullKeys() {
+        Product prod = new Product();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(null, "some value");
+
+        assertThrows(NullPointerException.class, () -> prod.setAttributes(attributes));
+    }
+
+    @Test
+    public void testSetAttributesDisallowsNullValues() {
+        Product prod = new Product();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("key", null);
+
+        assertThrows(NullPointerException.class, () -> prod.setAttributes(attributes));
     }
 }

--- a/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/server/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -313,8 +313,8 @@ public class AutobindRulesTest {
         //only enforce cores on pool 2:
         Product sku2 = mockStackingProduct("prod2", "Test Stack product", "1", "1");
         sku2.setAttribute(Product.Attributes.CORES, "6");
-        sku2.setAttribute(Product.Attributes.RAM, null);
-        sku2.setAttribute(Product.Attributes.SOCKETS, null);
+        sku2.removeAttribute(Product.Attributes.RAM);
+        sku2.removeAttribute(Product.Attributes.SOCKETS);
         sku2.addProvidedProduct(provided);
 
         Pool pool2 = TestUtil.createPool(owner, sku2)


### PR DESCRIPTION
- Fixed a bug with null-versioned product attributes causing
  version collisions due to being used in the version calculation
  before being silently discarded during entity persistence
- Null-valued attributes are now silently discarded at the API
  layer to retain the current behavior
- Product entities will no longer accept null values for product
  attributes, as Hibernate throws them out anyway