### PR TITLE
[M] Remove maven from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,3 @@ updates:
     target-branch: "master"
     ignore:
       - dependency-name: "org.jboss.resteasy"
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "master"
-    ignore:
-      - dependency-name: "org.jboss.resteasy"


### PR DESCRIPTION
Reason: dependabot is opening PRs for upgrading maven plugins, and we don't want that because we auto-generate them from gradle. Also, we don't necessarily need upgrading normal maven libraries, because we auto-generate them during the release pipeline anyway.