### PR TITLE
[4.0-HOSTED] 2112391: Add back the collected field to certs in manifest

### DIFF
--- a/server/spec/export_spec.rb
+++ b/server/spec/export_spec.rb
@@ -57,6 +57,18 @@ describe 'Export', :serial => true do
       exported_consumer['uuid'].should == @exporter.candlepin_client.uuid
     end
 
+    it 'exports upstream consumer identity certificate' do
+      count = 0
+      Dir["#{@cp_export.export_dir}/upstream_consumer/*.json"].find_all do |idcert|
+        json = parse_file(idcert)
+        count = count + 1
+        expect(json['serial']['collected']).to_not be_nil
+        expect(json['serial']['collected']).to eq(false)
+      end
+      # there should only be 1 identity cert
+      expect(count).to eq(1)
+    end
+
     it 'exports CDN URL' do
      exported_meta = parse_file(File.join(@cp_export.export_dir, 'meta.json'))
      exported_meta['cdnLabel'].should == @exporter.cdn_label

--- a/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialDTO.java
+++ b/server/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialDTO.java
@@ -36,6 +36,9 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
     protected BigInteger serial;
     protected Date expiration;
     protected Boolean revoked;
+    // we export this to false by default now that the CRL functionality is removed to avoid breaking old
+    // candlepin imports.
+    protected Boolean collected = Boolean.FALSE;
 
     /**
      * Initializes a new CertificateSerialDTO instance with null values.
@@ -90,6 +93,9 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
         this.revoked = revoked;
         return this;
     }
+    public Boolean isCollected() {
+        return this.collected;
+    }
 
     /**
      * {@inheritDoc}
@@ -100,8 +106,8 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
         String date = expiration != null ? String.format("%1$tF %1$tT%1$tz", expiration) : null;
 
         return String.format(
-            "CertificateSerialDTO [id: %s, serial: %s, expiration: %s, revoked: %s]",
-            this.getId(), this.getSerial(), date, this.isRevoked());
+            "CertificateSerialDTO [id: %s, serial: %s, expiration: %s, collected: %s, revoked: %s]",
+            this.getId(), this.getSerial(), date, this.isCollected(), this.isRevoked());
     }
 
     /**
@@ -120,6 +126,7 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
                 .append(this.getId(), that.getId())
                 .append(this.getSerial(), that.getSerial())
                 .append(this.getExpiration(), that.getExpiration())
+                .append(this.isCollected(), that.isCollected())
                 .append(this.isRevoked(), that.isRevoked());
 
             return builder.isEquals();
@@ -138,6 +145,7 @@ public class CertificateSerialDTO extends TimestampedCandlepinDTO<CertificateSer
             .append(this.getId())
             .append(this.getSerial())
             .append(this.getExpiration())
+            .append(this.isCollected())
             .append(this.isRevoked());
 
         return builder.toHashCode();

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialDTOTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialDTOTest.java
@@ -38,6 +38,7 @@ public class CertificateSerialDTOTest extends AbstractDTOTest<CertificateSerialD
         this.values.put("Date", new Date());
         this.values.put("Revoked", true);
         this.values.put("Expiration", new Date());
+        this.values.put("Collected", Boolean.FALSE);
         this.values.put("Created", new Date());
         this.values.put("Updated", new Date());
     }

--- a/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslatorTest.java
+++ b/server/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslatorTest.java
@@ -73,6 +73,7 @@ public class CertificateSerialTranslatorTest extends
             assertEquals(source.getSerial(), dest.getSerial());
             assertEquals(source.getExpiration(), dest.getExpiration());
             assertEquals(source.isRevoked(), dest.isRevoked());
+            assertEquals(false, dest.isCollected()); // we export this to false by default now
         }
         else {
             assertNull(dest);


### PR DESCRIPTION
- Add back the 'collected' field from certificates exported in
  manifests, to avoid breaking old (2.4 or older) candlepins
  importing manifests that expect it to be there.