### PR TITLE
Fix spec parallelization issues

### DIFF
--- a/client/src/main/java/org/candlepin/resource/HostedTestApi.java
+++ b/client/src/main/java/org/candlepin/resource/HostedTestApi.java
@@ -109,30 +109,6 @@ public class HostedTestApi {
         return localVarApiClient.buildCall(basePath, path, "GET", queryParams, collectionQueryParams, body, headers, cookies, form, auth, null);
     }
 
-    public void clearData() {
-        okhttp3.Call localVarCall = clearDataCall();
-        localVarApiClient.execute(localVarCall);
-    }
-
-    public okhttp3.Call clearDataCall() {
-        // Operation Servers
-        String basePath = getBasePath();
-
-        Object body = null;
-
-        // create path and map variables
-        String localVarPath = "/hostedtest";
-
-        List<Pair> queryParams = new ArrayList<>();
-        List<Pair> collectionQueryParams = new ArrayList<>();
-        Map<String, String> headers = new HashMap<>();
-        Map<String, String> cookies = new HashMap<>();
-        Map<String, Object> form = new HashMap<>();
-
-        String[] auth = new String[]{};
-        return localVarApiClient.buildCall(basePath, localVarPath, "DELETE", queryParams, collectionQueryParams, body, headers, cookies, form, auth, null);
-    }
-
     public OwnerDTO createOwner(OwnerDTO owner) {
         okhttp3.Call localVarCall = createOwnerCall(owner);
         Type localVarReturnType = new TypeToken<OwnerDTO>() {}.getType();

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/SpecTest.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/SpecTest.java
@@ -16,7 +16,6 @@
 package org.candlepin.spec.bootstrap.client;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestInstance;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -26,6 +25,5 @@ import java.lang.annotation.Target;
 @Tag("spec")
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public @interface SpecTest {
 }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ProductAttributes.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ProductAttributes.java
@@ -18,13 +18,22 @@ package org.candlepin.spec.bootstrap.data.builder;
 import org.candlepin.dto.api.client.v1.AttributeDTO;
 
 public enum ProductAttributes {
-    Arch("arch"),
-    Usage("usage"),
-    Roles("roles"),
+
     Addons("addons"),
+    Arch("arch"),
+    Cores("cores"),
+    ManagementEnabled("management_enabled"),
+    Ram("ram"),
+    Roles("roles"),
+    Sockets("sockets"),
+    StackingId("stacking_id"),
     SupportLevel("support_level"),
     SupportLevelExempt("support_level_exempt"),
-    SupportType("support_type");
+    SupportType("support_type"),
+    Usage("usage"),
+    Version("version"),
+    VirtOnly("virt_only"),
+    WarningPeriod("warning_period");
 
     private final String key;
     ProductAttributes(String key) {

--- a/spec-tests/src/test/java/org/candlepin/spec/ContentResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ContentResourceSpecTest.java
@@ -51,14 +51,14 @@ import java.util.Map;
 
 @SpecTest
 public class ContentResourceSpecTest {
-    private ConsumerClient consumerApi;
-    private OwnerApi ownerApi;
-    private OwnerContentApi ownerContentApi;
-    private OwnerProductApi ownerProductApi;
-    private ProductsApi productsApi;
+    private static ConsumerClient consumerApi;
+    private static OwnerApi ownerApi;
+    private static OwnerContentApi ownerContentApi;
+    private static OwnerProductApi ownerProductApi;
+    private static ProductsApi productsApi;
 
     @BeforeAll
-    public void beforeAll() throws Exception {
+    public static void beforeAll() throws Exception {
         ApiClient client = ApiClients.admin();
         consumerApi = client.consumers();
         productsApi = client.products();

--- a/spec-tests/src/test/java/org/candlepin/spec/HostedTestSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/HostedTestSpecTest.java
@@ -56,21 +56,6 @@ class HostedTestSpecTest {
     }
 
     @Test
-    void shouldCleanServerData() {
-        hosted.createContent(Content.random());
-        hosted.createContent(Content.random());
-        hosted.createProduct(Products.random());
-
-        assertThat(hosted.listProducts()).hasSizeGreaterThanOrEqualTo(1);
-        assertThat(hosted.listContent()).hasSizeGreaterThanOrEqualTo(2);
-
-        hosted.clearData();
-
-        assertThat(hosted.listProducts()).isEmpty();
-        assertThat(hosted.listContent()).isEmpty();
-    }
-
-    @Test
     void shouldCreateOwner() {
         OwnerDTO owner = hosted.createOwner(Owners.random());
 

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceConcurrentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceConcurrentSpecTest.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2009 - 2022 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.entitlements;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.dto.api.client.v1.AttributeDTO;
+import org.candlepin.dto.api.client.v1.ConsumerDTO;
+import org.candlepin.dto.api.client.v1.ConsumerTypeDTO;
+import org.candlepin.dto.api.client.v1.OwnerDTO;
+import org.candlepin.dto.api.client.v1.PoolDTO;
+import org.candlepin.dto.api.client.v1.ProductDTO;
+import org.candlepin.invoker.client.ApiException;
+import org.candlepin.resource.client.v1.OwnerProductApi;
+import org.candlepin.resource.client.v1.PoolsApi;
+import org.candlepin.spec.bootstrap.client.ApiClient;
+import org.candlepin.spec.bootstrap.client.ApiClients;
+import org.candlepin.spec.bootstrap.client.SpecTest;
+import org.candlepin.spec.bootstrap.client.api.ConsumerClient;
+import org.candlepin.spec.bootstrap.client.api.OwnerClient;
+import org.candlepin.spec.bootstrap.data.builder.Consumers;
+import org.candlepin.spec.bootstrap.data.builder.Owners;
+import org.candlepin.spec.bootstrap.data.builder.Pools;
+import org.candlepin.spec.bootstrap.data.builder.Products;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+@SpecTest
+public class EntitlementResourceConcurrentSpecTest {
+
+    private static ApiClient client;
+    private static OwnerProductApi ownerProductApi;
+    private static PoolsApi poolApi;
+    private static OwnerClient ownerClient;
+    private OwnerDTO owner;
+
+    @BeforeAll
+    public static void beforeAll() {
+        client = ApiClients.admin();
+        ownerClient = client.owners();
+        ownerProductApi = client.ownerProducts();
+        poolApi = client.pools();
+    }
+
+    @BeforeEach
+    void setUp() throws ApiException {
+        owner = ownerClient.createOwner(Owners.random());
+    }
+
+    @Test
+    public void shouldAllowConcurrentRequests() {
+        ProductDTO product = Products.random();
+        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
+        product = ownerProductApi.createProductByOwner(owner.getKey(), product);
+        PoolDTO pool = Pools.random().productId(product.getId()).quantity(50L);
+        pool = ownerClient.createPool(owner.getKey(), pool);
+
+        String poolId = pool.getId();
+        List<Runnable> threads = List.of(
+            () -> registerAndConsume(poolId, "system", 5),
+            () -> registerAndConsume(poolId, "candlepin", 7),
+            () -> registerAndConsume(poolId, "system", 6),
+            () -> registerAndConsume(poolId, "candlepin", 11));
+
+        runAllThreads(threads);
+
+        PoolDTO thePool = poolApi.getPool(pool.getId(), null, null);
+        assertEquals(29, thePool.getConsumed());
+        assertEquals(18, thePool.getExported());
+    }
+
+    @Test
+    public void shouldNotAllowOverConsumption() {
+        ProductDTO product = Products.random();
+        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
+        product = ownerProductApi.createProductByOwner(owner.getKey(), product);
+        PoolDTO pool = Pools.random().productId(product.getId()).quantity(3L);
+        pool = ownerClient.createPool(owner.getKey(), pool);
+
+        String poolId = pool.getId();
+        List<Runnable> threads = List.of(
+            () -> registerAndConsume(poolId, "candlepin", 1),
+            () -> registerAndConsume(poolId, "system", 1),
+            () -> registerAndConsume(poolId, "candlepin", 1),
+            () -> registerAndConsume(poolId, "candlepin", 1),
+            () -> registerAndConsume(poolId, "candlepin", 1));
+
+        runAllThreads(threads);
+
+        PoolDTO thePool = poolApi.getPool(pool.getId(), null, null);
+        assertEquals(3, thePool.getConsumed());
+    }
+
+    @Test
+    public void shouldEndAtZeroConsumption() {
+        ProductDTO product = Products.random();
+        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
+        product = ownerProductApi.createProductByOwner(owner.getKey(), product);
+        PoolDTO pool = Pools.random().productId(product.getId()).quantity(3L);
+        pool = ownerClient.createPool(owner.getKey(), pool);
+
+        String poolId = pool.getId();
+        List<Runnable> threads = List.of(
+            () -> registerConsumeUnregister(poolId, "candlepin", 1),
+            () -> registerConsumeUnregister(poolId, "system", 1),
+            () -> registerConsumeUnregister(poolId, "candlepin", 1),
+            () -> registerConsumeUnregister(poolId, "system", 1),
+            () -> registerConsumeUnregister(poolId, "candlepin", 1));
+
+        runAllThreads(threads);
+
+        PoolDTO thePool = poolApi.getPool(pool.getId(), null, null);
+        assertEquals(0, thePool.getConsumed());
+        assertEquals(0, thePool.getExported());
+    }
+
+    private static void runAllThreads(Collection<Runnable> threads) {
+        Set<Thread> toRun = threads.stream()
+            .map(Thread::new)
+            .collect(Collectors.toSet());
+        for (Thread t : toRun) {
+            t.start();
+        }
+        for (Thread t : toRun) {
+            try {
+                t.join();
+            }
+            catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void registerAndConsume(String poolId, String consumerType, Integer quantity) {
+        try {
+            doRegisterAndConsume(poolId, consumerType, quantity);
+        }
+        catch (Exception ae) {
+            throw new RuntimeException(ae);
+        }
+    }
+
+    public String doRegisterAndConsume(String poolId, String consumerType, int quantity)
+        throws ApiException {
+        ConsumerDTO consumer = client.consumers().createConsumer(
+            Consumers.random(owner).type(new ConsumerTypeDTO().label(consumerType)));
+        ConsumerClient consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
+        try {
+            consumerClient.bindPool(consumer.getUuid(), poolId, quantity);
+        }
+        catch (ApiException e) {
+            // tests will run that try to over consume, this is expected
+            // ensure that it's not something else
+            assertEquals(403, e.getCode());
+        }
+        return consumer.getUuid();
+    }
+
+    public void registerConsumeUnregister(String poolId, String consumerType, int quantity) {
+        try {
+            String consumerUuid = doRegisterAndConsume(poolId, consumerType, quantity);
+            client.consumers().deleteConsumer(consumerUuid);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceFilteringSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceFilteringSpecTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2009 - 2022 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.entitlements;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.dto.api.client.v1.AttributeDTO;
+import org.candlepin.dto.api.client.v1.CertificateDTO;
+import org.candlepin.dto.api.client.v1.CertificateSerialDTO;
+import org.candlepin.dto.api.client.v1.ConsumerDTO;
+import org.candlepin.dto.api.client.v1.EntitlementDTO;
+import org.candlepin.dto.api.client.v1.OwnerDTO;
+import org.candlepin.dto.api.client.v1.ProductDTO;
+import org.candlepin.invoker.client.ApiException;
+import org.candlepin.resource.client.v1.EntitlementsApi;
+import org.candlepin.resource.client.v1.OwnerProductApi;
+import org.candlepin.spec.bootstrap.client.ApiClient;
+import org.candlepin.spec.bootstrap.client.ApiClients;
+import org.candlepin.spec.bootstrap.client.SpecTest;
+import org.candlepin.spec.bootstrap.client.api.ConsumerClient;
+import org.candlepin.spec.bootstrap.client.api.OwnerClient;
+import org.candlepin.spec.bootstrap.data.builder.Consumers;
+import org.candlepin.spec.bootstrap.data.builder.Owners;
+import org.candlepin.spec.bootstrap.data.builder.Pools;
+import org.candlepin.spec.bootstrap.data.builder.Products;
+import org.candlepin.spec.bootstrap.data.util.StringUtil;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@SpecTest
+public class EntitlementResourceFilteringSpecTest {
+
+    private static ConsumerClient consumerClient;
+    private static EntitlementsApi entitlementsApi;
+    private static ConsumerDTO consumer;
+    private static ProductDTO monitoring;
+
+    @BeforeAll
+    public static void beforeAll() throws ApiException, JsonProcessingException {
+        ApiClient client = ApiClients.admin();
+        OwnerClient ownerClient = client.owners();
+        OwnerProductApi ownerProductApi = client.ownerProducts();
+        entitlementsApi = client.entitlements();
+
+        OwnerDTO owner = ownerClient.createOwner(Owners.random());
+
+        monitoring = ownerProductApi.createProductByOwner(owner.getKey(), Products.random()
+            .name(StringUtil.random("monitoring"))
+            .attributes(List.of(new AttributeDTO().name("variant").value("Satellite Starter Pack"))));
+        ProductDTO virtual = ownerProductApi.createProductByOwner(owner.getKey(), Products.random()
+            .name(StringUtil.random("virtualization")));
+
+        // entitle owner for the virt and monitoring products
+        ownerClient.createPool(owner.getKey(), Pools.random(monitoring));
+        ownerClient.createPool(owner.getKey(), Pools.random(virtual));
+
+        consumer = client.consumers().createConsumer(Consumers.random(owner));
+        consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
+
+        consumerClient.bindProduct(consumer.getUuid(), monitoring.getId());
+        consumerClient.bindProduct(consumer.getUuid(), virtual.getId());
+    }
+
+    @Test
+    public void canFilterEntitlementsWithMatches() {
+        List<EntitlementDTO> ents = entitlementsApi.listAllForConsumer(
+            consumer.getUuid(), "virtualization", null, null, null, null, null);
+        assertThat(ents).hasSize(1);
+    }
+
+    @Test
+    public void canFilterEntitlementsByProductAttribute() {
+        List<EntitlementDTO> ents = entitlementsApi.listAllForConsumer(
+            consumer.getUuid(), null, List.of("variant:Satellite Starter Pack"), null, null, null, null);
+        assertThat(ents).hasSize(1);
+        assertEquals("Satellite Starter Pack",
+            ents.get(0).getPool().getProductAttributes().get(0).getValue());
+    }
+
+    @Test
+    public void canFilterConsumerEntitlementsByProductAttribute() {
+        List<EntitlementDTO> ents = consumerClient.listEntitlements(
+            consumer.getUuid(), null, null, null, null, null, null, null);
+        assertThat(ents).hasSize(2);
+
+        ents = consumerClient.listEntitlements(consumer.getUuid(),
+            null, null, List.of("variant:Satellite Starter Pack"), null, null, null, null);
+        assertThat(ents).hasSize(1);
+
+        assertEquals("Satellite Starter Pack",
+            ents.get(0).getPool().getProductAttributes().get(0).getValue());
+    }
+
+    @Test
+    public void allowFilterCertsBySerial() {
+        List<EntitlementDTO> ents = consumerClient.listEntitlements(
+            consumer.getUuid(), monitoring.getId(), null, null, null, null, null, null);
+        assertThat(ents).hasSize(1);
+
+        List<CertificateSerialDTO> certSerials = ents.stream()
+            .flatMap(e -> e.getCertificates().stream().map(CertificateDTO::getSerial))
+            .collect(Collectors.toList());
+        assertThat(certSerials).hasSize(1);
+
+        assertThat(consumerClient.fetchCertificates(
+            consumer.getUuid(), certSerials.get(0).getSerial().toString())).hasSize(1);
+    }
+
+}

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceSpecTest.java
@@ -19,24 +19,18 @@ import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.asser
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertForbidden;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.candlepin.dto.api.client.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.client.v1.AttributeDTO;
 import org.candlepin.dto.api.client.v1.CertificateDTO;
-import org.candlepin.dto.api.client.v1.CertificateSerialDTO;
 import org.candlepin.dto.api.client.v1.ConsumerDTO;
-import org.candlepin.dto.api.client.v1.ConsumerTypeDTO;
 import org.candlepin.dto.api.client.v1.EntitlementDTO;
 import org.candlepin.dto.api.client.v1.OwnerDTO;
 import org.candlepin.dto.api.client.v1.PoolDTO;
 import org.candlepin.dto.api.client.v1.ProductDTO;
-import org.candlepin.dto.api.client.v1.UserDTO;
 import org.candlepin.invoker.client.ApiException;
-import org.candlepin.resource.client.v1.ConsumerApi;
 import org.candlepin.resource.client.v1.EntitlementsApi;
 import org.candlepin.resource.client.v1.OwnerProductApi;
-import org.candlepin.resource.client.v1.PoolsApi;
 import org.candlepin.spec.bootstrap.client.ApiClient;
 import org.candlepin.spec.bootstrap.client.ApiClients;
 import org.candlepin.spec.bootstrap.client.SpecTest;
@@ -47,130 +41,73 @@ import org.candlepin.spec.bootstrap.data.builder.Consumers;
 import org.candlepin.spec.bootstrap.data.builder.Owners;
 import org.candlepin.spec.bootstrap.data.builder.Pools;
 import org.candlepin.spec.bootstrap.data.builder.Products;
-import org.candlepin.spec.bootstrap.data.util.UserUtil;
+import org.candlepin.spec.bootstrap.data.util.StringUtil;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 
 
 @SpecTest
 class EntitlementResourceSpecTest {
 
     private static ApiClient client;
-    ApiClient userClient;
-    ConsumerClient consumerClient;
-    private static OwnerDTO owner;
-    private static OwnerDTO qowner;
-    private static UserDTO user;
-    private static ConsumerDTO consumer;
+    private static OwnerProductApi ownerProductApi;
+    private static EntitlementsApi entitlementsApi;
+    private static JobsClient jobsClient;
+    private static OwnerClient ownerClient;
+    private OwnerDTO owner;
+    private ConsumerDTO consumer;
+    private ConsumerClient consumerClient;
     private ProductDTO monitoring;
     private ProductDTO virtual;
-    private OwnerClient ownerClient;
-    private OwnerProductApi ownerProductApi;
-    private ConsumerApi consumerApi;
-    private PoolsApi poolApi;
-    private EntitlementsApi entitlementsApi;
-    private JobsClient jobsClient;
 
-
-    @BeforeEach
-    public void beforeEach() {
+    @BeforeAll
+    static void beforeAll() {
         client = ApiClients.admin();
         ownerClient = client.owners();
         jobsClient = client.jobs();
         ownerProductApi = client.ownerProducts();
-        consumerApi = client.consumers();
         entitlementsApi = client.entitlements();
-        poolApi = client.pools();
+    }
+
+    @BeforeEach
+    void setUp() throws ApiException {
         owner = ownerClient.createOwner(Owners.random());
-        // separate for quantity adjust tests - here for cleanup
-        qowner = ownerClient.createOwner(Owners.random());
-        user = UserUtil.createUser(client, owner);
-        userClient = ApiClients.trustedUser(user.getUsername());
 
-        monitoring = Products.random()
-            .name("monitoring")
-            .attributes(List.of(new AttributeDTO().name("variant").value("Satellite Starter Pack")));
-        monitoring = ownerProductApi.createProductByOwner(owner.getKey(), monitoring);
-        virtual = Products.random()
-            .name("virtualization");
-        virtual = ownerProductApi.createProductByOwner(owner.getKey(), virtual);
-
-        // entitle owner for the virt and monitoring products
-        PoolDTO monitoringPool = Pools.random(monitoring).quantity(6L);
-        monitoringPool = ownerClient.createPool(owner.getKey(), monitoringPool);
-        PoolDTO virtPool = Pools.random(virtual).quantity(6L);
-        virtPool = ownerClient.createPool(owner.getKey(), virtPool);
+        monitoring = ownerProductApi.createProductByOwner(owner.getKey(), Products.random()
+            .name(StringUtil.random("monitoring"))
+            .attributes(List.of(new AttributeDTO().name("variant").value("Satellite Starter Pack"))));
+        virtual = ownerProductApi.createProductByOwner(owner.getKey(), Products.random()
+            .name(StringUtil.random("virtualization")));
 
         consumer = client.consumers().createConsumer(Consumers.random(owner));
         consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
     }
 
     @Test
-    @DisplayName("can filter all entitlements by using matches param")
-    public void canFilterEntitlementsWithMatches() throws Exception {
-        consumerClient.bindProduct(consumer.getUuid(), monitoring.getId());
+    public void shouldNotCalculateAttributes() {
+        ownerClient.createPool(owner.getKey(), Pools.random(monitoring));
+        ownerClient.createPool(owner.getKey(), Pools.random(virtual));
         consumerClient.bindProduct(consumer.getUuid(), virtual.getId());
 
         List<EntitlementDTO> ents = entitlementsApi.listAllForConsumer(
             consumer.getUuid(), "virtualization", null, null, null, null, null);
-        assertThat(ents).hasSize(1);
+
+        assertThat(ents).hasSize(1)
+            .map(EntitlementDTO::getPool)
+            .map(PoolDTO::getCalculatedAttributes)
+            .containsOnlyNulls();
     }
 
     @Test
-    @DisplayName("should not re-calculate attributes when fetching entitlements")
-    public void shouldNotCalculateAttributes() throws Exception {
-        consumerClient.bindProduct(consumer.getUuid(), virtual.getId());
-
-        List<EntitlementDTO> ents = entitlementsApi.listAllForConsumer(
-            consumer.getUuid(), "virtualization", null, null, null, null, null);
-        assertThat(ents).hasSize(1);
-        assertNull(ents.get(0).getPool().getCalculatedAttributes());
-    }
-
-    @Test
-    @DisplayName("can filter all entitlements by product attribute")
-    public void canFilterEntitlementsByProductAttribute() throws Exception {
-        consumerClient.bindProduct(consumer.getUuid(), monitoring.getId());
-        consumerClient.bindProduct(consumer.getUuid(), virtual.getId());
-
-        List<EntitlementDTO> ents = entitlementsApi.listAllForConsumer(
-            consumer.getUuid(), null, List.of("variant:Satellite Starter Pack"), null, null, null, null);
-        assertThat(ents).hasSize(1);
-        assertEquals("Satellite Starter Pack",
-            ents.get(0).getPool().getProductAttributes().get(0).getValue());
-    }
-
-    @Test
-    @DisplayName("can filter consumer entitlements by product attribute")
-    public void canFilterConsumerEntitlementsByProductAttribute() throws Exception {
-        consumerClient.bindProduct(consumer.getUuid(), monitoring.getId());
-        consumerClient.bindProduct(consumer.getUuid(), virtual.getId());
-
-        List<EntitlementDTO> ents = consumerClient.listEntitlements(
-            consumer.getUuid(), null, null, null, null, null, null, null);
-        assertThat(ents).hasSize(2);
-
-        ents = consumerClient.listEntitlements(consumer.getUuid(),
-            null, null, List.of("variant:Satellite Starter Pack"), null, null, null, null);
-        assertThat(ents).hasSize(1);
-
-        assertEquals("Satellite Starter Pack",
-            ents.get(0).getPool().getProductAttributes().get(0).getValue());
-    }
-
-    @Test
-    @DisplayName("should allow entitlement certificate regeneration based on product id")
-    public void shouldAllowEntCertRegenOnProductId() throws Exception {
+    public void shouldAllowEntCertRegenOnProductId() {
+        ownerClient.createPool(owner.getKey(), Pools.random(monitoring));
+        ownerClient.createPool(owner.getKey(), Pools.random(virtual));
         consumerClient.bindProduct(consumer.getUuid(), monitoring.getId());
         CertificateDTO oldCert = consumerClient.fetchCertificates(consumer.getUuid()).get(0);
         AsyncJobStatusDTO job = entitlementsApi.regenerateEntitlementCertificatesForProduct(
@@ -183,55 +120,34 @@ class EntitlementResourceSpecTest {
     }
 
     @Test
-    @DisplayName("allows filtering certificates by serial number")
-    public void allowFilterCertsBySerial() throws Exception {
+    public void allowsListCertsBySerialNumbers() {
+        ownerClient.createPool(owner.getKey(), Pools.random(monitoring));
+        ownerClient.createPool(owner.getKey(), Pools.random(virtual));
         consumerClient.bindProduct(consumer.getUuid(), monitoring.getId());
-        consumerClient.bindProduct(consumer.getUuid(), virtual.getId());
 
-        List<EntitlementDTO> ents = consumerClient.listEntitlements(
-            consumer.getUuid(), monitoring.getId(), null, null, null, null, null, null);
-        assertThat(ents).hasSize(1);
-
-        List<CertificateSerialDTO> certSerials = ents.stream()
-            .flatMap(e -> e.getCertificates().stream().map(CertificateDTO :: getSerial))
-            .collect(Collectors.toList());
-        assertThat(certSerials).hasSize(1);
-
-        assertThat(consumerClient.fetchCertificates(
-            consumer.getUuid(), certSerials.get(0).getSerial().toString())).hasSize(1);
-    }
-
-    @Test
-    @DisplayName("allows listing certificates by serial numbers")
-    public void allowsListCertsBySerialNumbers() throws Exception {
-        consumerClient.bindProduct(consumer.getUuid(), monitoring.getId());
         assertThat(consumerClient.getEntitlementCertificateSerials(consumer.getUuid()))
             .hasSize(1);
     }
 
+
     @Test
-    @DisplayName("should allow consumer to change entitlement quantity")
-    public void shouldAllowConsumerToChangeQuantity() throws Exception {
-        consumer = client.consumers().createConsumer(Consumers.random(qowner));
-        consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
-        ProductDTO product = Products.random();
-        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
-        product = ownerProductApi.createProductByOwner(qowner.getKey(), product);
-        PoolDTO pool = Pools.random().productId(product.getId()).quantity(10L);
-        pool = ownerClient.createPool(qowner.getKey(), pool);
+    public void shouldAllowConsumerToChangeQuantity() {
+        ProductDTO product = ownerProductApi.createProductByOwner(owner.getKey(), Products.random()
+            .attributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes"))));
+        PoolDTO pool = ownerClient.createPool(owner.getKey(), Pools.random(product));
 
         JsonNode ent = consumerClient.bindPool(consumer.getUuid(), pool.getId(), 3).get(0);
         String entCertSer = ent.get("certificates").get(0).get("serial").get("id").asText();
         JsonNode ent2 = consumerClient.bindPool(consumer.getUuid(), pool.getId(), 2).get(0);
         assertEquals(2, ent2.get("quantity").asInt());
-        PoolDTO thePool = ownerClient.listOwnerPools(qowner.getKey()).get(0);
+        PoolDTO thePool = ownerClient.listOwnerPools(owner.getKey()).get(0);
         assertEquals(5, thePool.getConsumed());
 
         // change it higher
         client.entitlements().updateEntitlement(ent.get("id").asText(), new EntitlementDTO().quantity(5));
         EntitlementDTO adjustedEnt = client.entitlements().getEntitlement(ent.get("id").asText());
         String adjustedCertSer1 = adjustedEnt.getCertificates().iterator().next().getId();
-        PoolDTO adjustedPool = ownerClient.listOwnerPools(qowner.getKey()).get(0);
+        PoolDTO adjustedPool = ownerClient.listOwnerPools(owner.getKey()).get(0);
         assertEquals(5, adjustedEnt.getQuantity());
         assertEquals(7, adjustedPool.getConsumed());
         assertNotEquals(entCertSer, adjustedCertSer1);
@@ -240,28 +156,25 @@ class EntitlementResourceSpecTest {
         client.entitlements().updateEntitlement(ent.get("id").asText(), new EntitlementDTO().quantity(2));
         adjustedEnt = client.entitlements().getEntitlement(ent.get("id").asText());
         String adjustedCertSer2 = adjustedEnt.getCertificates().iterator().next().getId();
-        adjustedPool = ownerClient.listOwnerPools(qowner.getKey()).get(0);
+        adjustedPool = ownerClient.listOwnerPools(owner.getKey()).get(0);
         assertEquals(2, adjustedEnt.getQuantity());
         assertEquals(4, adjustedPool.getConsumed());
         assertNotEquals(adjustedCertSer1, adjustedCertSer2);
     }
 
     @Test
-    @DisplayName("should not allow consumer to change entitlement quantity out of bounds")
-    public void shouldNotAllowConsumerToChangeToExcessQuantity() throws Exception {
-        consumer = client.consumers().createConsumer(Consumers.random(qowner));
-        consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
-        ProductDTO product = Products.random();
-        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
-        product = ownerProductApi.createProductByOwner(qowner.getKey(), product);
+    public void shouldNotAllowConsumerToChangeToExcessQuantity() {
+        ProductDTO product = Products.random()
+            .attributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
+        product = ownerProductApi.createProductByOwner(owner.getKey(), product);
         PoolDTO pool = Pools.random().productId(product.getId()).quantity(10L);
-        pool = ownerClient.createPool(qowner.getKey(), pool);
+        pool = ownerClient.createPool(owner.getKey(), pool);
 
         JsonNode ent1 = consumerClient.bindPool(consumer.getUuid(), pool.getId(), 3).get(0);
         JsonNode ent2 = consumerClient.bindPool(consumer.getUuid(), pool.getId(), 2).get(0);
         assertEquals(3, ent1.get("quantity").asInt());
         assertEquals(2, ent2.get("quantity").asInt());
-        PoolDTO thePool = ownerClient.listOwnerPools(qowner.getKey()).get(0);
+        PoolDTO thePool = ownerClient.listOwnerPools(owner.getKey()).get(0);
         assertEquals(5, thePool.getConsumed());
 
         assertForbidden(() ->
@@ -273,170 +186,18 @@ class EntitlementResourceSpecTest {
     }
 
     @Test
-    @DisplayName("should not allow consumer to change entitlement quantity non-multi")
-    public void shouldNotAllowConsumerToChangeQuantityNonMulti() throws Exception {
-        consumer = client.consumers().createConsumer(Consumers.random(qowner));
-        consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
-        ProductDTO product = Products.random();
-        product = ownerProductApi.createProductByOwner(qowner.getKey(), product);
-        PoolDTO pool = Pools.random().productId(product.getId()).quantity(10L);
-        pool = ownerClient.createPool(qowner.getKey(), pool);
+    public void shouldNotAllowConsumerToChangeQuantityNonMulti() {
+        ProductDTO product = ownerProductApi.createProductByOwner(owner.getKey(), Products.random());
+        PoolDTO pool = ownerClient.createPool(owner.getKey(), Pools.random(product));
 
         JsonNode ent1 = consumerClient.bindPool(consumer.getUuid(), pool.getId(), 1).get(0);
         assertEquals(1, ent1.get("quantity").asInt());
-        PoolDTO thePool = ownerClient.listOwnerPools(qowner.getKey()).get(0);
+        PoolDTO thePool = ownerClient.listOwnerPools(owner.getKey()).get(0);
         assertEquals(1, thePool.getConsumed());
 
-        assertForbidden(() ->
-            client.entitlements().updateEntitlement(ent1.get("id").asText(),
-                new EntitlementDTO().quantity(2)));
+        assertForbidden(() -> client.entitlements()
+            .updateEntitlement(ent1.get("id").asText(), new EntitlementDTO().quantity(2)));
     }
 
-    @Test
-    @DisplayName("should handle concurrent requests to pool and maintain quanities")
-    public void shouldAllowConcurrentRequests() throws Exception {
-        ProductDTO product = Products.random();
-        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
-        product = ownerProductApi.createProductByOwner(owner.getKey(), product);
-        PoolDTO pool = Pools.random().productId(product.getId()).quantity(50L);
-        pool = ownerClient.createPool(owner.getKey(), pool);
-
-        List<Thread> threads = new ArrayList<>();
-        List<Map.Entry<String, Integer>> data = List.of(
-            Map.entry("system", 5),
-            Map.entry("candlepin", 7),
-            Map.entry("system", 6),
-            Map.entry("candlepin", 11));
-        for (Map.Entry<String, Integer> entry : data) {
-            final String poolId = pool.getId();
-            Thread t = new Thread(() -> {
-                try {
-                    registerAndConsume(poolId, entry.getKey(), entry.getValue());
-                }
-                catch (Exception ae) {
-                    throw new RuntimeException(ae);
-                }
-            });
-            threads.add(t);
-        }
-        // Run all the threads
-        for (Thread t : threads) {
-            t.start();
-        }
-        for (Thread t : threads) {
-            t.join();
-        }
-        PoolDTO thePool = poolApi.getPool(pool.getId(), null, null);
-        assertEquals(29, thePool.getConsumed());
-        assertEquals(18, thePool.getExported());
-    }
-
-    @Test
-    @DisplayName("should not allow over consumption in pool")
-    public void shouldNotAllowOverConsumption() throws Exception {
-        ProductDTO product = Products.random();
-        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
-        product = ownerProductApi.createProductByOwner(owner.getKey(), product);
-        PoolDTO pool = Pools.random().productId(product.getId()).quantity(3L);
-        pool = ownerClient.createPool(owner.getKey(), pool);
-
-        List<Thread> threads = new ArrayList<>();
-
-        List<Map.Entry<String, Integer>> data = List.of(
-            Map.entry("candlepin", 1),
-            Map.entry("system", 1),
-            Map.entry("candlepin", 1),
-            Map.entry("candlepin", 1),
-            Map.entry("candlepin", 1));
-        for (Map.Entry<String, Integer> entry : data) {
-            final String poolId = pool.getId();
-            Thread t = new Thread(() -> {
-                try {
-                    registerAndConsume(poolId, entry.getKey(), entry.getValue());
-                }
-                catch (Exception ae) {
-                    throw new RuntimeException(ae);
-                }
-            });
-            threads.add(t);
-        }
-        // Run all the threads
-        for (Thread t : threads) {
-            t.start();
-        }
-        for (Thread t : threads) {
-            t.join();
-        }
-        PoolDTO thePool = poolApi.getPool(pool.getId(), null, null);
-        assertEquals(3, thePool.getConsumed());
-    }
-
-    public void registerAndConsume(String poolId, String consumerType, int quantity) {
-        ConsumerDTO consumer = client.consumers().createConsumer(
-            Consumers.random(owner).type(new ConsumerTypeDTO().label(consumerType)));
-        ConsumerClient consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
-        try {
-            assertForbidden(() -> consumerClient.bindPool(consumer.getUuid(), poolId, quantity));
-        }
-        catch (ApiException e) {
-            // tests will run that try to over consume, this is expected
-            // ensure that it's not something else
-            assertEquals(403, e.getCode());
-        }
-    }
-
-    @Test
-    @DisplayName("should end at zero quantity consumed when all consumers are unregistered")
-    public void shouldEndAtZeroConsumption() throws InterruptedException {
-        ProductDTO product = Products.random();
-        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
-        product = ownerProductApi.createProductByOwner(owner.getKey(), product);
-        PoolDTO pool = Pools.random().productId(product.getId()).quantity(3L);
-        pool = ownerClient.createPool(owner.getKey(), pool);
-
-        List<Thread> threads = new ArrayList<>();
-        List<Map.Entry<String, Integer>> data = List.of(
-            Map.entry("candlepin", 1),
-            Map.entry("system", 1),
-            Map.entry("candlepin", 1),
-            Map.entry("system", 1),
-            Map.entry("candlepin", 1));
-        for (Map.Entry<String, Integer> entry : data) {
-            final String poolId = pool.getId();
-            Thread t = new Thread(() -> {
-                try {
-                    registerConsumeUnregister(poolId, entry.getKey(), entry.getValue());
-                }
-                catch (Exception ae) {
-                    throw new RuntimeException(ae);
-                }
-            });
-            threads.add(t);
-        }
-        // Run all the threads
-        for (Thread t : threads) {
-            t.start();
-        }
-        for (Thread t : threads) {
-            t.join();
-        }
-        PoolDTO thePool = poolApi.getPool(pool.getId(), null, null);
-        assertEquals(0, thePool.getConsumed());
-        assertEquals(0, thePool.getExported());
-    }
-
-    public void registerConsumeUnregister(String poolId, String consumerType, int quantity) {
-        ConsumerDTO consumer = client.consumers().createConsumer(
-            Consumers.random(owner).type(new ConsumerTypeDTO().label(consumerType)));
-        ConsumerClient consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
-        try {
-            consumerClient.bindPool(consumer.getUuid(), poolId, quantity);
-        }
-        catch (ApiException e) {
-            // tests will run that try to over consume, this is expected
-            // ensure that it's not something else
-            assertEquals(403, e.getCode());
-        }
-        client.consumers().deleteConsumer(consumer.getUuid());
-    }
 }
+

--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/JobScheduleSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/JobScheduleSpecTest.java
@@ -49,7 +49,7 @@ public class JobScheduleSpecTest {
     private static JobsClient jobsClient;
 
     @BeforeAll
-    public void beforeAll() {
+    public static void beforeAll() {
         client = ApiClients.admin();
         jobsClient = client.jobs();
     }

--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/JobStatusSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/JobStatusSpecTest.java
@@ -42,6 +42,7 @@ import org.candlepin.spec.bootstrap.data.builder.Products;
 import org.candlepin.spec.bootstrap.data.util.UserUtil;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -58,25 +59,30 @@ import java.util.stream.Collectors;
 class JobStatusSpecTest {
 
     private static ApiClient client;
-    ApiClient userClient;
-    private static OwnerDTO owner;
-    private static UserDTO user;
-    private OwnerApi ownerApi;
-    private OwnerProductApi ownerProductApi;
-    private ConsumerApi consumerApi;
-    private JobsClient jobsClient;
+    private static OwnerApi ownerApi;
+    private static OwnerProductApi ownerProductApi;
+    private static ConsumerApi consumerApi;
+    private static JobsClient jobsClient;
+    private ApiClient userClient;
+    private OwnerDTO owner;
+    private UserDTO user;
     private ProductDTO product;
     private PoolDTO pool;
 
     @BeforeAll
-    public void beforeAll() {
+    public static void beforeAll() {
         client = ApiClients.admin();
         ownerApi = client.owners();
         ownerProductApi = client.ownerProducts();
         jobsClient = client.jobs();
         consumerApi = client.consumers();
+    }
+
+    @BeforeEach
+    void beforeEach() {
         owner = ownerApi.createOwner(Owners.random());
         user = UserUtil.createUser(client, owner);
+
         userClient = ApiClients.trustedUser(user.getUsername());
 
         product = Products.random();

--- a/spec-tests/src/test/java/org/candlepin/spec/products/ProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/products/ProductResourceSpecTest.java
@@ -49,10 +49,10 @@ import java.util.List;
 
 @SpecTest
 public class ProductResourceSpecTest {
-    private ProductsApi productsApi;
-    private OwnerApi ownerApi;
-    private OwnerProductApi ownerProductApi;
-    private JobsClient jobsClient;
+    private static ProductsApi productsApi;
+    private static OwnerApi ownerApi;
+    private static OwnerProductApi ownerProductApi;
+    private static JobsClient jobsClient;
 
     private String p1ProductId;
     private String p2ProductId;
@@ -65,7 +65,7 @@ public class ProductResourceSpecTest {
     private String p6ProductId;
 
     @BeforeAll
-    public void beforeAll() {
+    public static void beforeAll() {
         ApiClient client = ApiClients.admin();
         productsApi = client.products();
         ownerApi = client.owners();


### PR DESCRIPTION
- Change test lifecycle to prevent sharing of instance variables
- Fix expectation of status endpoint spec as other tests might have
  changed the result
- Merge v3 cert test that was split in the previous fix attempt
- Update beforeAll to static as that is required in PER_METHOD
  lifecycle