### PR TITLE
Enable gzip compression support for el8

### DIFF
--- a/bin/deployment/update-server-xml.py
+++ b/bin/deployment/update-server-xml.py
@@ -217,6 +217,9 @@ class LegacySSLContextEditor(AbstractBaseEditor):
             ("keystoreFile", "conf/keystore"),
             ("keystorePass", "password"),
             ("keystoreType", "PKCS12"),
+            ("compression", "on"),
+            ("compressionMinSize", "11"),
+            ("compressableMimeType", "application/json,text/html,text/xml"),
         ])
 
         # Return our top-level node
@@ -251,7 +254,9 @@ class CandlepinConnectorEditorV3(AbstractBaseEditor):
             ('scheme', 'https'),
             ('secure', 'true'),
             ('SSLEnabled', 'true'),
-            ('maxThreads', '150')
+            ('maxThreads', '150'),
+            ("compression", "on"),
+            ("compressableMimeType", "application/json,text/html,text/xml")
         ]
 
     def _build_node(self):


### PR DESCRIPTION
This enables gzip compression settings for tomcat, this works well on el8 & has some weirdness on el7 where only some of the data is compressed.  

To test: 
deploy with standard test data:
```
./bin/deployment deploy -gat
````

Test with the list subscriptions endpoint (or really your endpoint of choice). Using curl on el8 to get the compressed & uncompressed output & compare to the uncompressed sizes / contents.

```
curl -verbose -k -u admin:admin "https://localhost:8443/candlepin/owners/snowwhite/subscriptions" --compressed --raw -o compressed.txt
curl -verbose -k -u admin:admin "https://localhost:8443/candlepin/owners/snowwhite/subscriptions" --raw -o uncompressed.txt
```

When using the test data I saw the subscriptions endpoint for snowwhite have the payload reduced from 1.9M to 45k. 


