### PR TITLE
Fix random failures of StatusSpecTest

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/StatusSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/StatusSpecTest.java
@@ -42,7 +42,7 @@ class StatusSpecTest {
         assertThat(status.getVersion()).isNotBlank();
         assertThat(status.getRulesVersion()).isNotBlank();
         assertThat(status.getStandalone()).isNotNull();
-        assertThat(status.getRulesSource()).isEqualTo("default");
+        assertThat(status.getRulesSource()).containsAnyOf("default", "database");
         assertThat(status.getManagerCapabilities()).isNotEmpty();
         assertThat(status.getTimeUTC()).isNotNull();
     }


### PR DESCRIPTION
- Spec expected "default" rules source but other tests occasionally run
  before this and update it to "database"