### PR TITLE
[M] 2076952: Fixed null pointer exception while testing products for cycles (ENT-4936)

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2379,17 +2379,6 @@ public class CandlepinPoolManager implements PoolManager {
 
                 this.consumerCurator.flush();
 
-                // Hydrate remaining consumer pools so we can skip some extra work during serialization
-                Set<Pool> poolsToHydrate = new HashSet<>();
-
-                for (Consumer consumer : consumerStackedEnts.keySet()) {
-                    for (Entitlement entitlement : consumer.getEntitlements()) {
-                        poolsToHydrate.add(entitlement.getPool());
-                    }
-                }
-
-                this.productCurator.hydratePoolProvidedProducts(poolsToHydrate);
-
                 // Fire post-unbind events for revoked entitlements
                 log.info("Firing post-unbind events for {} entitlements...", entitlements.size());
                 for (Entitlement entitlement : entitlements) {

--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -1415,8 +1415,8 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             return true;
         }
 
-        if (children != null && children.stream().anyMatch(product -> product.checkForCycle(chain,
-            product.getDerivedProduct(), product.getProvidedProducts()))) {
+        if (children != null && children.stream().anyMatch(product -> product != null &&
+            product.checkForCycle(chain, product.getDerivedProduct(), product.getProvidedProducts()))) {
 
             return true;
         }
@@ -1454,15 +1454,17 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
      * @return A reference to this product.
      */
     public Product setProvidedProducts(Collection<Product> providedProducts) {
+        this.providedProducts = new HashSet<>();
+        this.entityVersion = null;
+
         if (providedProducts != null) {
             this.checkForCycle(null, providedProducts);
-            this.providedProducts = new HashSet<>(providedProducts);
-        }
-        else {
-            this.providedProducts = new HashSet<>();
+
+            providedProducts.stream()
+                .filter(Objects::nonNull)
+                .forEach(this.providedProducts::add);
         }
 
-        this.entityVersion = null;
         return this;
     }
 

--- a/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/src/main/java/org/candlepin/model/ProductCurator.java
@@ -17,7 +17,6 @@ package org.candlepin.model;
 import org.candlepin.config.Configuration;
 import org.candlepin.util.AttributeValidator;
 
-import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
@@ -32,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +38,6 @@ import java.util.Set;
 
 import javax.inject.Singleton;
 import javax.persistence.Cache;
-import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 
@@ -178,6 +175,7 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
                 productsNotInCache.add(uuid);
             }
         }
+
         if (productsNotInCache.size() > 0) {
             log.debug("Loading objects that were not already in the cache: " + productsNotInCache.size());
             Session session = this.currentSession();
@@ -199,124 +197,6 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
         }
 
         return products;
-    }
-
-    /**
-     * Loads the set of products from database and triggers all lazy loads.
-     * @param uuids
-     * @return Map of UUID to Product instance
-     */
-    public Map<String, Product> getHydratedProductsByUuid(Set<String> uuids) {
-        Map<String, Product> productsByUuid = new HashMap<>();
-
-        if (uuids != null && !uuids.isEmpty()) {
-            for (Product product : this.listAllByUuids(uuids)) {
-                // Fetching the size on these collections triggers a lazy load of the collections
-                product.getAttributes().size();
-                product.getDependentProductIds().size();
-                for (ProductContent pc : product.getProductContent()) {
-                    pc.getContent().getModifiedProductIds().size();
-                }
-
-                productsByUuid.put(product.getUuid(), product);
-            }
-        }
-
-        return productsByUuid;
-    }
-
-    /**
-     * Fetches the provided and derived provided products for the specified pools, populating the
-     * respective collections in each pool object. The products will be pulled from the product
-     * cache where possible, and the cache will be hydrated with products that must be pulled from
-     * the database.
-     *
-     * @param pools
-     *  A collection of pools for which to fetch provided and derived provided products
-     *
-     * @return
-     *  the number of products cached as a result of this operation
-     */
-    public int hydratePoolProvidedProducts(Iterable<Pool> pools) {
-        int count = 0;
-        if (pools != null && pools.iterator().hasNext()) {
-            EntityManager entityManager = this.getEntityManager();
-
-            // We use these set for both product UUIDs and product instances, once populated
-            Map<String, Set<String>> poolProvidedProducts = new HashMap<>();
-            Map<String, Set<String>> poolDerivedProvidedProducts = new HashMap<>();
-            Map<String, Product> allProducts = new HashMap<>();
-
-            for (Pool pool : pools) {
-                poolProvidedProducts.put(pool.getId(), new HashSet<>());
-                poolDerivedProvidedProducts.put(pool.getId(), new HashSet<>());
-            }
-
-            String ppSql =
-                "SELECT po.id, pp.provided_product_uuid FROM cp2_product_provided_products pp " +
-                "JOIN cp_pool po on po.product_uuid = pp.product_uuid " +
-                "WHERE po.id IN (:poolIds)";
-
-            String dpSql =
-                "SELECT po.id, pp.provided_product_uuid FROM cp2_product_provided_products pp " +
-                "JOIN cp_pool po on po.derived_product_uuid = pp.product_uuid " +
-                "WHERE po.id IN (:poolIds)";
-
-            Query ppUuidQuery = entityManager.createNativeQuery(ppSql);
-            Query dpUuidQuery = entityManager.createNativeQuery(dpSql);
-
-            int blockSize = this.getInBlockSize();
-            for (List<String> block : Iterables.partition(poolProvidedProducts.keySet(), blockSize)) {
-                // Fetch pool provided products...
-                ppUuidQuery.setParameter("poolIds", block);
-
-                for (Object[] row : (List<Object[]>) ppUuidQuery.getResultList()) {
-                    String poolId = (String) row[0];
-                    String productUuid = (String) row[1];
-                    Set<String> ppSet = poolProvidedProducts.get(poolId);
-                    ppSet.add(productUuid);
-                    allProducts.put(productUuid, null);
-                }
-
-                dpUuidQuery.setParameter("poolIds", block);
-
-                for (Object[] row : (List<Object[]>) dpUuidQuery.getResultList()) {
-                    String poolId = (String) row[0];
-                    String productUuid = (String) row[1];
-                    Set<String> dpSet = poolDerivedProvidedProducts.get(poolId);
-                    dpSet.add(productUuid);
-                    allProducts.put(productUuid, null);
-                }
-            }
-
-            // Now go get all the products and hydrate them
-            Set<Product> hydratedProducts = getProductsByUuidCached(allProducts.keySet());
-            for (Product product : hydratedProducts) {
-                allProducts.put(product.getUuid(), product);
-            }
-
-            // Use the UUID sets for each pools provided & derived provided products
-            // to populate the actual product models.
-            for (Pool pool : pools) {
-                Set<Product> providedProducts = new HashSet<>();
-                for (String uuid : poolProvidedProducts.get(pool.getId())) {
-                    providedProducts.add(allProducts.get(uuid));
-                }
-
-                Set<Product> derivedProvidedProducts = new HashSet<>();
-                for (String uuid : poolDerivedProvidedProducts.get(pool.getId())) {
-                    derivedProvidedProducts.add(allProducts.get(uuid));
-                }
-
-                pool.getProduct().setProvidedProducts(providedProducts);
-
-                if (pool.getDerivedProduct() != null) {
-                    pool.getDerivedProduct().setProvidedProducts(derivedProvidedProducts);
-                }
-            }
-        }
-
-        return count;
     }
 
     /**

--- a/src/main/resources/db/changelog/20220420165513-drop_pool_derived_product_constraint.xml
+++ b/src/main/resources/db/changelog/20220420165513-drop_pool_derived_product_constraint.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20220420165513-1" author="crog">
+        <dropForeignKeyConstraint baseTableName="cp_pool" constraintName="cp_pool_fk2"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1263,4 +1263,5 @@
     <include file="db/changelog/20220328090000-accommodate_large_overrides.xml"/>
     <include file="db/changelog/20220329140000-add_consumer_name_to_cp_deleted_consumers.xml"/>
     <include file="db/changelog/20220329154201-owner-product-key-change.xml"/>
+    <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2355,4 +2355,5 @@
     <include file="db/changelog/20220328090000-accommodate_large_overrides.xml"/>
     <include file="db/changelog/20220329140000-add_consumer_name_to_cp_deleted_consumers.xml"/>
     <include file="db/changelog/20220329154201-owner-product-key-change.xml"/>
+    <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -172,4 +172,5 @@
     <include file="db/changelog/20220328090000-accommodate_large_overrides.xml"/>
     <include file="db/changelog/20220329140000-add_consumer_name_to_cp_deleted_consumers.xml"/>
     <include file="db/changelog/20220329154201-owner-product-key-change.xml"/>
+    <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -513,20 +513,6 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testGetHydratedProductsByUuid() {
-        Product prod = TestUtil.createProduct("test-label-hydrated", "test-product-name-hydrated");
-        productCurator.create(prod);
-        prod.setAttribute("testattr", "testVal");
-
-        Set<String> uuids = new HashSet<>();
-        uuids.add(prod.getUuid());
-        uuids.add(product.getUuid());
-
-        Map<String, Product> products = productCurator.getHydratedProductsByUuid(uuids);
-        assertEquals(2, products.size());
-    }
-
-    @Test
     public void testPoolProvidedProducts() {
         Set<String> uuids = productCurator.getPoolProvidedProductUuids(pool.getId());
         assertEquals(new HashSet<>(Arrays.asList(providedProduct.getUuid())), uuids);

--- a/src/test/java/org/candlepin/model/ProductTest.java
+++ b/src/test/java/org/candlepin/model/ProductTest.java
@@ -17,6 +17,8 @@ package org.candlepin.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
@@ -30,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -394,6 +397,29 @@ public class ProductTest {
 
         List<Product> children = List.of(new Product(), new Product(), chain);
         assertThrows(IllegalStateException.class, () -> parent.setProvidedProducts(children));
+    }
+
+    @Test
+    public void testSetProvidedProductsFiltersNullElements() {
+        Product product = new Product();
+        Product child1 = new Product().setId("child1");
+        Product child2 = new Product().setId("child2");
+
+        List<Product> children = new ArrayList<>();
+        children.add(child1);
+        children.add(null);
+        children.add(child2);
+
+        Product output = product.setProvidedProducts(children);
+        assertSame(output, product);
+
+        Collection<Product> providedProducts = product.getProvidedProducts();
+        assertNotNull(providedProducts);
+        assertEquals(2, providedProducts.size());
+
+        assertTrue(providedProducts.contains(child1));
+        assertTrue(providedProducts.contains(child2));
+        assertFalse(providedProducts.contains(null));
     }
 
     private List<Product> buildTestProducts() {


### PR DESCRIPTION
- Fixed a null pointer exception (NPE) that could occur while testing
  a product for a cyclical product reference if one or more products
  in the graph had a collection of provided products containing a null
  product
- Product.setProvidedProducts now filters null elements from the incoming
  collection
- Dropped an obsolete foreign key from pool to products on the derived
  product field
- Removed some obsolete code surrounding pool provided product
  hydration, as these fields are now stored on the products