### PR TITLE
[4.1] Removed length requirement on cloud registration signature (ENT-5283)

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -8404,7 +8404,6 @@ components:
           minLength: 1
         signature:
           type: string
-          minLength: 1
 
     ConsumerDTO:
       description: Represents a consumer

--- a/spec/cloud_registration_spec.rb
+++ b/spec/cloud_registration_spec.rb
@@ -13,16 +13,22 @@ describe 'Cloud Registration' do
         skip("cloud registration is not enabled") unless @cp.is_capability_present("cloud_registration")
     end
 
-    def generate_token(org)
+    def generate_token(org, params={})
         create_upstream_owner(org)
 
         # Test note: At the time of writing, the testing cloud registration adapter does not care
         # at all about the type or signature, and assumes the metadata is the owner key in question.
-        token = @cp.get_cloud_registration_token({
+        token_info = {
             :type => "test_type",
             :metadata => org,
             :signature => "test_signature"
-        })
+        }
+
+        params.each do |key, value|
+            token_info[key] = value
+        end
+
+        token = @cp.get_cloud_registration_token(token_info)
 
         return token
     end
@@ -47,4 +53,10 @@ describe 'Cloud Registration' do
             @cp.get_cloud_registration_token(nil)
         }.to raise_exception(RestClient::BadRequest)
     end
+
+    it "allows registration with an empty signature" do
+        token = generate_token("test_org", {:signature => ""})
+        expect(token).to_not be_nil
+    end
+
 end


### PR DESCRIPTION
- Cloud registration info no longer has a size requirement on
  the signature field; the field is still required to be present,
  and null values are still not permitted, but empty signature
  strings are now allowed