### PR TITLE
Fix maven transitive dependency resolution issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -507,6 +507,7 @@ publishing {
                 PomToolkit.generateRepositories(asNode())
                 PomToolkit.generateBuild(asNode())
                 PomToolkit.generateProfiles(asNode())
+                PomToolkit.generateDependencyManagement(asNode())
             }
         }
     }

--- a/buildSrc/src/main/groovy/PomToolkit.groovy
+++ b/buildSrc/src/main/groovy/PomToolkit.groovy
@@ -107,6 +107,17 @@ class PomToolkit implements Plugin<Project> {
         createProfileNode(profilesNode, 'build-with-jss5-plus', '/usr/lib64/jss/jss.jar', '5.0.0')
     }
 
+    public static void generateDependencyManagement(Node parent) {
+        def depManagementNode = parent.appendNode('dependencyManagement')
+        def depsNode = depManagementNode.appendNode('dependencies')
+        /* This is to avoid issue https://groups.google.com/g/ehcache-users/c/U1bO6QArswQ where ehcache has set a
+         * version range for the jaxb-runtime dependency, and maven is trying to resolve all transitive depencency
+         * versions in that range and failing due to some of them pointing to insecure maven repos.
+         *
+         * The solution here is to pin the jaxb-runtime lib to a specific version.
+         */
+        createDependencyNode(depsNode, 'org.glassfish.jaxb', 'jaxb-runtime', '2.3.6', null, null)
+    }
 
     private static void createDependencyNode(Node parentNode, String groupId, String artifactId, String version, String scope, String systemPath) {
         if (groupId) {

--- a/pom.xml
+++ b/pom.xml
@@ -88,43 +88,43 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jsonSchema</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-hibernate5</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
-      <version>4.9.1</version>
+      <version>4.12.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -178,7 +178,7 @@
     <dependency>
       <groupId>net.logstash.logback</groupId>
       <artifactId>logstash-logback-encoder</artifactId>
-      <version>7.0.1</version>
+      <version>7.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -214,13 +214,13 @@
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>3.0.2</version>
+      <version>4.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
-      <version>3.0.2</version>
+      <version>4.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -268,13 +268,13 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-server</artifactId>
-      <version>2.21.0</version>
+      <version>2.23.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-stomp-protocol</artifactId>
-      <version>2.21.0</version>
+      <version>2.23.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -292,13 +292,13 @@
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-servlet-filter-adapter</artifactId>
-      <version>17.0.1</version>
+      <version>18.0.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-jpamodelgen</artifactId>
-      <version>5.6.7.Final</version>
+      <version>5.6.9.Final</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -310,13 +310,13 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.3.3</version>
+      <version>42.4.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
-      <version>3.0.4</version>
+      <version>3.0.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -340,13 +340,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>4.4.0</version>
+      <version>4.6.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.mattbertolini</groupId>
       <artifactId>liquibase-slf4j</artifactId>
-      <version>4.0.0</version>
+      <version>4.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -604,4 +604,13 @@
       </properties>
     </profile>
   </profiles>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-runtime</artifactId>
+        <version>2.3.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>


### PR DESCRIPTION
- Pin jaxb-runtime to a specific version to avoid issue with maven
  resolution of transitive dependencies with a version range.
- Also, add autogenerated pom changes based on gradle upgrades.