### PR TITLE
[M] Made logback.xml a config file to prevent overwriting (ENT-5300)

### DIFF
--- a/candlepin.spec.tmpl
+++ b/candlepin.spec.tmpl
@@ -234,6 +234,9 @@ fi
 ## else logroate fails
 %attr(750, tomcat, tomcat) %{_localstatedir}/log/%{name}
 
+## logback.xml should not be overridden during rpm upgrade/install
+%config(noreplace) %{_sharedstatedir}/tomcat/webapps/%{name}/WEB-INF/classes/logback.xml
+
 %files selinux
 %defattr(-,root,root,0755)
 %doc selinux/*


### PR DESCRIPTION
I was unable to test these changes as the `tito build --rpm --test --verbose` command is not working for me.

The error that I was running into when attempting to run the tito command:
```
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.swWspV
+ umask 022
+ cd /tmp/tito/rpmbuild-candlepinxisoscm9/BUILD
+ cd /tmp/tito/rpmbuild-candlepinxisoscm9/BUILD
+ rm -rf candlepin-4.2.7
+ /usr/bin/gzip -dc /tmp/tito/rpmbuild-candlepinxisoscm9/SOURCES/candlepin-4.2.7-complete.tar.gz
+ /usr/bin/tar -xof -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd candlepin-4.2.7
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ pathfix.py -pni '/usr/bin/python3 -s' bin/scripts/code/setup/cpdb bin/scripts/code/setup/cpsetup
usage: pathfix.py [-h] [--config CONFIG] path
pathfix.py: error: unrecognized arguments: -pni bin/scripts/code/setup/cpdb bin/scripts/code/setup/cpsetup
error: Bad exit status from /var/tmp/rpm-tmp.swWspV (%prep)

RPM build warnings:
    line 23: It's not recommended to have unversioned Obsoletes: Obsoletes: candlepin-tomcat
    line 24: It's not recommended to have unversioned Obsoletes: Obsoletes: candlepin-tomcat6
    line 25: It's not recommended to have unversioned Obsoletes: Obsoletes: candlepin-devel
    line 26: It's not recommended to have unversioned Obsoletes: Obsoletes: candlepin-certgen-lib
    line 23: It's not recommended to have unversioned Obsoletes: Obsoletes: candlepin-tomcat
    line 24: It's not recommended to have unversioned Obsoletes: Obsoletes: candlepin-tomcat6
    line 25: It's not recommended to have unversioned Obsoletes: Obsoletes: candlepin-devel
    line 26: It's not recommended to have unversioned Obsoletes: Obsoletes: candlepin-certgen-lib

RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.swWspV (%prep)

```