### PR TITLE
[4.0] 2076955: Fixed null pointer exception while testing products for cycles (ENT-4936)

### DIFF
--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2382,17 +2382,6 @@ public class CandlepinPoolManager implements PoolManager {
 
                 this.consumerCurator.flush();
 
-                // Hydrate remaining consumer pools so we can skip some extra work during serialization
-                Set<Pool> poolsToHydrate = new HashSet<>();
-
-                for (Consumer consumer : consumerStackedEnts.keySet()) {
-                    for (Entitlement entitlement : consumer.getEntitlements()) {
-                        poolsToHydrate.add(entitlement.getPool());
-                    }
-                }
-
-                this.productCurator.hydratePoolProvidedProducts(poolsToHydrate);
-
                 // Fire post-unbind events for revoked entitlements
                 log.info("Firing post-unbind events for {} entitlements...", entitlements.size());
                 for (Entitlement entitlement : entitlements) {

--- a/server/src/main/java/org/candlepin/model/Product.java
+++ b/server/src/main/java/org/candlepin/model/Product.java
@@ -1415,8 +1415,8 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             return true;
         }
 
-        if (children != null && children.stream().anyMatch(product -> product.checkForCycle(chain,
-            product.getDerivedProduct(), product.getProvidedProducts()))) {
+        if (children != null && children.stream().anyMatch(product -> product != null &&
+            product.checkForCycle(chain, product.getDerivedProduct(), product.getProvidedProducts()))) {
 
             return true;
         }
@@ -1454,15 +1454,17 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      * @return A reference to this product.
      */
     public Product setProvidedProducts(Collection<Product> providedProducts) {
+        this.providedProducts = new HashSet<>();
+        this.entityVersion = null;
+
         if (providedProducts != null) {
             this.checkForCycle(null, providedProducts);
-            this.providedProducts = new HashSet<>(providedProducts);
-        }
-        else {
-            this.providedProducts = new HashSet<>();
+
+            providedProducts.stream()
+                .filter(Objects::nonNull)
+                .forEach(this.providedProducts::add);
         }
 
-        this.entityVersion = null;
         return this;
     }
 

--- a/server/src/main/resources/db/changelog/20220420165513-drop_pool_derived_product_constraint.xml
+++ b/server/src/main/resources/db/changelog/20220420165513-drop_pool_derived_product_constraint.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20220420165513-1" author="crog">
+        <dropForeignKeyConstraint baseTableName="cp_pool" constraintName="cp_pool_fk2"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1257,4 +1257,5 @@
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
     <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
+    <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2349,4 +2349,5 @@
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
     <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
+    <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -166,4 +166,5 @@
     <include file="db/changelog/20220117152105-add_system_lock_table.xml"/>
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
     <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
+    <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -513,20 +513,6 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testGetHydratedProductsByUuid() {
-        Product prod = TestUtil.createProduct("test-label-hydrated", "test-product-name-hydrated");
-        productCurator.create(prod);
-        prod.setAttribute("testattr", "testVal");
-
-        Set<String> uuids = new HashSet<>();
-        uuids.add(prod.getUuid());
-        uuids.add(product.getUuid());
-
-        Map<String, Product> products = productCurator.getHydratedProductsByUuid(uuids);
-        assertEquals(2, products.size());
-    }
-
-    @Test
     public void testPoolProvidedProducts() {
         Set<String> uuids = productCurator.getPoolProvidedProductUuids(pool.getId());
         assertEquals(new HashSet<>(Arrays.asList(providedProduct.getUuid())), uuids);

--- a/server/src/test/java/org/candlepin/model/ProductTest.java
+++ b/server/src/test/java/org/candlepin/model/ProductTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
@@ -31,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -395,6 +397,29 @@ public class ProductTest {
 
         List<Product> children = List.of(new Product(), new Product(), chain);
         assertThrows(IllegalStateException.class, () -> parent.setProvidedProducts(children));
+    }
+
+    @Test
+    public void testSetProvidedProductsFiltersNullElements() {
+        Product product = new Product();
+        Product child1 = new Product().setId("child1");
+        Product child2 = new Product().setId("child2");
+
+        List<Product> children = new ArrayList<>();
+        children.add(child1);
+        children.add(null);
+        children.add(child2);
+
+        Product output = product.setProvidedProducts(children);
+        assertSame(output, product);
+
+        Collection<Product> providedProducts = product.getProvidedProducts();
+        assertNotNull(providedProducts);
+        assertEquals(2, providedProducts.size());
+
+        assertTrue(providedProducts.contains(child1));
+        assertTrue(providedProducts.contains(child2));
+        assertFalse(providedProducts.contains(null));
     }
 
     private List<Product> buildTestProducts() {


### PR DESCRIPTION
- Fixed a null pointer exception (NPE) that could occur while testing
  a product for a cyclical product reference if one or more products
  in the graph had a collection of provided products containing a null
  product
- Product.setProvidedProducts now filters null elements from the incoming
  collection
- Dropped an obsolete foreign key from pool to products on the derived
  product field
- Removed some obsolete code surrounding pool provided product
  hydration, as these fields are now stored on the products