### PR TITLE
2110031: add config for enabling/disabling the DB check on startup

### DIFF
--- a/config/candlepin/candlepin.conf.template
+++ b/config/candlepin/candlepin.conf.template
@@ -34,6 +34,7 @@ candlepin.pretty_print=true
 candlepin.async.scheduler.enabled=<%= candlepin.async_scheduler_enabled %>
 
 candlepin.hidden_resources=
+candlepin.db.halt_on_liquibase_desync=true
 
 <% if (candlepin.hidden_capabilities) { %>\
 candlepin.hidden_capabilities=<%= candlepin.hidden_capabilities %>

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -129,6 +129,8 @@ public class ConfigProperties {
     // Space separated list of resources to hide in GET /status
     public static final String HIDDEN_CAPABILITIES = "candlepin.hidden_capabilities";
 
+    public static final String HALT_ON_LIQUIBASE_DESYNC = "candlepin.db.halt_on_liquibase_desync";
+
     // Authentication
     public static final String TRUSTED_AUTHENTICATION = "candlepin.auth.trusted.enable";
     public static final String SSL_AUTHENTICATION = "candlepin.auth.ssl.enable";
@@ -409,6 +411,7 @@ public class ConfigProperties {
             // submit one when registering.
             this.put(HIDDEN_RESOURCES, "environments");
             this.put(HIDDEN_CAPABILITIES, "");
+            this.put(HALT_ON_LIQUIBASE_DESYNC, "true");
             this.put(SSL_VERIFY, "false");
 
             this.put(FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");

--- a/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -367,6 +367,9 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
      * @throws RuntimeException if there are missing changesets or a LiqubaseException
      */
     protected void checkDbChangelog() {
+        if (!config.getBoolean(HALT_ON_LIQUIBASE_DESYNC)) {
+            return;
+        }
         try {
             Liquibase liquibase = getLiquibase();
             List<ChangeSet> unrunChangesets = liquibase.listUnrunChangeSets(null, null);


### PR DESCRIPTION
The report of the missing sets will still happen, but the runtime error
 will not be thrown. This will allow the startup to continue