### PR TITLE
[M] Improved spec test random string generation and job waiting routines (ENT-5354)

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ActivationKeys.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ActivationKeys.java
@@ -33,7 +33,7 @@ public final class ActivationKeys {
     public static ActivationKeyDTO random(NestedOwnerDTO owner) {
         return new ActivationKeyDTO()
             .owner(owner)
-            .name(StringUtil.random("test_activation_key"));
+            .name(StringUtil.random("test_activation_key-"));
     }
 
 }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Branding.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Branding.java
@@ -41,8 +41,9 @@ public final class Branding {
      *  a BrandingDTO instance with a randomly generated name and type
      */
     public static BrandingDTO random() {
-        String name = StringUtil.random("branding");
-        return random(name);
+        String suffix = StringUtil.random(8, StringUtil.CHARSET_NUMERIC_HEX);
+
+        return build("branding-" + suffix, "brand_type-" + suffix);
     }
 
     /**
@@ -55,8 +56,7 @@ public final class Branding {
      *  a BrandingDTO instance with the given name and a randomly generated type
      */
     public static BrandingDTO random(String name) {
-        String type = StringUtil.random("brand_type");
-        return build(name, type);
+        return build(name, StringUtil.random("brand_type-", 8, StringUtil.CHARSET_NUMERIC_HEX));
     }
 
     /**

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Consumers.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Consumers.java
@@ -43,7 +43,7 @@ public final class Consumers {
     private static ConsumerDTO random(NestedOwnerDTO owner) {
         // TODO: fill in rest of the data
         return new ConsumerDTO()
-            .name(StringUtil.random("test_consumer"))
+            .name(StringUtil.random("test_consumer-", 8, StringUtil.CHARSET_NUMERIC_HEX))
             .owner(owner)
             .type(ConsumerTypes.System.value())
             .putFactsItem("system.certificate_version", "3.3");

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Owners.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Owners.java
@@ -37,10 +37,11 @@ public final class Owners {
     }
 
     public static OwnerDTO random() {
-        // todo fill in rest of the data
+        String suffix = StringUtil.random(8, StringUtil.CHARSET_NUMERIC_HEX);
+
         return new OwnerDTO()
-            .key(StringUtil.random("test_owner"))
-            .displayName(StringUtil.random("Test Owner"))
+            .key("test_owner-" + suffix)
+            .displayName("Test Owner " + suffix)
             .contentAccessMode(ENT_ACCESS_MODE)
             .contentAccessModeList(ACCESS_MODE_LIST);
     }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Pools.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Pools.java
@@ -57,10 +57,12 @@ public final class Pools {
      *  a randomly generated upstream pool
      */
     public static PoolDTO randomUpstream(ProductDTO product) {
+        String suffix = StringUtil.random(8, StringUtil.CHARSET_NUMERIC_HEX);
+
         return random(product)
-            .subscriptionId(StringUtil.random("source_sub"))
+            .subscriptionId("source_sub" + suffix)
             .subscriptionSubKey("master")
-            .upstreamPoolId(StringUtil.random("upstream_pool_id"));
+            .upstreamPoolId("upstream_pool_id" + suffix);
     }
 
 }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Products.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Products.java
@@ -43,7 +43,7 @@ public final class Products {
      *  a product DTO with a randomly generated SKU ID and name
      */
     public static ProductDTO randomEng() {
-        String id = String.valueOf((int) (Math.random() * 100000));
+        String id = StringUtil.random(8, StringUtil.CHARSET_NUMERIC);
 
         return new ProductDTO()
             .id(id)
@@ -58,7 +58,7 @@ public final class Products {
      *  a product DTO with a randomly generated engineering ID and name
      */
     public static ProductDTO randomSKU() {
-        String id = StringUtil.random("test_product");
+        String id = StringUtil.random("test_product-", 8, StringUtil.CHARSET_NUMERIC_HEX);
 
         return new ProductDTO()
             .id(id)

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Roles.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Roles.java
@@ -37,13 +37,13 @@ public final class Roles {
     }
 
     private static RoleDTO createRole(OwnerDTO owner, String access) {
-        List<PermissionBlueprintDTO> permissions = List.of(new PermissionBlueprintDTO()
+        PermissionBlueprintDTO ownerPermission = new PermissionBlueprintDTO()
             .owner(Owners.toNested(owner))
             .type("OWNER")
-            .access(access)
-        );
+            .access(access);
+
         return new RoleDTO()
-            .name(StringUtil.random("test-role"))
-            .permissions(permissions);
+            .name(StringUtil.random("test-role-", 8, StringUtil.CHARSET_NUMERIC_HEX))
+            .permissions(List.of(ownerPermission));
     }
 }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Subscriptions.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Subscriptions.java
@@ -35,7 +35,7 @@ public final class Subscriptions {
 
     public static SubscriptionDTO random(OwnerDTO owner, ProductDTO product) {
         return new SubscriptionDTO()
-            .id(StringUtil.random("test_sub"))
+            .id(StringUtil.random("test_sub-", 8, StringUtil.CHARSET_NUMERIC_HEX))
             .owner(Owners.toNested(owner))
             .product(product)
             .quantity(10L)

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/StringUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/StringUtil.java
@@ -21,21 +21,114 @@ public final class StringUtil {
 
     private static final Random RANDOM = new Random();
 
+    /** Default length of randomly generated strings */
+    public static final int DEFAULT_RANDOM_STRING_LENGTH = 8;
+
+    /** Character set consisting of upper- and lower-case alphabetical ASCII characters */
+    public static final String CHARSET_ALPHABETICAL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    /** Character set consisting of numeric ASCII characters */
+    public static final String CHARSET_NUMERIC = "0123456789";
+
+    /** Character set consisting of characters representing base-16 (hexidecimal) values (0-9, A-F) */
+    public static final String CHARSET_NUMERIC_HEX = "0123456789ABCDEF";
+
+    /** Character set consisting of numeric and upper- and lower-case alphabetical ASCII characters */
+    public static final String CHARSET_ALPHANUMERIC = CHARSET_ALPHABETICAL + CHARSET_NUMERIC;
+
     private StringUtil() {
         throw new UnsupportedOperationException();
     }
 
     /**
-     * Generates a random suffix of 7 characters or fewer.
+     * Generates a random string of characters from the specified charset string.
      *
-     * @param base
-     *  The base string to concatenate to the generated suffix
+     * @param length
+     *  the length of the string to generate; must be a positive integer
+     *
+     * @param charset
+     *  a string representing the character set to use for generating the string
+     *
+     * @throws IllegalArgumentException
+     *  if length is a non-positive integer, or charset is null or empty
      *
      * @return
-     *  the provided base string concatenated with a randomly generated suffix
+     *  a randomly generated string using the characters from the specified charset string
      */
-    public static String random(String base) {
-        return base + "-" + RANDOM.nextInt(100000);
+    public static String random(int length, String charset) {
+        if (length < 1) {
+            throw new IllegalArgumentException("length is a non-positive integer");
+        }
+
+        if (charset == null || charset.isEmpty()) {
+            throw new IllegalArgumentException("charset is null or empty");
+        }
+
+        return RANDOM.ints(length, 0, charset.length())
+            .map(charset::charAt)
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
+    }
+
+    /**
+     * Generates a string of characters from the specified charset string, appended to the given
+     * prefix string. If the prefix is null or empty, the resultant string will only contain the
+     * generated portion.
+     *
+     * @param prefix
+     *  the prefix to prepend to the generated string
+     *
+     * @param length
+     *  the length of the string to generate, not counting the prefix; must be a positive integer
+     *
+     * @param charset
+     *  a string representing the character set to use for generating the string
+     *
+     * @throws IllegalArgumentException
+     *  if length is a non-positive integer, or charset is null or empty
+     *
+     * @return
+     *  a randomly generated string using the characters from the specified charset string appended
+     *  to the provided prefix
+     */
+    public static String random(String prefix, int length, String charset) {
+        String suffix = random(length, charset);
+
+        return (prefix != null && !prefix.isEmpty()) ?
+            prefix + suffix :
+            suffix;
+    }
+
+    /**
+     * Generates a random alphanumeric string of the specified length.
+     *
+     * @param length
+     *  the length of the string to generate; must be a positive integer
+     *
+     * @throws IllegalArgumentException
+     *  if length is a non-positive integer
+     *
+     * @return
+     *  a randomly generated, alphanumeric string of the given length
+     */
+    public static String random(int length) {
+        return random(length, CHARSET_ALPHANUMERIC);
+    }
+
+    /**
+     * Generates a random, base-16, numeric string, eight characters in length, appended to the
+     * given prefix string. If the prefix is null or empty, the resultant string will only contain
+     * the generated portion.
+     *
+     * @param prefix
+     *  the prefix to prepend to the generated string
+     *
+     * @return
+     *  an eight-character, randomly generated, base-16 numeric string appended to the provided
+     *  prefix
+     */
+    public static String random(String prefix) {
+        return random(prefix, DEFAULT_RANDOM_STRING_LENGTH, CHARSET_NUMERIC_HEX);
     }
 
 }

--- a/spec-tests/src/test/java/org/candlepin/spec/EntitlementCertificateV3SpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/EntitlementCertificateV3SpecTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.candlepin.ApiException;
-import org.candlepin.dto.api.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.v1.AttributeDTO;
 import org.candlepin.dto.api.v1.ConsumerDTO;
 import org.candlepin.dto.api.v1.ContentDTO;
@@ -108,10 +107,6 @@ public class EntitlementCertificateV3SpecTest {
         pool.setProductName(product.getName());
         pool = ownerApi.createPool(owner.getKey(), pool);
 
-        AsyncJobStatusDTO refresh = ownerApi.refreshPools(owner.getKey(), false);
-        if (refresh != null) {
-            client.jobs().waitForJobToComplete(refresh.getId(), 15000);
-        }
         ConsumerDTO consumer = client.consumers().register(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.trustedConsumer(consumer.getUuid());
         consumerApi = consumerClient.consumers();

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceSpecTest.java
@@ -176,7 +176,8 @@ class EntitlementResourceSpecTest {
         CertificateDTO oldCert = consumerClient.fetchCertificates(consumer.getUuid()).get(0);
         AsyncJobStatusDTO job = entitlementsApi.regenerateEntitlementCertificatesForProduct(
             monitoring.getId(), false);
-        jobsClient.waitForJobToComplete(job.getId(), 15000);
+        job = jobsClient.waitForJob(job);
+        assertEquals("FINISHED", job.getState());
 
         CertificateDTO newCert = consumerClient.fetchCertificates(consumer.getUuid()).get(0);
         assertNotEquals(oldCert.getSerial(), newCert.getSerial());

--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/InactiveConsumerCleanerJobSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/InactiveConsumerCleanerJobSpecTest.java
@@ -108,7 +108,7 @@ public class InactiveConsumerCleanerJobSpecTest {
         createProductAndPoolForConsumer(consumerWithEntitlement);
 
         String jobId = jobsClient.scheduleJob(JOB_KEY).getId();
-        AsyncJobStatusDTO status = jobsClient.waitForJobToComplete(jobId);
+        AsyncJobStatusDTO status = jobsClient.waitForJob(jobId);
         assertEquals("FINISHED", status.getState());
 
         // Verify that the inactive consumer has been deleted.

--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/JobScheduleSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/JobScheduleSpecTest.java
@@ -72,7 +72,9 @@ public class JobScheduleSpecTest {
     public void shouldScheduleCronTasksCaseIndependant() throws Exception {
         AsyncJobStatusDTO jobStatus = client.jobs().scheduleJob("ExpiredPoolsCleanupJob");
         assertEquals("CREATED", jobStatus.getState());
-        jobsClient.waitForJobToComplete(jobStatus.getId(), 15000);
+
+        jobStatus = jobsClient.waitForJob(jobStatus);
+        assertEquals("FINISHED", jobStatus.getState());
     }
 
     @Test
@@ -95,7 +97,8 @@ public class JobScheduleSpecTest {
         assertNotNull(poolsApi.getPool(pool.getId(), null, null));
 
         AsyncJobStatusDTO jobStatus = client.jobs().scheduleJob("ExpiredPoolsCleanupJob");
-        jobsClient.waitForJobToComplete(jobStatus.getId(), 15000);
+        jobStatus = jobsClient.waitForJob(jobStatus.getId());
+        assertEquals("FINISHED", jobStatus.getState());
 
         final String poolId = pool.getId();
         assertNotFound(() -> poolsApi.getPool(poolId, null, null));

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/PoolSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/PoolSpecTest.java
@@ -115,7 +115,7 @@ class PoolSpecTest {
     }
 
     private ApiClient createConsumerClient(ApiClient client, OwnerDTO owner) throws ApiException {
-        String consumerName = StringUtil.random("test_consumer");
+        String consumerName = StringUtil.random("test_consumer-");
         ConsumerDTO consumer = this.createConsumer(client, owner, consumerName, null);
 
         return this.createConsumerClient(client, consumer);
@@ -264,9 +264,9 @@ class PoolSpecTest {
             .createPool(owner.getKey(), pool);
 
         ConsumerDTO consumer1 = this.createConsumer(ownerClient, owner,
-            StringUtil.random("test_consumer_1"), null);
+            StringUtil.random("test_consumer_1-"), null);
         ConsumerDTO consumer2 = this.createConsumer(ownerClient, owner,
-            StringUtil.random("test_consumer_2"), null);
+            StringUtil.random("test_consumer_2-"), null);
         ApiClient consumerClient1 = this.createConsumerClient(ownerClient, consumer1);
         ApiClient consumerClient2 = this.createConsumerClient(ownerClient, consumer2);
 
@@ -307,7 +307,7 @@ class PoolSpecTest {
 
         // Create a consumer with a different arch than the product
         ConsumerDTO consumer = this.createConsumer(ownerClient, owner,
-            StringUtil.random("test_consumer"), Map.of("uname.machine", "x86_64"));
+            StringUtil.random("test_consumer-"), Map.of("uname.machine", "x86_64"));
 
         ApiClient consumerClient = this.createConsumerClient(ownerClient, consumer);
 
@@ -329,7 +329,7 @@ class PoolSpecTest {
         ApiClient ownerClient = this.createUserClient(adminClient, owner);
 
         ConsumerDTO consumer = this.createConsumer(ownerClient, owner,
-            StringUtil.random("test_consumer"), null);
+            StringUtil.random("test_consumer-"), null);
 
         ApiClient consumerClient = this.createConsumerClient(ownerClient, consumer);
 
@@ -446,7 +446,7 @@ class PoolSpecTest {
 
         ApiClient ownerClient = this.createUserClient(adminClient, owner);
 
-        String consumerName = StringUtil.random("test_consumer");
+        String consumerName = StringUtil.random("test_consumer-");
         ConsumerDTO consumer = this.createConsumer(ownerClient, owner, consumerName, null);
         ApiClient consumerClient = this.createConsumerClient(ownerClient, consumer);
 

--- a/spec-tests/src/test/java/org/candlepin/spec/products/ProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/products/ProductResourceSpecTest.java
@@ -224,13 +224,16 @@ public class ProductResourceSpecTest {
         pool.setQuantity(10L);
         pool.setStartDate(Instant.now().atOffset(ZoneOffset.UTC));
         pool.setEndDate(Instant.now().plus(10, ChronoUnit.DAYS).atOffset(ZoneOffset.UTC));
+
         return ownerApi.createPool(ownerKey, pool);
     }
 
     private void verifyRefreshPoolsForProducts(AsyncJobStatusDTO job)
         throws ApiException, InterruptedException {
+
         assertEquals("Refresh Pools", job.getName());
-        AsyncJobStatusDTO finishedJobStatus = jobsClient.waitForJobToComplete(job.getId());
+
+        AsyncJobStatusDTO finishedJobStatus = jobsClient.waitForJob(job);
         assertEquals("FINISHED", finishedJobStatus.getState());
     }
 


### PR DESCRIPTION
- Updated how random string generation works, allowing for specific
  character sets to be used, removing the automatic hyphenation, and
  generating fixed-length strings rather than dynamic-lengthed ones
- Updated the API around waiting for jobs, permitting both the job ID
  and the job object itself; the latter of which will also verify
  the job itself exists and has a valid job ID
- waitForJob now throws an exception if a job vanishes during the
  wait loop, or if the job does not terminate within the alloted time
- Updated several tests and builders to use the new string generation
  method with appropriate charsets
- Updated several tests to also verify jobs they wait on terminate
  with a successful status