### PR TITLE
[M] Set the OpenApi 'useTags' property in pom.xml

### DIFF
--- a/buildSrc/src/main/groovy/PomToolkit.groovy
+++ b/buildSrc/src/main/groovy/PomToolkit.groovy
@@ -168,6 +168,7 @@ class PomToolkit implements Plugin<Project> {
         configOptions.appendNode('interfaceOnly', 'true')
         configOptions.appendNode('generatePom', 'false')
         configOptions.appendNode('dateLibrary', 'java8')
+        configOptions.appendNode('useTags', 'true')
         configOptions.appendNode('sourceFolder', 'src/gen/java/main')
         configurationsNode.appendNode('templateDirectory', '${project.basedir}/buildSrc/src/main/resources/templates')
     }

--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,7 @@
                 <interfaceOnly>true</interfaceOnly>
                 <generatePom>false</generatePom>
                 <dateLibrary>java8</dateLibrary>
+                <useTags>true</useTags>
                 <sourceFolder>src/gen/java/main</sourceFolder>
               </configOptions>
               <templateDirectory>${project.basedir}/buildSrc/src/main/resources/templates</templateDirectory>


### PR DESCRIPTION
- The property was only changed in the build.gradle which caused
  our maven build to fail.