### PR TITLE
Fix issue with deploy script, when Python 3 is used

### DIFF
--- a/bin/deployment/create_test_repos.py
+++ b/bin/deployment/create_test_repos.py
@@ -764,6 +764,8 @@ def main():
     if ret == 0:
         pattern = re.compile(r'^ *Keygrip = (.*)$')
         for line in pgp_output:
+            if type(line) == bytes:
+                line = line.decode()
             result = pattern.search(line)
             # When gpg supported key_grip, then preset passphrase has to be used
             if result is not None:


### PR DESCRIPTION
* When ./bin/deployment/deploy script was started with -r
  option and test RPM repository was generated, then deploy
  script failed, when Python 3 was used (e.g. RHEL 8)