### PR TITLE
[M] Added minor state management to the CandlepinContextListener (ENT-5386)

### DIFF
--- a/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -393,7 +393,7 @@ public class CandlepinContextListenerTest {
         // Runtime exception for changeset that is not in db
         prepareForInitialization();
         RuntimeException re = assertThrows(RuntimeException.class, () -> spy.contextInitialized(evt));
-        assertEquals("The database is missing Liquibase changeset(s).", re.getMessage());
+        assertEquals("The database is missing Liquibase changeset(s)", re.getMessage());
     }
 
     @Test


### PR DESCRIPTION
- Added state tracking to the CandlepinContextListener to avoid
  exceptions on shutdown if initialization doesn't complete
  successfully
- Reformatted string generation in cases where unrun Liquibase
  changes are detected