### PR TITLE
1993223: Stop Candlepin initialization if database is not updated

### DIFF
--- a/src/main/resources/db/changelog/20130315171104-migrate-upstream-uuid.xml
+++ b/src/main/resources/db/changelog/20130315171104-migrate-upstream-uuid.xml
@@ -7,7 +7,7 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
     <changeSet id="20130315171104-1" author="jesusr" dbms="postgresql">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
             <columnExists tableName="cp_import_record" columnName="upstream_name" />
         </preConditions>
         <comment>Create Upstream Consumer records</comment>
@@ -36,7 +36,7 @@
     </changeSet>
 
     <changeSet id="20130315171104-2" author="jesusr" dbms="postgresql">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
             <columnExists tableName="cp_import_record" columnName="upstream_name" />
         </preConditions>
         <comment>Link UpstreamConsumers to Owners</comment>

--- a/src/main/resources/db/changelog/20140408160212-add-pool-source-sub-table.xml
+++ b/src/main/resources/db/changelog/20140408160212-add-pool-source-sub-table.xml
@@ -102,7 +102,7 @@
     </changeSet>
 
     <changeSet id="20140408160212-4" author="ckozak">
-        <preConditions onSqlOutput="TEST" onFail="CONTINUE">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
             <changeSetExecuted
                 changeLogFile="20140408160212-add-pool-source-sub-table.xml"
                 id="20140408160212-3"
@@ -132,7 +132,7 @@
     </changeSet>
 
     <changeSet id="20140408160212-5" author="ckozak">
-        <preConditions onSqlOutput="TEST" onFail="CONTINUE">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
             <changeSetExecuted
                 changeLogFile="20140408160212-add-pool-source-sub-table.xml"
                 id="20140408160212-4"

--- a/src/main/resources/db/changelog/20150401140006-add-pool-type-to-db.xml
+++ b/src/main/resources/db/changelog/20150401140006-add-pool-type-to-db.xml
@@ -25,7 +25,7 @@
     </changeSet>
 
     <changeSet id="20150401140006-3" author="crog">
-        <preConditions onSqlOutput="TEST" onFail="CONTINUE">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
             <changeSetExecuted
                 changeLogFile="20150401140006-add-pool-type-to-db.xml"
                 id="20150401140006-2"

--- a/src/main/resources/db/changelog/20180110092945-cleanup-uebercerts-round4-premigration.xml
+++ b/src/main/resources/db/changelog/20180110092945-cleanup-uebercerts-round4-premigration.xml
@@ -80,7 +80,7 @@
             value="delete c from cp_consumer c where c.name = 'ueber_cert_consumer';" />
 
     <changeSet id="20180110092945-1" author="vrjain">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onSqlOutput="TEST"  onFail="MARK_RAN">
             <and>
                 <tableExists tableName="cp_subscription" />
                 <columnExists tableName="cp_pool" columnName="productname" />

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1113,6 +1113,7 @@
     <include file="db/changelog/20130319175255-order-number-to-pool.xml"/>
     <include file="db/changelog/20130329094102-drop-account-and-contract-from-entitlement.xml"/>
     <include file="db/changelog/20121019144118-create-upstream-consumer.xml"/>
+    <include file="db/changelog/20130315171104-migrate-upstream-uuid.xml"/>
     <include file="db/changelog/20130319110704-drop-upstream-uuid.xml"/>
     <include file="db/changelog/20130319112409-drop-columns-from-import-record.xml"/>
     <include file="db/changelog/20130402153704-add-upstream-consumer-fk.xml"/>
@@ -1173,6 +1174,7 @@
     <include file="db/changelog/20150211111319-add-last-guest-update-table.xml"/>
     <include file="db/changelog/20150316122833-add-entitlement-end-date-override.xml"/>
     <include file="db/changelog/20150311151612-force-all-content-metadataexpire-to-0.xml"/>
+    <include file="db/changelog/20180110092945-cleanup-uebercerts-round4-premigration.xml"/>
     <include file="db/changelog/20150210094558-perorgproducts-phase-1.xml"/>
     <include file="db/changelog/20150401140006-add-pool-type-to-db.xml"/>
     <include file="db/changelog/20150416090438-mysql-quartz-longblob.xml"/>

--- a/src/test/java/org/candlepin/junit/LiquibaseExtension.java
+++ b/src/test/java/org/candlepin/junit/LiquibaseExtension.java
@@ -87,6 +87,10 @@ public class LiquibaseExtension implements BeforeAllCallback, AfterAllCallback, 
         this("db/changelog/changelog-testing.xml");
     }
 
+    public Liquibase getLiquibase() {
+        return this.liquibase;
+    }
+
     private File setupTempDirectory() throws IOException {
         Path tmp = Files.createTempDirectory(HSQLDB_DIR_PREFIX);
         System.setProperty(HSQLDB_DIR_PROPERTY, tmp.toString());


### PR DESCRIPTION
Check to determine if any changesets have not been run by liquibase.
Failure results in a runtime error that will end the intialization.