### PR TITLE
Use jdbc jars from java dependencies instead of rpm

### DIFF
--- a/bin/bash_functions
+++ b/bin/bash_functions
@@ -116,6 +116,17 @@ cert_from_pkcs12() {
     fi
 }
 
+select_jdbc_jar() {
+    for jar in "$@"
+    do
+        if [ -f "$jar" ]; then
+            JDBC_JAR="$jar"
+            return 0
+        fi
+    done
+    return 1
+}
+
 recreate_postgresql() {
     local db_name="$1"
     local db_user="${2:-$db_name}"
@@ -136,8 +147,12 @@ recreate_postgresql() {
 init_postgresql_jdbc() {
     local db_name="$1"
     local db_host="${DBHOSTNAME:-localhost}"
+    local postgresql_jdbc_jar=$(find $CP_EXTRACT_CLASSPATH -type f -name "postgresql*.jar")
+    if ! select_jdbc_jar $postgresql_jdbc_jar; then
+        err_msg "No JDBC jar file available for PostgreSQL"
+        exit
+    fi
     JDBC_DRIVER="org.postgresql.Driver"
-    JDBC_JAR="/usr/share/java/postgresql-jdbc.jar"
     JDBC_URL="jdbc:postgresql://$db_host/$db_name"
 }
 
@@ -158,8 +173,14 @@ init_mysql_jdbc() {
     local db_host="${DBHOSTNAME:-localhost}"
     local password="$DBPASSWORD"
     [ -z "$password" ] && password=''
+
+    local mysql_client_jar=$(find $CP_EXTRACT_CLASSPATH -type f -name "mysql-connector-java*.jar")
+    if ! select_jdbc_jar $mysql_client_jar; then
+        err_msg "No JDBC jar file available for MariaDB/MySQL"
+        exit
+    fi
+
     JDBC_DRIVER="com.mysql.jdbc.Driver"
-    JDBC_JAR="/usr/share/java/mysql-connector-java.jar"
     JDBC_URL="jdbc:mysql://$db_host/$db_name"
 
     # Change once the mariadb-java-client RPM is available in EPEL

--- a/server/bin/deploy
+++ b/server/bin/deploy
@@ -12,10 +12,12 @@ prepare_classpath() {
     jar xf $(find ${PROJECT_DIR}/build -name 'candlepin*.war' | head -n 1)
     chmod -R 744 ${CP_EXTRACT_DIR}
     cd -
-    export CP_LIQUIBASE_CLASSPATH="${CP_EXTRACT_DIR}/WEB-INF/lib"
+    export CP_EXTRACT_CLASSPATH="${CP_EXTRACT_DIR}/WEB-INF/lib"
 }
 
 gendb() {
+    prepare_classpath
+
     if [ "$USE_MYSQL" == "1" ]; then
         init_mysql_jdbc $APP_DB_NAME
     else
@@ -40,8 +42,6 @@ gendb() {
         MESSAGE="Updating Database"
         CHANGELOG="changelog-update.xml"
     fi
-
-    prepare_classpath
 
     info_msg "$MESSAGE"
     LQCOMMAND="${PROJECT_DIR}/bin/liquibase.sh --driver=${JDBC_DRIVER} --classpath=$PROJECT_DIR/src/main/resources/:build/classes/java/main/:${JDBC_JAR} --changeLogFile=db/changelog/$CHANGELOG --url=${JDBC_URL} --username=candlepin"

--- a/server/bin/liquibase.sh
+++ b/server/bin/liquibase.sh
@@ -19,7 +19,7 @@ MAIN_CLASS=liquibase.integration.commandline.Main
 BASE_FLAGS=""
 BASE_OPTIONS=""
 
-CP_CLASSPATH=${CP_LIQUIBASE_CLASSPATH:-/var/lib/tomcat/webapps/candlepin/WEB-INF/lib}
+CP_CLASSPATH=${CP_EXTRACT_CLASSPATH:-/var/lib/tomcat/webapps/candlepin/WEB-INF/lib}
 CLASSPATH=$(JARS=("$CP_CLASSPATH"/*.jar); IFS=:; echo "${JARS[*]}")
 
 # Set parameters


### PR DESCRIPTION
- The postgresql/mysql/mariadb rpms are no longer part of the
  docker image. Use the jars from our java dependencies instead.