### PR TITLE
Enable parallel execution of spec tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,14 +17,13 @@ plugins {
     id "org.owasp.dependencycheck"
     id "jacoco"
     id "org.sonarqube"
-    id "com.adarshr.test-logger"
-
 
     // The following are plugins are plugins we wrote in the buildSrc folder
     id "org.candlepin.gradle.gettext"
     id "org.candlepin.gradle.msgfmt"
     id "org.candlepin.gradle.SpecVersion"
     id "org.candlepin.gradle.PomToolkit"
+    id "test-logging-convention"
 }
 
 apply from: "dependencies.gradle"
@@ -318,26 +317,6 @@ test {
             '-XX:+HeapDumpOnOutOfMemoryError'
     ]
 
-}
-
-testlogger {
-    theme 'standard'
-    showExceptions true
-    showStackTraces true
-    showFullStackTraces project.hasProperty("full")
-    showCauses true
-    slowThreshold 2000
-    showSummary true
-    showSimpleNames false
-    showPassed true
-    showSkipped true
-    showFailed true
-    showOnlySlow false
-    showStandardStreams project.hasProperty("full")
-    showPassedStandardStreams false
-    showSkippedStandardStreams false
-    showFailedStandardStreams project.hasProperty("full")
-    logLevel 'lifecycle'
 }
 
 jacocoTestReport {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java'
+    id "java"
     id "groovy-gradle-plugin"
     id "java-gradle-plugin"
 }

--- a/buildSrc/src/main/groovy/test-logging-convention.gradle
+++ b/buildSrc/src/main/groovy/test-logging-convention.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id "com.adarshr.test-logger"
+}
+
+testlogger {
+    theme 'standard'
+    showExceptions true
+    showStackTraces true
+    showFullStackTraces project.hasProperty("full")
+    showCauses true
+    slowThreshold 2000
+    showSummary true
+    showSimpleNames false
+    showPassed true
+    showSkipped true
+    showFailed true
+    showOnlySlow false
+    showStandardStreams project.hasProperty("full")
+    showPassedStandardStreams false
+    showSkippedStandardStreams false
+    showFailedStandardStreams project.hasProperty("full")
+    logLevel 'lifecycle'
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -103,4 +103,3 @@ libraries["slf4j"] = "org.slf4j:slf4j-api:2.0.0"
 libraries["spotbugs"] = "com.github.spotbugs:spotbugs-annotations:4.7.1"
 libraries["swagger"] = "io.swagger:swagger-annotations:1.6.6"
 libraries["resteasyValidator"] = "org.jboss.resteasy:resteasy-validator-provider:4.4.3.Final"
-

--- a/spec-tests/build.gradle
+++ b/spec-tests/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java"
     id "checkstyle"
-    id "com.adarshr.test-logger"
+    id "test-logging-convention"
 }
 apply from: "../dependencies.gradle"
 
@@ -37,6 +37,10 @@ dependencies {
     implementation fileTree(dir: '/usr/lib64/jss', include: '*.jar')
 }
 
+testlogger {
+    theme = "standard-parallel"
+}
+
 // Disable empty test task
 test {
     enabled = false
@@ -62,26 +66,6 @@ task spec(type: Test) {
             systemProperty properyKey, System.getProperty(properyKey)
         }
     }
-}
-
-testlogger {
-    theme 'standard'
-    showExceptions true
-    showStackTraces true
-    showFullStackTraces project.hasProperty("full")
-    showCauses true
-    slowThreshold 2000
-    showSummary true
-    showSimpleNames false
-    showPassed true
-    showSkipped true
-    showFailed true
-    showOnlySlow false
-    showStandardStreams project.hasProperty("full")
-    showPassedStandardStreams false
-    showSkippedStandardStreams false
-    showFailedStandardStreams project.hasProperty("full")
-    logLevel 'lifecycle'
 }
 
 // Create a single checkstyle task to make it easier to run both the checkstyleMain & checkstyleTest targets

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Branding.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Branding.java
@@ -19,7 +19,6 @@ import org.candlepin.dto.api.v1.ProductDTO;
 import org.candlepin.spec.bootstrap.data.util.StringUtil;
 
 
-
 /**
  * Class providing factory functions for BrandingDTO instances.
  */

--- a/spec-tests/src/test/resources/junit-platform.properties
+++ b/spec-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
- Extract test logger settings into a convention file
- Enable parallel execution of spec tests

Note: We've written a fair amount of spec tests and questions are starting to arise whether the choices we are making now will affect tests running in parallel. We should start with parallel execution in order to flush out issues early.
