### PR TITLE
[4.0] 2069165: Added grace period for product deletion during refresh/import (ENT-4881)

### DIFF
--- a/server/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/server/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -284,6 +284,10 @@ public class ConfigProperties {
     // How long (in seconds) to wait for job threads to finish during a graceful Tomcat shutdown
     public static final String ASYNC_JOBS_THREAD_SHUTDOWN_TIMEOUT = "candlepin.async.thread.shutdown.timeout";
 
+    // How many days to allow a product to be orphaned before removing it on the next refresh or
+    // manifest import. Default: 30 days
+    public static final String ORPHANED_ENTITY_GRACE_PERIOD = "candlepin.refresh.orphan_entity_grace_period";
+
     /**
      * Fetches a string representing the prefix for all per-job configuration for the specified job.
      * The job key or class name may be used, but the usage must be consistent.
@@ -480,6 +484,7 @@ public class ConfigProperties {
             // Set the triggerable jobs list
             this.put(ASYNC_JOBS_TRIGGERABLE_JOBS, String.join(", ", ASYNC_JOBS_TRIGGERABLE_JOBS_LIST));
 
+            this.put(ORPHANED_ENTITY_GRACE_PERIOD, "30");
         }
     };
 

--- a/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/server/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -220,7 +220,8 @@ public class CandlepinPoolManager implements PoolManager {
         Owner resolvedOwner = this.resolveOwner(owner);
         log.info("Refreshing pools for owner: {}", resolvedOwner);
 
-        RefreshWorker refresher = this.refreshWorkerProvider.get();
+        RefreshWorker refresher = this.refreshWorkerProvider.get()
+            .setOrphanedEntityGracePeriod(this.config.getInt(ConfigProperties.ORPHANED_ENTITY_GRACE_PERIOD));
 
         log.debug("Fetching subscriptions from adapter...");
         refresher.addSubscriptions(subAdapter.getSubscriptions(resolvedOwner.getKey()));

--- a/server/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
@@ -70,16 +70,20 @@ public class RefreshWorker {
      */
     private static final int VERSIONING_CONSTRAINT_VIOLATION_RETRIES = 4;
 
+    /** Default grace period for orphaned entities */
+    private static final int ORPHANED_ENTITY_DEFAULT_GRACE_PERIOD = -1;
 
-    private PoolCurator poolCurator;
-    private ContentCurator contentCurator;
-    private OwnerContentCurator ownerContentCurator;
-    private OwnerProductCurator ownerProductCurator;
-    private ProductCurator productCurator;
+    private final PoolCurator poolCurator;
+    private final ContentCurator contentCurator;
+    private final OwnerContentCurator ownerContentCurator;
+    private final OwnerProductCurator ownerProductCurator;
+    private final ProductCurator productCurator;
 
     private PoolMapper poolMapper;
     private ProductMapper productMapper;
     private ContentMapper contentMapper;
+
+    private int orphanedEntityGracePeriod;
 
 
     /**
@@ -99,6 +103,8 @@ public class RefreshWorker {
         this.poolMapper = new PoolMapper();
         this.productMapper = new ProductMapper();
         this.contentMapper = new ContentMapper();
+
+        this.orphanedEntityGracePeriod = ORPHANED_ENTITY_DEFAULT_GRACE_PERIOD;
     }
 
     /**
@@ -108,6 +114,35 @@ public class RefreshWorker {
         this.poolMapper.clear();
         this.productMapper.clear();
         this.contentMapper.clear();
+    }
+
+    /**
+     * Sets the orphaned entity grace period, which determines how long a given entity must be
+     * orphaned before it will be deleted as part of the cleanup step. The behavior of entity
+     * cleanup will differ depending on this value:
+     * <ul>
+     *  <li>
+     *  If the grace period is a positive integer, entities which have been orphaned for more
+     *  than the number of days will be removed
+     *  </li>
+     *  <li>
+     *  If the grace period is zero, entities which are orphaned will be cleaned up immediately
+     *  </li>
+     *  <li>
+     *  If the grace period is a negative integer, orphaned entities will not be removed at all
+     *  </li>
+     * </ul>
+     *
+     * @param period
+     *  the orphaned entity grace period in days, or a negative value to disable orphaned entity
+     *  cleanup
+     *
+     * @return
+     *  a reference to this refresh worker
+     */
+    public RefreshWorker setOrphanedEntityGracePeriod(int period) {
+        this.orphanedEntityGracePeriod = period;
+        return this;
     }
 
     /**
@@ -391,6 +426,18 @@ public class RefreshWorker {
     }
 
     /**
+     * Fetches the current orphaned entity grace period for this refresher. See the documentation
+     * associated with the setOrphanedEntityGracePeriod method for details on the meaning of
+     * specific values.
+     *
+     * @return
+     *  the current orphaned entity grace period for this refresher
+     */
+    public int getOrphanedEntityGracePeriod() {
+        return this.orphanedEntityGracePeriod;
+    }
+
+    /**
      * Fetches the compiled set of subscriptions to import, mapped by subscription ID. If no subscriptions
      * have been added, this method returns an empty map.
      *
@@ -429,6 +476,7 @@ public class RefreshWorker {
      * @return
      *  the result of this refresh operation
      */
+    @SuppressWarnings("indentation")
     public RefreshResult execute(Owner owner) {
         Transactional<RefreshResult> block = this.poolCurator.transactional((args) -> {
             NodeMapper nodeMapper = new NodeMapper();
@@ -445,7 +493,8 @@ public class RefreshWorker {
             NodeProcessor nodeProcessor = new NodeProcessor()
                 .setNodeMapper(nodeMapper)
                 .addVisitor(new PoolNodeVisitor(this.poolCurator))
-                .addVisitor(new ProductNodeVisitor(this.productCurator, this.ownerProductCurator))
+                .addVisitor(new ProductNodeVisitor(this.productCurator, this.ownerProductCurator,
+                    this.orphanedEntityGracePeriod))
                 .addVisitor(new ContentNodeVisitor(this.contentCurator, this.ownerContentCurator));
 
             // Clear existing entities in the event this isn't the first run of this refresher

--- a/server/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
+++ b/server/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
@@ -32,6 +32,8 @@ import org.candlepin.service.model.ProductInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -50,6 +52,7 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
 
     private final ProductCurator productCurator;
     private final OwnerProductCurator ownerProductCurator;
+    private final int orphanProductGracePeriod;
 
     // Various cross-stage cache collections
     private Set<OwnerProduct> ownerProductEntities;
@@ -57,6 +60,12 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
     private Map<Owner, Set<String>> deletedProductUuids;
     private Map<Owner, Set<Long>> ownerEntityVersions;
     private Map<Owner, Map<String, List<Product>>> ownerVersionedEntityMap;
+
+    // Orphan date tracking and grace period state caching
+    private Map<Owner, Map<String, Instant>> ownerOrphanedDateMap;
+    private Map<Owner, Set<String>> ownerOrphanEntityIdPrecache;
+    private Map<Owner, Set<String>> ownerOrphanedEntities;
+    private Map<Owner, Set<String>> ownerUnorphanedEntities;
 
 
     /**
@@ -69,10 +78,15 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
      * @param ownerProductCurator
      *  the OwnerProductCurator to use for owner-product database operations
      *
+     * @param orphanProductGracePeriod
+     *  the number of days a product is allowed to be orphaned before it will be removed
+     *
      * @throws IllegalArgumentException
      *  if any of the provided curators are null
      */
-    public ProductNodeVisitor(ProductCurator productCurator, OwnerProductCurator ownerProductCurator) {
+    public ProductNodeVisitor(ProductCurator productCurator, OwnerProductCurator ownerProductCurator,
+        int orphanProductGracePeriod) {
+
         if (productCurator == null) {
             throw new IllegalArgumentException("productCurator is null");
         }
@@ -83,12 +97,18 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
 
         this.productCurator = productCurator;
         this.ownerProductCurator = ownerProductCurator;
+        this.orphanProductGracePeriod = orphanProductGracePeriod;
 
         this.ownerProductEntities = new HashSet<>();
         this.ownerProductUuidMap = new HashMap<>();
         this.deletedProductUuids = new HashMap<>();
         this.ownerEntityVersions = new HashMap<>();
         this.ownerVersionedEntityMap = new HashMap<>();
+
+        this.ownerOrphanedDateMap = new HashMap<>();
+        this.ownerOrphanEntityIdPrecache = new HashMap<>();
+        this.ownerOrphanedEntities = new HashMap<>();
+        this.ownerUnorphanedEntities = new HashMap<>();
     }
 
     /**
@@ -122,6 +142,10 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
         node.setNodeState(NodeState.UNCHANGED);
 
         if (existingEntity != null) {
+            // Cache the ID of any existing entities for later bulk fetching orphan dates
+            this.ownerOrphanEntityIdPrecache.computeIfAbsent(node.getOwner(), key -> new HashSet<>())
+                .add(node.getEntityId());
+
             if (importedEntity != null) {
                 nodeChanged = ProductManager.isChangedBy(existingEntity, importedEntity);
             }
@@ -168,20 +192,95 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
      */
     private boolean clearedForDeletion(EntityNode<Product, ProductInfo> node) {
         // We don't delete custom entities, ever.
-        if (!node.getExistingEntity().isLocked()) {
-            return false;
-        }
+        boolean cleared = node.getExistingEntity().isLocked();
 
         // If the node is still defined upstream and is part of this refresh, we should keep it
         // around locally
-        if (node.getImportedEntity() != null) {
-            return false;
+        cleared = cleared && node.getImportedEntity() == null;
+
+        // If the node is referenced by one or more parent nodes that are not being deleted
+        // themselves, we should keep it.
+        cleared = cleared && !node.getParentNodes()
+            .anyMatch(elem -> elem.getNodeState() != NodeState.DELETED);
+
+        // If the grace period is set to infinity (negative values), we are never clear for deletion
+        cleared = cleared && this.orphanProductGracePeriod >= 0;
+
+        if (cleared) {
+            // At this point we're *almost* clear for deletion; just need to wait out the grace period:
+            // - If there is not a date set, it has not been previously cleared for deletion. Set the
+            //   date, update the owner-product ref to store the new date and return false
+            // - if there is a date set, check if we're beyond the grace period (in days). If the date
+            //   has been exceeded, flag the product for deletion
+            // - if the grace period is zero, we're setup to delete without delay; skip any further
+            //   checks
+
+            if (this.orphanProductGracePeriod > 0) {
+                Instant orphanedDate = this.getOwnerProductOrphanedDate(node);
+
+                if (orphanedDate == null) {
+                    this.ownerOrphanedEntities.computeIfAbsent(node.getOwner(), key -> new HashSet<>())
+                        .add(node.getEntityId());
+
+                    cleared = false;
+                }
+                else {
+                    Instant cutoff = Instant.now()
+                        .truncatedTo(ChronoUnit.DAYS)
+                        .minus(this.orphanProductGracePeriod, ChronoUnit.DAYS);
+
+                    cleared = orphanedDate.truncatedTo(ChronoUnit.DAYS)
+                        .isBefore(cutoff);
+                }
+            }
+        }
+        else {
+            // Entity is not cleared for deletion. Remove its orphaned date if it's been set.
+            if (this.getOwnerProductOrphanedDate(node) != null) {
+                this.ownerUnorphanedEntities.computeIfAbsent(node.getOwner(), key -> new HashSet<>())
+                    .add(node.getEntityId());
+            }
         }
 
-        // Otherwise, if the node is referenced by one or more parent nodes that are not being
-        // deleted themselves, we should keep it.
-        return !node.getParentNodes()
-            .anyMatch(elem -> elem.getNodeState() != NodeState.DELETED);
+        return cleared;
+    }
+
+    /**
+     * Fetches the orphaned date of the entity represented by the given node. If the node does not
+     * represent an orphaned entity, this method returns null.
+     *
+     * @param node
+     *  the entity node for which to fetch the orphaned entity date
+     *
+     * @return
+     *  the date the entity represented by the given node was orphaned, or null if the node does not
+     *  represent an orphaned entity
+     */
+    private Instant getOwnerProductOrphanedDate(EntityNode<Product, ProductInfo> node) {
+        Map<String, Instant> orphanDateMap = this.ownerOrphanedDateMap
+            .computeIfAbsent(node.getOwner(), key -> new HashMap<>());
+
+        // Check if we have some precached IDs to convert...
+        Set<String> entityIdPrecache = this.ownerOrphanEntityIdPrecache.remove(node.getOwner());
+        if (entityIdPrecache != null) {
+            Map<String, Instant> fetched = this.ownerProductCurator
+                .getOwnerProductOrphanedDates(node.getOwner(), entityIdPrecache);
+
+            orphanDateMap.putAll(fetched);
+        }
+
+        // If this node somehow missed the processing/precaching step, do an individual lookup and
+        // cache the result
+        if (!orphanDateMap.containsKey(node.getEntityId())) {
+            OwnerProduct op = this.ownerProductCurator
+                .getOwnerProduct(node.getOwner().getId(), node.getEntityId());
+
+            if (op != null) {
+                orphanDateMap.put(node.getEntityId(), op.getOrphanedDate());
+            }
+        }
+
+        return orphanDateMap.get(node.getEntityId());
     }
 
     /**
@@ -272,6 +371,17 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
             this.ownerProductCurator.removeOwnerProductReferences(entry.getKey(), entry.getValue());
         }
 
+        // Clear orphaned dates on unorphaned products
+        for (Map.Entry<Owner, Set<String>> entry : this.ownerUnorphanedEntities.entrySet()) {
+            this.ownerProductCurator.updateOwnerProductOrphanedDates(entry.getKey(), entry.getValue(), null);
+        }
+
+        // Set orphaned dates on newly-orphaned products
+        for (Map.Entry<Owner, Set<String>> entry : this.ownerOrphanedEntities.entrySet()) {
+            this.ownerProductCurator.updateOwnerProductOrphanedDates(entry.getKey(), entry.getValue(),
+                Instant.now());
+        }
+
         // Save new owner-product entities
         this.ownerProductEntities.stream()
             .forEach(elem -> this.ownerProductCurator.create(elem, false));
@@ -288,6 +398,11 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
         this.deletedProductUuids.clear();
         this.ownerEntityVersions.clear();
         this.ownerVersionedEntityMap.clear();
+
+        this.ownerOrphanEntityIdPrecache.clear();
+        this.ownerOrphanedDateMap.clear();
+        this.ownerOrphanedEntities.clear();
+        this.ownerUnorphanedEntities.clear();
     }
 
     private EntityNode<Product, ProductInfo> lookupProductNode(EntityNode<Product, ProductInfo> parentNode,

--- a/server/src/main/java/org/candlepin/model/OwnerProduct.java
+++ b/server/src/main/java/org/candlepin/model/OwnerProduct.java
@@ -15,6 +15,7 @@
 package org.candlepin.model;
 
 import java.io.Serializable;
+import java.time.Instant;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -71,6 +72,10 @@ public class OwnerProduct implements Persisted, Serializable {
     @Column(name = "product_uuid")
     private String productUuid;
 
+    /** The date at which the product became orphaned (unused/flagged for deletion) within the org */
+    @Column(name = "orphaned_date")
+    private Instant orphanedDate;
+
     public OwnerProduct() {
         // Intentionally left empty
     }
@@ -90,16 +95,47 @@ public class OwnerProduct implements Persisted, Serializable {
         return owner;
     }
 
-    public void setOwner(Owner owner) {
+    public OwnerProduct setOwner(Owner owner) {
         this.owner = owner;
+        return this;
     }
 
     public Product getProduct() {
         return product;
     }
 
-    public void setProduct(Product product) {
+    public OwnerProduct setProduct(Product product) {
         this.product = product;
+        return this;
+    }
+
+    /**
+     * Fetches the instant at which this product has been detected as orphaned (or unused) within
+     * the organization represented by this OwnerProduct linkage. If the product is still in use or
+     * otherwise hasn't been detected as an orphan, this method will return null.
+     *
+     * @return
+     *  the instant the product has been orphaned within the organization, or null if the product
+     *  has not yet been flagged for deletion.
+     */
+    public Instant getOrphanedDate() {
+        return this.orphanedDate;
+    }
+
+    /**
+     * Sets or clears the date this product has been orphaned within the organization represented by
+     * this OwnerProduct linkage. If the incoming date is null, any existing date will be cleared.
+     *
+     * @param date
+     *  the date at which this product has been orphaned within the organization, or null to clear
+     *  any existing orphan date
+     *
+     * @return
+     *  a reference to this OwnerProduct instance
+     */
+    public OwnerProduct setOrphanedDate(Instant date) {
+        this.orphanedDate = date;
+        return this;
     }
 
     @Override

--- a/server/src/main/resources/db/changelog/20220517162755-add_owner_product_orphaned_date.xml
+++ b/server/src/main/resources/db/changelog/20220517162755-add_owner_product_orphaned_date.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20220517162755-1" author="crog">
+        <addColumn tableName="cp2_owner_products">
+            <column name="orphaned_date" type="${timestamp.type}"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-create.xml
+++ b/server/src/main/resources/db/changelog/changelog-create.xml
@@ -1258,4 +1258,5 @@
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
     <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
     <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
+    <include file="db/changelog/20220517162755-add_owner_product_orphaned_date.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-testing.xml
+++ b/server/src/main/resources/db/changelog/changelog-testing.xml
@@ -2350,4 +2350,5 @@
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
     <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
     <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
+    <include file="db/changelog/20220517162755-add_owner_product_orphaned_date.xml"/>
 </databaseChangeLog>

--- a/server/src/main/resources/db/changelog/changelog-update.xml
+++ b/server/src/main/resources/db/changelog/changelog-update.xml
@@ -167,4 +167,5 @@
     <include file="db/changelog/20211110083000-disallow_duplicate_versioned_entities.xml"/>
     <include file="db/changelog/20220314130000-64bit_entity_versions.xml"/>
     <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
+    <include file="db/changelog/20220517162755-add_owner_product_orphaned_date.xml"/>
 </databaseChangeLog>

--- a/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/server/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -24,7 +24,12 @@ import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 
@@ -695,5 +701,468 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
             .collect(Collectors.toList());
 
         this.ownerProductCurator.getProductsByVersions(versions);
+    }
+
+    private Product createProduct() {
+        String id = "test_product-" + TestUtil.randomInt();
+
+        Product product = new Product()
+            .setId(id)
+            .setName(id);
+
+        return this.productCurator.create(product);
+    }
+
+    private List<OwnerProduct> buildOwnerProductData(List<Owner> owners, List<Product> products) {
+        Instant last = Instant.now();
+        List<OwnerProduct> output = new ArrayList<>();
+
+        for (Owner owner : owners) {
+            for (Product product : products) {
+                OwnerProduct op = new OwnerProduct(owner, product)
+                    .setOrphanedDate(last);
+
+                this.ownerProductCurator.create(op, false);
+                output.add(op);
+
+                last = last.minusSeconds(300);
+            }
+        }
+
+        this.ownerProductCurator.flush();
+
+        return output;
+    }
+
+    @Test
+    public void testGetOwnerProduct() {
+        Owner owner = this.createOwner();
+        Product product = this.createProduct();
+
+        OwnerProduct result = this.ownerProductCurator.getOwnerProduct(owner.getId(), product.getId());
+        assertNull(result);
+
+        OwnerProduct expected = new OwnerProduct()
+            .setOwner(owner)
+            .setProduct(product);
+
+        this.ownerProductCurator.create(expected, true);
+        this.ownerProductCurator.clear();
+
+        result = this.ownerProductCurator.getOwnerProduct(owner.getId(), product.getId());
+        assertNotNull(result);
+        assertNotNull(result.getOwner());
+        assertNotNull(result.getProduct());
+
+        assertEquals(owner, result.getOwner());
+        assertEquals(product, result.getProduct());
+    }
+
+    @Test
+    public void testGetOwnerProductHandlesInvalidIds() {
+        Owner owner = this.createOwner();
+        Product product = this.createProduct();
+        OwnerProduct expected = new OwnerProduct()
+            .setOwner(owner)
+            .setProduct(product);
+
+        this.ownerProductCurator.create(expected, true);
+        this.ownerProductCurator.clear();
+
+
+        OwnerProduct result = this.ownerProductCurator.getOwnerProduct(owner.getId(), "invalid_product_id");
+        assertNull(result);
+
+        result = this.ownerProductCurator.getOwnerProduct("invalid_owner_id", product.getId());
+        assertNull(result);
+
+        result = this.ownerProductCurator.getOwnerProduct("invalid_owner_id", "invalid_product_id");
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetOwnerProductHandlesNullIds() {
+        Owner owner = this.createOwner();
+        Product product = this.createProduct();
+        OwnerProduct expected = new OwnerProduct()
+            .setOwner(owner)
+            .setProduct(product);
+
+        this.ownerProductCurator.create(expected, true);
+        this.ownerProductCurator.clear();
+
+
+        OwnerProduct result = this.ownerProductCurator.getOwnerProduct(owner.getId(), null);
+        assertNull(result);
+
+        result = this.ownerProductCurator.getOwnerProduct(null, product.getId());
+        assertNull(result);
+
+        result = this.ownerProductCurator.getOwnerProduct(null, null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testGetOwnerProductOrphanedDates() {
+        Owner owner1 = this.createOwner();
+        Owner owner2 = this.createOwner();
+        Owner owner3 = this.createOwner();
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+        Product product3 = this.createProduct();
+
+        List<OwnerProduct> ownerProducts = this.buildOwnerProductData(List.of(owner1, owner2, owner3),
+            List.of(product1, product2, product3));
+
+        List<Product> expectedProducts = List.of(product2, product3);
+
+        Map<String, Instant> expected = ownerProducts.stream()
+            .filter(op -> op.getOwner().equals(owner2))
+            .filter(op -> expectedProducts.contains(op.getProduct()))
+            .collect(Collectors.toMap(op -> op.getProduct().getId(), op -> op.getOrphanedDate()));
+
+        this.ownerProductCurator.clear();
+
+        Map<String, Instant> output = this.ownerProductCurator.getOwnerProductOrphanedDates(owner2,
+            List.of(product2.getId(), product3.getId()));
+
+        assertNotNull(output);
+        assertEquals(expected.size(), output.size());
+
+        for (Map.Entry<String, Instant> entry : expected.entrySet()) {
+            assertTrue(output.containsKey(entry.getKey()));
+            assertEquals(entry.getValue(), output.get(entry.getKey()));
+        }
+
+        for (Map.Entry<String, Instant> entry : output.entrySet()) {
+            assertTrue(expected.containsKey(entry.getKey()));
+            assertEquals(entry.getValue(), expected.get(entry.getKey()));
+        }
+    }
+
+    @Test
+    public void testGetOwnerProductOrphanedDatesIncludesProductsWithNullDates() {
+        Owner owner = this.createOwner();
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+
+        OwnerProduct op1 = new OwnerProduct(owner, product1);
+        OwnerProduct op2 = new OwnerProduct(owner, product2)
+            .setOrphanedDate(Instant.now());
+
+        this.ownerProductCurator.create(op1);
+        this.ownerProductCurator.create(op2);
+        this.ownerProductCurator.flush();
+
+        Map<String, Instant> output = this.ownerProductCurator.getOwnerProductOrphanedDates(owner,
+            List.of(product1.getId(), product2.getId()));
+
+        assertNotNull(output);
+        assertEquals(2, output.size());
+
+        assertTrue(output.containsKey(product1.getId()));
+        assertNull(output.get(product1.getId()));
+
+        assertTrue(output.containsKey(product2.getId()));
+        assertEquals(op2.getOrphanedDate(), output.get(product2.getId()));
+    }
+
+    @Test
+    public void testGetOwnerProductOrphanedDatesIgnoresInvalidProductIds() {
+        Owner owner = this.createOwner();
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+
+        OwnerProduct op1 = new OwnerProduct(owner, product1);
+        OwnerProduct op2 = new OwnerProduct(owner, product2)
+            .setOrphanedDate(Instant.now());
+
+        this.ownerProductCurator.create(op1);
+        this.ownerProductCurator.create(op2);
+        this.ownerProductCurator.flush();
+
+        Map<String, Instant> output = this.ownerProductCurator.getOwnerProductOrphanedDates(owner,
+            List.of(product1.getId(), product2.getId(), "bad_product_id"));
+
+        assertNotNull(output);
+        assertEquals(2, output.size());
+
+        assertTrue(output.containsKey(product1.getId()));
+        assertNull(output.get(product1.getId()));
+
+        assertTrue(output.containsKey(product2.getId()));
+        assertEquals(op2.getOrphanedDate(), output.get(product2.getId()));
+    }
+
+    @Test
+    public void testGetOwnerProductOrphanedDateRequiresOwner() {
+        assertThrows(IllegalArgumentException.class, () ->
+            this.ownerProductCurator.getOwnerProductOrphanedDates((Owner) null, List.of("a", "b", "c")));
+    }
+
+    @Test
+    public void testGetOwnerProductOrphanedDatesByOwnerId() {
+        Owner owner1 = this.createOwner();
+        Owner owner2 = this.createOwner();
+        Owner owner3 = this.createOwner();
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+        Product product3 = this.createProduct();
+
+        List<OwnerProduct> ownerProducts = this.buildOwnerProductData(List.of(owner1, owner2, owner3),
+            List.of(product1, product2, product3));
+
+        List<Product> expectedProducts = List.of(product2, product3);
+
+        Map<String, Instant> expected = ownerProducts.stream()
+            .filter(op -> op.getOwner().equals(owner2))
+            .filter(op -> expectedProducts.contains(op.getProduct()))
+            .collect(Collectors.toMap(op -> op.getProduct().getId(), op -> op.getOrphanedDate()));
+
+        this.ownerProductCurator.clear();
+
+        Map<String, Instant> output = this.ownerProductCurator.getOwnerProductOrphanedDates(owner2.getId(),
+            List.of(product2.getId(), product3.getId()));
+
+        assertNotNull(output);
+        assertEquals(expected.size(), output.size());
+
+        for (Map.Entry<String, Instant> entry : expected.entrySet()) {
+            assertTrue(output.containsKey(entry.getKey()));
+            assertEquals(entry.getValue(), output.get(entry.getKey()));
+        }
+
+        for (Map.Entry<String, Instant> entry : output.entrySet()) {
+            assertTrue(expected.containsKey(entry.getKey()));
+            assertEquals(entry.getValue(), expected.get(entry.getKey()));
+        }
+    }
+
+    @Test
+    public void testGetOwnerProductOrphanedDatesByOwnerIdIncludesProductsWithNullDates() {
+        Owner owner = this.createOwner();
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+
+        OwnerProduct op1 = new OwnerProduct(owner, product1);
+        OwnerProduct op2 = new OwnerProduct(owner, product2)
+            .setOrphanedDate(Instant.now());
+
+        this.ownerProductCurator.create(op1);
+        this.ownerProductCurator.create(op2);
+        this.ownerProductCurator.flush();
+
+        Map<String, Instant> output = this.ownerProductCurator.getOwnerProductOrphanedDates(owner.getId(),
+            List.of(product1.getId(), product2.getId()));
+
+        assertNotNull(output);
+        assertEquals(2, output.size());
+
+        assertTrue(output.containsKey(product1.getId()));
+        assertNull(output.get(product1.getId()));
+
+        assertTrue(output.containsKey(product2.getId()));
+        assertEquals(op2.getOrphanedDate(), output.get(product2.getId()));
+    }
+
+    @Test
+    public void testGetOwnerProductOrphanedDatesByOwnerIdIgnoresInvalidProductIds() {
+        Owner owner = this.createOwner();
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+
+        OwnerProduct op1 = new OwnerProduct(owner, product1);
+        OwnerProduct op2 = new OwnerProduct(owner, product2)
+            .setOrphanedDate(Instant.now());
+
+        this.ownerProductCurator.create(op1);
+        this.ownerProductCurator.create(op2);
+        this.ownerProductCurator.flush();
+
+        Map<String, Instant> output = this.ownerProductCurator.getOwnerProductOrphanedDates(owner.getId(),
+            List.of(product1.getId(), product2.getId(), "bad_product_id"));
+
+        assertNotNull(output);
+        assertEquals(2, output.size());
+
+        assertTrue(output.containsKey(product1.getId()));
+        assertNull(output.get(product1.getId()));
+
+        assertTrue(output.containsKey(product2.getId()));
+        assertEquals(op2.getOrphanedDate(), output.get(product2.getId()));
+    }
+
+    @Test
+    public void testGetOwnerProductOrphanedDateByOwnerIdRequiresOwnerId() {
+        assertThrows(IllegalArgumentException.class, () ->
+            this.ownerProductCurator.getOwnerProductOrphanedDates((String) null, List.of("a", "b", "c")));
+    }
+
+    public static Stream<Arguments> productOrphanedDatesProvider() {
+        return Stream.of(
+            Arguments.of(Instant.now().plusSeconds(5000)),
+            Arguments.of((Instant) null));
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @MethodSource("productOrphanedDatesProvider")
+    public void testUpdateOwnerProductOrphanedDates(Instant update) {
+        Owner owner1 = this.createOwner();
+        Owner owner2 = this.createOwner();
+        Owner owner3 = this.createOwner();
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+        Product product3 = this.createProduct();
+
+        List<OwnerProduct> ownerProducts = this.buildOwnerProductData(List.of(owner1, owner2, owner3),
+            List.of(product1, product2, product3));
+
+        List<Product> expectedProducts = List.of(product2, product3);
+        List<OwnerProduct> expected = ownerProducts.stream()
+            .filter(op -> op.getOwner().equals(owner2))
+            .filter(op -> expectedProducts.contains(op.getProduct()))
+            .collect(Collectors.toList());
+
+        this.ownerProductCurator.clear();
+
+        int output = this.ownerProductCurator.updateOwnerProductOrphanedDates(owner2,
+            List.of(product2.getId(), product3.getId()), update);
+
+        assertEquals(2, output);
+
+        for (OwnerProduct op : ownerProducts) {
+            OwnerProduct refreshed = this.ownerProductCurator
+                .getOwnerProduct(op.getOwner().getId(), op.getProduct().getId());
+            assertNotNull(refreshed);
+
+            if (expected.contains(op)) {
+                assertEquals(update, refreshed.getOrphanedDate());
+            }
+            else {
+                assertEquals(op.getOrphanedDate(), refreshed.getOrphanedDate());
+            }
+        }
+    }
+
+    @Test
+    public void testUpdateOwnerProductOrphanedDatesIgnoresInvalidProductIds() {
+        Owner owner = this.createOwner();
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+
+        OwnerProduct op1 = new OwnerProduct(owner, product1);
+        OwnerProduct op2 = new OwnerProduct(owner, product2)
+            .setOrphanedDate(Instant.now());
+
+        this.ownerProductCurator.create(op1);
+        this.ownerProductCurator.create(op2);
+        this.ownerProductCurator.flush();
+        this.ownerProductCurator.clear();
+
+        Instant update = Instant.now().plusSeconds(5000);
+
+        int count = this.ownerProductCurator.updateOwnerProductOrphanedDates(owner,
+            List.of(product1.getId(), "bad_product_id", "another_bad_id"), update);
+
+        assertEquals(1, count);
+
+        OwnerProduct refreshedOp1 = this.ownerProductCurator
+            .getOwnerProduct(op1.getOwner().getId(), op1.getProduct().getId());
+        assertNotNull(refreshedOp1);
+        assertEquals(update, refreshedOp1.getOrphanedDate());
+
+        OwnerProduct refreshedOp2 = this.ownerProductCurator
+            .getOwnerProduct(op2.getOwner().getId(), op2.getProduct().getId());
+        assertNotNull(refreshedOp2);
+        assertEquals(op2.getOrphanedDate(), refreshedOp2.getOrphanedDate());
+    }
+
+    @Test
+    @SuppressWarnings("indentation")
+    public void testUpdateOwnerProductOrphanedDatesRequiresOwner() {
+        assertThrows(IllegalArgumentException.class, () ->
+            this.ownerProductCurator.updateOwnerProductOrphanedDates((Owner) null, List.of("a", "b", "c"),
+                Instant.now()));
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @MethodSource("productOrphanedDatesProvider")
+    public void testUpdateOwnerProductByOwnerIdOrphanedDates(Instant update) {
+        Owner owner1 = this.createOwner();
+        Owner owner2 = this.createOwner();
+        Owner owner3 = this.createOwner();
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+        Product product3 = this.createProduct();
+
+        List<OwnerProduct> ownerProducts = this.buildOwnerProductData(List.of(owner1, owner2, owner3),
+            List.of(product1, product2, product3));
+
+        List<Product> expectedProducts = List.of(product2, product3);
+        List<OwnerProduct> expected = ownerProducts.stream()
+            .filter(op -> op.getOwner().equals(owner2))
+            .filter(op -> expectedProducts.contains(op.getProduct()))
+            .collect(Collectors.toList());
+
+        this.ownerProductCurator.clear();
+
+        int output = this.ownerProductCurator.updateOwnerProductOrphanedDates(owner2.getId(),
+            List.of(product2.getId(), product3.getId()), update);
+
+        assertEquals(2, output);
+
+        for (OwnerProduct op : ownerProducts) {
+            OwnerProduct refreshed = this.ownerProductCurator
+                .getOwnerProduct(op.getOwner().getId(), op.getProduct().getId());
+            assertNotNull(refreshed);
+
+            if (expected.contains(op)) {
+                assertEquals(update, refreshed.getOrphanedDate());
+            }
+            else {
+                assertEquals(op.getOrphanedDate(), refreshed.getOrphanedDate());
+            }
+        }
+    }
+
+    @Test
+    public void testUpdateOwnerProductByOwnerIdOrphanedDatesIgnoresInvalidProductIds() {
+        Owner owner = this.createOwner();
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+
+        OwnerProduct op1 = new OwnerProduct(owner, product1);
+        OwnerProduct op2 = new OwnerProduct(owner, product2)
+            .setOrphanedDate(Instant.now());
+
+        this.ownerProductCurator.create(op1);
+        this.ownerProductCurator.create(op2);
+        this.ownerProductCurator.flush();
+        this.ownerProductCurator.clear();
+
+        Instant update = Instant.now().plusSeconds(5000);
+
+        int count = this.ownerProductCurator.updateOwnerProductOrphanedDates(owner.getId(),
+            List.of(product1.getId(), "bad_product_id", "another_bad_id"), update);
+
+        assertEquals(1, count);
+
+        OwnerProduct refreshedOp1 = this.ownerProductCurator
+            .getOwnerProduct(op1.getOwner().getId(), op1.getProduct().getId());
+        assertNotNull(refreshedOp1);
+        assertEquals(update, refreshedOp1.getOrphanedDate());
+
+        OwnerProduct refreshedOp2 = this.ownerProductCurator
+            .getOwnerProduct(op2.getOwner().getId(), op2.getProduct().getId());
+        assertNotNull(refreshedOp2);
+        assertEquals(op2.getOrphanedDate(), refreshedOp2.getOrphanedDate());
+    }
+
+    @Test
+    @SuppressWarnings("indentation")
+    public void testUpdateOwnerByOwnerIdProductOrphanedDatesRequiresOwner() {
+        assertThrows(IllegalArgumentException.class, () ->
+            this.ownerProductCurator.updateOwnerProductOrphanedDates((String) null, List.of("a", "b", "c"),
+                Instant.now()));
     }
 }


### PR DESCRIPTION
- Products orphaned during refresh or manifest import can now
  have a grace period before they will be deleted
- Added the config "candlepin.refresh.orphaned_entity_grace_period"
  to control the duration of the grace period in days, or disable
  it entirely. By default this option is set to 30 days.