### PR TITLE
[M] CandlepinQueryInterceptor now processes CPQ instances in a transaction (ENT-5400)

### DIFF
--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -29,7 +29,6 @@
             <property name="hibernate.c3p0.idle_test_period" value="300" />
             <!-- max_statements should always be 0 -->
             <property name="hibernate.c3p0.max_statements" value="0" />
-            <property name="hibernate.connection.release_mode" value="on_close"/>
         </properties>
     </persistence-unit>
 


### PR DESCRIPTION
- The CandlepinQueryInterceptor now processes CandlepinQuery (CPQ) instances in a transaction rather than individually, to work around a potential Hibernate configuration issue which will cause connections to be closed before the CPQ has been fully read
- Removed the default persistence connection release mode of "on_close"