### PR TITLE
ENT-5390: Fix bundle install

### DIFF
--- a/docker/candlepin-base-cs8/Dockerfile
+++ b/docker/candlepin-base-cs8/Dockerfile
@@ -3,6 +3,9 @@ LABEL author="Chris Rog <crog@redhat.com>"
 
 ENV LANG en_US.UTF-8
 
+# gai.conf is needed to avoid timeouts when accessing rubygems
+# https://help.rubygems.org/discussions/problems/31074-timeout-error
+COPY /gai.conf /etc/gai.conf
 COPY /base-scripts/dockerlib.sh /root/
 COPY /candlepin-base-cs8/setup-devel-env.sh /root/
 RUN /bin/bash /root/setup-devel-env.sh

--- a/docker/candlepin-base-cs8/setup-devel-env.sh
+++ b/docker/candlepin-base-cs8/setup-devel-env.sh
@@ -14,27 +14,27 @@ export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION
 dnf install -y epel-release
 
 PACKAGES=(
+    createrepo_c
+    expect
     gettext
     git
     hostname
     java-11-openjdk-devel
     java-$JAVA_VERSION-openjdk-devel
     jss
-    pki-servlet-engine
     mariadb
     openssl
+    pki-servlet-engine
     postgresql
+    procps
     python3-pip
+    python3-pyyaml
+    python3-requests
+    rpm-build
+    rpm-sign
     rsyslog
     wget
     which
-    createrepo_c
-    rpm-build
-    rpm-sign
-    python3-requests
-    expect
-    python3-pyyaml
-    procps
     zlib
     zlib-devel
 )
@@ -76,7 +76,7 @@ set -v
 
 # Install all ruby deps
 gem install bundler -v 1.16.1
-bundle install --without=proton
+bundle install --without=proton --retry=5 --verbose --full-index
 
 # Installs all Java deps into the image, big time saver
 ./gradlew --no-daemon dependencies

--- a/docker/candlepin-base/Dockerfile
+++ b/docker/candlepin-base/Dockerfile
@@ -3,6 +3,9 @@ LABEL author="Chris Rog <crog@redhat.com>"
 
 ENV LANG en_US.UTF-8
 
+# gai.conf is needed to avoid timeouts when accessing rubygems
+# https://help.rubygems.org/discussions/problems/31074-timeout-error
+COPY /gai.conf /etc/gai.conf
 COPY /base-scripts/dockerlib.sh /root/
 COPY /candlepin-base/setup-devel-env.sh /root/
 RUN /bin/bash /root/setup-devel-env.sh

--- a/docker/candlepin-base/setup-devel-env.sh
+++ b/docker/candlepin-base/setup-devel-env.sh
@@ -14,6 +14,8 @@ export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION
 yum install -y epel-release
 
 PACKAGES=(
+    createrepo_c
+    expect
     gettext
     git
     hostname
@@ -23,16 +25,15 @@ PACKAGES=(
     mariadb
     openssl
     python-pip
+    python-requests
+    PyYAML
+    rpm-build
+    rpm-sign
     rsyslog
+    ruby-devel
     tomcat
     which
     wget
-    createrepo_c
-    rpm-build
-    rpm-sign
-    python-requests
-    expect
-    PyYAML
 )
 
 yum install -y ${PACKAGES[@]}
@@ -76,7 +77,7 @@ set -v
 
 # Install all ruby deps
 gem install bundler -v 1.16.1
-bundle install --without=proton
+bundle install --without=proton --retry=5 --verbose --full-index
 
 # Installs all Java deps into the image, big time saver
 ./gradlew --no-daemon dependencies

--- a/docker/gai.conf
+++ b/docker/gai.conf
@@ -1,0 +1,9 @@
+# Defaults
+precedence  ::1/128         50
+precedence  ::/0            40
+precedence  2002::/16       30
+precedence  ::/96           20
+precedence  ::ffff:0:0/96   10
+
+# Low precedence for api.rubygems.org IPv6 addresses
+precedence  2a04:4e42::0/32  5


### PR DESCRIPTION
- Bundler had trouble accessing rubygems when ipv6 was used. All requests were timing-out. This fix changes the precedence so that ipv4 is used for accessing rubygems.
- Centos 7 was missing ruby-devel dependency which caused issues for some of the gems.