### PR TITLE
Slow docker image builds

### DIFF
--- a/docker/README.mkd
+++ b/docker/README.mkd
@@ -5,8 +5,7 @@ the following is useful for running tests directly (for example, you want to tes
 ideally this would be triggered automatically via jenkins [[1]](https://github.com/candlepin/candlepin-jobs).
 
 ## Building Images
-To build the images run the `build-images` script.  Its build configuration is located in `docker-compose-build.yml`.
-`docker-compose-build.yml`  Is only used for building the images and will not work to bring up containers using docker-compose.
+To build the images run the `build-images` script.
 If you choose to push the images to a different docker registry, change the REGISTRY value found in `./.env`.
 Basic invocations of `build-images` are as follows:
 

--- a/docker/build-images
+++ b/docker/build-images
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 unset CDPATH
-SCRIPT_NAME=$( basename "$0" )
-SCRIPT_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_HOME=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CURRENT_DIR=$PWD
 
 # defaults
@@ -11,15 +11,15 @@ BUILD_ARGS="--no-cache"
 PUSH='false'
 
 evalrc() {
-    if [ "$1" -ne "0" ]; then
-        echo "$2"
-        cd $CURRENT_DIR
-        exit $1
-    fi
+  if [ "$1" -ne "0" ]; then
+    echo "$2"
+    cd $CURRENT_DIR
+    exit $1
+  fi
 }
 
 usage() {
-    cat <<HELP
+  cat <<HELP
 Usage: $SCRIPT_NAME [options] [IMAGE]
   * if IMAGE is omitted, all images will be built
 
@@ -29,61 +29,78 @@ OPTIONS:
   -d <repo>   Specify the destination repo to receive the images; implies -p;
               defaults to: "$REGISTRY"
   -c          Use cached layers when building containers; defaults to false
+  -e          docker or podman. Used to build and run the container. Defaults to what is available, preferring podman.
   -v          Enable verbose/debug output
 HELP
 }
 
-while getopts ":pd:cv" opt; do
-    case $opt in
-        h  ) usage; exit 0;;
-        p  ) PUSH='true';;
-        d  ) PUSH='true'
-             REGISTRY="${OPTARG}";;
-        c  ) BUILD_ARGS="$(echo $BUILD_ARGS | sed -e s/--no-cache//g)";;
-        v  ) set -x;;
-        \?)
-          echo "Invalid option: -$OPTARG" >&2
-          usage
-          exit 1
-          ;;
-        :)
-          echo "Option -$OPTARG requires an argument." >&2
-          usage
-          exit 1
-          ;;
-    esac
+while getopts ":pd:ce:v" opt; do
+  case $opt in
+  h)
+    usage
+    exit 0
+    ;;
+  p) PUSH='true' ;;
+  d)
+    PUSH='true'
+    REGISTRY="${OPTARG}"
+    ;;
+  c) BUILD_ARGS="$(echo $BUILD_ARGS | sed -e s/--no-cache//g)" ;;
+  e)
+    if [ "${OPTARG}" != "podman" ] && [ "${OPTARG}" != "docker" ]; then
+      echo >&2 "Not a valid e: ${OPTARG}. podman or docker supported."
+      exit 1
+    fi
+    CONTAINER_ENGINE="${OPTARG}"
+    ;;
+  v) set -x ;;
+  \?)
+    echo "Invalid option: -$OPTARG" >&2
+    usage
+    exit 1
+    ;;
+  :)
+    echo "Option -$OPTARG requires an argument." >&2
+    usage
+    exit 1
+    ;;
+  esac
 done
+
+if [ "$CONTAINER_ENGINE" == "" ]; then
+  if type podman >/dev/null 2>&1; then
+    CONTAINER_ENGINE="podman"
+  else
+    CONTAINER_ENGINE="docker"
+  fi
+fi
 
 shift $(($OPTIND - 1))
 
 # Determine image name
 if [ "$1" != "" ]; then
-    IMAGE=$1
+  IMAGE=$1
 fi
 
 get_image_names() {
-  python -c 'import yaml,sys;y=yaml.safe_load(sys.stdin); print(" ".join(y["services"].keys()))' < $SCRIPT_HOME/docker-compose-build.yml
-}
-
-# tags a docker image with a version
-tag_images() {
-  TAG_IMAGES=${IMAGE:-$(get_image_names)}
-  CP_VERSION="$( git describe | cut -d- -f 2 )"
-  for IMG in ${TAG_IMAGES}; do
-    docker tag $REGISTRY/$IMG:latest $REGISTRY/$IMG:$CP_VERSION
-  done
+  python -c 'import yaml,sys;y=yaml.safe_load(sys.stdin); print(" ".join(y["services"].keys()))' <$SCRIPT_HOME/docker-compose-build.yml
 }
 
 echo "Building images..."
 cd $SCRIPT_HOME
-docker-compose -f docker-compose-build.yml build $BUILD_ARGS $IMAGE && tag_images
-evalrc $? "Build not successful."
+IMAGES=${IMAGE:-$(get_image_names)}
+CP_VERSION="$(git describe | cut -d- -f 2)"
+for IMG in ${IMAGES}; do
+  "${CONTAINER_ENGINE}" build -f $IMG/Dockerfile . -t $REGISTRY/$IMG:latest
+  evalrc $? "Build not successful."
+  "${CONTAINER_ENGINE}" tag $REGISTRY/$IMG:latest $REGISTRY/$IMG:$CP_VERSION
+done
 
 if [ $PUSH = true ]; then
   echo "Pushing images..."
   # pushes the version tag
-  for IMG in ${TAG_IMAGES}; do
-    docker push $REGISTRY/$IMG
+  for IMG in ${IMAGES}; do
+    "${CONTAINER_ENGINE}" push $REGISTRY/$IMG
     evalrc $? "Push not successful."
   done
 fi

--- a/docker/build-images
+++ b/docker/build-images
@@ -82,13 +82,11 @@ if [ "$1" != "" ]; then
   IMAGE=$1
 fi
 
-get_image_names() {
-  python -c 'import yaml,sys;y=yaml.safe_load(sys.stdin); print(" ".join(y["services"].keys()))' <$SCRIPT_HOME/docker-compose-build.yml
-}
+DEFAULT_IMAGES='candlepin-base candlepin-base-cs8'
+IMAGES=${IMAGE:-$DEFAULT_IMAGES}
 
 echo "Building images..."
 cd $SCRIPT_HOME
-IMAGES=${IMAGE:-$(get_image_names)}
 CP_VERSION="$(git describe | cut -d- -f 2)"
 for IMG in ${IMAGES}; do
   "${CONTAINER_ENGINE}" build -f $IMG/Dockerfile . -t $REGISTRY/$IMG:latest


### PR DESCRIPTION
Currently there is some bug with Docker (most likely our configuration of it) where it CPU limits commands run in the container.  When yum inside the container hits 100% CPU usage it hangs for some undetermined time and makes each package install VERY slow.  I've tried manually opening up Docker to use all CPUs and other available resources but this does not prevent any one CPU from hitting full usage.

Conveniently, podman does not have any of this problem, and since the build stage of candlepin tests don't strictly require docker, I'm doing a simple fix of using that for the builds only.

Note that this doesn't include a fix for the other build script in `docker/gating-test-images/build.sh`  and we will likely hit that problem there also.  This PR makes the job run much faster but we might need to discuss what to do in that script.

This allows for the fixes in: https://github.com/candlepin/candlepin-jobs/pull/85