### PR TITLE
[M] Fix long-running job spec test

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/JobStatusSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/JobStatusSpecTest.java
@@ -283,16 +283,18 @@ class JobStatusSpecTest {
     @DisplayName("should not allow user to cancel job from another user")
     public void shouldNotAllowUserToCancelJobFromAnotherUser() throws Exception {
         jobsClient.setSchedulerStatus(false);
+        String jobId = null;
         try {
             AsyncJobStatusDTO job = userClient.owners().healEntire(owner.getKey());
             UserDTO otherUser = UserUtil.createUser(client, owner);
             ApiClient otherUserClient = ApiClients.trustedUser(otherUser.getUsername());
             assertForbidden(() -> otherUserClient.jobs().cancelJob(job.getId()));
-            // wait for job to complete, or test clean up will conflict with the asynchronous job.
-            jobsClient.waitForJobToComplete(job.getId(), 15000);
+            jobId = job.getId();
         }
         finally {
             jobsClient.setSchedulerStatus(true);
+            AsyncJobStatusDTO statusDTO = jobsClient.waitForJobToComplete(jobId, 5000);
+            assertEquals("FINISHED", statusDTO.getState());
         }
     }
 


### PR DESCRIPTION
- Move the call for wating for the job to finish at the end.
  The test was always waiting the full timeout (15 seconds) for the
  job to finish because the scheduler was turned off, waisting time.