### PR TITLE
[4.1] Use jdbc jars from java dependencies instead of rpm

### DIFF
--- a/bin/deployment/bash_functions
+++ b/bin/deployment/bash_functions
@@ -148,10 +148,11 @@ recreate_postgresql() {
 init_postgresql_jdbc() {
     local db_name="$1"
     local db_host="${DBHOSTNAME:-localhost}"
-
-    select_jdbc_jar "/usr/share/java/postgresql-jdbc.jar"
-    evalrc $? "No JDBC jar file available for PostgreSQL"
-
+    local postgresql_jdbc_jar=$(find $CP_EXTRACT_CLASSPATH -type f -name "postgresql*.jar")
+    if ! select_jdbc_jar $postgresql_jdbc_jar; then
+        err_msg "No JDBC jar file available for PostgreSQL"
+        exit
+    fi
     JDBC_DRIVER="org.postgresql.Driver"
     JDBC_URL="jdbc:postgresql://$db_host/$db_name"
 }
@@ -173,10 +174,11 @@ init_mysql_jdbc() {
     local db_host="${DBHOSTNAME:-localhost}"
     local password="$DBPASSWORD"
     [ -z "$password" ] && password=''
-
-    select_jdbc_jar "/usr/lib/java/mariadb-java-client.jar" "/usr/share/java/mysql-connector-java.jar"
-    evalrc $? "No JDBC jar file available for MariaDB/MySQL"
-
+    local mysql_client_jar=$(find $CP_EXTRACT_CLASSPATH -type f -name "mysql-connector-java*.jar")
+    if ! select_jdbc_jar $mysql_client_jar; then
+        err_msg "No JDBC jar file available for MariaDB/MySQL"
+        exit
+    fi
     JDBC_DRIVER="com.mysql.cj.jdbc.Driver"
     JDBC_URL="jdbc:mysql://$db_host/$db_name"
 

--- a/bin/deployment/deploy
+++ b/bin/deployment/deploy
@@ -12,10 +12,12 @@ prepare_classpath() {
     jar xf $(find ${PROJECT_DIR}/build -name 'candlepin*.war' | head -n 1)
     chmod -R 744 ${CP_EXTRACT_DIR}
     cd -
-    export CP_LIQUIBASE_CLASSPATH="${CP_EXTRACT_DIR}/WEB-INF/lib"
+    export CP_EXTRACT_CLASSPATH="${CP_EXTRACT_DIR}/WEB-INF/lib"
 }
 
 gendb() {
+    prepare_classpath
+
     if [ "$USE_MYSQL" == "1" ]; then
         init_mysql_jdbc $APP_DB_NAME
     else
@@ -40,8 +42,6 @@ gendb() {
         MESSAGE="Updating Database"
         CHANGELOG="changelog-update.xml"
     fi
-
-    prepare_classpath
 
     info_msg "$MESSAGE"
     LQCOMMAND="${PROJECT_DIR}/bin/deployment/liquibase.sh --driver=${JDBC_DRIVER} --classpath=$PROJECT_DIR/src/main/resources/:build/classes/java/main/:${JDBC_JAR} --changeLogFile=db/changelog/$CHANGELOG --url=${JDBC_URL} --username=candlepin"

--- a/bin/deployment/liquibase.sh
+++ b/bin/deployment/liquibase.sh
@@ -19,7 +19,7 @@ MAIN_CLASS=liquibase.integration.commandline.Main
 BASE_FLAGS=""
 BASE_OPTIONS=""
 
-CP_CLASSPATH=${CP_LIQUIBASE_CLASSPATH:-/var/lib/tomcat/webapps/candlepin/WEB-INF/lib}
+CP_CLASSPATH=${CP_EXTRACT_CLASSPATH:-/var/lib/tomcat/webapps/candlepin/WEB-INF/lib}
 CLASSPATH=$(JARS=("$CP_CLASSPATH"/*.jar); IFS=:; echo "${JARS[*]}")
 
 # Set parameters


### PR DESCRIPTION
- The postgresql/mysql/mariadb rpms are no longer part of the
  docker image. Use the jars from our java dependencies instead.