### PR TITLE
[M] Added spec-test naming standards documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,8 @@ To run Java spec tests:
 * `./gradlew spec --tests org.candlepin.spec.StatusSpec*` runs only the spec  
    tests matched by the given package/class and wildcard(s).
 
+[More information on Java spec tests](/spec-tests/README.md#Contributing)
+
 ### Liquibase
 * `buildr "changeset:my changeset name"`  
   Much like the `rspec` task, the `changeset` task is followed by a  

--- a/spec-tests/README.md
+++ b/spec-tests/README.md
@@ -1,11 +1,35 @@
 # Candlepin - Java base spec tests
 Java spec tests for candlepin. 
   
-# Getting Started
-To run spec tests use the following commnand.
+# Running Tests
+To run spec tests use the following command.
 ```
 ./gradlew clean spec
 ```
 By default it expects candlepin running on **localhost:8443**. Defaults can be changed in **settings.properties** located in test resources. You can also override separate defaults by passing them as **-Dsome.key=value** to gradle
 
 > Tests can be run from IDEA or any other IDE as well
+
+# Contributing
+## Standards
+- **SpecTest annotation** - The test class should use the SpecTest annotation.
+- **Test Display Name** - Test should include the DisplayName annotation with a descriptive summary of the test. This should start either with the verb **should** or **should not**.
+- **Test Name** - The name of the test should be the display name in camel case .
+
+Example:
+``` java
+@SpecTest
+class testClass {
+    @Test
+    @DisplayName("should retrieve content")
+    public void shouldRetrieveContent() {
+        // Test logic
+    }
+
+    @Test
+    @DisplayName("should not retrieve content")
+    public void shouldNotRetrieveContent() {
+        // Test logic
+    }
+}
+```


### PR DESCRIPTION
There was some discussion about the standardization of spec-test test names and display names and I thought that we should document these standards.