### PR TITLE
[M] Refresh Mapping Resolution (ENT-5384)

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -8805,8 +8805,8 @@ components:
     EnvironmentContentDTO:
       description: EnvironmentContent represents the promotion of content into a particular environment.
       properties:
-        content:
-          $ref: "#/components/schemas/ContentDTO"
+        contentId:
+          type: string
         enabled:
           type: boolean
 

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -292,10 +292,6 @@ public class ConfigProperties {
     // How long (in seconds) to wait for job threads to finish during a graceful Tomcat shutdown
     public static final String ASYNC_JOBS_THREAD_SHUTDOWN_TIMEOUT = "candlepin.async.thread.shutdown.timeout";
 
-    // How many days to allow a product to be orphaned before removing it on the next refresh or
-    // manifest import. Default: 30 days
-    public static final String ORPHANED_ENTITY_GRACE_PERIOD = "candlepin.refresh.orphan_entity_grace_period";
-
     /**
      * Fetches a string representing the prefix for all per-job configuration for the specified job.
      * The job key or class name may be used, but the usage must be consistent.
@@ -499,8 +495,6 @@ public class ConfigProperties {
 
             // Set the triggerable jobs list
             this.put(ASYNC_JOBS_TRIGGERABLE_JOBS, String.join(", ", ASYNC_JOBS_TRIGGERABLE_JOBS_LIST));
-
-            this.put(ORPHANED_ENTITY_GRACE_PERIOD, "30");
         }
     };
 }

--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -217,8 +217,7 @@ public class CandlepinPoolManager implements PoolManager {
         Owner resolvedOwner = this.resolveOwner(owner);
         log.info("Refreshing pools for owner: {}", resolvedOwner);
 
-        RefreshWorker refresher = this.refreshWorkerProvider.get()
-            .setOrphanedEntityGracePeriod(this.config.getInt(ConfigProperties.ORPHANED_ENTITY_GRACE_PERIOD));
+        RefreshWorker refresher = this.refreshWorkerProvider.get();
 
         log.debug("Fetching subscriptions from adapter...");
         refresher.addSubscriptions(subAdapter.getSubscriptions(resolvedOwner.getKey()));

--- a/src/main/java/org/candlepin/controller/refresher/RefreshResult.java
+++ b/src/main/java/org/candlepin/controller/refresher/RefreshResult.java
@@ -126,6 +126,11 @@ public class RefreshResult {
             return stream;
         }
 
+        public Stream<T> streamEntities(Collection<EntityState> states) {
+            return this.getEntityStream(states)
+                .map(EntityData::getEntity);
+        }
+
         public Map<String, T> getEntities(Collection<EntityState> states) {
             return this.getEntityStream(states)
                 .collect(Collectors.toMap(EntityData::getEntityId, EntityData::getEntity));
@@ -323,6 +328,48 @@ public class RefreshResult {
 
         EntityStore<T> entityStore = this.getEntityStore(cls, false);
         return entityStore != null ? entityStore.getEntities(states) : new HashMap<>();
+    }
+
+    /**
+     * Fetches a stream of entities matching the given class and optional collection of entity
+     * states.
+     *
+     * @param cls
+     *  the class of entities to fetch
+     *
+     * @param states
+     *  an optional collection of entity states to use to filter the output. If provided, only
+     *  entities in the states provided will be fetched.
+     *
+     * @return
+     *  a stream of entities matching the given class and entity states, or an empty stream if no
+     *  matching entities were part of this refresh
+     */
+    public <T extends AbstractHibernateObject> Stream<T> streamEntities(Class<T> cls,
+        Collection<EntityState> states) {
+
+        EntityStore<T> entityStore = this.getEntityStore(cls, false);
+        return entityStore != null ? entityStore.streamEntities(states) : Stream.empty();
+    }
+
+    /**
+     * Fetches a stream of entities matching the given class and optional array of entity states.
+     *
+     * @param cls
+     *  the class of entities to fetch
+     *
+     * @param states
+     *  an optional array of entity states to use to filter the output. If provided, only entities
+     *  in the states provided will be fetched
+     *
+     * @return
+     *  a stream of entities matching the given class and entity states, or an empty stream if no
+     *  matching entities were part of this refresh
+     */
+    public <T extends AbstractHibernateObject> Stream<T> streamEntities(Class<T> cls,
+        EntityState... states) {
+
+        return this.streamEntities(cls, states != null && states.length > 0 ? Arrays.asList(states) : null);
     }
 
     /**

--- a/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
@@ -223,12 +223,55 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
     int addImportedEntities(Collection<I> entities);
 
     /**
+     * Checks if any existing entity mapped by this mapper is "dirty," indicating it has been given
+     * two or more different versions of the same entity, or it contains a reference to an entity
+     * which is not mapped to the owning organization.
+     *
+     * @return
+     *  true if any mapped existing entities have dirty references
+     */
+    boolean isDirty();
+
+    /**
+     * Checks if the existing entity mapped to the given ID is "dirty," indicating it has been
+     * mapped to two or more different versions of the entity, or is mapped to an entity which
+     * is not mapped to the owning organization.
+     *
+     * @param id
+     *  the ID of the entity to check
+     *
+     * @throws IllegalArgumentException
+     *  if the provided ID is null or invalid
+     *
+     * @return
+     *  true if the existing entity mapped to the given ID is dirty; false otherwise
+     */
+    boolean isDirty(String id);
+
+    /**
+     * Validates that this mapper only contains existing entity mappings for the entities with the
+     * given IDs. Any mapped existing entities with IDs not present in the provided collection will
+     * be flagged as "dirty," indicating that the mapping is to an entity that exists outside of the
+     * owning organization.
+     * This method returns true if any mapping is flagged as dirty upon completion of this check,
+     * even if the dirty flag was already set prior to the call to this method.
+     *
+     * @param ids
+     *  a collection containing the superset of entity IDs known to the owning organization
+     *
+     * @return
+     *  true if any existing entity mapping is dirty after a call to this method; false otherwise
+     */
+    boolean validateExistingEntities(Collection<String> ids);
+
+    /**
      * Clears this entity mapper, removing all known existing and imported entities
      */
     void clear();
 
     /**
-     * Clears any existing entities from this mapper
+     * Clears any existing entities from this mapper, and clears any dirty flags set for existing
+     * entities.
      */
     void clearExistingEntities();
 

--- a/src/main/java/org/candlepin/controller/util/PromotedContent.java
+++ b/src/main/java/org/candlepin/controller/util/PromotedContent.java
@@ -67,9 +67,9 @@ public class PromotedContent {
 
         log.debug("Checking for promoted content in environment: {}", environment.getName());
         for (EnvironmentContent envContent : environment.getEnvironmentContent()) {
-            log.debug("  promoted content: {}", envContent.getContent());
+            log.debug("  promoted content: {}", envContent);
 
-            this.contents.putIfAbsent(envContent.getContent().getId(), envContent);
+            this.contents.putIfAbsent(envContent.getContentId(), envContent);
         }
 
         return this;

--- a/src/main/java/org/candlepin/dto/api/v1/ActivationKeyTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ActivationKeyTranslator.java
@@ -24,7 +24,6 @@ import org.candlepin.dto.api.server.v1.NestedOwnerDTO;
 import org.candlepin.dto.api.server.v1.ReleaseVerDTO;
 import org.candlepin.model.ContentOverride;
 import org.candlepin.model.Owner;
-import org.candlepin.model.Product;
 import org.candlepin.model.Release;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyPool;
@@ -33,6 +32,7 @@ import org.candlepin.util.Util;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 
 
 /**
@@ -90,22 +90,13 @@ public class ActivationKeyTranslator implements ObjectTranslator<ActivationKey, 
             .role(source.getRole());
 
         // Set activation key product IDs
-        Set<Product> products = source.getProducts();
-        if (products != null) {
-            Set<String> productIds = new HashSet<>();
+        Set<String> productIds = source.getProductIds();
+        if (productIds != null) {
+            Set<ActivationKeyProductDTO> akpdtos = productIds.stream()
+                .map(pid -> new ActivationKeyProductDTO().productId(pid))
+                .collect(Collectors.toSet());
 
-            for (Product prod : products) {
-                if (prod != null && prod.getId() != null && !prod.getId().isEmpty()) {
-                    productIds.add(prod.getId());
-                }
-            }
-            Set<ActivationKeyProductDTO> productIdObjects = productIds.stream().map(productId ->  {
-                ActivationKeyProductDTO newProduct = new ActivationKeyProductDTO();
-                newProduct.setProductId(productId);
-                return newProduct;
-            }).collect(Collectors.toSet());
-
-            dest.setProducts(productIdObjects);
+            dest.setProducts(akpdtos);
         }
         else {
             dest.setProducts(null);

--- a/src/main/java/org/candlepin/dto/api/v1/EnvironmentTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/EnvironmentTranslator.java
@@ -16,18 +16,18 @@ package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.ObjectTranslator;
-import org.candlepin.dto.api.server.v1.ContentDTO;
 import org.candlepin.dto.api.server.v1.EnvironmentContentDTO;
 import org.candlepin.dto.api.server.v1.EnvironmentDTO;
 import org.candlepin.dto.api.server.v1.NestedOwnerDTO;
-import org.candlepin.model.Content;
 import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.Owner;
 import org.candlepin.util.Util;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+
 
 /**
  * The EnvironmentTranslator provides translation from Environment model objects to EnvironmentDTOs
@@ -85,24 +85,18 @@ public class EnvironmentTranslator implements ObjectTranslator<Environment, Envi
 
             Set<EnvironmentContent> envContents = source.getEnvironmentContent();
             if (envContents != null) {
-                Set<EnvironmentContentDTO> setOfEnvironmentContents = new HashSet<>();
+                Set<EnvironmentContentDTO> ecdtos = envContents.stream()
+                    .map(ec -> {
+                        return new EnvironmentContentDTO()
+                            .contentId(ec.getContentId())
+                            .enabled(ec.getEnabled());
+                    })
+                    .collect(Collectors.toSet());
 
-                ObjectTranslator<Content, ContentDTO> contentTranslator = translator
-                    .findTranslatorByClass(Content.class, ContentDTO.class);
-
-                for (EnvironmentContent ec : envContents) {
-                    if (ec != null) {
-                        ContentDTO dto = contentTranslator.translate(translator, ec.getContent());
-
-                        if (dto != null) {
-                            setOfEnvironmentContents.add(new EnvironmentContentDTO()
-                                .content(dto)
-                                .enabled(ec.getEnabled()));
-                        }
-                    }
-                }
-
-                dest.setEnvironmentContent(setOfEnvironmentContents);
+                dest.setEnvironmentContent(ecdtos);
+            }
+            else {
+                dest.setEnvironmentContent(null);
             }
         }
         else {

--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -191,8 +191,12 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @NotNull
     private String typeId;
 
-    @Column(name = "owner_id")
+    @Column(name = "owner_id", nullable = false)
     private String ownerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", insertable = false, updatable = false)
+    private Owner owner;
 
     @Column(name = "entitlement_count")
     @NotNull
@@ -264,10 +268,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @Basic(fetch = FetchType.LAZY)
     @Column(name = "annotations", length = 4194304)
     private String annotations;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_id", insertable = false, updatable = false)
-    private Owner owner;
 
     @Column(name = "rh_cloud_profile_modified")
     private Date rhCloudProfileModified;
@@ -471,12 +471,10 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
      *  The owner of this consumer, if the owner ID is populated; null otherwise.
      */
     @Override
-    @JsonIgnore
     public Owner getOwner() {
         return this.owner;
     }
 
-    @JsonIgnore
     public Consumer setOwner(Owner owner) {
         if (owner == null || owner.getId() == null) {
             throw new IllegalArgumentException("owner is null or lacks an ID");

--- a/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import javax.inject.Singleton;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
@@ -1309,61 +1310,89 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         return predicates.toArray(array);
     }
 
+
+
+
     /**
-     * Returns the map of entitlement ID & its content UUIDs for consumers.
-     * Note - Both of the queries below, covers the case when
-     * 1) Content is present in provided products (eng products).
-     * 2) Content is present in main products.
+     * Returns a mapping of entitlement ID to consumer IDs for the given collection of consumer IDs.
+     * If none of the consumers have entitlements, this method returns an empty map.
      *
      * @param consumerIds
-     *  list of consumers for which entitlement IDs & content UUIDs to be returned
+     *  a collection of consumer IDs for which to fetch an entitlement-consumer mapping
      *
      * @return
-     *  Map of entitlement IDs & its associated content UUIDs
+     *  the entitlement-consumer map for the given consumers
      */
-    public Map<String, Set<String>> getEntitlementContentUUIDs(Collection<String> consumerIds) {
-        Map<String, Set<String>> contentMap = new HashMap<>();
-        int blockSize = Math.min(this.getInBlockSize(), this.getQueryParameterLimit() - 1);
+    public Map<String, String> getEntitlementConsumerIdMap(Iterable<String> consumerIds) {
+        Map<String, String> entConsumerIdMap = new HashMap<>();
 
-        String getContentFromProduct = "SELECT ce.id, c2pc.content_uuid FROM cp2_product_content c2pc " +
-            "JOIN cp_pool cp on c2pc.product_uuid = cp.product_uuid " +
-            "JOIN cp_entitlement ce on cp.id = ce.pool_id " +
-            "JOIN cp_consumer cc on ce.consumer_id = cc.id " +
-            "WHERE cc.id IN (:consumerIds) ";
+        if (consumerIds != null) {
+            String jpql = "SELECT ent.id, consumer.id FROM Entitlement ent JOIN ent.consumer consumer " +
+                "WHERE consumer.id IN (:consumer_ids)";
 
-        String getContentFromProvidedProducts =
-            "SELECT ce.id, c2pc.content_uuid from cp_consumer cc " +
-            "JOIN cp_entitlement ce on cc.id = ce.consumer_id " +
-            "JOIN cp_pool cp on ce.pool_id = cp.id " +
-            "JOIN cp2_product_provided_products c2ppp on cp.product_uuid = c2ppp.product_uuid " +
-            "JOIN cp2_product_content c2pc on c2ppp.provided_product_uuid = c2pc.product_uuid " +
-            "WHERE cc.id IN (:consumerIds) ";
+            Query query = this.getEntityManager()
+                .createQuery(jpql);
 
-        for (List<String> block : Iterables.partition(consumerIds, blockSize)) {
-            List<Object[]> contentFromProduct = this.getEntityManager()
-                .createNativeQuery(getContentFromProduct)
-                .setParameter("consumerIds", block)
-                .getResultList();
-            getMapOfEntIDAndContentUUID(contentFromProduct, contentMap);
+            for (List<String> block : this.partition(consumerIds)) {
+                List<Object[]> rows = query.setParameter("consumer_ids", block)
+                    .getResultList();
+
+                rows.forEach(row -> entConsumerIdMap.put((String) row[0], (String) row[1]));
+            }
         }
 
-        for (List<String> block : Iterables.partition(consumerIds, blockSize)) {
-            List<Object[]> contentFromProvidedProducts = this.getEntityManager()
-                .createNativeQuery(getContentFromProvidedProducts)
-                .setParameter("consumerIds", block)
-                .getResultList();
-            getMapOfEntIDAndContentUUID(contentFromProvidedProducts, contentMap);
-        }
-
-        return contentMap;
+        return entConsumerIdMap;
     }
 
-    private void getMapOfEntIDAndContentUUID(List<Object[]> rawData, Map<String, Set<String>> map) {
-        for (Object[] obj : rawData) {
-            String entitlementId = obj[0].toString();
-            Set<String> listOfContentUUIDs = map.getOrDefault(entitlementId, new HashSet<>());
-            listOfContentUUIDs.add(obj[1].toString());
-            map.put(entitlementId, listOfContentUUIDs);
+
+    /**
+     * Returns a mapping of entitlement ID to content IDs attached to the base product and provided
+     * products for the pool of the entitlement. Entitlements which do not have any content will not
+     * have an entry in the map. If none of the specified entitlements exist, or none of the
+     * entitlements contain any content, this method returns an empty map.
+     *
+     * @param entitlementIds
+     *  a collection of entitlements for which to fetch an entitlement-content mapping
+     *
+     * @return
+     *  the entitlement-content map for the given entitlements
+     */
+    public Map<String, Set<String>> getEntitlementContentIdMap(Iterable<String> entitlementIds) {
+        Map<String, Set<String>> entContentIdMap = new HashMap<>();
+
+        if (entitlementIds != null) {
+            String sql = "SELECT ent.id, content.content_id FROM cp_entitlement ent " +
+                "    JOIN cp_pool pool ON pool.id = ent.pool_id " +
+                "    JOIN cp2_product_content pc ON pc.product_uuid = pool.product_uuid " +
+                "    JOIN cp2_content content ON content.uuid = pc.content_uuid " +
+                "    WHERE ent.id IN (:ent_ids_1) " +
+                "UNION " +
+                "SELECT ent.id, content.content_id FROM cp_entitlement ent " +
+                "    JOIN cp_pool pool ON pool.id = ent.pool_id " +
+                "    JOIN cp2_product_provided_products ppp ON ppp.product_uuid = pool.product_uuid " +
+                "    JOIN cp2_product_content pc ON pc.product_uuid = ppp.provided_product_uuid " +
+                "    JOIN cp2_content content ON content.uuid = pc.content_uuid " +
+                "    WHERE ent.id IN (:ent_ids_2) ";
+
+            // Since we're using a union and slaping down the ID block twice, we have to halve our
+            // block size to not risk running over the parameter limit
+            int blockSize = this.getInBlockSize() / 2;
+
+            Query query = this.getEntityManager()
+                .createNativeQuery(sql);
+
+            for (List<String> block : this.partition(entitlementIds, blockSize)) {
+                List<Object[]> rows = query.setParameter("ent_ids_1", block)
+                    .setParameter("ent_ids_2", block)
+                    .getResultList();
+
+                for (Object[] row : rows) {
+                    entContentIdMap.computeIfAbsent((String) row[0], (key) -> new HashSet<>())
+                        .add((String) row[1]);
+                }
+            }
         }
+
+        return entContentIdMap;
     }
 }

--- a/src/main/java/org/candlepin/model/Environment.java
+++ b/src/main/java/org/candlepin/model/Environment.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import org.candlepin.util.SetView;
+
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
@@ -98,8 +100,9 @@ public class Environment extends AbstractHibernateObject implements Serializable
         return id;
     }
 
-    public void setId(String id) {
+    public Environment setId(String id) {
         this.id = id;
+        return this;
     }
 
     public Owner getOwner() {
@@ -114,32 +117,67 @@ public class Environment extends AbstractHibernateObject implements Serializable
         return (owner == null) ? null : owner.getId();
     }
 
-    public void setOwner(Owner owner) {
+    public Environment setOwner(Owner owner) {
         this.owner = owner;
+        return this;
     }
 
     public Set<EnvironmentContent> getEnvironmentContent() {
-        return environmentContent;
+        return new SetView<>(this.environmentContent);
     }
 
-    public void setEnvironmentContent(Set<EnvironmentContent> environmentContent) {
-        this.environmentContent = environmentContent;
+    public Environment setEnvironmentContent(Set<EnvironmentContent> environmentContent) {
+        this.environmentContent = new HashSet<>();
+
+        if (environmentContent != null) {
+            environmentContent.forEach(this::addEnvironmentContent);
+        }
+
+        return this;
+    }
+
+    public Environment addEnvironmentContent(EnvironmentContent envcontent) {
+        if (envcontent == null) {
+            throw new IllegalArgumentException("envcontent is null");
+        }
+
+        // Ensure it's set to this environment. Really this should be immutable and created internally.
+        envcontent.setEnvironment(this);
+
+        this.environmentContent.add(envcontent);
+        return this;
+    }
+
+    public Environment addContent(Content content, boolean enabled) {
+        if (content == null) {
+            throw new IllegalArgumentException("content is null");
+        }
+
+        EnvironmentContent envcontent = new EnvironmentContent()
+            .setEnvironment(this)
+            .setContent(content)
+            .setEnabled(enabled);
+
+        this.environmentContent.add(envcontent);
+        return this;
     }
 
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
+    public Environment setName(String name) {
         this.name = name;
+        return this;
     }
 
     public String getDescription() {
         return description;
     }
 
-    public void setDescription(String description) {
+    public Environment setDescription(String description) {
         this.description = description;
+        return this;
     }
 
     @Override

--- a/src/main/java/org/candlepin/model/EnvironmentContent.java
+++ b/src/main/java/org/candlepin/model/EnvironmentContent.java
@@ -20,13 +20,16 @@ import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
-import javax.xml.bind.annotation.XmlTransient;
+
+// TODO: This should be made to be immutable.
+
 
 /**
  * EnvironmentContent represents the promotion of content into a particular environment.
@@ -39,7 +42,7 @@ import javax.xml.bind.annotation.XmlTransient;
 public class EnvironmentContent extends AbstractHibernateObject {
 
     /** Name of the table backing this object in the database */
-    public static final String DB_TABLE = "cp2_environment_content";
+    public static final String DB_TABLE = "cp_environment_content";
 
     @Id
     @GeneratedValue(generator = "system-uuid")
@@ -48,15 +51,18 @@ public class EnvironmentContent extends AbstractHibernateObject {
     @NotNull
     private String id;
 
-    @ManyToOne
-    @JoinColumn(name = "environment_id", nullable = false)
-    @NotNull
+    @Column(name = "environment_id", nullable = false)
+    private String environmentId;
+
+    // Convenience value for performing lazy environment lookups off this object, but will not be
+    // pulled until fetched via getEnvironment; should be avoided to reduce the frequency of N+1
+    // perf issues
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "environment_id", updatable = false, insertable = false)
     private Environment environment;
 
-    @ManyToOne
-    @JoinColumn(name = "content_uuid", nullable = false)
-    @NotNull
-    private Content content;
+    @Column(name = "content_id", nullable = false)
+    private String contentId;
 
     private Boolean enabled;
 
@@ -64,72 +70,119 @@ public class EnvironmentContent extends AbstractHibernateObject {
         // Intentionally left empty
     }
 
-    public EnvironmentContent(Environment env, Content content, Boolean enabled) {
-        this.setEnvironment(env);
-        this.setContent(content);
-        this.setEnabled(enabled);
-        env.getEnvironmentContent().add(this);
-    }
-
     public String getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public EnvironmentContent setId(String id) {
         this.id = id;
+        return this;
     }
 
-    public void setContent(Content content) {
-        this.content = content;
+    public String getEnvironmentId() {
+        return this.environmentId;
     }
 
-    public Content getContent() {
-        return content;
-    }
-
-    public void setEnvironment(Environment env) {
-        this.environment = env;
-    }
-
-    @XmlTransient
+    /**
+     * Fetches the environment this EnvironmentContent instance belongs to, if the environment ID
+     * has been set. This may perform a lazy lookup of the environment, and should generally be
+     * avoided in cases where the environment ID is sufficient.
+     *
+     * @return
+     *  the environment for this environment content, or null if the environment has not yet been
+     *  set
+     */
     public Environment getEnvironment() {
         return environment;
     }
 
-    public void setEnabled(Boolean enabled) {
-        this.enabled = enabled;
+    /**
+     * Sets the environment for this environment content. The environment cannot be null and must
+     * have a valid ID.
+     *
+     * @param environment
+     *  the environment with which to associate this environment content
+     *
+     * @return
+     *  a reference to this environment content instance
+     */
+    public EnvironmentContent setEnvironment(Environment environment) {
+        if (environment == null || environment.getId() == null) {
+            throw new IllegalArgumentException("environment is null or lacks an ID");
+        }
+
+        this.environment = environment;
+        this.environmentId = environment.getId();
+
+        return this;
     }
 
+    public String getContentId() {
+        return this.contentId;
+    }
+
+    public EnvironmentContent setContentId(String contentId) {
+        this.contentId = contentId;
+        return this;
+    }
+
+    public EnvironmentContent setContent(Content content) {
+        if (content == null || content.getId() == null) {
+            throw new IllegalArgumentException("content is null or lacks an ID");
+        }
+
+        this.contentId = content.getId();
+        return this;
+    }
+
+    /**
+     * Returns a boolean value indicating the content's enablement if the default enablement has
+     * been overridden in this environment. If the content's enablement should use the default set
+     * on the product, this method returns null.
+     *
+     * @return
+     *  a boolean value indicating the content's enablement if overridden in the environment; null
+     *  if it should use the content's default enablement from the product
+     */
     public Boolean getEnabled() {
-        return enabled;
+        return this.enabled;
+    }
+
+    public EnvironmentContent setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+        return this;
     }
 
     @Override
     public int hashCode() {
-        HashCodeBuilder hcBuilder = new HashCodeBuilder(3, 23)
-            .append(this.content.hashCode());
-        return hcBuilder.toHashCode();
+        return new HashCodeBuilder(3, 23)
+            .append(this.id)
+            .toHashCode();
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (this == other) {
+    public boolean equals(Object obj) {
+        if (this == obj) {
             return true;
         }
-        if (other instanceof EnvironmentContent) {
-            EnvironmentContent that = (EnvironmentContent) other;
-            return new EqualsBuilder().append(this.enabled, that.enabled)
-                .isEquals() && this.content.equals(that.content);
+
+        if (!(obj instanceof EnvironmentContent)) {
+            return false;
         }
-        return false;
+
+        EnvironmentContent that = (EnvironmentContent) obj;
+
+        return new EqualsBuilder()
+            .append(this.getEnvironmentId(), that.getEnvironmentId())
+            .append(this.getContentId(), that.getContentId())
+            .append(this.getEnabled(), that.getEnabled())
+            .isEquals();
     }
 
     @Override
     public String toString() {
-        return "EnvironmentContent [id=" + id + ", environment=" +
-                 (environment != null ?  environment.getId() : "") +
-                 ", content=" +
-                 (content != null ? content.getId() : "" + "]");
+        return String.format("EnvironmentContent [environment: %s, content: %s, enabled: %s]",
+            this.getEnvironmentId(), this.getContentId(), this.getEnabled());
     }
 
 }

--- a/src/main/java/org/candlepin/model/EnvironmentCurator.java
+++ b/src/main/java/org/candlepin/model/EnvironmentCurator.java
@@ -23,11 +23,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Singleton;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
+
 
 
 @Singleton
@@ -121,15 +121,6 @@ public class EnvironmentCurator extends AbstractHibernateCurator<Environment> {
             .add(Restrictions.eq("name", envName));
 
         return this.cpQueryFactory.buildQuery(this.currentSession(), criteria);
-    }
-
-    @SuppressWarnings("unchecked")
-    public List<Environment> listWithContent(Set<String> contentIds) {
-        return currentSession().createCriteria(Environment.class)
-            .createCriteria("environmentContent")
-            .createCriteria("content")
-            .add(Restrictions.in("id", contentIds))
-            .list();
     }
 
     /**

--- a/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -428,18 +428,6 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
             return;
         }
 
-        this.updateOwnerContentJoinTable(owner, contentUuidMap);
-        this.updateOwnerContentEnvironments(owner, contentUuidMap);
-    }
-
-    /**
-     * Part of the updateOwnerContentReferences operation; updates the owner to content join table.
-     * See updateOwnerContentReferences for additional details.
-     *
-     * @param owner
-     * @param contentUuidMap
-     */
-    private void updateOwnerContentJoinTable(Owner owner, Map<String, String> contentUuidMap) {
         String sql = "UPDATE " + OwnerContent.DB_TABLE + " SET content_uuid = :updated " +
             "WHERE content_uuid = :current AND owner_id = :owner_id";
 
@@ -456,64 +444,6 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
 
         log.debug("{} owner-content relations updated", count);
     }
-
-    /**
-     * Part of the updateOwnerContentReferences operation; updates the owner to content join table.
-     * See updateOwnerContentReferences for additional details.
-     *
-     * @param owner
-     * @param contentUuidMap
-     */
-    private void updateOwnerContentEnvironments(Owner owner, Map<String, String> contentUuidMap) {
-        EntityManager entityManager = this.getEntityManager();
-
-        String jpql = "SELECT env.id, content.uuid FROM EnvironmentContent ec " +
-            "JOIN ec.content content " +
-            "JOIN ec.environment env " +
-            "WHERE env.owner.id = :owner_id " +
-            "  AND content.uuid IN (:content_uuids)";
-
-        Query query = entityManager.createQuery(jpql)
-            .setParameter("owner_id", owner.getId());
-
-        Map<String, Set<String>> envMap = new HashMap<>();
-        for (List<String> block : this.partition(contentUuidMap.keySet())) {
-            List<Object> rows = query.setParameter("content_uuids", block)
-                .getResultList();
-
-            for (Object row : rows) {
-                String envid = (String) ((Object[]) row)[0];
-                String uuid = (String) ((Object[]) row)[1];
-
-                envMap.computeIfAbsent(uuid, key -> new HashSet<>())
-                    .add(envid);
-            }
-        }
-
-        int count = 0;
-        if (!envMap.isEmpty()) {
-            String sql = "UPDATE cp2_environment_content SET content_uuid = :updated " +
-                "WHERE environment_id = :env_id AND content_uuid = :current";
-
-            query = entityManager.createNativeQuery(sql);
-
-            for (Map.Entry<String, Set<String>> entry : envMap.entrySet()) {
-                String cUuid = entry.getKey();
-                String uUuid = contentUuidMap.get(cUuid);
-
-                query.setParameter("current", cUuid)
-                    .setParameter("updated", uUuid);
-
-                for (String envid : entry.getValue()) {
-                    count += query.setParameter("env_id", envid)
-                        .executeUpdate();
-                }
-            }
-        }
-
-        log.debug("{} environment-content relations updated", count);
-    }
-
 
     /**
      * Removes the content references currently pointing to the specified content for the given
@@ -553,30 +483,6 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
                     .executeUpdate();
 
                 log.info("{} owner-content relations removed", count);
-
-                // environment content
-                jpql = "SELECT e.id FROM Environment e WHERE e.owner.id = :owner_id";
-
-                List<String> envIds = entityManager.createQuery(jpql, String.class)
-                    .setParameter("owner_id", owner.getId())
-                    .getResultList();
-
-                count = 0;
-                if (envIds != null && !envIds.isEmpty()) {
-                    jpql = "DELETE FROM EnvironmentContent ec " +
-                        "WHERE ec.environment.id IN (:environment_ids) " +
-                        "AND ec.content.uuid IN (:content_uuids)";
-
-                    Query query = entityManager.createQuery(jpql)
-                        .setParameter("content_uuids", block);
-
-                    for (List<String> envBlock : this.partition(envIds)) {
-                        count += query.setParameter("environment_ids", envBlock)
-                            .executeUpdate();
-                    }
-                }
-
-                log.info("{} environment-content relations removed", count);
             }
         }
     }

--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -264,6 +264,7 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
     @ManyToOne
     @JoinColumn(name = "derived_product_uuid", nullable = true)
+    @Immutable // is this necessary?
     private Product derivedProduct;
 
     public Product() {

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -40,7 +40,6 @@ import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.server.v1.ActivationKeyDTO;
 import org.candlepin.dto.api.server.v1.ActivationKeyPoolDTO;
-import org.candlepin.dto.api.server.v1.ActivationKeyProductDTO;
 import org.candlepin.dto.api.server.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.server.v1.ConsumerDTOArrayElement;
 import org.candlepin.dto.api.server.v1.ContentAccessDTO;
@@ -649,21 +648,13 @@ public class OwnerResource implements OwnerApi {
         }
 
         if (dto.getProducts() != null) {
-            if (dto.getProducts().isEmpty()) {
-                entity.setProducts(new HashSet<>());
-            }
-            else {
-                Set<String> productIds = dto.getProducts().stream()
-                    .map(ActivationKeyProductDTO::getProductId)
-                    .collect(Collectors.toSet());
+            Set<String> pids = new HashSet<>();
 
-                for (String productId : productIds) {
-                    if (productId != null) {
-                        Product product = findProduct(entity.getOwner(), productId);
-                        entity.addProduct(product);
-                    }
-                }
-            }
+            dto.getProducts().stream()
+                .map(keyprod -> this.findProduct(entity.getOwner(), keyprod.getProductId()).getId())
+                .forEach(pids::add);
+
+            entity.setProductIds(pids);
         }
     }
 

--- a/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -28,7 +28,6 @@ import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
-import org.candlepin.model.Product;
 import org.candlepin.model.Release;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyContentOverride;
@@ -175,15 +174,18 @@ public class ConsumerBindUtil {
             Set<String> productIds = new HashSet<>();
             List<String> poolIds = new ArrayList<>();
 
-            for (Product akp : key.getProducts()) {
-                productIds.add(akp.getId());
+            if (key.getProductIds() != null) {
+                productIds.addAll(key.getProductIds());
             }
+
             for (ConsumerInstalledProduct cip : consumer.getInstalledProducts()) {
                 productIds.add(cip.getProductId());
             }
+
             for (ActivationKeyPool p : key.getPools()) {
                 poolIds.add(p.getPool().getId());
             }
+
             Owner owner = ownerCurator.findOwnerById(consumer.getOwnerId());
             AutobindData autobindData = AutobindData.create(consumer, owner)
                 .forProducts(productIds.toArray(new String[0]))

--- a/src/main/java/org/candlepin/resource/util/EntitlementEnvironmentFilter.java
+++ b/src/main/java/org/candlepin/resource/util/EntitlementEnvironmentFilter.java
@@ -18,17 +18,14 @@ import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.EnvironmentContentCurator;
 import org.candlepin.util.Util;
 
-import org.apache.commons.collections.CollectionUtils;
-
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
+
+
 
 /**
  * The EntitlementEnvironmentFilter class filters the consumer's entitlement
@@ -37,6 +34,7 @@ import java.util.stream.Collectors;
  * This filtering avoids re-generating all the consumer entitlement certificates.
  */
 public class EntitlementEnvironmentFilter {
+
     private final EntitlementCurator entitlementCurator;
     private final EnvironmentContentCurator environmentContentCurator;
 
@@ -48,78 +46,56 @@ public class EntitlementEnvironmentFilter {
     }
 
     /**
-     * Filters the entitlements whose certificates are needed to be re-generated due to environments
-     * being added, removed or re-prioritized for a consumer.
-     * Idea is to avoid regenerating all the consumer's entitlements certs & filter the
-     * necessary entitlements whose certificates are actually needed to be re-generated.
+     * Fetches a set of entitlement IDs whose certificates should be regenerated as a result of
+     * the given environment updates. If no entitlements need regeneration, this method returns
+     * an empty set.
      *
      * @param updates
-     *  A collection of consumers, their original environments and their updated environments
+     *  an EnvironmentUpdates instance containing the environment changes to process
+     *
+     * @throws IllegalArgumentException
+     *  if updates is null
+     *
      * @return
-     *  List of entitlement IDs selected for certificate regeneration
+     *  a set of entitlement IDs whose certificates need regeneration as a result of the given
+     *  environment updates
      */
     public Set<String> filterEntitlements(EnvironmentUpdates updates) {
+        if (updates == null) {
+            throw new IllegalArgumentException("updates is null");
+        }
+
         Set<String> entitlementsToRegen = new HashSet<>();
-        Set<String> consumerIds = updates.consumers();
-        Set<String> allEnvIds = updates.environments();
 
-        Map<String, List<String>> mapOfEnvironmentContentUUID = this.environmentContentCurator
-            .getEnvironmentContentUUIDs(allEnvIds);
-        Map<String, Set<String>> mapOfEntitlementContentUUID = this.entitlementCurator
-            .getEntitlementContentUUIDs(consumerIds);
+        Map<String, Set<String>> environmentContentIdMap = this.environmentContentCurator
+            .getEnvironmentContentIdMap(updates.environments());
 
-        for (String consumerId : consumerIds) {
-            List<String> updatedEnvs = updates.currentEnvsOf(consumerId);
-            List<String> preExistingEnvs = updates.updatedEnvsOf(consumerId);
-            List<String> envRemoved = new ArrayList<>(differenceOf(updatedEnvs, preExistingEnvs));
-            Set<String> envChangeList = getEnvironmentChangeList(envRemoved, preExistingEnvs, updatedEnvs);
+        Map<String, String> entConsumerIdMap = this.entitlementCurator
+            .getEntitlementConsumerIdMap(updates.consumers());
 
-            for (String entitlementId : mapOfEntitlementContentUUID.keySet()) {
-                boolean entToRegen = false;
-                Set<String> entitlementContentUUIDs = mapOfEntitlementContentUUID.get(entitlementId);
+        Map<String, Set<String>> entitlementContentIdMap = this.entitlementCurator
+            .getEntitlementContentIdMap(entConsumerIdMap.keySet());
 
-                for (String environmentId : envChangeList) {
-                    List<String> environmentContentUUIDs = mapOfEnvironmentContentUUID.get(environmentId);
+        for (Map.Entry<String, Set<String>> entry : entitlementContentIdMap.entrySet()) {
+            String entitlementId = entry.getKey();
+            Set<String> entContentIds = entry.getValue();
 
-                    if (environmentContentUUIDs == null) {
-                        // No content present for this env
-                        continue;
-                    }
+            String consumerId = entConsumerIdMap.get(entitlementId);
+            List<String> currentEnvList = updates.currentEnvsOf(consumerId);
+            List<String> updatedEnvList = updates.updatedEnvsOf(consumerId);
 
-                    List<String> currentHigher = new ArrayList<>(
-                        findCurrentHigher(updatedEnvs, environmentId));
-                    Set<String> currentHigherContentUUIDs = contentOf(
-                        mapOfEnvironmentContentUUID, currentHigher);
+            // Entitlement needs to be regenerated if any of the following occur:
+            // - the first environment that has promoted the content has changed
+            // - all environments that have promoted the content are removed
+            // - the content was not promoted previously
 
-                    if (isCertRegenerationRequired(environmentContentUUIDs,
-                        entitlementContentUUIDs, currentHigherContentUUIDs)) {
-                        entToRegen = true;
-                        break;
-                    }
-                }
+            for (String contentId : entContentIds) {
+                String cEnv = this.getContentEnvironment(contentId, currentEnvList, environmentContentIdMap);
+                String uEnv = this.getContentEnvironment(contentId, updatedEnvList, environmentContentIdMap);
 
-                // Case where env of higher priority is being removed
-                if (!envRemoved.isEmpty() && !entToRegen) {
-                    for (String environmentId : envRemoved) {
-                        List<String> currentLower = findCurrentLower(
-                            envRemoved, preExistingEnvs, environmentId);
-                        List<String> contentProvided = mapOfEnvironmentContentUUID
-                            .getOrDefault(environmentId, Collections.emptyList());
-
-                        Set<String> contentOfLowerEnvs = contentOf(mapOfEnvironmentContentUUID, currentLower);
-
-                        entToRegen = contentProvided.stream()
-                            .filter(entitlementContentUUIDs::contains)
-                            .anyMatch(contentOfLowerEnvs::contains);
-
-                        if (entToRegen) {
-                            break;
-                        }
-                    }
-                }
-
-                if (entToRegen) {
+                if (uEnv != null ? !uEnv.equals(cEnv) : cEnv != null) {
                     entitlementsToRegen.add(entitlementId);
+                    break;
                 }
             }
         }
@@ -127,101 +103,33 @@ public class EntitlementEnvironmentFilter {
         return entitlementsToRegen;
     }
 
-    private Set<String> contentOf(Map<String, List<String>> envContents, List<String> envIds) {
-        return envIds.stream()
-            .map(envContents::get)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toSet());
-    }
-
-    private List<String> findCurrentLower(List<String> envRemoved, List<String> preExistingEnvs,
-        String environmentId) {
-        int fromIndex = envRemoved.indexOf(environmentId) + 1;
-        List<String> currentLower = new ArrayList<>(
-            preExistingEnvs.subList(fromIndex, preExistingEnvs.size()));
-        return (List<String>) differenceOf(envRemoved, currentLower);
-    }
-
-    private List<String> findCurrentHigher(List<String> updatedEnvs, String environmentId) {
-        if (updatedEnvs.contains(environmentId)) {
-            return updatedEnvs.subList(0, updatedEnvs.indexOf(environmentId));
-        }
-        else {
-            return updatedEnvs;
-        }
-    }
-
     /**
-     * Returns the list of environment IDs which got added, removed or re-prioritized
-     * from consumers current existing environments.
+     * Fetches the first environment in the given list in which the specified content is promoted.
+     * If the content has not been promoted in any of the environments, this method returns null.
+     *
+     * @param contentId
+     *  the ID of the content to lookup
+     *
+     * @param environmentIds
+     *  the list of environments to check, in descending order of priority
+     *
+     * @map environmentContentIdMap
+     *  a map consisting of the environment IDs mapped to their promoted content IDs
      *
      * @return
-     *  Returns the unique environmentIds which got added, removed or re-prioritized
+     *  the ID of the first environment in which the specified content is promoted, or null if the
+     *  content has not been promoted in any of the given environments
      */
-    private Set<String> getEnvironmentChangeList(List<String> envRemoved,
-        List<String> preExistingEnvs, List<String> updatedEnvs) {
+    private String getContentEnvironment(String contentId, List<String> environmentIds,
+        Map<String, Set<String>> environmentContentIdMap) {
 
-        Set<String> environmentChangeList = new HashSet<>();
-
-        // Envs Added
-        environmentChangeList.addAll(differenceOf(preExistingEnvs, updatedEnvs));
-
-        // Env removed are kept in separate list for special use cases
-        environmentChangeList.addAll(envRemoved);
-
-        // Env reordered
-        environmentChangeList.addAll(Util.getReorderedItems(preExistingEnvs, updatedEnvs));
-
-        return environmentChangeList;
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> Collection<T> differenceOf(List<T> preExistingEnvs, List<T> updatedEnvs) {
-        return CollectionUtils.subtract(updatedEnvs, preExistingEnvs);
-    }
-
-    /**
-     * Method to check if entitlement cert needs to be regenerated or not,
-     * based on environment content UUIDs, content UUIDs of environment having
-     * higher priority & content UUIDs provided by entitlement itself.
-     *
-     * @param environmentContentUUIDs
-     *  Content UUIDs associated with environment
-     *
-     * @param entitlementContentUUIDs
-     *  Content UUIDs associated with entitlement
-     *
-     * @param currentHigherContentUUIDs
-     *  Content UUIDs belonging to environment having higher priority
-     *
-     * @return
-     *  Returns true or false, whether to regenerate entitlement cert or not.
-     */
-
-    private boolean isCertRegenerationRequired(List<String> environmentContentUUIDs,
-        Set<String> entitlementContentUUIDs, Set<String> currentHigherContentUUIDs) {
-        boolean regenRequired = false;
-        // If current env is of the highest priority,
-        // we only check if any one of environment content UUID is being provided
-        // by the entitlement
-        if (currentHigherContentUUIDs.isEmpty()) {
-            for (String contentUUID : environmentContentUUIDs) {
-                if (entitlementContentUUIDs.contains(contentUUID)) {
-                    regenRequired = true;
-                    break;
-                }
-            }
-        }
-        else {
-            for (String contentUUID : environmentContentUUIDs) {
-                if (entitlementContentUUIDs.contains(contentUUID) &&
-                    !currentHigherContentUUIDs.contains(contentUUID)) {
-                    regenRequired = true;
-                    break;
-                }
+        for (String envId : environmentIds) {
+            if (environmentContentIdMap.getOrDefault(envId, Collections.emptySet()).contains(contentId)) {
+                return envId;
             }
         }
 
-        return regenRequired;
+        return null;
     }
+
 }

--- a/src/main/resources/db/changelog/20221003160605-remove_direct_ak_product_reference.xml
+++ b/src/main/resources/db/changelog/20221003160605-remove_direct_ak_product_reference.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20221003160605-1" author="crog">
+        <createTable tableName="cp_activation_key_products">
+            <column name="key_id" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="product_id" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="20221003160605-2" author="crog">
+        <addPrimaryKey tableName="cp_activation_key_products" columnNames="key_id, product_id"
+            constraintName="cp_akproducts_pkey"/>
+
+        <addForeignKeyConstraint constraintName="cp_akproducts_fk1"
+            baseTableName="cp_activation_key_products"
+            baseColumnNames="key_id"
+            referencedTableName="cp_activation_key"
+            referencedColumnNames="id"
+            deleteCascade="true"/>
+    </changeSet>
+
+    <changeSet id="20221003160605-3" author="crog">
+        <createIndex indexName="cp_akproducts_idx1" tableName="cp_activation_key_products">
+            <column name="key_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20221003160605-4" author="crog">
+        <sql dbms="postgresql, mysql">
+            INSERT INTO cp_activation_key_products
+                SELECT akp2.key_id, prod.product_id
+                    FROM cp2_activation_key_products akp2
+                    JOIN cp2_products prod ON prod.uuid = akp2.product_uuid;
+        </sql>
+    </changeSet>
+
+<!--
+    <changeSet id="20221003160605-5" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="cp2_activation_key_products"/>
+        </preConditions>
+
+        <dropTable tableName="cp2_activation_key_products"/>
+    </changeSet>
+-->
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/20221003160623-remove_direct_env_content_reference.xml
+++ b/src/main/resources/db/changelog/20221003160623-remove_direct_env_content_reference.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20221003160623-1" author="crog">
+        <createTable tableName="cp_environment_content">
+            <column name="id" type="varchar(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="${timestamp.type}"/>
+            <column name="updated" type="${timestamp.type}"/>
+            <column name="environment_id" type="varchar(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="content_id" type="varchar(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="enabled" type="boolean"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="20221003160623-2" author="crog">
+        <addPrimaryKey tableName="cp_environment_content" columnNames="id" constraintName="cp_envcontent_pkey"/>
+
+        <addForeignKeyConstraint constraintName="cp_envcontent_fk1"
+            baseTableName="cp_environment_content"
+            baseColumnNames="environment_id"
+            referencedTableName="cp_environment"
+            referencedColumnNames="id"
+            deleteCascade="true"/>
+
+        <addUniqueConstraint constraintName="cp_envcontent_uidx1"
+            tableName="cp_environment_content"
+            columnNames="environment_id, content_id"/>
+    </changeSet>
+
+    <changeSet id="20221003160623-3" author="crog">
+        <createIndex indexName="cp_envcontent_idx1" tableName="cp_environment_content">
+            <column name="environment_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20221003160623-4" author="crog">
+        <sql dbms="postgresql, mysql">
+            INSERT INTO cp_environment_content
+                SELECT ec.id, ec.created, ec.updated, ec.environment_id, c.content_id, ec.enabled
+                    FROM cp2_environment_content ec
+                    JOIN cp2_content c ON c.uuid = ec.content_uuid;
+        </sql>
+    </changeSet>
+
+<!--
+    <changeSet id="20221003160623-5" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="cp2_environment_content"/>
+        </preConditions>
+
+        <dropTable tableName="cp2_environment_content"/>
+    </changeSet>
+-->
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1270,4 +1270,6 @@
     <include file="db/changelog/20220621122940-add_pool_product_index.xml"/>
     <include file="db/changelog/20220722000000-add_delete_cascade_to_consumer_fks.xml"/>
     <include file="db/changelog/20220901113942-delete_unused_table_and_columns.xml"/>
+    <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
+    <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2360,4 +2360,6 @@
     <include file="db/changelog/20220621122940-add_pool_product_index.xml"/>
     <include file="db/changelog/20220722000000-add_delete_cascade_to_consumer_fks.xml"/>
     <include file="db/changelog/20220901113942-delete_unused_table_and_columns.xml"/>
+    <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
+    <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -177,4 +177,6 @@
     <include file="db/changelog/20220621122940-add_pool_product_index.xml"/>
     <include file="db/changelog/20220722000000-add_delete_cascade_to_consumer_fks.xml"/>
     <include file="db/changelog/20220901113942-delete_unused_table_and_columns.xml"/>
+    <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
+    <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -122,7 +122,11 @@ public class EventSinkImplTest {
         this.eventFilter = new EventFilter(new CandlepinCommonTestConfig());
 
         this.eventSinkImpl = createEventSink(mockSessionFactory);
-        o = new Owner("test owner");
+
+        this.o = new Owner()
+            .setId("test_owner")
+            .setKey("test_owner")
+            .setDisplayName("Test Owner");
     }
 
     /**
@@ -206,7 +210,7 @@ public class EventSinkImplTest {
 
     @Test
     public void emptyKeyShouldEmitSuccessfully() throws Exception {
-        ActivationKey key = TestUtil.createActivationKey(new Owner("deadbeef"), null);
+        ActivationKey key = TestUtil.createActivationKey(this.o, null);
         eventSinkImpl.emitActivationKeyCreated(key);
         eventSinkImpl.sendEvents();
         verify(mockClientProducer).send(any(ClientMessage.class));
@@ -217,7 +221,7 @@ public class EventSinkImplTest {
         ArrayList<Pool> pools = new ArrayList<>();
         pools.add(TestUtil.createPool(o, TestUtil.createProduct()));
         pools.add(TestUtil.createPool(o, TestUtil.createProduct()));
-        ActivationKey key = TestUtil.createActivationKey(new Owner("deadbeef"), pools);
+        ActivationKey key = TestUtil.createActivationKey(this.o, pools);
         eventSinkImpl.emitActivationKeyCreated(key);
         eventSinkImpl.sendEvents();
         verify(mockClientProducer).send(any(ClientMessage.class));

--- a/src/test/java/org/candlepin/auth/ActivationKeyAuthTest.java
+++ b/src/test/java/org/candlepin/auth/ActivationKeyAuthTest.java
@@ -153,7 +153,7 @@ class ActivationKeyAuthTest {
 
     private void mockKey(String owner, String key) {
         when(this.activationKeyCurator.findByKeyNames(eq(owner), anyCollection()))
-            .thenReturn(List.of(new ActivationKey(key, new Owner())));
+            .thenReturn(List.of(new ActivationKey(key, new Owner().setId("test_owner"))));
     }
 
     private ActivationKeyAuth createActivationKeyAuth() {

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -292,8 +292,19 @@ public class ContentAccessManagerTest {
     }
 
     private Environment mockEnvironment(Owner owner, Consumer consumer, Content content) {
-        Environment environment = new Environment("test_environment", "test_environment", owner);
-        environment.setEnvironmentContent(Util.asSet(new EnvironmentContent(environment, content, true)));
+        int rnd = TestUtil.randomInt();
+
+        Environment environment = new Environment()
+            .setId("test_environment-" + rnd)
+            .setName("test_environment-" + rnd)
+            .setOwner(owner);
+
+        EnvironmentContent ec = new EnvironmentContent()
+            .setEnvironment(environment)
+            .setContent(content)
+            .setEnabled(true);
+
+        environment.addEnvironmentContent(ec);
 
         consumer.addEnvironment(environment);
 

--- a/src/test/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitorTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitorTest.java
@@ -38,13 +38,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -61,14 +58,8 @@ import java.util.stream.Stream;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class ProductNodeVisitorTest extends DatabaseTestFixture {
 
-    private static final int DEFAULT_ORPHANED_ENTITY_GRACE_PERIOD = 30;
-
     public ProductNodeVisitor buildNodeVisitor() {
-        return this.buildNodeVisitor(DEFAULT_ORPHANED_ENTITY_GRACE_PERIOD);
-    }
-
-    public ProductNodeVisitor buildNodeVisitor(int orphanEntityGracePeriod) {
-        return new ProductNodeVisitor(this.productCurator, this.ownerProductCurator, orphanEntityGracePeriod);
+        return new ProductNodeVisitor(this.productCurator, this.ownerProductCurator);
     }
 
     @Test
@@ -405,9 +396,7 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
         assertEquals(importedEntity.getName(), pnode.getMergedEntity().getName());
     }
 
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(ints = { -1, 0, 30 })
-    public void testPruneNodeOmitsActiveRoot(int orphanedEntityGracePeriod) {
+    public void testPruneNodeOmitsActiveRoot() {
         Owner owner = this.createOwner();
         Product existingEntity = this.createProduct("test_prod-1", "Test Product", owner)
             .setLocked(true);
@@ -419,16 +408,14 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
 
         assertNull(pnode.getNodeState());
 
-        ProductNodeVisitor visitor = this.buildNodeVisitor(orphanedEntityGracePeriod);
+        ProductNodeVisitor visitor = this.buildNodeVisitor();
         visitor.processNode(pnode);
         visitor.pruneNode(pnode);
 
         assertEquals(NodeState.UNCHANGED, pnode.getNodeState());
     }
 
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(ints = { -1, 0, 30 })
-    public void testPruneNodeNeverDeletesCustomProducts(int orphanedEntityGracePeriod) {
+    public void testPruneNodeNeverDeletesCustomProducts() {
         Owner owner = this.createOwner();
         Product existingEntity = this.createProduct("test_prod-1", "Test Product", owner)
             .setLocked(false);
@@ -438,7 +425,7 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
 
         assertNull(pnode.getNodeState());
 
-        ProductNodeVisitor visitor = this.buildNodeVisitor(orphanedEntityGracePeriod);
+        ProductNodeVisitor visitor = this.buildNodeVisitor();
         visitor.processNode(pnode);
         visitor.pruneNode(pnode);
 
@@ -452,91 +439,8 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
         assertNull(op.getOrphanedDate());
     }
 
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(ints = { 1, 5, 30 })
-    public void testPruneNodeDoesntFlagNewlyOrphanedEntitiesWithinGracePeriod(int orphanedEntityGracePeriod) {
-        Owner owner = this.createOwner();
-        Product existingEntity = this.createProduct("test_prod-1", "Test Product", owner)
-            .setLocked(true);
-
-        EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existingEntity.getId())
-            .setExistingEntity(existingEntity);
-
-        assertNull(pnode.getNodeState());
-
-        ProductNodeVisitor visitor = this.buildNodeVisitor(orphanedEntityGracePeriod);
-        visitor.processNode(pnode);
-        visitor.pruneNode(pnode);
-
-        assertEquals(NodeState.UNCHANGED, pnode.getNodeState());
-    }
-
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(ints = { 1, 5, 30 })
-    public void testPruneNodeDoesntFlagOrphanedEntitiesWithinGracePeriod(int orphanedEntityGracePeriod) {
-        Owner owner = this.createOwner();
-        Product existing = new Product()
-            .setId("test_product")
-            .setName("test product")
-            .setLocked(true);
-
-        Instant orphanedDate = Instant.now()
-            .minus(orphanedEntityGracePeriod / 2, ChronoUnit.DAYS);
-
-        OwnerProduct op = new OwnerProduct()
-            .setOwner(owner)
-            .setProduct(existing)
-            .setOrphanedDate(orphanedDate);
-
-        this.productCurator.create(existing);
-        this.ownerProductCurator.create(op);
-
-        EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existing.getId())
-            .setExistingEntity(existing);
-
-        assertNull(pnode.getNodeState());
-
-        ProductNodeVisitor visitor = this.buildNodeVisitor(orphanedEntityGracePeriod);
-        visitor.processNode(pnode);
-        visitor.pruneNode(pnode);
-
-        assertEquals(NodeState.UNCHANGED, pnode.getNodeState());
-    }
-
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(ints = { 1, 5, 30 })
-    public void testPruneNodeFlagsOrphanedEntitiesAfterGracePeriod(int orphanedEntityGracePeriod) {
-        Owner owner = this.createOwner();
-        Product existing = new Product()
-            .setId("test_product")
-            .setName("test product")
-            .setLocked(true);
-
-        Instant orphanedDate = Instant.now()
-            .minus(orphanedEntityGracePeriod + 5, ChronoUnit.DAYS);
-
-        OwnerProduct op = new OwnerProduct()
-            .setOwner(owner)
-            .setProduct(existing)
-            .setOrphanedDate(orphanedDate);
-
-        this.productCurator.create(existing);
-        this.ownerProductCurator.create(op);
-
-        EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existing.getId())
-            .setExistingEntity(existing);
-
-        assertNull(pnode.getNodeState());
-
-        ProductNodeVisitor visitor = this.buildNodeVisitor(orphanedEntityGracePeriod);
-        visitor.processNode(pnode);
-        visitor.pruneNode(pnode);
-
-        assertEquals(NodeState.DELETED, pnode.getNodeState());
-    }
-
     @Test
-    public void testPruneNodeFlagsUnusedNodeForDeletionWithNoGracePeriod() {
+    public void testPruneNodeFlagsUnusedNodeForDeletion() {
         Owner owner = this.createOwner();
         Product existingEntity = this.createProduct("test_prod-1", "Test Product", owner)
             .setLocked(true);
@@ -546,30 +450,11 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
 
         assertNull(pnode.getNodeState());
 
-        ProductNodeVisitor visitor = this.buildNodeVisitor(0);
+        ProductNodeVisitor visitor = this.buildNodeVisitor();
         visitor.processNode(pnode);
         visitor.pruneNode(pnode);
 
         assertEquals(NodeState.DELETED, pnode.getNodeState());
-    }
-
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(ints = { -1, -5, -5000 })
-    public void testPruneNodeNeverFlagsNodesWithInfiniteGracePeriod(int orphanedEntityGracePeriod) {
-        Owner owner = this.createOwner();
-        Product existingEntity = this.createProduct("test_prod-1", "Test Product", owner)
-            .setLocked(true);
-
-        EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existingEntity.getId())
-            .setExistingEntity(existingEntity);
-
-        assertNull(pnode.getNodeState());
-
-        ProductNodeVisitor visitor = this.buildNodeVisitor(orphanedEntityGracePeriod);
-        visitor.processNode(pnode);
-        visitor.pruneNode(pnode);
-
-        assertEquals(NodeState.UNCHANGED, pnode.getNodeState());
     }
 
     @Test
@@ -589,7 +474,7 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
 
         assertNull(pnode.getNodeState());
 
-        ProductNodeVisitor visitor = this.buildNodeVisitor(0);
+        ProductNodeVisitor visitor = this.buildNodeVisitor();
         visitor.pruneNode(pnode);
 
         assertEquals(NodeState.DELETED, pnode.getNodeState());
@@ -612,7 +497,7 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
 
         assertNull(pnode.getNodeState());
 
-        ProductNodeVisitor visitor = this.buildNodeVisitor(0);
+        ProductNodeVisitor visitor = this.buildNodeVisitor();
         visitor.pruneNode(pnode);
 
         assertNull(pnode.getNodeState());
@@ -815,128 +700,8 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
         assertEquals(product.getName(), updated.getName());
     }
 
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(ints = { 1, 5, 30 })
-    public void testFullCycleSetsOrphanedDateOnNewlyOrphanedEntitiesWithGracePeriod(int gracePeriod) {
-        Owner owner = this.createOwner();
-        Product existing = new Product()
-            .setId("test_product")
-            .setName("test product")
-            .setLocked(true);
-
-        Instant creationDate = Instant.now();
-
-        OwnerProduct op = new OwnerProduct()
-            .setOwner(owner)
-            .setProduct(existing);
-
-        this.productCurator.create(existing);
-        this.ownerProductCurator.create(op);
-
-        assertNull(op.getOrphanedDate());
-
-        EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existing.getId())
-            .setExistingEntity(existing);
-
-        ProductNodeVisitor visitor = this.buildNodeVisitor(gracePeriod);
-        visitor.processNode(pnode);
-        visitor.pruneNode(pnode);
-        visitor.applyChanges(pnode);
-        visitor.complete();
-
-        assertEquals(NodeState.UNCHANGED, pnode.getNodeState());
-        assertNull(pnode.getMergedEntity());
-
-        this.productCurator.flush();
-        this.productCurator.clear();
-
-        OwnerProduct updated = this.ownerProductCurator.getOwnerProduct(owner.getId(), existing.getId());
-        assertNotNull(updated);
-        assertNotNull(updated.getOrphanedDate());
-        assertTrue(creationDate.isBefore(updated.getOrphanedDate()));
-    }
-
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(ints = { 1, 5, 30 })
-    public void testFullCycleOmitsOrphanedEntitiesWithinGracePeriod(int gracePeriod) {
-        Owner owner = this.createOwner();
-        Product existing = new Product()
-            .setId("test_product")
-            .setName("test product")
-            .setLocked(true);
-
-        Instant orphanedDate = Instant.now()
-            .minus(gracePeriod / 2, ChronoUnit.DAYS);
-
-        OwnerProduct op = new OwnerProduct()
-            .setOwner(owner)
-            .setProduct(existing)
-            .setOrphanedDate(orphanedDate);
-
-        this.productCurator.create(existing);
-        this.ownerProductCurator.create(op);
-
-        EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existing.getId())
-            .setExistingEntity(existing);
-
-        ProductNodeVisitor visitor = this.buildNodeVisitor(gracePeriod);
-        visitor.processNode(pnode);
-        visitor.pruneNode(pnode);
-        visitor.applyChanges(pnode);
-        visitor.complete();
-
-        assertEquals(NodeState.UNCHANGED, pnode.getNodeState());
-        assertNull(pnode.getMergedEntity());
-
-        this.productCurator.flush();
-        this.productCurator.clear();
-
-        OwnerProduct updated = this.ownerProductCurator.getOwnerProduct(owner.getId(), existing.getId());
-        assertNotNull(updated);
-        assertEquals(orphanedDate, updated.getOrphanedDate());
-    }
-
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(ints = { 1, 5, 30 })
-    public void testFullCycleOmitsDeletedOrphanedEntitiesOutsideOfGracePeriod(int gracePeriod) {
-        Owner owner = this.createOwner();
-        Product existing = new Product()
-            .setId("test_product")
-            .setName("test product")
-            .setLocked(true);
-
-        Instant orphanedDate = Instant.now()
-            .minus(gracePeriod + 5, ChronoUnit.DAYS);
-
-        OwnerProduct op = new OwnerProduct()
-            .setOwner(owner)
-            .setProduct(existing)
-            .setOrphanedDate(orphanedDate);
-
-        this.productCurator.create(existing);
-        this.ownerProductCurator.create(op);
-
-        EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existing.getId())
-            .setExistingEntity(existing);
-
-        ProductNodeVisitor visitor = this.buildNodeVisitor(gracePeriod);
-        visitor.processNode(pnode);
-        visitor.pruneNode(pnode);
-        visitor.applyChanges(pnode);
-        visitor.complete();
-
-        assertEquals(NodeState.DELETED, pnode.getNodeState());
-        assertNull(pnode.getMergedEntity());
-
-        this.productCurator.flush();
-        this.productCurator.clear();
-
-        Product deleted = this.ownerProductCurator.getProductById(owner, existing.getId());
-        assertNull(deleted);
-    }
-
     @Test
-    public void testFullCycleDeletesUnusedEntityWithNoGracePeriod() {
+    public void testFullCycleDeletesUnusedEntity() {
         Owner owner = this.createOwner();
 
         Product existing = this.createProduct("test_product", "product name", owner);
@@ -945,7 +710,7 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
         EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existing.getId())
             .setExistingEntity(existing);
 
-        ProductNodeVisitor visitor = this.buildNodeVisitor(0);
+        ProductNodeVisitor visitor = this.buildNodeVisitor();
         visitor.processNode(pnode);
         visitor.pruneNode(pnode);
         visitor.applyChanges(pnode);
@@ -959,34 +724,6 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
 
         Product deleted = this.ownerProductCurator.getProductById(owner, existing.getId());
         assertNull(deleted);
-    }
-
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(ints = { -1, -5, -9000 })
-    public void testFullCycleOmitsUnusedEntityWithInfiniteGracePeriod(int gracePeriod) {
-        Owner owner = this.createOwner();
-
-        Product existing = this.createProduct("test_product", "product name", owner);
-        existing.setLocked(true);
-
-        EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existing.getId())
-            .setExistingEntity(existing);
-
-        ProductNodeVisitor visitor = this.buildNodeVisitor(gracePeriod);
-        visitor.processNode(pnode);
-        visitor.pruneNode(pnode);
-        visitor.applyChanges(pnode);
-        visitor.complete();
-
-        assertEquals(NodeState.UNCHANGED, pnode.getNodeState());
-        assertNull(pnode.getMergedEntity());
-
-        this.productCurator.flush();
-        this.productCurator.clear();
-
-        OwnerProduct updated = this.ownerProductCurator.getOwnerProduct(owner.getId(), existing.getId());
-        assertNotNull(updated);
-        assertNull(updated.getOrphanedDate());
     }
 
     /**
@@ -1022,7 +759,7 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
 
         assertEquals(1, count);
 
-        ProductNodeVisitor visitor = this.buildNodeVisitor(-1);
+        ProductNodeVisitor visitor = this.buildNodeVisitor();
         visitor.processNode(pnode);
         visitor.pruneNode(pnode);
         visitor.applyChanges(pnode);

--- a/src/test/java/org/candlepin/controller/util/PromotedContentTest.java
+++ b/src/test/java/org/candlepin/controller/util/PromotedContentTest.java
@@ -247,7 +247,7 @@ class PromotedContentTest {
         Owner owner = this.mockOwner();
         Consumer consumer = this.mockConsumer(owner);
         Environment environment = this.mockEnvironment(owner, consumer, content);
-        environment.getEnvironmentContent().add(new EnvironmentContent(environment, content, true));
+
         return environment;
     }
 
@@ -309,8 +309,19 @@ class PromotedContentTest {
     }
 
     private Environment mockEnvironment(Owner owner, Consumer consumer, Content content) {
-        Environment environment = new Environment("test_environment", "test_environment", owner);
-        environment.setEnvironmentContent(Util.asSet(new EnvironmentContent(environment, content, true)));
+        int rnd = (int) (Math.random() * 10000);
+
+        Environment environment = new Environment()
+            .setId("test_environment-" + rnd)
+            .setName("test environment " + rnd)
+            .setOwner(owner);
+
+        EnvironmentContent ec = new EnvironmentContent()
+            .setEnvironment(environment)
+            .setContent(content)
+            .setEnabled(true);
+
+        environment.addEnvironmentContent(ec);
 
         consumer.addEnvironment(environment);
 
@@ -327,9 +338,17 @@ class PromotedContentTest {
     }
 
     private PromotedContent createPromotedContent(String prefix) {
-        Environment environment = new Environment(ENV_ID, "env1", new Owner());
-        environment.getEnvironmentContent()
-            .add(new EnvironmentContent(environment, new Content(CONTENT_ID), true));
+        Environment environment = new Environment()
+            .setId(ENV_ID)
+            .setName("env1")
+            .setOwner(new Owner());
+
+        EnvironmentContent envcontent = new EnvironmentContent()
+            .setEnvironment(environment)
+            .setContent(new Content().setId(CONTENT_ID))
+            .setEnabled(true);
+
+        environment.addEnvironmentContent(envcontent);
 
         return new PromotedContent(prefix(prefix))
             .with(environment);

--- a/src/test/java/org/candlepin/dto/api/v1/ActivationKeyTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ActivationKeyTranslatorTest.java
@@ -80,9 +80,6 @@ public class ActivationKeyTranslatorTest extends
         source.setServiceLevel("key-service-level");
         source.setAutoAttach(true);
 
-
-        Set<Product> products = new HashSet<>();
-        Set<ActivationKeyPool> akpools = new HashSet<>();
         Set<ActivationKeyContentOverride> overrides = new HashSet<>();
 
         for (int i = 0; i < 3; ++i) {
@@ -92,21 +89,17 @@ public class ActivationKeyTranslatorTest extends
             Pool pool = new Pool();
             pool.setId("test_pool-" + i);
 
-            ActivationKeyPool akp = new ActivationKeyPool(source, pool, 1L);
-
             ActivationKeyContentOverride override = new ActivationKeyContentOverride();
             override.setKey(source);
             override.setContentLabel("test_content_label-" + i);
             override.setName("test_name-" + i);
             override.setValue("test_value-" + i);
 
-            products.add(product);
-            akpools.add(akp);
+            source.addProduct(product);
+            source.addPool(pool, 1L);
             overrides.add(override);
         }
 
-        source.setProducts(products);
-        source.setPools(akpools);
         source.setContentOverrides(overrides);
 
         return source;
@@ -127,22 +120,20 @@ public class ActivationKeyTranslatorTest extends
             assertEquals(source.isAutoAttach(), dest.getAutoAttach());
 
             // Check product IDs
-            Collection<Product> products = source.getProducts();
+            Collection<String> productIds = source.getProductIds();
             Collection<ActivationKeyProductDTO> productDTOs = dest.getProducts();
 
-            if (products != null) {
+            if (productIds != null) {
                 assertNotNull(productDTOs);
-                assertEquals(products.size(), productDTOs.size());
+                assertEquals(productIds.size(), productDTOs.size());
 
-                for (Product product : products) {
-                    assertNotNull(product);
-                    assertNotNull(product.getId());
+                Set<String> dtoProductIds = productDTOs.stream()
+                    .map(ActivationKeyProductDTO::getProductId)
+                    .collect(Collectors.toSet());
 
-                    Collection<String> productIds = productDTOs.stream()
-                        .map(ActivationKeyProductDTO::getProductId)
-                        .collect(Collectors.toSet());
-
-                    assertTrue(productIds.contains(product.getId()));
+                for (String pid : productIds) {
+                    assertNotNull(pid);
+                    assertTrue(dtoProductIds.contains(pid));
                 }
             }
             else {

--- a/src/test/java/org/candlepin/dto/api/v1/EnvironmentTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/EnvironmentTranslatorTest.java
@@ -28,8 +28,11 @@ import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentContent;
 import org.candlepin.test.TestUtil;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
 
 /**
  * Test suite for the ProductTranslator class
@@ -66,14 +69,13 @@ public class EnvironmentTranslatorTest extends
         source.setDescription("test_description");
         source.setOwner(ownerTranslatorTest.initSourceObject());
 
-        Set<EnvironmentContent> environmentContents = new HashSet<>();
         for (int i = 0; i < 3; ++i) {
             Content content = TestUtil.createContent("content-" + i);
             content.setUuid(content.getId() + "_uuid");
-            EnvironmentContent environmentContent = new EnvironmentContent(source, content, true);
-            environmentContents.add(environmentContent);
+
+            source.addContent(content, true);
         }
-        source.setEnvironmentContent(environmentContents);
+
         return source;
     }
 
@@ -91,25 +93,23 @@ public class EnvironmentTranslatorTest extends
             assertEquals(source.getDescription(), dto.getDescription());
 
             if (childrenGenerated) {
-                this.nestedOwnerTranslatorTest.verifyOutput(source.getOwner(),
-                    dto.getOwner(), childrenGenerated);
+                this.nestedOwnerTranslatorTest.verifyOutput(source.getOwner(), dto.getOwner(), true);
+
                 assertNotNull(dto.getEnvironmentContent());
-                for (EnvironmentContent ec : source.getEnvironmentContent()) {
-                    for (EnvironmentContentDTO ecdto : dto.getEnvironmentContent()) {
-                        Content content = ec.getContent();
-                        ContentDTO cdto = ecdto.getContent();
 
-                        assertNotNull(cdto);
-                        assertNotNull(cdto.getUuid());
+                Collection<EnvironmentContent> envcontent = source.getEnvironmentContent();
+                Collection<EnvironmentContentDTO> envcontentDtos = dto.getEnvironmentContent();
 
-                        if (cdto.getUuid().equals(content.getUuid())) {
-                            assertEquals(ec.getEnabled(), ecdto.getEnabled());
+                assertNotNull(envcontentDtos);
+                assertEquals(envcontent.size(), envcontentDtos.size());
 
-                            // Pass the content off to the ContentTranslatorTest to verify it
-                            this.contentTranslatorTest.verifyOutput(content, cdto, childrenGenerated);
-                        }
-                    }
-                }
+                Map<String, Boolean> ecMap = envcontent.stream().collect(
+                    Collectors.toMap(EnvironmentContent::getContentId, EnvironmentContent::isEnabled));
+
+                Map<String, Boolean> ecDtoMap = envcontentDtos.stream().collect(
+                    Collectors.toMap(EnvironmentContentDTO::getContentId, EnvironmentContentDTO::getEnabled));
+
+                assertEquals(ecMap, ecDtoMap);
             }
             else {
                 assertNull(dto.getEnvironmentContent());

--- a/src/test/java/org/candlepin/dto/rules/v1/ActivationKeyTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ActivationKeyTranslatorTest.java
@@ -67,9 +67,10 @@ public class ActivationKeyTranslatorTest extends
                 mktProduct.setAttribute("prod_attr-key" + j, "prod_attr-value" + j);
             }
 
-            ActivationKeyPool akp = new ActivationKeyPool(source, pool, 1L);
-
-            akpools.add(akp);
+            akpools.add(new ActivationKeyPool()
+                .setKey(source)
+                .setPool(pool)
+                .setQuantity(1L));
         }
 
         source.setPools(akpools);

--- a/src/test/java/org/candlepin/model/EnvironmentContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EnvironmentContentCuratorTest.java
@@ -34,7 +34,7 @@ public class EnvironmentContentCuratorTest extends DatabaseTestFixture {
     private EnvironmentContent envContent;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws Exception {
         owner = this.createOwner("test-owner", "Test Owner");
 
         e = this.createEnvironment(owner, "env1", "Env 1");
@@ -44,8 +44,14 @@ public class EnvironmentContentCuratorTest extends DatabaseTestFixture {
         p.addContent(c, true);
         p = this.createProduct(p, owner);
 
-        envContent = new EnvironmentContent(e, c, true);
+        envContent = new EnvironmentContent()
+            .setEnvironment(e)
+            .setContent(c)
+            .setEnabled(true);
+
         envContent = environmentContentCurator.create(envContent);
+        environmentContentCurator.flush();
+        environmentContentCurator.clear();
     }
 
     @Test
@@ -68,7 +74,11 @@ public class EnvironmentContentCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void createDuplicate() {
-        envContent = new EnvironmentContent(e, c, true);
+        envContent = new EnvironmentContent()
+            .setEnvironment(e)
+            .setContent(c)
+            .setEnabled(true);
+
         assertThrows(PersistenceException.class, () -> environmentContentCurator.create(envContent));
     }
 

--- a/src/test/java/org/candlepin/model/EnvironmentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EnvironmentCuratorTest.java
@@ -23,10 +23,9 @@ import org.candlepin.test.DatabaseTestFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -53,39 +52,30 @@ public class EnvironmentCuratorTest extends DatabaseTestFixture {
         assertEquals(owner, e.getOwner());
     }
 
-    @Test public void delete() {
+    @Test
+    public void delete() {
         envCurator.delete(environment);
         assertEquals(0, envCurator.listAll().list().size());
     }
 
-    @Test public void listForOwner() {
+    @Test
+    public void listForOwner() {
         List<Environment> envs = envCurator.listForOwner(owner).list();
         assertEquals(1, envs.size());
         assertEquals(envs.get(0), environment);
     }
 
-    @Test public void listForOwnerByName() {
-        Environment e = envCurator.create(new Environment("env2", "Another Env", owner));
+    @Test
+    public void listForOwnerByName() {
+        Environment environment = new Environment()
+            .setId("env2")
+            .setName("Another Env")
+            .setOwner(owner);
+
+        this.envCurator.create(environment);
 
         List<Environment> envs = envCurator.listForOwnerByName(owner, "Another Env").list();
-        assertEquals(1, envs.size());
-        assertEquals(e, envs.get(0));
-    }
-
-    @Test
-    public void listWithContent() {
-        envCurator.create(new Environment("env2", "Another Env", owner));
-
-        final String contentId = "contentId";
-        Content content = this.createContent(contentId, "test content", this.owner);
-
-        envContentCurator.create(new EnvironmentContent(environment, content, true));
-
-        Set<String> ids = new HashSet<>();
-        ids.add(contentId);
-
-        List<Environment> envs = envCurator.listWithContent(ids);
-
+        assertNotNull(envs);
         assertEquals(1, envs.size());
         assertEquals(environment, envs.get(0));
     }
@@ -98,17 +88,14 @@ public class EnvironmentCuratorTest extends DatabaseTestFixture {
         Content content2 = this.createContent("c2", "c2", owner1);
         Content content3 = this.createContent("c3", "c3", owner2);
 
-        Environment environment1 = this.createEnvironment(
-            owner1, "test_env-1", "test_env-1", null, null, List.of(content1)
-        );
+        Environment environment1 = this.createEnvironment(owner1, "test_env-1", "test_env-1", null, null,
+            List.of(content1));
 
-        Environment environment2 = this.createEnvironment(
-            owner1, "test_env-2", "test_env-2", null, null, List.of(content2)
-        );
+        Environment environment2 = this.createEnvironment(owner1, "test_env-2", "test_env-2", null, null,
+            List.of(content2));
 
-        Environment environment3 = this.createEnvironment(
-            owner2, "test_env-3", "test_env-3", null, null, List.of(content3)
-        );
+        Environment environment3 = this.createEnvironment(owner2, "test_env-3", "test_env-3", null, null,
+            List.of(content3));
 
         int output = this.environmentCurator.deleteEnvironmentsForOwner(owner1);
         assertEquals(2, output);
@@ -124,9 +111,9 @@ public class EnvironmentCuratorTest extends DatabaseTestFixture {
         assertNull(environment2);
         assertNotNull(environment3);
 
-        assertEquals(1, environment3.getEnvironmentContent().size());
-        assertEquals(content3.getUuid(), environment3.getEnvironmentContent().iterator().next().getContent()
-            .getUuid());
+        Collection<EnvironmentContent> envcontent = environment3.getEnvironmentContent();
+        assertEquals(1, envcontent.size());
+        assertEquals(content3.getId(), envcontent.iterator().next().getContentId());
     }
 
     @Test

--- a/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -517,11 +517,6 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
 
         assertTrue(original.getUuid() != modified.getUuid());
 
-        Environment environment1 = this.createEnvironment(owner1, "test_env-1", "test_env-1", null, null,
-            List.of(original));
-        Environment environment2 = this.createEnvironment(owner2, "test_env-2", "test_env-2", null, null,
-            List.of(original));
-
         assertTrue(this.isContentMappedToOwner(original, owner1));
         assertTrue(this.isContentMappedToOwner(original, owner2));
         assertFalse(this.isContentMappedToOwner(modified, owner1));
@@ -534,18 +529,6 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         assertTrue(this.isContentMappedToOwner(modified, owner1));
         assertTrue(this.isContentMappedToOwner(original, owner2));
         assertFalse(this.isContentMappedToOwner(modified, owner2));
-
-        this.environmentCurator.evict(environment1);
-        this.environmentCurator.evict(environment2);
-        environment1 = this.environmentCurator.get(environment1.getId());
-        environment2 = this.environmentCurator.get(environment2.getId());
-
-        assertEquals(1, environment1.getEnvironmentContent().size());
-        assertEquals(1, environment2.getEnvironmentContent().size());
-        assertEquals(modified.getUuid(), environment1.getEnvironmentContent().iterator().next().getContent()
-            .getUuid());
-        assertEquals(original.getUuid(), environment2.getEnvironmentContent().iterator().next().getContent()
-            .getUuid());
     }
 
     @Test
@@ -554,11 +537,6 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         Owner owner2 = this.createOwner("owner2");
         Content content = this.createContent("c1", "c1a", owner1, owner2);
 
-        Environment environment1 = this.createEnvironment(owner1, "test_env-1", "test_env-1", null, null,
-            List.of(content));
-        Environment environment2 = this.createEnvironment(owner2, "test_env-2", "test_env-2", null, null,
-            List.of(content));
-
         assertTrue(this.isContentMappedToOwner(content, owner1));
         assertTrue(this.isContentMappedToOwner(content, owner2));
 
@@ -566,16 +544,6 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
 
         assertFalse(this.isContentMappedToOwner(content, owner1));
         assertTrue(this.isContentMappedToOwner(content, owner2));
-
-        this.environmentCurator.evict(environment1);
-        this.environmentCurator.evict(environment2);
-        environment1 = this.environmentCurator.get(environment1.getId());
-        environment2 = this.environmentCurator.get(environment2.getId());
-
-        assertEquals(0, environment1.getEnvironmentContent().size());
-        assertEquals(1, environment2.getEnvironmentContent().size());
-        assertEquals(content.getUuid(), environment2.getEnvironmentContent().iterator().next().getContent()
-            .getUuid());
     }
 
     @Test

--- a/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -18,10 +18,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
-import org.candlepin.util.Util;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -532,11 +530,6 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         Pool pool = TestUtil.createPool(owner, original);
         this.poolCurator.create(pool);
 
-        ActivationKey key = TestUtil.createActivationKey(owner, null);
-        key.setProducts(Util.asSet(original));
-
-        this.activationKeyCurator.create(key);
-
         assertTrue(this.isProductMappedToOwner(original, owner));
         assertFalse(this.isProductMappedToOwner(updated, owner));
         assertTrue(this.isProductMappedToOwner(untouched, owner));
@@ -550,11 +543,6 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         assertTrue(this.isProductMappedToOwner(updated, owner));
         assertTrue(this.isProductMappedToOwner(untouched, owner));
 
-        this.activationKeyCurator.refresh(key);
-        Collection<Product> products = key.getProducts();
-        assertEquals(1, products.size());
-        assertEquals(updated.getUuid(), products.iterator().next().getUuid());
-
         this.poolCurator.refresh(pool);
         assertEquals(updated.getUuid(), pool.getProduct().getUuid());
     }
@@ -565,20 +553,11 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         Product original = this.createProduct();
         this.createOwnerProductMapping(owner, original);
 
-        ActivationKey key = TestUtil.createActivationKey(owner, null);
-        key.setProducts(Util.asSet(original));
-
-        this.activationKeyCurator.create(key);
-
         assertTrue(this.isProductMappedToOwner(original, owner));
 
         this.ownerProductCurator.removeOwnerProductReferences(owner, Arrays.asList(original.getUuid()));
 
         assertFalse(this.isProductMappedToOwner(original, owner));
-
-        this.activationKeyCurator.refresh(key);
-        Collection<Product> products = key.getProducts();
-        assertEquals(0, products.size());
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
@@ -36,7 +36,6 @@ import org.candlepin.model.Release;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyContentOverrideCurator;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
-import org.candlepin.model.activationkeys.ActivationKeyPool;
 import org.candlepin.policy.activationkey.ActivationKeyRules;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
@@ -255,9 +254,7 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
 
         akr.addPoolToKey("testKey", "testPool1", 1L);
         assertEquals(1, ak.getPools().size());
-        Set<ActivationKeyPool> akPools = new HashSet<>();
-        akPools.add(new ActivationKeyPool(ak, p1, 1L));
-        ak.setPools(akPools);
+
         akr.addPoolToKey("testKey", "testPool2", 1L);
         assertEquals(2, ak.getPools().size());
     }
@@ -344,9 +341,9 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
 
         assertNotNull(key.getId());
         activationKeyResource.addProductIdToKey(key.getId(), product.getId());
-        assertEquals(1, key.getProducts().size());
+        assertEquals(1, key.getProductIds().size());
         activationKeyResource.removeProductIdFromKey(key.getId(), product.getId());
-        assertEquals(0, key.getProducts().size());
+        assertEquals(0, key.getProductIds().size());
     }
 
     @Test
@@ -362,12 +359,11 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         assertNotNull(key.getId());
 
         activationKeyResource.addProductIdToKey(key.getId(), product.getId());
-        assertEquals(1, key.getProducts().size());
+        assertEquals(1, key.getProductIds().size());
 
         ActivationKey finalKey = key;
         assertThrows(BadRequestException.class, () ->
-            activationKeyResource.addProductIdToKey(finalKey.getId(), product.getId())
-        );
+            activationKeyResource.addProductIdToKey(finalKey.getId(), product.getId()));
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
@@ -231,19 +231,12 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
     public void deleteContent() {
         Owner owner = this.createOwner("test_owner");
         Content content = this.createContent("test_content", "test_content", owner);
-        Environment environment = this.createEnvironment(owner, "test_env", "test_env", null, null,
-            Arrays.asList(content));
 
         assertNotNull(this.ownerContentCurator.getContentById(owner, content.getId()));
 
         this.ownerContentResource.remove(owner.getKey(), content.getId());
 
         assertNull(this.ownerContentCurator.getContentById(owner, content.getId()));
-
-        this.environmentCurator.evict(environment);
-        environment = this.environmentCurator.get(environment.getId());
-
-        assertEquals(0, environment.getEnvironmentContent().size());
     }
 
     @Test

--- a/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -527,9 +527,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         throws CertificateSizeException {
 
         // Environment, with promoted content:
-        Environment e = this.mockEnvironment(new Environment("env1", "Env 1", owner));
+        Environment e = this.mockEnvironment(new Environment("env1", "Env 1", owner))
+            .addContent(content, true);
 
-        e.getEnvironmentContent().add(new EnvironmentContent(e, content, true));
         this.consumer.addEnvironment(e);
 
         PromotedContent promotedContent = new PromotedContent(prefix(""))
@@ -546,11 +546,13 @@ public class DefaultEntitlementCertServiceAdapterTest {
     public void testContentExtensionIncludesPromotedContentFromMultipleEnvs()
         throws CertificateSizeException {
 
-        Environment e1 = this.mockEnvironment(new Environment("env1", "Env 1", owner));
-        Environment e2 = this.mockEnvironment(new Environment("env2", "Env 2", owner));
-        e1.getEnvironmentContent().add(new EnvironmentContent(e1, content, true));
+        Environment e1 = this.mockEnvironment(new Environment("env1", "Env 1", owner))
+            .addContent(content, true);
+
+        Environment e2 = this.mockEnvironment(new Environment("env2", "Env 2", owner))
+            .addContent(noArchContent, true);
+
         this.consumer.addEnvironment(e1);
-        e2.getEnvironmentContent().add(new EnvironmentContent(e2, noArchContent, true));
         this.consumer.addEnvironment(e2);
 
         PromotedContent promotedContent = new PromotedContent(prefix(""))
@@ -662,7 +664,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         // Make sure that we filter by environment when asked.
         Environment environment = this.mockEnvironment(new Environment());
-        environment.getEnvironmentContent().add(new EnvironmentContent(environment, normalContent, true));
+
+        environment.addEnvironmentContent(new EnvironmentContent()
+            .setEnvironment(environment)
+            .setContent(normalContent)
+            .setEnabled(true));
+
         consumer.addEnvironment(environment);
 
         promotedContent.with(environment);

--- a/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -52,7 +52,6 @@ import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Environment;
-import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.EnvironmentContentCurator;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.IdentityCertificateCurator;
@@ -536,21 +535,17 @@ public class DatabaseTestFixture {
     protected Environment createEnvironment(Owner owner, String id, String name, String description,
         Collection<Consumer> consumers, Collection<Content> content) {
 
-        Environment environment = new Environment(id, name, owner);
-        environment.setDescription(description);
+        Environment environment = new Environment()
+            .setId(id)
+            .setName(name)
+            .setOwner(owner)
+            .setDescription(description);
 
         if (content != null) {
-            for (Content elem : content) {
-                EnvironmentContent envContent = new EnvironmentContent(environment, elem, true);
-
-                // Impl note:
-                // At the time of writing, this line is redundant. But if we ever fix environment,
-                // this will be good to have as a backup.
-                environment.getEnvironmentContent().add(envContent);
-            }
+            content.forEach(elem -> environment.addContent(elem, true));
         }
 
-        environment = this.environmentCurator.create(environment);
+        this.environmentCurator.create(environment);
 
         // Update consumers to point to the new environment
         if (consumers != null) {

--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -46,7 +46,6 @@ import org.candlepin.model.RulesCurator;
 import org.candlepin.model.SourceSubscription;
 import org.candlepin.model.User;
 import org.candlepin.model.activationkeys.ActivationKey;
-import org.candlepin.model.activationkeys.ActivationKeyPool;
 import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.ProductData;
@@ -652,17 +651,14 @@ public class TestUtil {
     }
 
     public static ActivationKey createActivationKey(Owner owner, List<Pool> pools) {
-        ActivationKey key = new ActivationKey();
-        key.setOwner(owner);
-        key.setName("A Test Key");
-        key.setServiceLevel("TestLevel");
-        key.setDescription("A test description for the test key.");
+        ActivationKey key = new ActivationKey()
+            .setOwner(owner)
+            .setName("A Test Key")
+            .setServiceLevel("TestLevel")
+            .setDescription("A test description for the test key.");
+
         if (pools != null) {
-            Set<ActivationKeyPool> akPools = new HashSet<>();
-            for (Pool p : pools) {
-                akPools.add(new ActivationKeyPool(key, p, (long) 1));
-            }
-            key.setPools(akPools);
+            pools.forEach(pool -> key.addPool(pool, 1L));
         }
 
         return key;


### PR DESCRIPTION
Added logic for detecting and fixing entity mapping issues during refresh

- During refresh and manifest import, certain issues with org-entity
  mapping issues will be detected and, if present, will remap products
  and content to ensure correct entity usage

Reverted product/content link from activation key and environments

- ActivationKey no longer references products directly, instead
  referencing products by Red Hat product ID
- Environment no longer references content directly, instead
  referencing content by Red Hat content ID
- Removed the ActivationKey and Environment entity remapping logic
  from org refresh and product/content update flows
- Internal entity model API improvements, cleanup, and changes
- Removed some long-unused code

Removed orphaned product grace period functionality

- Removed the orphaned product grace period functionality entirely,
  as its purpose is superceded by removing the hard link between
  activation key and environment to product and content