### PR TITLE
[M] Added same-ID entity version collision resolution (ENT-5324)

### DIFF
--- a/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
@@ -232,15 +232,25 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
 
         for (Content candidate : entityMap.getOrDefault(entity.getId(), Collections.emptyList())) {
             if (entityVersion == candidate.getEntityVersion()) {
-                if (!entity.equals(candidate)) {
-                    String errmsg = String.format("Entity version collision detected: %s != %s",
-                        entity, candidate);
-
-                    log.error(errmsg);
-                    throw new IllegalStateException(errmsg);
+                if (entity.equals(candidate)) {
+                    // We found a match! Map to the candidate entity
+                    return candidate;
                 }
 
-                return candidate;
+                // If we have a version collision, and the entity IDs are the same, there's likely
+                // some shenanigans going on. Rather than halting all behavior, let's just clear
+                // the old entity's version so we start mapping to the new one.
+                // If we have a collision where the products are actually different, we won't
+                // fail at this point (but we *will* fail), and we won't be able to detect it.
+
+                // Impl note:
+                // We've already implicitly checked the ID above by how we're pulling candidate
+                // entities from the map
+                log.error("Entity version collision detected; attempting resolution... {} != {}",
+                    entity, candidate);
+
+                this.ownerContentCurator.clearContentEntityVersion(candidate);
+                break;
             }
         }
 

--- a/src/main/java/org/candlepin/model/Content.java
+++ b/src/main/java/org/candlepin/model/Content.java
@@ -660,7 +660,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     @Override
     public String toString() {
         return String.format("Content [uuid: %s, id: %s, name: %s, label: %s]",
-            this.uuid, this.id, this.name, this.label);
+            this.getUuid(), this.getId(), this.getName(), this.getLabel());
     }
 
     @PrePersist

--- a/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -653,4 +653,38 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
 
         return activeContent;
     }
+
+    /**
+     * Clears the entity version for the given content. Calling this method will not unlink the
+     * content from any entities referencing it, but it will prevent further updates from converging
+     * on the content.
+     *
+     * @param entity
+     *  the content of which to clear the entity version
+     */
+    public void clearContentEntityVersion(Content entity) {
+        if (entity != null) {
+            this.clearContentEntityVersion(entity.getUuid());
+        }
+    }
+
+    /**
+     * Clears the entity version for the content with the given UUID. Calling this method will not
+     * unlink the content from any entities referencing it, but it will prevent further updates from
+     * converging on the content.
+     *
+     * @param contentUuid
+     *  the UUID of the content of which to clear the entity version
+     */
+    public void clearContentEntityVersion(String contentUuid) {
+        if (contentUuid == null || contentUuid.isEmpty()) {
+            return;
+        }
+
+        this.getEntityManager()
+            .createQuery("UPDATE Content SET entityVersion = NULL WHERE uuid = :content_uuid")
+            .setParameter("content_uuid", contentUuid)
+            .executeUpdate();
+    }
+
 }

--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -403,7 +403,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
     }
 
     @Override
-    public Object clone() {
+    public Product clone() {
         Product copy;
 
         try {

--- a/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -753,4 +753,159 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         // Make sure c1 is true in actual result, as enabled content will have precedence.
         assertEquals(actualResult.get(c1), true);
     }
+
+    private Long getContentEntityVersion(String uuid) {
+        // We need to query this directly, since the objects will automatically regenerate the
+        // entity version if it's null
+        return this.getEntityManager()
+            .createQuery("SELECT entityVersion FROM Content WHERE uuid = :uuid", Long.class)
+            .setParameter("uuid", uuid)
+            .getSingleResult();
+    }
+
+    @Test
+    public void testClearContentEntityVersionByEntity() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Content content1 = this.createContent(owner);
+        Content content2 = this.createContent(owner);
+
+        long version1 = content1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = content2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        this.ownerContentCurator.clearContentEntityVersion(content1);
+
+        Long fetched1 = this.getContentEntityVersion(content1.getUuid());
+        Long fetched2 = this.getContentEntityVersion(content2.getUuid());
+
+        assertNull(fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
+    @Test
+    public void testClearContentEntityVersionByEntityWithNullEntity() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Content content1 = this.createContent(owner);
+        Content content2 = this.createContent(owner);
+
+        long version1 = content1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = content2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        // This should be a silent no-op
+        this.ownerContentCurator.clearContentEntityVersion((Content) null);
+
+        Long fetched1 = this.getContentEntityVersion(content1.getUuid());
+        Long fetched2 = this.getContentEntityVersion(content2.getUuid());
+
+        assertNotNull(fetched1);
+        assertEquals(version1, fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
+    @Test
+    public void testClearContentEntityVersionByEntityWithNullEntityUuid() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Content content1 = this.createContent(owner);
+        Content content2 = this.createContent(owner);
+
+        long version1 = content1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = content2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        // This should be a silent no-op
+        this.ownerContentCurator.clearContentEntityVersion(new Content());
+
+        Long fetched1 = this.getContentEntityVersion(content1.getUuid());
+        Long fetched2 = this.getContentEntityVersion(content2.getUuid());
+
+        assertNotNull(fetched1);
+        assertEquals(version1, fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
+    @Test
+    public void testClearContentEntityVersionByUUID() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Content content1 = this.createContent(owner);
+        Content content2 = this.createContent(owner);
+
+        long version1 = content1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = content2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        this.ownerContentCurator.clearContentEntityVersion(content1.getUuid());
+
+        Long fetched1 = this.getContentEntityVersion(content1.getUuid());
+        Long fetched2 = this.getContentEntityVersion(content2.getUuid());
+
+        assertNull(fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
+    @Test
+    public void testClearContentEntityVersionByUUIDWithNullUUID() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Content content1 = this.createContent(owner);
+        Content content2 = this.createContent(owner);
+
+        long version1 = content1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = content2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        // This should be a silent no-op
+        this.ownerContentCurator.clearContentEntityVersion((String) null);
+
+        Long fetched1 = this.getContentEntityVersion(content1.getUuid());
+        Long fetched2 = this.getContentEntityVersion(content2.getUuid());
+
+        assertNotNull(fetched1);
+        assertEquals(version1, fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
+    @Test
+    public void testClearContentEntityVersionByUUIDWithEmptyUUID() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Content content1 = this.createContent(owner);
+        Content content2 = this.createContent(owner);
+
+        long version1 = content1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = content2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        // This should be a silent no-op
+        this.ownerContentCurator.clearContentEntityVersion("");
+
+        Long fetched1 = this.getContentEntityVersion(content1.getUuid());
+        Long fetched2 = this.getContentEntityVersion(content2.getUuid());
+
+        assertNotNull(fetched1);
+        assertEquals(version1, fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
 }

--- a/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -1269,4 +1269,160 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
             this.ownerProductCurator.updateOwnerProductOrphanedDates((String) null, List.of("a", "b", "c"),
                 Instant.now()));
     }
+
+    private Long getProductEntityVersion(String uuid) {
+        // We need to query this directly, since the objects will automatically regenerate the
+        // entity version if it's null
+        return this.getEntityManager()
+            .createQuery("SELECT entityVersion FROM Product WHERE uuid = :uuid", Long.class)
+            .setParameter("uuid", uuid)
+            .getSingleResult();
+    }
+
+    @Test
+    public void testClearProductEntityVersionByEntity() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Product product1 = this.createProduct(owner);
+        Product product2 = this.createProduct(owner);
+
+        long version1 = product1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = product2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        this.ownerProductCurator.clearProductEntityVersion(product1);
+
+        Long fetched1 = this.getProductEntityVersion(product1.getUuid());
+        Long fetched2 = this.getProductEntityVersion(product2.getUuid());
+
+        assertNull(fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
+    @Test
+    public void testClearProductEntityVersionByEntityWithNullEntity() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Product product1 = this.createProduct(owner);
+        Product product2 = this.createProduct(owner);
+
+        long version1 = product1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = product2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        // This should be a silent no-op
+        this.ownerProductCurator.clearProductEntityVersion((Product) null);
+
+        Long fetched1 = this.getProductEntityVersion(product1.getUuid());
+        Long fetched2 = this.getProductEntityVersion(product2.getUuid());
+
+        assertNotNull(fetched1);
+        assertEquals(version1, fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
+    @Test
+    public void testClearProductEntityVersionByEntityWithNullEntityUuid() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Product product1 = this.createProduct(owner);
+        Product product2 = this.createProduct(owner);
+
+        long version1 = product1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = product2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        // This should be a silent no-op
+        this.ownerProductCurator.clearProductEntityVersion(new Product());
+
+        Long fetched1 = this.getProductEntityVersion(product1.getUuid());
+        Long fetched2 = this.getProductEntityVersion(product2.getUuid());
+
+        assertNotNull(fetched1);
+        assertEquals(version1, fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
+    @Test
+    public void testClearProductEntityVersionByUUID() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Product product1 = this.createProduct(owner);
+        Product product2 = this.createProduct(owner);
+
+        long version1 = product1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = product2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        this.ownerProductCurator.clearProductEntityVersion(product1.getUuid());
+
+        Long fetched1 = this.getProductEntityVersion(product1.getUuid());
+        Long fetched2 = this.getProductEntityVersion(product2.getUuid());
+
+        assertNull(fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
+    @Test
+    public void testClearProductEntityVersionByUUIDWithNullUUID() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Product product1 = this.createProduct(owner);
+        Product product2 = this.createProduct(owner);
+
+        long version1 = product1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = product2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        // This should be a silent no-op
+        this.ownerProductCurator.clearProductEntityVersion((String) null);
+
+        Long fetched1 = this.getProductEntityVersion(product1.getUuid());
+        Long fetched2 = this.getProductEntityVersion(product2.getUuid());
+
+        assertNotNull(fetched1);
+        assertEquals(version1, fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
+    @Test
+    public void testClearProductEntityVersionByUUIDWithEmptyUUID() {
+        Owner owner = createOwner("test-owner", "owner-test");
+        Product product1 = this.createProduct(owner);
+        Product product2 = this.createProduct(owner);
+
+        long version1 = product1.getEntityVersion();
+        assertNotEquals(0, version1);
+
+        long version2 = product2.getEntityVersion();
+        assertNotEquals(0, version2);
+
+        // This should be a silent no-op
+        this.ownerProductCurator.clearProductEntityVersion("");
+
+        Long fetched1 = this.getProductEntityVersion(product1.getUuid());
+        Long fetched2 = this.getProductEntityVersion(product2.getUuid());
+
+        assertNotNull(fetched1);
+        assertEquals(version1, fetched1);
+
+        assertNotNull(fetched2);
+        assertEquals(version2, fetched2);
+    }
+
 }


### PR DESCRIPTION
- The versioned entity update logic will now clear the entity version
  for an existing entity on collision when the colliding entities
  have the same entity ID