### PR TITLE
2078780: Added filter for fetching SCA certs with cert serial Id

### DIFF
--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -95,7 +95,6 @@ import org.candlepin.model.DistributorVersion;
 import org.candlepin.model.DistributorVersionCapability;
 import org.candlepin.model.DistributorVersionCurator;
 import org.candlepin.model.Entitlement;
-import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.EntitlementFilterBuilder;
 import org.candlepin.model.EnvironmentContentCurator;
@@ -163,6 +162,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -2068,29 +2068,52 @@ public class ConsumerResource implements ConsumersApi {
         }
 
         Consumer consumer = consumerCurator.verifyAndLookupConsumer(consumerUuid);
-        ConsumerType ctype = this.consumerTypeCurator.getConsumerType(consumer);
 
         revokeOnGuestMigration(consumer);
         poolManager.regenerateDirtyEntitlements(consumer);
 
         Set<Long> serialSet = this.extractSerials(serials);
+        List<? extends Certificate> entitlementCerts = this.entCertService.listForConsumer(consumer);
+        Certificate caCert = this.contentAccessManager.getCertificate(consumer);
+        Stream<? extends Certificate> certStream = this.buildCertificateStream(entitlementCerts, caCert);
 
-        List<CertificateDTO> returnCerts = new LinkedList<>();
-        List<EntitlementCertificate> allCerts = entCertService.listForConsumer(consumer);
-
-        for (EntitlementCertificate cert : allCerts) {
-            if (serialSet.isEmpty() || serialSet.contains(cert.getSerial().getId())) {
-                returnCerts.add(translator.translate(cert, CertificateDTO.class));
-            }
+        // Check if we should filter certs by the cert serial
+        if (serialSet != null && !serialSet.isEmpty()) {
+            certStream = certStream
+                .filter(cert -> cert.getSerial() != null && serialSet.contains(cert.getSerial().getId()));
         }
 
-        // we want to insert the content access cert to this list if appropriate
-        Certificate cert = this.contentAccessManager.getCertificate(consumer);
-        if (cert != null) {
-            returnCerts.add(translator.translate(cert, CertificateDTO.class));
-        }
+        return certStream.map(this.translator.getStreamMapper(Certificate.class, CertificateDTO.class))
+            .collect(Collectors.toList());
+    }
 
-        return returnCerts;
+    /**
+     * Builds a stream containing all of the certificates in the provided collection, and any
+     * additional certificates that might not be included in the collection (such as the content
+     * access cert). Null elements will be filtered from the resulting stream.
+     *
+     * @param certificates
+     *  a collection of certificates to include in the certificate stream
+     *
+     * @param extraCerts
+     *  any additional certificates to include in the certificate stream
+     *
+     * @return
+     *  a stream containing a combination of all the certificates
+     */
+    private Stream<? extends Certificate> buildCertificateStream(
+        Collection<? extends Certificate> certificates, Certificate... extraCerts) {
+
+        Stream<? extends Certificate> baseCertStream = certificates != null ?
+            certificates.stream() :
+            Stream.empty();
+
+        Stream<? extends Certificate> extraCertStream = extraCerts != null ?
+            Stream.of(extraCerts) :
+            Stream.empty();
+
+        return Stream.concat(baseCertStream, extraCertStream)
+            .filter(Objects::nonNull);
     }
 
     @Override

--- a/src/main/java/org/candlepin/sync/Exporter.java
+++ b/src/main/java/org/candlepin/sync/Exporter.java
@@ -191,7 +191,7 @@ public class Exporter {
 
             exportMeta(baseDir, null);
             exportEntitlementsCerts(baseDir, consumer, serials, false);
-            exportContentAccessCerts(baseDir, consumer);
+            exportContentAccessCerts(baseDir, consumer, serials);
             return makeArchive(consumer, tmpDir, baseDir);
         }
         catch (IOException e) {
@@ -409,19 +409,25 @@ public class Exporter {
      * Exports content access certificates for a consumer.
      * Consumer must belong to owner with SCA enabled.
      *
+     * @param baseDir
+     *  Base directory path.
+     *
      * @param consumer
      *  Consumer for which content access certificates needs to be exported.
      *
-     * @param baseDir
-     *  Base directory path.
+     * @param serials
+     *  certificate serials used to filter content access certificates.
      *
      * @throws IOException
      *  Throws IO exception if unable to export content access certs for the consumer.
      */
-    private void exportContentAccessCerts(File baseDir, Consumer consumer) throws IOException {
+    private void exportContentAccessCerts(File baseDir, Consumer consumer,
+        Set<Long> serials) throws IOException {
         ContentAccessCertificate contentAccessCert = this.contentAccessManager.getCertificate(consumer);
 
-        if (contentAccessCert != null) {
+        if (contentAccessCert != null &&
+            (serials == null || contentAccessCert.getSerial() == null ||
+            serials.contains(contentAccessCert.getSerial().getId()))) {
             File contentAccessCertDir = new File(baseDir.getCanonicalPath(), "content_access_certificates");
             contentAccessCertDir.mkdir();
 

--- a/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -75,6 +75,7 @@ import org.candlepin.model.ConsumerInstalledProduct;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.ContentAccessCertificate;
 import org.candlepin.model.DeletedConsumer;
 import org.candlepin.model.DeletedConsumerCurator;
 import org.candlepin.model.DistributorVersionCurator;
@@ -662,6 +663,24 @@ public class ConsumerResourceTest {
         return toReturn;
     }
 
+    private EntitlementCertificate createEntitlementCertificate(String key, String cert, long serialId) {
+        EntitlementCertificate certificate = new EntitlementCertificate();
+        CertificateSerial expectedSerial = new CertificateSerial(serialId, new Date());
+        certificate.setKeyAsBytes(key.getBytes());
+        certificate.setCertAsBytes(cert.getBytes());
+        certificate.setSerial(expectedSerial);
+        return certificate;
+    }
+
+    private ContentAccessCertificate createContentAccessCertificate(String key, String cert, long serialId) {
+        ContentAccessCertificate certificate = new ContentAccessCertificate();
+        CertificateSerial expectedSerial = new CertificateSerial(serialId, new Date());
+        certificate.setKeyAsBytes(key.getBytes());
+        certificate.setCertAsBytes(cert.getBytes());
+        certificate.setSerial(expectedSerial);
+        return certificate;
+    }
+
     @Test
     public void testNullPerson() {
         Owner owner = this.createOwner();
@@ -842,6 +861,75 @@ public class ConsumerResourceTest {
         );
     }
 
+    @Test
+    public void testGetEntitlementCertificatesWithExistingSerialIdForEntitlementCertificate() {
+        Consumer consumer = createConsumer();
+        doReturn(consumer).when(consumerCurator).verifyAndLookupConsumer(consumer.getId());
+
+        EntitlementCertificate expectedCertificate = createEntitlementCertificate("expected-key",
+            "expected-cert", 18084729L);
+        List<EntitlementCertificate> certificates = new ArrayList<>();
+        certificates.add(createEntitlementCertificate("key-1", "cert-1"));
+        certificates.add(createEntitlementCertificate("key-2", "cert-2"));
+        certificates.add(expectedCertificate);
+        doReturn(certificates).when(entitlementCertServiceAdapter).listForConsumer(any(Consumer.class));
+
+        List<CertificateDTO> actual = consumerResource.getEntitlementCertificates(consumer.getId(),
+            Long.toString(expectedCertificate.getSerial().getId()));
+
+        assertEquals(1, actual.size());
+        CertificateDTO actualCertificate = actual.get(0);
+        assertEquals(expectedCertificate.getId(), actualCertificate.getId());
+        assertEquals(expectedCertificate.getKey(), actualCertificate.getKey());
+        assertEquals(expectedCertificate.getCert(), actualCertificate.getCert());
+        assertEquals(expectedCertificate.getCreated(), actualCertificate.getCreated());
+        assertEquals(expectedCertificate.getUpdated(), actualCertificate.getUpdated());
+
+        assertEquals(expectedCertificate.getSerial().getId(), actualCertificate.getSerial().getId());
+    }
+
+    @Test
+    public void testGetEntitlementCertificatesWithExistingSerialIdForSimpleContentAccessCert() {
+        Consumer consumer = createConsumer();
+        doReturn(consumer).when(consumerCurator).verifyAndLookupConsumer(consumer.getId());
+
+        List<EntitlementCertificate> certificates = new ArrayList<>();
+        certificates.add(createEntitlementCertificate("key-1", "cert-1"));
+        certificates.add(createEntitlementCertificate("key-2", "cert-2"));
+        doReturn(certificates).when(entitlementCertServiceAdapter).listForConsumer(any(Consumer.class));
+
+        ContentAccessCertificate expectedCertificate = createContentAccessCertificate("expected-key",
+            "expected-cert", 18084729L);
+        doReturn(expectedCertificate).when(contentAccessManager).getCertificate(any(Consumer.class));
+
+        List<CertificateDTO> actual = consumerResource.getEntitlementCertificates(consumer.getId(),
+            Long.toString(expectedCertificate.getSerial().getId()));
+
+        assertEquals(1, actual.size());
+        CertificateDTO actualCertificate = actual.get(0);
+        assertEquals(expectedCertificate.getId(), actualCertificate.getId());
+        assertEquals(expectedCertificate.getKey(), actualCertificate.getKey());
+        assertEquals(expectedCertificate.getCert(), actualCertificate.getCert());
+        assertEquals(expectedCertificate.getCreated(), actualCertificate.getCreated());
+        assertEquals(expectedCertificate.getUpdated(), actualCertificate.getUpdated());
+
+        assertEquals(expectedCertificate.getSerial().getId(), actualCertificate.getSerial().getId());
+    }
+
+    @Test
+    public void testGetEntitlementCertificatesWithUnknownSerialId() {
+        Consumer consumer = createConsumer();
+        doReturn(consumer).when(consumerCurator).verifyAndLookupConsumer(consumer.getId());
+        List<EntitlementCertificate> certificates = createEntitlementCertificates();
+        doReturn(certificates).when(entitlementCertServiceAdapter).listForConsumer(any(Consumer.class));
+        ContentAccessCertificate certificate = createContentAccessCertificate(
+            "key-1", "key-2", 18084729L);
+        doReturn(certificate).when(contentAccessManager).getCertificate(any(Consumer.class));
+
+        List<CertificateDTO> actual = consumerResource.getEntitlementCertificates(consumer.getId(), "123456");
+
+        assertEquals(0, actual.size());
+    }
 
     @Test
     void shouldThrowWhenConsumerNotFound() {


### PR DESCRIPTION
I also verified the changes with the following steps:

1. Register with Subscription Manager to an organization that is org_environment content access mode.
2. Use a Get request on the candlepin/consumers/<Consumer ID>/certificates endpoint and use and serial number as a query parameter. (curl -k -u admin:admin --request GET --header 'accept: application/json' "https://localhost:8443/candlepin/consumers/<Consumer ID>/certificates?serials=12345678")
3. Verify that we do not get any certificates back.