### PR TITLE
[M] Changed Maven plugin to maven-publish for Gradle 7+ (ENT-4797)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
     // Openapi version is set in the buildscript block for use in the pom generation as well
     id "org.openapi.generator" version '5.4.0'
     id "java"
-    id "maven"
+    id "maven-publish"
     id "war"
     id "checkstyle"
     id 'org.owasp.dependencycheck' version '7.0.0'
@@ -37,6 +37,7 @@ plugins {
     id 'org.candlepin.gradle.gettext'
     id 'org.candlepin.gradle.msgfmt'
     id "org.candlepin.gradle.SpecVersion"
+    id "org.candlepin.gradle.PomToolkit"
 }
 
 group = "org.candlepin"
@@ -489,284 +490,50 @@ tasks.withType(Checkstyle) {
 }
 
 task pom {
-    doLast {
-        conf2ScopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY + 1, configurations.compileOnly, 'provided')
-        conf2ScopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY + 1, configurations.runtimeOnly, 'runtime')
-        conf2ScopeMappings.addMapping(MavenPlugin.COMPILE_PRIORITY + 1, configurations.implementation, 'compile')
+    dependsOn "generatePomFileForLocalPublication"
+}
+
+publishing {
+  publications {
+    local(MavenPublication) {
+
+        generatePomFileForLocalPublication {
+           destination = file("./pom.xml")
+        }
 
         pom {
-            project {
-                description "The Candlepin Entitlement Engine"
-                groupId "org.candlepin"
-                artifactId "candlepin"
-                packaging "war"
-                licenses {
-                    license {
-                        name = 'GNU Public License (GPL) version 2.0'
-                        url = 'http://www.gnu.org/licenses/gpl-2.0.html'
-                        distribution = 'repo'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/candlepin/candlepin.git'
-                    developerConnection = 'scm:git:git@github.com:candlepin/candlepin.git'
-                }
-                dependencies {
-                    dependency {
-                        groupId 'org.mozilla'
-                        artifactId 'jss'
-                        version '${jssVersion}'
-                        scope 'system'
-                        systemPath '${jssLocation}'
-                    }
-                }
-                // Choose which jss library to use by activating the appropriate profile
-                // based on which version of the jss jar exists on the file system.
-                profiles {
-                    profile {
-                        id 'build-with-jss4'
-                        activation {
-                            file {
-                                exists '/usr/lib64/jss/jss4.jar'
-                            }
-                        }
-                        properties {
-                            jssVersion '4.9.1'
-                            jssLocation '/usr/lib64/jss/jss4.jar'
-                        }
-                    }
-                    profile {
-                        id 'build-with-jss5-plus'
-                        activation {
-                            file {
-                                exists '/usr/lib64/jss/jss.jar'
-                            }
-                        }
-                        properties {
-                            jssVersion '5.0.0'
-                            jssLocation '/usr/lib64/jss/jss.jar'
-                        }
-                    }
-                }
-                repositories {
-                    repository {
-                        id 'jboss'
-                        name 'JBoss'
-                        url 'https://repository.jboss.org/nexus/content/groups/public/'
-                    }
-                    repository {
-                        id 'oauth'
-                        name 'Oauth'
-                        url 'https://oauth.googlecode.com/svn/code/maven/'
-                    }
-                    repository {
-                        id 'awood'
-                        name 'awood.fedorapeople.org'
-                        url 'https://awood.fedorapeople.org/ivy/candlepin/'
-                    }
-                    repository {
-                        id 'barnabycourt'
-                        name 'barnabycourt.fedorapeople.org'
-                        url 'https://barnabycourt.fedorapeople.org/repo/candlepin/'
-                    }
-                }
-                build([:]) {
-                    resources {
-                        resource {
-                            directory 'src/main/resources'
-                            filtering 'true'
-                        }
-                        resource {
-                            directory '${project.build.directory}/generated-resources'
-                            filtering 'true'
-                        }
-                    }
-                    testResources {
-                        testResource {
-                            directory 'src/test/resources'
-                            // Do not filter test resources.  It will corrupt the binary CRL files.
-                            filtering 'false'
-                        }
-                    }
-                    plugins {
-                        plugin {
-                            groupId 'org.openapitools'
-                            artifactId 'openapi-generator-maven-plugin'
-                            version "$openapi_version"
-                            executions {
-                                execution {
-                                    goals {
-                                        goal 'generate'
-                                    }
-                                    configuration {
-                                        inputSpec '${project.basedir}/api/candlepin-api-spec.yaml'
-                                        generatorName 'jaxrs-spec'
-                                        configurationFile '${project.basedir}/api/candlepin-api-config.json'
-                                        configOptions {
-                                            interfaceOnly 'true'
-                                            generatePom 'false'
-                                            dateLibrary 'java8'
-                                            sourceFolder 'src/gen/java/main'
-                                        }
-                                        templateDirectory '${project.basedir}/buildSrc/src/main/resources/templates'
-                                    }
-                                }
-                            }
-                        }
-                        plugin {
-                            groupId 'org.bsc.maven'
-                            artifactId 'maven-processor-plugin'
-                            version '5.0-jdk8-rc1'
-                            executions {
-                                execution {
-                                    id 'process'
-                                    phase 'generate-sources'
-                                    goals {
-                                        goal 'process'
-                                    }
-                                    configuration {
-                                        outputDirectory '${project.build.directory}/generated-sources/jpamodel/gen/java'
-                                        processors {
-                                            processor 'org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor'
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        plugin {
-                            groupId 'org.codehaus.mojo'
-                            artifactId 'build-helper-maven-plugin'
-                            version '3.2.0'
-                            executions {
-                                execution {
-                                    id 'add-source'
-                                    phase 'generate-sources'
-                                    goals {
-                                        goal 'add-source'
-                                    }
-                                    configuration {
-                                        sources {
-                                            source '${project.build.directory}/generated-sources/jpamodel/gen/java'
-                                            source '${project.build.directory}/generated-sources/openapi/src/gen/java'
-                                            source 'src/main/java'
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        plugin {
-                            groupId 'com.googlecode.gettext-commons'
-                            artifactId 'gettext-maven-plugin'
-                            version '1.2.4'
-                            executions {
-                                execution {
-                                    phase 'generate-resources'
-                                    goals {
-                                        goal 'dist'
-                                    }
-                                }
-                            }
-                            configuration {
-                                targetBundle 'org.candlepin.common.i18n.Messages'
-                                poDirectory 'po'
-                            }
-                        }
-                        plugin {
-                            groupId 'org.apache.maven.plugins'
-                            artifactId 'maven-resources-plugin'
-                            version '3.1.0'
-                            executions {
-                                execution {
-                                    phase 'validate'
-                                    goals {
-                                        goal 'copy-resources'
-                                    }
-                                    configuration {
-                                        outputDirectory 'src/main/webapp/docs/'
-                                        resources {
-                                            resource {
-                                                directory '${basedir}/api'
-                                                includes {
-                                                    include 'candlepin-api-spec.yaml'
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        plugin {
-                            groupId 'org.apache.maven.plugins'
-                            artifactId 'maven-compiler-plugin'
-                            version '3.8.0'
-                            configuration {
-                                source '11'
-                                target '11'
-                                debug 'true'
-                                debuglevel 'lines,vars,source'
-                                compilerArgument '-proc:none'
-                            }
-                        }
-                        plugin {
-                            groupId 'org.apache.maven.plugins'
-                            artifactId 'maven-surefire-plugin'
-                            version '2.22.1'
-                            configuration {
-                                skipTests 'true'
-                            }
-                        }
-                        plugin {
-                            groupId 'org.apache.maven.plugins'
-                            artifactId 'maven-assembly-plugin'
-                            version '2.4'
-                            executions {
-                                execution {
-                                    id 'create-archive'
-                                    phase 'package'
-                                    goals {
-                                        goal 'single'
-                                    }
-                                }
-                            }
-                            configuration {
-                                descriptors {
-                                    descriptor '${project.basedir}/assembly.xml'
-                                }
-                            }
-                        }
-                        plugin {
-                            artifactId 'maven-clean-plugin'
-                            version '3.1.0'
-                            configuration {
-                                filesets {
-                                    fileset {
-                                        directory 'src/main/webapp/docs/'
-                                        includes {
-                                            include 'candlepin-api-spec.yaml'
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        // This helps debugging by printing out which profiles
-                        // are active during the compilation phase
-                        plugin {
-                            groupId 'org.apache.maven.plugins'
-                            artifactId 'maven-help-plugin'
-                            version '3.2.0'
-                            executions {
-                                execution {
-                                    id 'show-profiles'
-                                    phase 'compile'
-                                    goals {
-                                        goal 'active-profiles'
-                                    }
-                                }
-                            }
-                        }
-                    }
+            description = 'The Candlepin Entitlement Engine'
+            packaging = 'war'
+            licenses {
+                license {
+                    name = 'GNU Public License (GPL) version 2.0'
+                    url = 'http://www.gnu.org/licenses/gpl-2.0.html'
+                    distribution = 'repo'
                 }
             }
-        }.writeTo("pom.xml")
+
+            scm {
+                connection = 'scm:git:git://github.com/candlepin/candlepin.git'
+                developerConnection = 'scm:git:git@github.com:candlepin/candlepin.git'
+            }
+
+            pom.withXml {
+                PomToolkit.generatePomDependencies(
+                    asNode(),
+                    configurations.annotationProcessor.dependencies,
+                    configurations.compileOnly.dependencies,
+                    configurations.implementation.dependencies,
+                    configurations.providedCompile.dependencies,
+                    configurations.runtimeOnly.dependencies,
+                    configurations.testImplementation.dependencies,
+                    configurations.testRuntime.dependencies
+                )
+
+                PomToolkit.generateRepositories(asNode())
+                PomToolkit.generateBuild(asNode())
+                PomToolkit.generateProfiles(asNode())
+            }
+        }
     }
+  }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -25,5 +25,9 @@ gradlePlugin {
             implementationClass = "Msgfmt"
         }
 
+        pomToolkitPlugin {
+            id = "org.candlepin.gradle.PomToolkit"
+            implementationClass = "PomToolkit"
+        }
     }
 }

--- a/buildSrc/src/main/groovy/PomToolkit.groovy
+++ b/buildSrc/src/main/groovy/PomToolkit.groovy
@@ -1,0 +1,291 @@
+/*
+ *  Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ *  This software is licensed to you under the GNU General Public License,
+ *  version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ *  implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ *  FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ *  along with this software; if not, see
+ *  http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ *  Red Hat trademarks are not licensed under GPLv2. No permission is
+ *  granted to use or replicate Red Hat trademarks that are incorporated
+ *  in this software or its documentation.
+ */
+
+
+import org.gradle.api.internal.artifacts.DefaultDependencySet
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class PomToolkit implements Plugin<Project> {
+    
+    void apply(Project project) {
+    }
+
+    public static void generatePomDependencies(
+        Node parent,
+        DefaultDependencySet annotationProcessorDependencies, 
+        DefaultDependencySet compileOnlyDependencies,
+        DefaultDependencySet implementationDependencies,
+        DefaultDependencySet providedCompileDependencies,
+        DefaultDependencySet runtimeOnlyDependencies,
+        DefaultDependencySet testImplementationDependencies,
+        DefaultDependencySet testRuntimeDependencies) {
+
+        def dependenciesNode = parent.appendNode('dependencies')
+        createDependencyNode(dependenciesNode, 'org.mozilla', 'jss', '${jssVersion}', 'system', '${jssLocation}')
+        annotationProcessorDependencies.each { dependency ->
+            createDependencyNode(dependenciesNode, dependency.group, dependency.name, dependency.version, 'compile', null)
+        }
+        
+        compileOnlyDependencies.each { dependency ->
+            createDependencyNode(dependenciesNode, dependency.group, dependency.name, dependency.version, 'provided', null)
+        }
+
+        implementationDependencies.each { dependency ->
+            createDependencyNode(dependenciesNode, dependency.group, dependency.name, dependency.version, 'compile', null)
+        }
+
+        providedCompileDependencies.each { dependency ->
+            createDependencyNode(dependenciesNode, dependency.group, dependency.name, dependency.version, 'provided', null)
+        }
+
+        runtimeOnlyDependencies.each { dependency ->
+            createDependencyNode(dependenciesNode, dependency.group, dependency.name, dependency.version, 'runtime', null)
+        }
+
+        testImplementationDependencies.each { dependency ->
+            createDependencyNode(dependenciesNode, dependency.group, dependency.name, dependency.version, 'test', null)
+        }
+
+        testRuntimeDependencies.each { dependency ->
+            createDependencyNode(dependenciesNode, dependency.group, dependency.name, dependency.version, 'test', null)
+        }
+    }
+
+    public static void generateRepositories(Node parent) {
+        def repositoriesNode = parent.appendNode('repositories')
+        createRepoNode(repositoriesNode, 'jboss', 'JBoss', 'https://repository.jboss.org/nexus/content/groups/public/')
+        createRepoNode(repositoriesNode, 'oauth', 'Oauth', 'https://oauth.googlecode.com/svn/code/maven/')
+        createRepoNode(repositoriesNode, 'awood', 'awood.fedorapeople.org', 'https://awood.fedorapeople.org/ivy/candlepin/')
+        createRepoNode(repositoriesNode, 'barnabycourt', 'barnabycourt.fedorapeople.org', 'https://barnabycourt.fedorapeople.org/repo/candlepin/')
+    }
+
+    public static void generateBuild(Node parent) {
+        def buildNode = parent.appendNode('build')
+        def resourcesNode = buildNode.appendNode('resources')
+        def resource1 = resourcesNode.appendNode('resource')
+        resource1.appendNode('filtering', 'true')
+        resource1.appendNode('directory', 'src/main/resources')
+
+        def resource2 = resourcesNode.appendNode('resource')
+        resource2.appendNode('filtering', 'true')
+        resource2.appendNode('directory', '${project.build.directory}/generated-resources')
+
+        def testResourcesNode = buildNode.appendNode('testResources')
+        def testResource = testResourcesNode.appendNode('testResource')
+        testResource.appendNode('filtering', 'false')
+        testResource.appendNode('directory', 'src/test/resources')
+
+        def pluginsNode = buildNode.appendNode('plugins')
+        createOpenapiGeneratorPlugin(pluginsNode)
+        createMavenProcessorPlugin(pluginsNode)
+        createBuilderHelperMavenPlugin(pluginsNode)
+        createGettextMavenPlugin(pluginsNode)
+        createMavenResourcePlugin(pluginsNode)
+        createMavenCompilerPlugin(pluginsNode)
+        createMavenSurefirePlugin(pluginsNode)
+        createMavenAssemblyPlugin(pluginsNode)
+        createMavenCleanPlugin(pluginsNode)
+        createMavenHelpPlugin(pluginsNode)        
+    }
+    
+    public static void generateProfiles(Node parent) {
+        def profilesNode = parent.appendNode('profiles')
+        createProfileNode(profilesNode, 'build-with-jss4', '/usr/lib64/jss/jss4.jar', '4.9.1')
+        createProfileNode(profilesNode, 'build-with-jss5-plus', '/usr/lib64/jss/jss.jar', '5.0.0')
+    }
+
+
+    private static void createDependencyNode(Node parentNode, String groupId, String artifactId, String version, String scope, String systemPath) {
+        if (groupId) {
+            def dependencyNode = parentNode.appendNode('dependency')
+            dependencyNode.appendNode('groupId', groupId)
+            dependencyNode.appendNode('artifactId', artifactId)
+            if (version != null)
+                dependencyNode.appendNode('version', version)
+            if (scope != null)
+                dependencyNode.appendNode('scope', scope)
+            if (systemPath != null)
+                dependencyNode.appendNode('systemPath', systemPath)
+        }
+    }
+
+    private static void createProfileNode(Node parentNode, String id, String jarLocation, String version) {
+        def profileNode = parentNode.appendNode('profile')
+        profileNode.appendNode('id', id)
+        def profileActivationNode = profileNode.appendNode('activation')
+        def activationFileNode = profileActivationNode.appendNode('file')
+        activationFileNode.appendNode('exists', jarLocation)
+        def profilePropertiesNode = profileNode.appendNode('properties')
+        profilePropertiesNode.appendNode('jssVersion', version)
+        profilePropertiesNode.appendNode('jssLocation', jarLocation)
+    }
+
+    private static void createRepoNode(Node parentNode, String id, String name, String url) {
+        def repoNode = parentNode.appendNode('repository')
+        repoNode.appendNode('id', id)
+        repoNode.appendNode('name', name)
+        repoNode.appendNode('url', url)
+    }
+
+    private static void createOpenapiGeneratorPlugin(Node parentNode) {
+        def plugin = parentNode.appendNode('plugin')
+        plugin.appendNode('groupId', 'org.openapitools')
+        plugin.appendNode('artifactId', 'openapi-generator-maven-plugin')
+        plugin.appendNode('version', '5.4.0')
+        def executionsNode = plugin.appendNode('executions')
+        def executionNode = executionsNode.appendNode('execution')
+        def goalsNode = executionNode.appendNode('goals')
+        goalsNode.appendNode('goal', 'generate')
+        def configurationsNode = executionNode.appendNode('configuration')
+        configurationsNode.appendNode('inputSpec', '${project.basedir}/api/candlepin-api-spec.yaml')
+        configurationsNode.appendNode('generatorName', 'jaxrs-spec')
+        configurationsNode.appendNode('configurationFile', '${project.basedir}/api/candlepin-api-config.json')
+        def configOptions = configurationsNode.appendNode('configOptions')
+        configOptions.appendNode('interfaceOnly', 'true')
+        configOptions.appendNode('generatePom', 'false')
+        configOptions.appendNode('dateLibrary', 'java8')
+        configOptions.appendNode('sourceFolder', 'src/gen/java/main')
+        configurationsNode.appendNode('templateDirectory', '${project.basedir}/buildSrc/src/main/resources/templates')
+    }
+
+    private static void createMavenProcessorPlugin(Node parentNode) {
+        def plugin = parentNode.appendNode('plugin')
+        plugin.appendNode('groupId', 'org.bsc.maven')
+        plugin.appendNode('artifactId', 'maven-processor-plugin')
+        plugin.appendNode('version', '5.0-jdk8-rc1')
+        def executionsNode = plugin.appendNode('executions')
+        def executionNode = executionsNode.appendNode('execution')
+        executionNode.appendNode('id', 'process')
+        executionNode.appendNode('phase', 'generate-sources')
+        def goalsNode = executionNode.appendNode('goals')
+        goalsNode.appendNode('goal', 'process')
+
+        def configurationsNode = executionNode.appendNode('configuration')
+        configurationsNode.appendNode('outputDirectory', '${project.build.directory}/generated-sources/jpamodel/gen/java')
+        def processorsNode = configurationsNode.appendNode('processors')
+        processorsNode.appendNode('processor', 'org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor')
+    }
+
+    private static void createBuilderHelperMavenPlugin(Node parentNode) {
+        def plugin = parentNode.appendNode('plugin')
+        plugin.appendNode('groupId', 'org.codehaus.mojo')
+        plugin.appendNode('artifactId', 'build-helper-maven-plugin')
+        plugin.appendNode('version', '3.2.0')
+        def executionsNode = plugin.appendNode('executions')
+        def executionNode = executionsNode.appendNode('execution')
+        executionNode.appendNode('id', 'add-source')
+        executionNode.appendNode('phase', 'generate-sources')
+        def goalsNode = executionNode.appendNode('goals')
+        goalsNode.appendNode('goal', 'add-source')
+        def configurationsNode = executionNode.appendNode('configuration')
+        def sourcesNode = configurationsNode.appendNode('sources')
+        sourcesNode.appendNode('source', '${project.build.directory}/generated-sources/jpamodel/gen/java')
+        sourcesNode.appendNode('source', '${project.build.directory}/generated-sources/openapi/src/gen/java')
+        sourcesNode.appendNode('source', 'src/main/java')
+    }
+
+    private static void createGettextMavenPlugin(Node parentNode) {
+        def plugin = parentNode.appendNode('plugin')
+        plugin.appendNode('groupId', 'com.googlecode.gettext-commons')
+        plugin.appendNode('artifactId', 'gettext-maven-plugin')
+        plugin.appendNode('version', '1.2.4')
+        def executionsNode = plugin.appendNode('executions')
+        def executionNode = executionsNode.appendNode('execution')
+        executionNode.appendNode('phase', 'generate-resources')
+        def goalsNode = executionNode.appendNode('goals')
+        goalsNode.appendNode('goal', 'dist')
+        def configurationsNode = plugin.appendNode('configuration')
+        configurationsNode.appendNode('targetBundle', 'org.candlepin.common.i18n.Messages')
+        configurationsNode.appendNode('poDirectory', 'po')
+    }
+
+    private static void createMavenResourcePlugin(Node parentNode) {
+        def plugin = parentNode.appendNode('plugin')
+        plugin.appendNode('artifactId', 'maven-resources-plugin')
+        plugin.appendNode('version', '3.1.0')
+        def executionsNode = plugin.appendNode('executions')
+        def executionNode = executionsNode.appendNode('execution')
+        executionNode.appendNode('phase', 'validate')
+        def goalsNode = executionNode.appendNode('goals')
+        goalsNode.appendNode('goal', 'copy-resources')
+        def configurationsNode = executionNode.appendNode('configuration')
+        configurationsNode.appendNode('outputDirectory', 'src/main/webapp/docs/')
+        def resourcesNode = configurationsNode.appendNode('resources')
+        def resourceNode = resourcesNode.appendNode('resource')
+        resourceNode.appendNode('directory', '${basedir}/api')
+        def includesNode = resourceNode.appendNode('includes')
+        includesNode.appendNode('include', 'candlepin-api-spec.yaml')
+    }
+
+    private static void createMavenCompilerPlugin(Node parentNode) {
+        def plugin = parentNode.appendNode('plugin')
+        plugin.appendNode('artifactId', 'maven-compiler-plugin')
+        plugin.appendNode('version', '3.8.0')
+        def configurationsNode = plugin.appendNode('configuration')
+        configurationsNode.appendNode('source', '11')
+        configurationsNode.appendNode('target', '11')
+        configurationsNode.appendNode('debug', 'true')
+        configurationsNode.appendNode('debuglevel', 'lines,vars,source')
+        configurationsNode.appendNode('compilerArgument', '-proc:none')
+    }
+
+    private static void createMavenSurefirePlugin(Node parentNode) {
+        def plugin = parentNode.appendNode('plugin')
+        plugin.appendNode('artifactId', 'maven-surefire-plugin')
+        plugin.appendNode('version', '2.22.1')
+        def configurationsNode = plugin.appendNode('configuration')
+        configurationsNode.appendNode('skipTests', 'true')
+    }
+
+    private static void createMavenAssemblyPlugin(Node parentNode) {
+        def plugin = parentNode.appendNode('plugin')
+        plugin.appendNode('artifactId', 'maven-assembly-plugin')
+        plugin.appendNode('version', '2.4')
+        def executionsNode = plugin.appendNode('executions')
+        def executionNode = executionsNode.appendNode('execution')
+        executionNode.appendNode('id', 'create-archive')
+        executionNode.appendNode('phase', 'package')
+        def goalsNode = executionNode.appendNode('goals')
+        goalsNode.appendNode('goal', 'single')
+        def configurationsNode = plugin.appendNode('configuration')
+        def descriptorsNode = configurationsNode.appendNode('descriptors')
+        descriptorsNode.appendNode('descriptor', '${project.basedir}/assembly.xml')
+    }
+
+    private static void createMavenCleanPlugin(Node parentNode) {
+        def plugin = parentNode.appendNode('plugin')
+        plugin.appendNode('artifactId', 'maven-clean-plugin')
+        plugin.appendNode('version', '3.1.0')
+        def configurationsNode = plugin.appendNode('configuration')
+        def fileSetsNode = configurationsNode.appendNode('filesets')
+        def fileSetNode = fileSetsNode.appendNode('fileset')
+        fileSetNode.appendNode('directory', 'src/main/webapp/docs/')
+        def includesNode = fileSetNode.appendNode('includes')
+        includesNode.appendNode('include', 'candlepin-api-spec.yaml')
+    }
+
+    private static void createMavenHelpPlugin(Node parentNode) {
+        def plugin = parentNode.appendNode('plugin')
+        plugin.appendNode('artifactId', 'maven-help-plugin')
+        plugin.appendNode('version', '3.2.0')
+        def executionsNode = plugin.appendNode('executions')
+        def executionNode = executionsNode.appendNode('execution')
+        executionNode.appendNode('id', 'show-profiles')
+        executionNode.appendNode('phase', 'compile')
+        def goalsNode = executionNode.appendNode('goals')
+        goalsNode.appendNode('goal', 'active-profiles')
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.candlepin</groupId>
   <artifactId>candlepin</artifactId>
@@ -294,6 +293,12 @@
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-servlet-filter-adapter</artifactId>
       <version>17.0.1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-jpamodelgen</artifactId>
+      <version>5.6.7.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Changed build.gradle to use the maven-publish plugin instead of the maven plugin for compatibility using Gradle 7+.  Unfortunately we are somewhat limited with the properties and methods with maven-publish and I had to generate most of the pom.xml with the withXml method.

https://docs.gradle.org/current/dsl/org.gradle.api.publish.maven.MavenPom.html

**Pom is generated running the following:**
`gradlew generatePomFileForLocalPublication`