### PR TITLE
[M] Added support for the device_auth capability and status (ENT-3599)

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -9447,11 +9447,22 @@ components:
           uniqueItems: true
           items:
             type: string
+        # Temporary keycloak stuff -- eventually remove these as they've been supplanted by the device_auth
+        # fields
         keycloakRealm:
           type: string
         keycloakAuthUrl:
           type: string
         keycloakResource:
+          type: string
+        # Device auth fields
+        deviceAuthRealm:
+          type: string
+        deviceAuthUrl:
+          type: string
+        deviceAuthClientId:
+          type: string
+        deviceAuthScope:
           type: string
 
     SubscriptionDTO:

--- a/src/main/java/org/candlepin/guice/CandlepinCapabilities.java
+++ b/src/main/java/org/candlepin/guice/CandlepinCapabilities.java
@@ -33,7 +33,15 @@ public class CandlepinCapabilities extends HashSet<String> {
         "multi_environment"
     };
 
+    /**
+     * @deprecated
+     *  Keycloak-specific capability; predates the more generic device_auth capability and should no
+     *  longer be used. Will eventually be removed entirely.
+     */
+    @Deprecated
     public static final String KEYCLOAK_AUTH_CAPABILITY = "keycloak_auth";
+
+    public static final String DEVICE_AUTH_CAPABILITY = "device_auth";
 
     public static final String CLOUD_REGISTRATION_CAPABILITY = "cloud_registration";
 

--- a/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -278,6 +278,7 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
         // Update our capabilities with configurable features
         if (config.getBoolean(ConfigProperties.KEYCLOAK_AUTHENTICATION, false)) {
             capabilities.add(CandlepinCapabilities.KEYCLOAK_AUTH_CAPABILITY);
+            capabilities.add(CandlepinCapabilities.DEVICE_AUTH_CAPABILITY);
         }
 
         if (config.getBoolean(ConfigProperties.CLOUD_AUTHENTICATION, false)) {
@@ -437,7 +438,7 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
 
     /**
      * Initializes the connection to the database and a Liquibase object for detection of the state
-     *  of the database compared to the liquibase changeset list.
+     * of the database compared to the liquibase changeset list.
      *
      * @return Liquibase initialized for the changeset comparison
      * @throws RuntimeException if there is an issue with establishing the Liquibase object

--- a/src/main/java/org/candlepin/resource/StatusResource.java
+++ b/src/main/java/org/candlepin/resource/StatusResource.java
@@ -162,10 +162,15 @@ public class StatusResource implements StatusApi {
 
         if (keycloakEnabled) {
             AdapterConfig adapterConfig = keycloakConfig.getAdapterConfig();
-            status
-                .keycloakResource(adapterConfig.getResource())
+
+            status.keycloakResource(adapterConfig.getResource())
                 .keycloakAuthUrl(adapterConfig.getAuthServerUrl())
                 .keycloakRealm(adapterConfig.getRealm());
+
+            status.deviceAuthRealm(adapterConfig.getRealm())
+                .deviceAuthUrl(adapterConfig.getAuthServerUrl())
+                .deviceAuthClientId(adapterConfig.getResource())
+                .deviceAuthScope(""); // Currently not applicable
         }
 
         statusCache.setStatus(status);

--- a/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -156,6 +156,7 @@ public class CandlepinContextListenerTest {
 
         CandlepinCapabilities expected = new CandlepinCapabilities();
         expected.add(CandlepinCapabilities.KEYCLOAK_AUTH_CAPABILITY);
+        expected.add(CandlepinCapabilities.DEVICE_AUTH_CAPABILITY);
 
         CandlepinCapabilities actual = CandlepinCapabilities.getCapabilities();
 
@@ -173,6 +174,9 @@ public class CandlepinContextListenerTest {
 
         assertFalse(actual.contains(CandlepinCapabilities.KEYCLOAK_AUTH_CAPABILITY),
             "keycloak_auth present but not expected");
+
+        assertFalse(actual.contains(CandlepinCapabilities.DEVICE_AUTH_CAPABILITY),
+            "device_auth present but not expected");
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/StatusResourceTest.java
+++ b/src/test/java/org/candlepin/resource/StatusResourceTest.java
@@ -177,11 +177,19 @@ public class StatusResourceTest {
     public void keycloakParamsPresentWhenKeycloakActive() {
         when(config.getBoolean(eq(ConfigProperties.KEYCLOAK_AUTHENTICATION))).thenReturn(true);
 
+        AdapterConfig config = this.mockKeycloakAdapterConfig;
+
         StatusResource sr = this.createResource();
         StatusDTO statusDTO = sr.status();
-        assertEquals("realm", statusDTO.getKeycloakRealm());
-        assertEquals("https://example.com/auth", statusDTO.getKeycloakAuthUrl());
-        assertEquals("resource", statusDTO.getKeycloakResource());
+        assertEquals(config.getRealm(), statusDTO.getKeycloakRealm());
+        assertEquals(config.getAuthServerUrl(), statusDTO.getKeycloakAuthUrl());
+        assertEquals(config.getResource(), statusDTO.getKeycloakResource());
+
+        // Also verify that keycloak's presence populates the generic device auth fields
+        assertEquals(config.getRealm(), statusDTO.getDeviceAuthRealm());
+        assertEquals(config.getAuthServerUrl(), statusDTO.getDeviceAuthUrl());
+        assertEquals(config.getResource(), statusDTO.getDeviceAuthClientId());
+        assertEquals("", statusDTO.getDeviceAuthScope());
     }
 
     @Test
@@ -194,5 +202,10 @@ public class StatusResourceTest {
         assertNull(statusDTO.getKeycloakRealm(), "keycloak realm is not null");
         assertNull(statusDTO.getKeycloakAuthUrl(), "keycloak auth URL is not null");
         assertNull(statusDTO.getKeycloakResource(), "keycloak resource is not null");
+
+        assertNull(statusDTO.getDeviceAuthRealm());
+        assertNull(statusDTO.getDeviceAuthUrl());
+        assertNull(statusDTO.getDeviceAuthClientId());
+        assertNull(statusDTO.getDeviceAuthScope());
     }
 }


### PR DESCRIPTION
- Added support for the device_auth capability
- Added new fields to the status DTO for indicating OAuth2 device auth details (realm, url, client_id, and scope)
- Updated keycloak flows to also populate the device auth fields and capabilities