### PR TITLE
[M] Removed setting encoding on FileConfiguration implementation (ENT-5322)

### DIFF
--- a/src/main/java/org/candlepin/config/EncryptedConfiguration.java
+++ b/src/main/java/org/candlepin/config/EncryptedConfiguration.java
@@ -21,56 +21,27 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.Properties;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+
+
 /**
  * EncryptedValueConfigurationParser
  */
 public class EncryptedConfiguration extends PropertiesFileConfiguration {
-    private static Logger log = LoggerFactory.getLogger(EncryptedConfiguration.class);
+    private static final Logger log = LoggerFactory.getLogger(EncryptedConfiguration.class);
 
     private String passphrase = null;
 
     public EncryptedConfiguration() {
-        super();
-    }
-
-    public EncryptedConfiguration(String fileName) throws ConfigurationException {
-        super(fileName);
-    }
-
-    public EncryptedConfiguration(String fileName, Charset encoding) throws ConfigurationException {
-        super(fileName, encoding);
-    }
-
-    public EncryptedConfiguration(File file) throws ConfigurationException {
-        super(file);
-    }
-
-    public EncryptedConfiguration(File file, Charset encoding) throws ConfigurationException {
-        super(file, encoding);
-    }
-
-    public EncryptedConfiguration(InputStream inStream) throws ConfigurationException {
-        super(inStream);
-    }
-
-    public EncryptedConfiguration(InputStream inStream, Charset encoding)
-        throws ConfigurationException {
-        super(inStream, encoding);
-    }
-
-    public EncryptedConfiguration(Properties properties) {
-        super(properties);
+        // Intentionally left empty
     }
 
     public EncryptedConfiguration use(String passphraseProperty) throws ConfigurationException {
@@ -78,28 +49,30 @@ public class EncryptedConfiguration extends PropertiesFileConfiguration {
         return this;
     }
 
-    public void toDecrypt(String... encryptedProperties) throws ConfigurationException {
+    public EncryptedConfiguration toDecrypt(String... encryptedProperties) throws ConfigurationException {
         for (String p : encryptedProperties) {
             toDecrypt(p);
         }
+
+        return this;
     }
 
-    public void toDecrypt(String property) throws ConfigurationException {
+    public EncryptedConfiguration toDecrypt(String property) throws ConfigurationException {
         if (passphrase == null) {
-            log.debug("Passphrase is null.  Skipping decrypt.");
-            return;
+            log.debug("Passphrase is null. Skipping decrypt.");
+            return this;
         }
 
         if (!containsKey(property)) {
             log.debug("Can't decrypt missing property: {}", property);
-            return;
+            return this;
         }
 
         String toDecrypt = getString(property);
         if (!toDecrypt.startsWith("$1$")) {
             // this is not an encrypted password, just return it
             log.debug("Value for {} is not an encrypted string", property);
-            return;
+            return this;
         }
 
         // remove the magic string
@@ -131,6 +104,7 @@ public class EncryptedConfiguration extends PropertiesFileConfiguration {
             throw new ConfigurationException(e);
         }
 
+        return this;
     }
 
     protected String readPassphrase(String passphraseProperty) throws ConfigurationException {

--- a/src/main/java/org/candlepin/config/FileConfiguration.java
+++ b/src/main/java/org/candlepin/config/FileConfiguration.java
@@ -19,16 +19,137 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
 
+
+
 /**
  * Classes implementing FileConfiguration take their configuration from a file source and can
  * therefore specify an encoding.
  */
 public interface FileConfiguration extends Configuration {
-    Charset getEncoding();
-    void setEncoding(Charset encoding);
 
-    void load(String fileName) throws ConfigurationException;
+    /**
+     * Fetches the default character set this configuration object will use to load configuration
+     * data from files when no character set is provided.
+     *
+     * @return
+     *  the default charset used when none is provided while loading configuration data
+     */
+    Charset getDefaultCharset();
+
+    /**
+     * Reads the configuration from the given file, clearing any currently loaded or stored
+     * configuration.
+     *
+     * @param filename
+     *  the name of the file to load
+     *
+     * @throws IllegalArgumentException
+     *  if filename is null
+     *
+     * @throws ConfigurationException
+     *  if the given file cannot be read for any reason
+     */
+    void load(String filename) throws ConfigurationException;
+
+    /**
+     * Reads the configuration from the given file, processing it with the specified encoding,
+     * clearing any currently loaded or stored configuration.
+     *
+     * @param filename
+     *  the name of the file to load
+     *
+     * @param encoding
+     *  the character encoding to use while processing the file
+     *
+     * @throws IllegalArgumentException
+     *  if filename is null
+     *
+     * @throws ConfigurationException
+     *  if the given file cannot be read for any reason
+     */
+    void load(String filename, Charset encoding) throws ConfigurationException;
+
+    /**
+     * Reads the configuration from the given file, clearing any currently loaded or stored
+     * configuration.
+     *
+     * @param file
+     *  a File object representing the file to load
+     *
+     * @throws IllegalArgumentException
+     *  if file is null
+     *
+     * @throws ConfigurationException
+     *  if the given file cannot be read for any reason
+     */
     void load(File file) throws ConfigurationException;
-    void load(InputStream inStream) throws ConfigurationException;
+
+    /**
+     * Reads the configuration from the given file, processing it with the specified encoding,
+     * clearing any currently loaded or stored configuration.
+     *
+     * @param file
+     *  a File object representing the file to load
+     *
+     * @param encoding
+     *  the character encoding to use while processing the file
+     *
+     * @throws IllegalArgumentException
+     *  if file is null
+     *
+     * @throws ConfigurationException
+     *  if the given file cannot be read for any reason
+     */
+    void load(File file, Charset encoding) throws ConfigurationException;
+
+    /**
+     * Reads the configuration from the given input stream, clearing any currently loaded or stored
+     * configuration.
+     *
+     * @param istream
+     *  an input stream from which to read configuration
+     *
+     * @throws IllegalArgumentException
+     *  if istream is null
+     *
+     * @throws ConfigurationException
+     *  if the given input stream cannot be read for any reason
+     */
+    void load(InputStream istream) throws ConfigurationException;
+
+    /**
+     * Reads the configuration from the given input stream, processing it with the specified
+     * encoding, clearing any currently loaded or stored configuration.
+     *
+     * @param istream
+     *  an input stream from which to read configuration
+     *
+     * @param encoding
+     *  the character encoding to use while processing the stream
+     *
+     * @throws IllegalArgumentException
+     *  if istream is null
+     *
+     * @throws ConfigurationException
+     *  if the given input stream cannot be read for any reason
+     */
+    void load(InputStream istream, Charset encoding) throws ConfigurationException;
+
+    /**
+     * Reads the configuration from the given reader, clearing any currently loaded or stored
+     * configuration.
+     * <p></p>
+     * <strong>Note:</strong> this method does not enforce any specific character encoding, and will
+     * use whichever encoding is imparted by the reader itself.
+     *
+     * @param reader
+     *  a reader from which to read configuration
+     *
+     * @throws IllegalArgumentException
+     *  if reader is null
+     *
+     * @throws ConfigurationException
+     *  if the given reader cannot be read for any reason
+     */
     void load(Reader reader) throws ConfigurationException;
 }

--- a/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18nManager;
 
 import java.io.File;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -264,20 +264,16 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
         CandlepinCapabilities.setCapabilities(capabilities);
     }
 
-    protected Configuration readConfiguration(ServletContext context)
-        throws ConfigurationException {
-
-        // Use StandardCharsets.UTF_8 when we move to Java 7
-        Charset utf8 = Charset.forName("UTF-8");
-        EncryptedConfiguration systemConfig = new EncryptedConfiguration();
-
-        systemConfig.setEncoding(utf8);
+    protected Configuration readConfiguration(ServletContext context) throws ConfigurationException {
         File configFile = new File(ConfigProperties.DEFAULT_CONFIG_FILE);
+
+        EncryptedConfiguration systemConfig = new EncryptedConfiguration();
 
         if (configFile.canRead()) {
             log.debug("Loading system configuration");
+
             // First, read the system configuration
-            systemConfig.load(configFile);
+            systemConfig.load(configFile, StandardCharsets.UTF_8);
             log.debug("System configuration: {}", systemConfig);
         }
 
@@ -287,8 +283,8 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
         MapConfiguration defaults = new MapConfiguration(ConfigProperties.DEFAULT_PROPERTIES);
 
         // Default to Postgresql if jpa.config.hibernate.dialect is unset
-        DatabaseConfigFactory.SupportedDatabase db = determinDatabaseConfiguration(systemConfig.getString
-            ("jpa.config.hibernate.dialect", PostgreSQL92Dialect.class.getName()));
+        DatabaseConfigFactory.SupportedDatabase db = determinDatabaseConfiguration(
+            systemConfig.getString("jpa.config.hibernate.dialect", PostgreSQL92Dialect.class.getName()));
         log.info("Running under {}", db.getLabel());
         Configuration databaseConfig = DatabaseConfigFactory.fetchConfig(db);
 

--- a/src/test/java/org/candlepin/config/PropertiesFileConfigurationTest.java
+++ b/src/test/java/org/candlepin/config/PropertiesFileConfigurationTest.java
@@ -14,105 +14,229 @@
  */
 package org.candlepin.config;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.Properties;
+
 
 
 public class PropertiesFileConfigurationTest {
-
     private static final String UTF8_FILE = "config/utf8.properties";
     private static final String ASCII_FILE = "config/ascii.properties";
 
-    // Use StandardCharsets.UTF_8/US_ASCII when we move to Java 7
-    private static final Charset UTF8 = Charset.forName("UTF-8");
-    private static final Charset ASCII = Charset.forName("US-ASCII");
+    private ClassLoader getClassLoader() {
+        return this.getClass().getClassLoader();
+    }
 
-    private ClassLoader cl;
-    private PropertiesFileConfiguration config;
+    private String getResourceAsFile(String filename) {
+        return this.getClassLoader()
+            .getResource(filename)
+            .getFile();
+    }
 
-    @BeforeEach
-    public void init() {
-        cl = this.getClass().getClassLoader();
-        config = new PropertiesFileConfiguration();
+    private InputStream getResourceAsStream(String filename) {
+        return this.getClassLoader()
+            .getResourceAsStream(filename);
     }
 
     @Test
-    public void testLoadInputStreamWithSpecificEncoding() throws Exception {
-        InputStream utf8Stream = cl.getResourceAsStream(UTF8_FILE);
+    public void testGetDefaultCharset() {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
 
-        config.setEncoding(ASCII);
-        config.load(utf8Stream);
+        assertEquals(UTF_8, config.getDefaultCharset());
+    }
 
+    @Test
+    public void testLoadFileByNameWithDefaultCharset() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        String filename = this.getResourceAsFile(UTF8_FILE);
+
+        config.load(filename);
+
+        assertEquals("Mötley Crüe", config.getString("glam.band"));
+        assertNotEquals(new String("Mötley Crüe".getBytes(UTF_8), US_ASCII), config.getString("glam.band"));
+    }
+
+    @Test
+    public void testLoadFileByNameWithSpecificCharset() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        String filename = this.getResourceAsFile(UTF8_FILE);
+
+        config.load(filename, UTF_8);
+        assertEquals("Mötley Crüe", config.getString("glam.band"));
+        assertNotEquals(new String("Mötley Crüe".getBytes(UTF_8), US_ASCII), config.getString("glam.band"));
+
+        config.load(filename, US_ASCII);
+        assertNotEquals("Mötley Crüe", config.getString("glam.band"));
+        assertEquals(new String("Mötley Crüe".getBytes(UTF_8), US_ASCII), config.getString("glam.band"));
+    }
+
+    @Test
+    public void testLoadFileByNameFailsOnNullFile() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        assertThrows(IllegalArgumentException.class, () -> config.load((String) null));
+    }
+
+    @Test
+    public void testLoadFileByNameFailsOnNullFileWithCharset() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        assertThrows(IllegalArgumentException.class, () -> config.load((String) null, UTF_8));
+        assertThrows(IllegalArgumentException.class, () -> config.load((String) null, US_ASCII));
+        assertThrows(IllegalArgumentException.class, () -> config.load((String) null, null));
+    }
+
+    @Test
+    public void testLoadFileByNameFailsOnBadFile() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        String filename = "/does/not/exist";
+
+        Throwable t = assertThrows(ConfigurationException.class, () -> config.load(filename));
+        assertThat(t.getCause(), IsInstanceOf.instanceOf(FileNotFoundException.class));
+    }
+
+    @Test
+    public void testLoadFileWithDefaultCharset() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        String filename = this.getResourceAsFile(UTF8_FILE);
+        File file = new File(filename);
+
+        config.load(file);
+
+        assertEquals("Mötley Crüe", config.getString("glam.band"));
+        assertNotEquals(new String("Mötley Crüe".getBytes(UTF_8), US_ASCII), config.getString("glam.band"));
+    }
+
+    @Test
+    public void testLoadFileWithSpecificCharset() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        String filename = this.getResourceAsFile(UTF8_FILE);
+        File file = new File(filename);
+
+        config.load(file, UTF_8);
+        assertEquals("Mötley Crüe", config.getString("glam.band"));
+        assertNotEquals(new String("Mötley Crüe".getBytes(UTF_8), US_ASCII), config.getString("glam.band"));
+
+        config.load(file, US_ASCII);
+        assertNotEquals("Mötley Crüe", config.getString("glam.band"));
+        assertEquals(new String("Mötley Crüe".getBytes(UTF_8), US_ASCII), config.getString("glam.band"));
+    }
+
+    @Test
+    public void testLoadFileFailsOnNullFile() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        assertThrows(IllegalArgumentException.class, () -> config.load((File) null));
+    }
+
+    @Test
+    public void testLoadFileFailsOnNullFileWithCharset() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        assertThrows(IllegalArgumentException.class, () -> config.load((File) null, UTF_8));
+        assertThrows(IllegalArgumentException.class, () -> config.load((File) null, US_ASCII));
+        assertThrows(IllegalArgumentException.class, () -> config.load((File) null, null));
+    }
+
+    @Test
+    public void testLoadFileFailsOnBadFile() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        File file = new File("/does/not/exist");
+
+        Throwable t = assertThrows(ConfigurationException.class, () -> config.load(file));
+        assertThat(t.getCause(), IsInstanceOf.instanceOf(FileNotFoundException.class));
+    }
+
+    @Test
+    public void testLoadInputStreamWithDefaultCharset() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        InputStream stream = this.getResourceAsStream(UTF8_FILE);
+
+        config.load(stream);
+
+        assertEquals("Motörhead", config.getString("great.band"));
+        assertNotEquals(new String("Motörhead".getBytes(UTF_8), US_ASCII), config.getString("great.band"));
+    }
+
+    @Test
+    public void testLoadInputStreamWithSpecificCharset() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        InputStream utf8stream = this.getResourceAsStream(UTF8_FILE);
+
+        config.load(utf8stream, UTF_8);
+        assertEquals("Motörhead", config.getString("great.band"));
+        assertNotEquals(new String("Motörhead".getBytes(UTF_8), US_ASCII), config.getString("great.band"));
+
+        InputStream asciiStream = this.getResourceAsStream(UTF8_FILE);
+
+        config.load(asciiStream, US_ASCII);
         assertNotEquals("Motörhead", config.getString("great.band"));
-        assertEquals(new String("Motörhead".getBytes(), ASCII), config.getString("great.band"));
+        assertEquals(new String("Motörhead".getBytes(UTF_8), US_ASCII), config.getString("great.band"));
+    }
+
+    @Test
+    public void testLoadReaderFailsOnNullInputStream() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        assertThrows(IllegalArgumentException.class, () -> config.load((InputStream) null));
+    }
+
+    @Test
+    public void testLoadReaderFailsOnNullInputStreamWithCharset() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        assertThrows(IllegalArgumentException.class, () -> config.load((InputStream) null, UTF_8));
+        assertThrows(IllegalArgumentException.class, () -> config.load((InputStream) null, US_ASCII));
+        assertThrows(IllegalArgumentException.class, () -> config.load((InputStream) null, null));
     }
 
     @Test
     public void testLoadReader() throws Exception {
-        String file = cl.getResource(UTF8_FILE).getFile();
-        Reader r = new FileReader(file);
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        InputStream stream = this.getResourceAsStream(UTF8_FILE);
 
-        config.setEncoding(UTF8);
-        config.load(r);
+        Reader reader = new InputStreamReader(stream, UTF_8);
+        config.load(reader);
 
         assertEquals("Blue Öyster Cult", config.getString("cowbell.band"));
     }
 
     @Test
-    public void testLoadProperties() throws Exception {
-        Properties p = new Properties();
-        p.load(cl.getResourceAsStream(ASCII_FILE));
+    public void testLoadReaderFailsOnNullReader() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        assertThrows(IllegalArgumentException.class, () -> config.load((Reader) null));
+    }
 
-        config.setEncoding(UTF8);
-        config.load(p);
-        assertEquals(Arrays.asList("chocolate chip", "oatmeal", "peanut butter"),
-            config.getList("cookies"));
-        assertEquals("chocolate chip, oatmeal, peanut butter", config.getString("cookies"));
+    @Test
+    public void testLoadReaderDoesNotApplyDefaultCharset() throws Exception {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        InputStream utf8Stream = this.getResourceAsStream(UTF8_FILE);
+
+        Reader reader = new InputStreamReader(utf8Stream, US_ASCII);
+        config.load(reader);
+
+        // We're forcing ASCII encoding, so the encoding of the unicode characters should be busted
+        assertNotEquals("Motörhead", config.getString("great.band"));
+        assertEquals(new String("Motörhead".getBytes(UTF_8), US_ASCII), config.getString("great.band"));
     }
 
     @Test
     public void testLoadMultiline() throws Exception {
-        Properties p = new Properties();
-        p.load(cl.getResourceAsStream(ASCII_FILE));
-
-        config.setEncoding(UTF8);
-        config.load(p);
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+        config.load(this.getResourceAsFile(ASCII_FILE));
 
         String poem = "The Assyrian came down like the wolf on the fold," +
             "And his cohorts were gleaming in purple and gold;" +
             "And the sheen of their spears was like stars on the sea," +
             "When the blue wave rolls nightly on deep Galilee.";
+
         assertEquals(poem, config.getString("poem"));
-    }
-
-    @Test
-    public void testLoadFile() throws Exception {
-        String file = cl.getResource(UTF8_FILE).getFile();
-        config = new PropertiesFileConfiguration(file, ASCII);
-        assertNotEquals("Mötley Crüe", config.getString("glam.band"));
-        assertEquals(new String("Mötley Crüe".getBytes(), ASCII), config.getString("glam.band"));
-    }
-
-    @Test
-    public void testEmptyReader() throws Exception {
-        Throwable t = assertThrows(ConfigurationException.class,
-            () -> config.load(new File("/does/not/exist")));
-
-        assertThat(t.getCause(), IsInstanceOf.instanceOf(FileNotFoundException.class));
     }
 }

--- a/src/test/java/org/candlepin/guice/CustomizableModulesTest.java
+++ b/src/test/java/org/candlepin/guice/CustomizableModulesTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.config.Configuration;
+import org.candlepin.config.ConfigurationException;
 import org.candlepin.config.PropertiesFileConfiguration;
 
 import com.google.inject.Module;
@@ -30,10 +31,18 @@ import java.util.Set;
 
 public class CustomizableModulesTest {
 
+    private Configuration loadConfig(String filename) throws URISyntaxException, ConfigurationException {
+        PropertiesFileConfiguration config = new PropertiesFileConfiguration();
+
+        String path = this.getClass().getResource(filename).toURI().getPath();
+        config.load(path);
+
+        return config;
+    }
+
     @Test
     public void shouldLoadAndParseConfigurationFile() throws Exception {
-        Configuration config = new PropertiesFileConfiguration(
-            getAbsolutePath("customizable_modules_test.conf"));
+        Configuration config = this.loadConfig("customizable_modules_test.conf");
         Set<Module> loaded = new CustomizableModules().load(config);
 
         assertEquals(1, loaded.size());
@@ -41,17 +50,11 @@ public class CustomizableModulesTest {
     }
 
     @Test
-    public void shouldFailWhenConfigurationContainsMissingClass()
-        throws Exception {
-
-        Configuration config = new PropertiesFileConfiguration(
-            getAbsolutePath("customizable_modules_with_missing_class.conf"));
+    public void shouldFailWhenConfigurationContainsMissingClass() throws Exception {
+        Configuration config = this.loadConfig("customizable_modules_with_missing_class.conf");
 
         // TODO: We should probably be more specific...
         assertThrows(RuntimeException.class, () -> new CustomizableModules().load(config));
     }
 
-    private String getAbsolutePath(String fileName) throws URISyntaxException {
-        return getClass().getResource(fileName).toURI().getPath();
-    }
 }


### PR DESCRIPTION
- Removed the getEncoding and setEncoding methods from
  FileConfiguration and all implementation classes, as it could
  not be applied in all cases, and could be lost or desync'd in
  some cases
- Added new methods to FileConfiguration for specifying the
  character encoding during config load