### PR TITLE
[4.1] Updated Vagrant configuration to support upcoming Ansible changes (ENT-5303)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,9 +4,61 @@ ANSIBLE_TAGS_VAR = "ansible_tags"
 ANSIBLE_SKIP_TAGS_VAR = "ansible_skip_tags"
 ANSIBLE_VAR_PREFIX = "cp_"
 
+ANSIBLE_VARS = {
+  :ansible_user => "vagrant",
+  :candlepin_user => "vagrant",
+  :candlepin_home => "/vagrant",
+
+  :cp_configure_postgresql => true,
+  :cp_configure_mariadb => true,
+  :cp_configure_user_env => true,
+  :cp_configure_debugging => true,
+
+  :cp_git_checkout => false,
+  :cp_deploy => false
+}
+
+def configure_ansible_provisioning(vm_config)
+  vm_config.vm.provision "ansible" do |ansible|
+    # ansible.verbose = "vvv"
+    ansible.compatibility_mode = "2.0"
+    ansible.playbook = "vagrant/candlepin.yml"
+    ansible.galaxy_role_file = "vagrant/requirements.yml"
+
+    # Impl note:
+    # At the time of writing, specifying the role path (as the default command does) prevents
+    # collections from being installed in some environments. Since we're now reliant on a number of
+    # non-core collections, it's critical that we pull both roles and collections at runtime.
+    # As a side effect, this will install roles and collections in the user's ~/.ansible directory,
+    # rather than in the candlepin/ansible/roles directory as it has in the past.
+    ansible.galaxy_command = "ansible-galaxy install -r %{role_file} --force"
+
+    ansible.extra_vars = ANSIBLE_VARS.clone
+
+    # Pass through ansible variables and tags from the environment variables
+    ENV.each do |key, value|
+      # Pass through anything starting with the "cp_" prefix
+      if key.downcase.start_with?(ANSIBLE_VAR_PREFIX)
+        ansible.extra_vars[key.downcase] = value
+      end
+
+      # Pass through ansible tags
+      if key.downcase == ANSIBLE_TAGS_VAR
+        ansible.tags = value
+      end
+
+      # Pass through ansible tags to skip
+      if key.downcase == ANSIBLE_SKIP_TAGS_VAR
+        ansible.skip_tags = value
+      end
+    end
+  end
+end
+
+
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.synced_folder ".", "/vagrant", type: "sshfs", sshfs_opts_append: "-o nonempty"
+  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
   config.vm.host_name = "candlepin.example.com"
   config.ssh.forward_agent = true
 
@@ -34,30 +86,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # vm_config.vm.networking "forwarded_port", protocol: "tcp", guest: 8443, host: 8443
 
     vm_config.vm.provision "shell", inline: "yum update -y yum python ca-certificates"
-    vm_config.vm.provision "ansible" do |ansible|
-      ansible.playbook = "vagrant/candlepin.yml"
-      ansible.galaxy_role_file = "vagrant/requirements.yml"
-      # ansible.verbose = "v"
-      ansible.extra_vars = {}
-
-      # Pass through ansible variables and tags from the environment variables
-      ENV.each do |key, value|
-        # Pass through anything starting with the "cp_" prefix
-        if key.downcase.start_with?(ANSIBLE_VAR_PREFIX)
-          ansible.extra_vars[key.downcase] = value
-        end
-
-        # Pass through ansible tags
-        if key.downcase == ANSIBLE_TAGS_VAR
-          ansible.tags = value
-        end
-
-        # Pass through ansible tags to skip
-        if key.downcase == ANSIBLE_SKIP_TAGS_VAR
-          ansible.skip_tags = value
-        end
-      end
-    end
+    configure_ansible_provisioning(vm_config)
   end
 
   config.vm.define("el8", primary: true) do |vm_config|
@@ -70,30 +99,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # vm_config.vm.networking "forwarded_port", protocol: "tcp", guest: 8443, host: 8443
 
     vm_config.vm.provision "shell", inline: "dnf update -y dnf ca-certificates"
-    vm_config.vm.provision "ansible" do |ansible|
-      ansible.playbook = "vagrant/candlepin.yml"
-      ansible.galaxy_role_file = "vagrant/requirements.yml"
-      # ansible.verbose = "v"
-      ansible.extra_vars = {}
+    configure_ansible_provisioning(vm_config)
+  end
 
-      # Pass through ansible variables and tags from the environment variables
-      ENV.each do |key, value|
-        # Pass through anything starting with the "cp_" prefix
-        if key.downcase.start_with?(ANSIBLE_VAR_PREFIX)
-          ansible.extra_vars[key.downcase] = value
-        end
+  config.vm.define("f35", autostart: false) do |vm_config|
+    vm_config.vm.box = "fedora/35-cloud-base"
+    vm_config.vm.host_name = "candlepin-f35.example.com"
 
-        # Pass through ansible tags
-        if key.downcase == ANSIBLE_TAGS_VAR
-          ansible.tags = value
-        end
+    # Uncomment these lines for forward the Candlepin standard dev ports to this guest
+    # vm_config.vm.networking "forwarded_port", protocol: "tcp", guest: 8080, host: 8080
+    # vm_config.vm.networking "forwarded_port", protocol: "tcp", guest: 8443, host: 8443
 
-        # Pass through ansible tags to skip
-        if key.downcase == ANSIBLE_SKIP_TAGS_VAR
-          ansible.skip_tags = value
-        end
-      end
-    end
+    vm_config.vm.provision "shell", inline: "dnf update -y dnf python ca-certificates"
+    configure_ansible_provisioning(vm_config)
   end
 
 end

--- a/vagrant/requirements.yml
+++ b/vagrant/requirements.yml
@@ -1,6 +1,13 @@
 ---
-- src: https://github.com/candlepin/ansible-role-candlepin.git
-  name: candlepin
-  version: master
+roles:
+  - src: https://github.com/candlepin/ansible-role-candlepin.git
+    name: candlepin
+    version: master
 
-- src: rvm.ruby
+  - src: rvm.ruby
+
+collections:
+  - name: ansible.posix
+  - name: community.general
+  - name: community.mysql
+  - name: community.postgresql


### PR DESCRIPTION
- Updated the requirements.yml to include non-core Ansible collections
  used by the Candlepin role
- Updated the Vagrantfile to use a newer compatibility mode and support
  fetching both roles and collections via ansible-galaxy