### PR TITLE
[M] Eliminate trustedConsumer/trustedUser usage in spec tests

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClientFactory.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClientFactory.java
@@ -80,9 +80,9 @@ public class ApiClientFactory {
         return apiClient;
     }
 
-    public ApiClient createCloudAuthClient(String token) {
+    public ApiClient createBearerTokenAuthClient(String token) {
         ApiClient apiClient = createDefaultClient();
-        apiClient.setHttpClient(createOkHttpClient(new CloudAuthInterceptor(token)));
+        apiClient.setHttpClient(createOkHttpClient(new BearerTokenAuthInterceptor(token)));
 
         return apiClient;
     }
@@ -309,11 +309,11 @@ public class ApiClientFactory {
 
     }
 
-    public static class CloudAuthInterceptor implements Interceptor {
+    public static class BearerTokenAuthInterceptor implements Interceptor {
 
         private final String token;
 
-        public CloudAuthInterceptor(String token) {
+        public BearerTokenAuthInterceptor(String token) {
             this.token = token;
         }
 

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClients.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClients.java
@@ -28,43 +28,126 @@ public final class ApiClients {
 
     private static final ApiClientFactory CLIENT_FACTORY = new ApiClientFactory();
 
+    /**
+     * Returns a client to make API calls with, that uses one or more activation keys for authentication.
+     *
+     * @param owner the owner key that the authentication key(s) belong to
+     * @param activationKeys a comma separated list of activation keys to authenticate with
+     * @return a client to make API calls with that uses one or more activation keys for authentication
+     */
     public static ApiClient activationKey(String owner, String activationKeys) {
         return new ApiClient(CLIENT_FACTORY.createActivationKeyClient(owner, activationKeys));
     }
 
+    /**
+     * Returns a client to make API calls by using basic authentication with the special 'admin'/'admin'
+     * username/password. Equivalent to using ApiClients.basic('admin', 'admin').
+     *
+     * @return a client to make API calls by using basic authentication with the special
+     * 'admin'/'admin' username/password
+     */
     public static ApiClient admin() {
         return new ApiClient(CLIENT_FACTORY.createAdminClient());
     }
 
+    /**
+     * Returns a client to make API calls with, that uses basic username/password authentication.
+     *
+     * @param username username of the user
+     * @param password password of the user
+     * @return a client to make API calls with using basic username/password authentication
+     */
     public static ApiClient basic(String username, String password) {
         return new ApiClient(CLIENT_FACTORY.createClient(username, password));
     }
 
+    /**
+     * Returns a client to make API calls with, that uses no authentication whatsoever.
+     *
+     * @return a client to make API calls with that uses no authentication at all
+     */
     public static ApiClient noAuth() {
         return new ApiClient(CLIENT_FACTORY.createNoAuthClient());
     }
 
+    /**
+     * <b>WARNING: should not be used in spec tests, except for the rare case of testing this feature
+     * directly</b>
+     * <p></p>
+     * Returns a client to make API calls with, that uses the special 'cp-consumer: uuid' header, without
+     * doing any actual authentication (except checking that a consumer with that uuid exists), which should
+     * only be used by clients in a trusted environment.
+     *
+     * @param consumerUuid an uuid of the consumer we are trying to authenticate as
+     * @return a client to make API calls with that uses the special 'cp-consumer: uuid' header
+     */
     public static ApiClient trustedConsumer(String consumerUuid) {
         return new ApiClient(CLIENT_FACTORY.createTrustedConsumerClient(consumerUuid));
     }
 
+    /**
+     * <b>WARNING: should not be used in spec tests, except for the rare case of testing this feature
+     * directly</b>
+     * <p></p>
+     * Returns a client to make API calls with, that uses the special 'cp-user: username' header, without
+     * doing any actual authentication (except checking that a user with that username exists), which should
+     * only be used by clients in a trusted environment.
+     *
+     * @param username the username of the user we are trying to authenticate as
+     * @return a client to make API calls with that uses the special 'cp-user: username' header
+     */
     public static ApiClient trustedUser(String username) {
         return new ApiClient(CLIENT_FACTORY.createTrustedUserClient(username, true));
     }
 
+    /**
+     * <b>WARNING: should not be used in spec tests, except for the rare case of testing this feature
+     * directly</b>
+     * <p></p>
+     * Returns a client to make API calls with, that uses the special 'cp-user: username' header, and
+     * optionally the 'cp-lookup-permissions: true/false' header, without doing any actual authentication
+     * (except checking that a user with that username exists), which should only be used by clients in a
+     * trusted environment. When cp-lookup-permissions is set to false, then even the username lookup is
+     * skipped, which automatically results in granting a principal with super-admin priviledges.
+     *
+     * @param username the username of the user we are trying to authenticate as
+     * @param lookupPermissions if true, the username is checked for existence. if false, it isn't, and a
+     * principal with super-admin privileges is granted
+     * @return a client to make API calls with that uses the special 'cp-user: username' header
+     */
     public static ApiClient trustedUser(String username, boolean lookupPermissions) {
         return new ApiClient(CLIENT_FACTORY.createTrustedUserClient(username, lookupPermissions));
     }
 
-    public static ApiClient cloudAuthUser(String token) {
-        return new ApiClient(CLIENT_FACTORY.createCloudAuthClient(token));
+    /**
+     * Returns a client to make API calls with, that uses a bearer token authentication.
+     *
+     * @param token a JWT formatted bearer token
+     * @return a client to make API calls with, that uses a bearer token authentication
+     */
+    public static ApiClient bearerToken(String token) {
+        return new ApiClient(CLIENT_FACTORY.createBearerTokenAuthClient(token));
     }
 
+    /**
+     * Returns a client to make API calls with, that uses two-way SSL authentication (uses a
+     * client/identity certificate and key).
+     *
+     * @param cert a consumer's certificate DTO to authenticate with
+     * @return a client to make API calls with, that uses two-way SSL authentication
+     */
     public static ApiClient ssl(CertificateDTO cert) {
         String certificate = cert.getCert() + cert.getKey();
         return new ApiClient(CLIENT_FACTORY.createSslClient(certificate));
     }
 
+    /**
+     * Returns a client to make API calls with, that uses two-way SSL authentication (uses a
+     * client/identity certificate and key).
+     *
+     * @param consumer a consumer DTO whose identity certificate will be used to authenticate with
+     * @return a client to make API calls with, that uses two-way SSL authentication
+     */
     public static ApiClient ssl(ConsumerDTO consumer) {
         if (consumer == null || consumer.getIdCert() == null) {
             throw new IllegalArgumentException("Expected consumer with identity certificate but got null.");

--- a/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
@@ -64,7 +64,7 @@ class CloudRegistrationSpecTest {
         OwnerDTO owner = upstreamClient.createOwner(Owners.random());
         String key = cloudRegistration.cloudAuthorize(generateToken(owner.getKey(), "test_type",
             "test_signature"));
-        ConsumerDTO consumer = ApiClients.cloudAuthUser(key).consumers()
+        ConsumerDTO consumer = ApiClients.bearerToken(key).consumers()
             .createConsumer(Consumers.random(owner));
         assertNotNull(consumer);
     }
@@ -85,7 +85,7 @@ class CloudRegistrationSpecTest {
         OwnerDTO owner = upstreamClient.createOwner(Owners.random());
         String key = cloudRegistration.cloudAuthorize(generateToken(owner.getKey(),
             "test_type", ""));
-        ConsumerDTO consumer = ApiClients.cloudAuthUser(key).consumers()
+        ConsumerDTO consumer = ApiClients.bearerToken(key).consumers()
             .createConsumer(Consumers.random(owner));
         assertNotNull(consumer);
     }

--- a/spec-tests/src/test/java/org/candlepin/spec/HypervisorCheckInSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/HypervisorCheckInSpecTest.java
@@ -113,7 +113,7 @@ public class HypervisorCheckInSpecTest {
     public void beforeEach() throws ApiException, IOException {
         owner = ownerApi.createOwner(Owners.random());
         user = UserUtil.createUser(client, owner);
-        userClient = ApiClients.trustedUser(user.getUsername());
+        userClient = ApiClients.basic(user.getUsername(), user.getPassword());
 
         guest1VirtUuid = StringUtil.random("uuid");
         guest2VirtUuid = StringUtil.random("uuid");
@@ -128,7 +128,7 @@ public class HypervisorCheckInSpecTest {
             .hypervisorId(new HypervisorIdDTO().hypervisorId(expectedHostHypervisorId));
         hostConsumer = consumerApi.createConsumer(hostConsumer);
         hostUuid = hostConsumer.getUuid();
-        hostConsumerClient = ApiClients.trustedConsumer(hostConsumer.getUuid());
+        hostConsumerClient = ApiClients.ssl(hostConsumer);
 
         reporterId = StringUtil.random("reporter");
         hypervisorCheckin(owner, userClient, expectedHostName,
@@ -318,7 +318,7 @@ public class HypervisorCheckInSpecTest {
     @OnlyInStandalone
     public void shouldNotRevokeGuestEntitlementsWhenGuestNoLongerMapped() throws Exception {
         initConsumersAndPools();
-        ApiClient guest1Client = ApiClients.trustedConsumer(guestConsumer1.getUuid());
+        ApiClient guest1Client = ApiClients.ssl(guestConsumer1);
         guest1Client.consumers().bindPool(guestConsumer1.getUuid(), virtLimitPool.getId(), 1);
         assertEquals(1, guest1Client.consumers().listEntitlements(guestConsumer1.getUuid()).size());
         // Host stops reporting guest:
@@ -354,7 +354,7 @@ public class HypervisorCheckInSpecTest {
     @OnlyInStandalone
     public void shouldNotRevokeHostAndGuestEntitlementsWhenGuestIdListIsEmpty() throws Exception {
         initConsumersAndPools();
-        ApiClient guest1Client = ApiClients.trustedConsumer(guestConsumer1.getUuid());
+        ApiClient guest1Client = ApiClients.ssl(guestConsumer1);
         guest1Client.consumers().bindPool(guestConsumer1.getUuid(), virtLimitPool.getId(), 1);
         assertEquals(1, guest1Client.consumers().listEntitlements(guestConsumer1.getUuid()).size());
 
@@ -384,14 +384,16 @@ public class HypervisorCheckInSpecTest {
     public void shouldSupportMultipleOrgsReportingTheSameCluster() throws Exception {
         OwnerDTO owner1 = ownerApi.createOwner(Owners.random());
         OwnerDTO owner2 = ownerApi.createOwner(Owners.random());
-        ApiClient userClient1 = ApiClients.trustedUser(UserUtil.createUser(client, owner1).getUsername());
-        ApiClient userClient2 = ApiClients.trustedUser(UserUtil.createUser(client, owner2).getUsername());
+        UserDTO user1 = UserUtil.createUser(client, owner1);
+        UserDTO user2 = UserUtil.createUser(client, owner2);
+        ApiClient userClient1 = ApiClients.basic(user1.getUsername(), user1.getPassword());
+        ApiClient userClient2 = ApiClients.basic(user2.getUsername(), user2.getPassword());
         ConsumerDTO consumer1 = Consumers.random(owner1);
         consumer1 = userClient1.consumers().createConsumer(consumer1);
-        ApiClient consumerClient1 = ApiClients.trustedConsumer(consumer1.getUuid());
+        ApiClient consumerClient1 = ApiClients.ssl(consumer1);
         ConsumerDTO consumer2 = Consumers.random(owner2);
         consumer2 = userClient2.consumers().createConsumer(consumer2);
-        ApiClient consumerClient2 = ApiClients.trustedConsumer(consumer2.getUuid());
+        ApiClient consumerClient2 = ApiClients.ssl(consumer2);
         String hostHypId = StringUtil.random("host");
         String hostName = StringUtil.random("name");
         List<String> firstGuestList = List.of("guest1", "guest2", "guest3");
@@ -509,7 +511,7 @@ public class HypervisorCheckInSpecTest {
     public void shouldAllowASingleGuestToBeMigratedAndRevokeHostLimitedEnts() throws Exception {
         OwnerDTO owner = ownerApi.createOwner(Owners.random());
         UserDTO user = UserUtil.createUser(client, owner);
-        ApiClient userClient = ApiClients.trustedUser(user.getUsername());
+        ApiClient userClient = ApiClients.basic(user.getUsername(), user.getPassword());
         String hypervisorId1 = StringUtil.random("hypervisor").toLowerCase();
         String hypervisorId2 = StringUtil.random("hypervisor").toLowerCase();
         String uuid1 = StringUtil.random("uuid");
@@ -539,9 +541,9 @@ public class HypervisorCheckInSpecTest {
         PoolDTO pool = Pools.random(superAwesome);
         ownerApi.createPool(owner.getKey(), pool);
 
-        ApiClient hostConsumerClient = ApiClients.trustedConsumer(hostConsumer.getUuid());
-        ApiClient newHostConsumerClient = ApiClients.trustedConsumer(newHostConsumer.getUuid());
-        ApiClient guestConsumerClient = ApiClients.trustedConsumer(guestConsumer.getUuid());
+        ApiClient hostConsumerClient = ApiClients.ssl(hostConsumer);
+        ApiClient newHostConsumerClient = ApiClients.ssl(newHostConsumer);
+        ApiClient guestConsumerClient = ApiClients.ssl(guestConsumer);
 
         hypervisorCheckin(owner, userClient, "tester",
             hypervisorId1, List.of(uuid1), null, reporterId, true);
@@ -592,7 +594,7 @@ public class HypervisorCheckInSpecTest {
             hostedTestApi = client.hosted();
             owner = ownerApi.createOwner(Owners.random());
             user = UserUtil.createUser(client, owner);
-            userClient = ApiClients.trustedUser(user.getUsername());
+            userClient = ApiClients.basic(user.getUsername(), user.getPassword());
 
             hostConsumer = Consumers.random(owner)
                 .name(expectedHostName)
@@ -601,7 +603,7 @@ public class HypervisorCheckInSpecTest {
                 .hypervisorId(new HypervisorIdDTO().hypervisorId(expectedHostHypervisorId));
             hostConsumer = consumerApi.createConsumer(hostConsumer);
             hostUuid = hostConsumer.getUuid();
-            hostConsumerClient = ApiClients.trustedConsumer(hostConsumer.getUuid());
+            hostConsumerClient = ApiClients.ssl(hostConsumer);
 
             hypervisorCheckin(owner, userClient, expectedHostName,
                 expectedHostHypervisorId, expectedGuestIds,
@@ -649,7 +651,7 @@ public class HypervisorCheckInSpecTest {
         @Test
         public void shouldNotRevokeGuestEntitlementsWhenGuestNoLongerMapped() throws Exception {
             initConsumersAndSubs();
-            ApiClient guest1Client = ApiClients.trustedConsumer(guestConsumer1.getUuid());
+            ApiClient guest1Client = ApiClients.ssl(guestConsumer1);
             guest1Client.consumers().bindPool(guestConsumer1.getUuid(), virtLimitPool.getId(), 1);
             assertEquals(1, guest1Client.consumers().listEntitlements(guestConsumer1.getUuid()).size());
             // Host stops reporting guest:
@@ -668,7 +670,7 @@ public class HypervisorCheckInSpecTest {
         @Test
         public void shouldNotRevokeHostAndGuestEntitlementsWhenGuestIdListIsEmpty() throws Exception {
             initConsumersAndSubs();
-            ApiClient guest1Client = ApiClients.trustedConsumer(guestConsumer1.getUuid());
+            ApiClient guest1Client = ApiClients.ssl(guestConsumer1);
             guest1Client.consumers().bindPool(guestConsumer1.getUuid(), virtLimitPool.getId(), 1);
             assertEquals(1, guest1Client.consumers().listEntitlements(guestConsumer1.getUuid()).size());
 
@@ -689,7 +691,7 @@ public class HypervisorCheckInSpecTest {
         public void shouldAllowASingleGuestToBeMigratedAndRevokeHostLimitedEntsHosted() throws Exception {
             OwnerDTO owner = ownerApi.createOwner(Owners.random());
             UserDTO user = UserUtil.createUser(client, owner);
-            ApiClient userClient = ApiClients.trustedUser(user.getUsername());
+            ApiClient userClient = ApiClients.basic(user.getUsername(), user.getPassword());
             String hypervisorId1 = StringUtil.random("hypervisor").toLowerCase();
             String hypervisorId2 = StringUtil.random("hypervisor").toLowerCase();
             String uuid1 = StringUtil.random("uuid");
@@ -725,9 +727,9 @@ public class HypervisorCheckInSpecTest {
                 assertEquals("FINISHED", status.getState());
             }
 
-            ApiClient hostConsumerClient = ApiClients.trustedConsumer(hostConsumer.getUuid());
-            ApiClient newHostConsumerClient = ApiClients.trustedConsumer(newHostConsumer.getUuid());
-            ApiClient guestConsumerClient = ApiClients.trustedConsumer(guestConsumer.getUuid());
+            ApiClient hostConsumerClient = ApiClients.ssl(hostConsumer);
+            ApiClient newHostConsumerClient = ApiClients.ssl(newHostConsumer);
+            ApiClient guestConsumerClient = ApiClients.ssl(guestConsumer);
 
             hypervisorCheckin(owner, userClient, "tester",
                 hypervisorId1, List.of(uuid1), null, reporterId, true);
@@ -865,7 +867,7 @@ public class HypervisorCheckInSpecTest {
             .installedProducts(Set.of(
                 new ConsumerInstalledProductDTO().productId("installedProd").productName("Installed")));
         consumer = userClient.consumers().createConsumer(consumer);
-        return ApiClients.trustedConsumer(consumer.getUuid());
+        return ApiClients.ssl(consumer);
     }
 
     PoolDTO getVirtLimitPool(List<PoolDTO> pools) {

--- a/spec-tests/src/test/java/org/candlepin/spec/activationkey/ActivationKeySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/activationkey/ActivationKeySpecTest.java
@@ -226,7 +226,8 @@ public class ActivationKeySpecTest {
         ApiClient adminClient = ApiClients.admin();
         OwnerDTO owner = createOwner(adminClient);
         UserDTO superadminUser = UserUtil.createAdminUser(adminClient, owner);
-        ApiClient superadminClient = ApiClients.trustedUser(superadminUser.getUsername());
+        ApiClient superadminClient = ApiClients.basic(superadminUser.getUsername(),
+            superadminUser.getPassword());
 
         ActivationKeyDTO activationKey = createActivationKey(superadminClient, owner);
         List<ActivationKeyDTO> listOfActivationKeys =
@@ -675,7 +676,7 @@ public class ActivationKeySpecTest {
 
     private ApiClient createUserClient(ApiClient client, OwnerDTO owner) {
         UserDTO user = UserUtil.createUser(client, owner);
-        return ApiClients.trustedUser(user.getUsername(), true);
+        return ApiClients.basic(user.getUsername(), user.getPassword());
     }
 
     private ProductDTO createProduct(ApiClient client, OwnerDTO owner, AttributeDTO... attributes) {

--- a/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentSpecTest.java
@@ -76,7 +76,7 @@ class OwnerContentSpecTest {
 
     private ApiClient createOrgAdminClient(ApiClient adminClient, OwnerDTO owner) {
         UserDTO user = UserUtil.createUser(adminClient, owner);
-        return ApiClients.trustedUser(user.getUsername(), true);
+        return ApiClients.basic(user.getUsername(), user.getPassword());
     }
 
     private ApiClient createConsumerClient(ApiClient adminClient, OwnerDTO owner) {

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceConcurrentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceConcurrentSpecTest.java
@@ -164,7 +164,7 @@ public class EntitlementResourceConcurrentSpecTest {
         throws ApiException {
         ConsumerDTO consumer = client.consumers().createConsumer(
             Consumers.random(owner).type(new ConsumerTypeDTO().label(consumerType)));
-        ConsumerClient consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
+        ConsumerClient consumerClient = ApiClients.ssl(consumer).consumers();
         try {
             consumerClient.bindPool(consumer.getUuid(), poolId, quantity);
         }

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceFilteringSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceFilteringSpecTest.java
@@ -75,7 +75,7 @@ public class EntitlementResourceFilteringSpecTest {
         ownerClient.createPool(owner.getKey(), Pools.random(virtual));
 
         consumer = client.consumers().createConsumer(Consumers.random(owner));
-        consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
+        consumerClient = ApiClients.ssl(consumer).consumers();
 
         consumerClient.bindProduct(consumer.getUuid(), monitoring.getId());
         consumerClient.bindProduct(consumer.getUuid(), virtual.getId());

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceSpecTest.java
@@ -86,7 +86,7 @@ class EntitlementResourceSpecTest {
             .name(StringUtil.random("virtualization")));
 
         consumer = client.consumers().createConsumer(Consumers.random(owner));
-        consumerClient = ApiClients.trustedConsumer(consumer.getUuid()).consumers();
+        consumerClient = ApiClients.ssl(consumer).consumers();
     }
 
     @Test

--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/JobStatusSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/JobStatusSpecTest.java
@@ -82,7 +82,7 @@ class JobStatusSpecTest {
         owner = ownerApi.createOwner(Owners.random());
         user = UserUtil.createUser(client, owner);
 
-        userClient = ApiClients.trustedUser(user.getUsername());
+        userClient = ApiClients.basic(user.getUsername(), user.getPassword());
 
         product = Products.random();
         product = ownerProductApi.createProductByOwner(owner.getKey(), product);
@@ -268,7 +268,7 @@ class JobStatusSpecTest {
         try {
             AsyncJobStatusDTO job = userClient.owners().healEntire(owner.getKey());
             UserDTO otherUser = UserUtil.createUser(client, owner);
-            ApiClient otherUserClient = ApiClients.trustedUser(otherUser.getUsername());
+            ApiClient otherUserClient = ApiClients.basic(otherUser.getUsername(), otherUser.getPassword());
 
             assertForbidden(() -> otherUserClient.jobs().cancelJob(job.getId()));
             jobId = job.getId();
@@ -329,7 +329,7 @@ class JobStatusSpecTest {
     public void shouldNotAllowUserToViewJobStatusOutsideManagedOrg() throws Exception {
         OwnerDTO otherOwner = ownerApi.createOwner(Owners.random());
         UserDTO otherUser = UserUtil.createUser(client, otherOwner);
-        ApiClient otherUserClient = ApiClients.trustedUser(otherUser.getUsername());
+        ApiClient otherUserClient = ApiClients.basic(otherUser.getUsername(), otherUser.getPassword());
 
         ConsumerDTO consumer = Consumers.random(otherOwner);
         consumer = consumerApi.createConsumer(consumer, otherUser.getUsername(), otherOwner.getKey(), null,

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
@@ -109,7 +109,7 @@ class OwnerResourceSpecTest {
     void shouldRetrieveOnlyConsumerTypesForOwner() {
         OwnerDTO newOwner = owners.createOwner(Owners.random());
         UserDTO user = UserUtil.createUser(admin, newOwner);
-        ApiClient userClient = ApiClients.trustedUser(user.getUsername());
+        ApiClient userClient = ApiClients.basic(user.getUsername(), user.getPassword());
         userClient.consumers().createConsumer(Consumers.random(newOwner));
 
         List<ConsumerDTOArrayElement> consumers = userClient.owners()
@@ -131,7 +131,7 @@ class OwnerResourceSpecTest {
     void shouldRetrieveOnlyOwnersConsumers() {
         OwnerDTO testOwner = owners.createOwner(Owners.random());
         UserDTO user = UserUtil.createUser(admin, testOwner);
-        ApiClient userClient = ApiClients.trustedUser(user.getUsername());
+        ApiClient userClient = ApiClients.basic(user.getUsername(), user.getPassword());
         userClient.consumers().createConsumer(Consumers.random(testOwner));
 
         List<ConsumerDTOArrayElement> consumers = userClient.owners()
@@ -144,7 +144,7 @@ class OwnerResourceSpecTest {
     void shouldRetrieveConsumersServiceLevels() {
         OwnerDTO owner = owners.createOwner(Owners.random());
         UserDTO user = UserUtil.createUser(admin, owner);
-        ApiClient userClient = ApiClients.trustedUser(user.getUsername());
+        ApiClient userClient = ApiClients.basic(user.getUsername(), user.getPassword());
 
         ConsumerDTO consumer = userClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
@@ -166,7 +166,7 @@ class OwnerResourceSpecTest {
     void shouldRetrieveOnlyConsumersServiceLevels() {
         OwnerDTO testOwner = owners.createOwner(Owners.random());
         UserDTO user = UserUtil.createUser(admin, testOwner);
-        ApiClient userClient = ApiClients.trustedUser(user.getUsername());
+        ApiClient userClient = ApiClients.basic(user.getUsername(), user.getPassword());
         OwnerDTO testOwner2 = owners.createOwner(Owners.random());
 
         ConsumerDTO consumer = userClient.consumers().createConsumer(Consumers.random(testOwner));
@@ -243,7 +243,7 @@ class OwnerResourceSpecTest {
     void shouldLetOwnersListPoolsPagedForConsumer() {
         OwnerDTO owner = owners.createOwner(Owners.random());
         UserDTO user = UserUtil.createUser(admin, owner);
-        ApiClient userClient = ApiClients.trustedUser(user.getUsername());
+        ApiClient userClient = ApiClients.basic(user.getUsername(), user.getPassword());
         ConsumerDTO consumer = userClient.consumers().createConsumer(Consumers.random(owner));
         ProductDTO product = createProduct(owner);
 
@@ -298,9 +298,10 @@ class OwnerResourceSpecTest {
         UserDTO readOnlyUser = UserUtil.createReadOnlyUser(admin, owner);
         UserDTO readWriteUser = UserUtil.createUser(admin, owner);
         UserDTO adminUser = UserUtil.createAdminUser(admin, owner);
-        ApiClient readOnlyClient = ApiClients.trustedUser(readOnlyUser.getUsername());
-        ApiClient readWriteClient = ApiClients.trustedUser(readWriteUser.getUsername());
-        ApiClient adminClient = ApiClients.trustedUser(adminUser.getUsername());
+        ApiClient readOnlyClient = ApiClients.basic(readOnlyUser.getUsername(), readOnlyUser.getPassword());
+        ApiClient readWriteClient = ApiClients.basic(readWriteUser.getUsername(),
+            readWriteUser.getPassword());
+        ApiClient adminClient = ApiClients.basic(adminUser.getUsername(), adminUser.getPassword());
 
         assertForbidden(() -> readOnlyClient.owners().refreshPools(owner.getKey(), false));
         assertForbidden(() -> readWriteClient.owners().refreshPools(owner.getKey(), false));
@@ -312,8 +313,9 @@ class OwnerResourceSpecTest {
         OwnerDTO owner = owners.createOwner(Owners.random());
         UserDTO readOnlyUser = UserUtil.createReadOnlyUser(admin, owner);
         UserDTO readWriteUser = UserUtil.createUser(admin, owner);
-        ApiClient readOnlyClient = ApiClients.trustedUser(readOnlyUser.getUsername());
-        ApiClient readWriteClient = ApiClients.trustedUser(readWriteUser.getUsername());
+        ApiClient readOnlyClient = ApiClients.basic(readOnlyUser.getUsername(), readOnlyUser.getPassword());
+        ApiClient readWriteClient = ApiClients.basic(readWriteUser.getUsername(),
+            readWriteUser.getPassword());
 
         assertForbidden(() -> readOnlyClient.consumers().createConsumer(Consumers.random(owner)));
         ConsumerDTO consumer = readWriteClient.consumers().createConsumer(Consumers.random(owner));
@@ -325,7 +327,7 @@ class OwnerResourceSpecTest {
         OwnerDTO owner1 = owners.createOwner(Owners.random());
         OwnerDTO owner2 = owners.createOwner(Owners.random());
         UserDTO user = UserUtil.createReadOnlyUser(admin, owner1);
-        ApiClient ownerClient = ApiClients.trustedUser(user.getUsername());
+        ApiClient ownerClient = ApiClients.basic(user.getUsername(), user.getPassword());
 
         assertNotFound(() -> ownerClient.consumers().createConsumer(Consumers.random(owner2)));
     }
@@ -449,7 +451,7 @@ class OwnerResourceSpecTest {
     void shouldExemptServiceLevelFiltering() {
         OwnerDTO owner = owners.createOwner(Owners.random());
         UserDTO user = UserUtil.createUser(admin, owner);
-        ApiClient userClient = ApiClients.trustedUser(user.getUsername());
+        ApiClient userClient = ApiClients.basic(user.getUsername(), user.getPassword());
         ConsumerDTO consumer = userClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
@@ -538,7 +540,7 @@ class OwnerResourceSpecTest {
         owners.createPool(owner.getKey(), Pools.random(product));
 
         UserDTO user = UserUtil.createUser(admin, owner);
-        ApiClient userClient = ApiClients.trustedUser(user.getUsername());
+        ApiClient userClient = ApiClients.basic(user.getUsername(), user.getPassword());
         ConsumerDTO consumer = admin.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
@@ -587,7 +589,7 @@ class OwnerResourceSpecTest {
     void shouldLookupByConsumerType() {
         OwnerDTO owner = owners.createOwner(Owners.random());
         UserDTO user = UserUtil.createUser(admin, owner);
-        ApiClient userClient = ApiClients.trustedUser(user.getUsername());
+        ApiClient userClient = ApiClients.basic(user.getUsername(), user.getPassword());
         userClient.consumers().createConsumer(Consumers.random(owner));
         userClient.consumers().createConsumer(Consumers.random(owner));
         userClient.consumers().createConsumer(Consumers.random(owner, ConsumerTypes.Hypervisor));

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/PoolSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/PoolSpecTest.java
@@ -120,7 +120,7 @@ class PoolSpecTest {
 
     private ApiClient createUserClient(ApiClient client, OwnerDTO owner) {
         UserDTO user = UserUtil.createUser(client, owner);
-        return ApiClients.trustedUser(user.getUsername(), true);
+        return ApiClients.basic(user.getUsername(), user.getPassword());
     }
 
     private ApiClient createConsumerClient(ApiClient client, OwnerDTO owner) {

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/PostBindBonusPoolSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/PostBindBonusPoolSpecTest.java
@@ -73,7 +73,7 @@ class PostBindBonusPoolSpecTest {
         systemUser.setUsername("admin");
         systemUser = adminClient.consumers().createConsumer(systemUser, "admin",
         owner.getKey(), null, true);
-        ApiClient systemClient = ApiClients.trustedConsumer(systemUser.getUuid());
+        ApiClient systemClient = ApiClients.ssl(systemUser);
 
         ProductDTO limitedVirtProd = createLimitedVirtProduct(adminClient, ownerKey, 4);
         PoolDTO limitedMasterPool = Pools.randomUpstream(limitedVirtProd);
@@ -90,7 +90,7 @@ class PostBindBonusPoolSpecTest {
         systemUser.setUsername("admin");
         systemUser = adminClient.consumers().createConsumer(systemUser, "admin",
         owner.getKey(), null, true);
-        ApiClient systemClient = ApiClients.trustedConsumer(systemUser.getUuid());
+        ApiClient systemClient = ApiClients.ssl(systemUser);
 
         ProductDTO limitVirtProd = createLimitedVirtProduct(adminClient, ownerKey, 4);
         PoolDTO limitedMasterPool = Pools.randomUpstream(limitVirtProd);
@@ -105,7 +105,7 @@ class PostBindBonusPoolSpecTest {
         systemUser.setUsername("admin");
         systemUser = adminClient.consumers().createConsumer(systemUser, "admin",
         owner.getKey(), null, true);
-        ApiClient systemClient = ApiClients.trustedConsumer(systemUser.getUuid());
+        ApiClient systemClient = ApiClients.ssl(systemUser);
 
         ProductDTO hostLimitedProd = createHostLimitedProduct(adminClient, ownerKey);
         PoolDTO hostLimitedMasterPool = Pools.randomUpstream(hostLimitedProd);
@@ -121,7 +121,7 @@ class PostBindBonusPoolSpecTest {
         systemUser.setUsername("admin");
         systemUser = adminClient.consumers().createConsumer(systemUser, "admin",
         owner.getKey(), null, true);
-        ApiClient systemClient = ApiClients.trustedConsumer(systemUser.getUuid());
+        ApiClient systemClient = ApiClients.ssl(systemUser);
 
         ProductDTO virtLimitStackedProd = createVirtLimitStackedProduct(adminClient, ownerKey, 9);
         PoolDTO limitedMasterStackedPool = Pools.randomUpstream(virtLimitStackedProd);
@@ -137,7 +137,7 @@ class PostBindBonusPoolSpecTest {
         systemUser.setUsername("admin");
         systemUser = adminClient.consumers().createConsumer(systemUser, "admin",
         owner.getKey(), null, true);
-        ApiClient systemClient = ApiClients.trustedConsumer(systemUser.getUuid());
+        ApiClient systemClient = ApiClients.ssl(systemUser);
 
         ProductDTO hostLimitedStackedProd = createHostLimitedStackedProduct(adminClient, ownerKey, 9);
         PoolDTO hostLimitedMasterStackedPool = Pools.randomUpstream(hostLimitedStackedProd);
@@ -153,7 +153,7 @@ class PostBindBonusPoolSpecTest {
         systemUser.setUsername("admin");
         systemUser = adminClient.consumers().createConsumer(systemUser, "admin",
         owner.getKey(), null, true);
-        ApiClient systemClient = ApiClients.trustedConsumer(systemUser.getUuid());
+        ApiClient systemClient = ApiClients.ssl(systemUser);
 
         ProductDTO hostLimitedProd = createHostLimitedProduct(adminClient, ownerKey);
         PoolDTO hostLimitedMasterPool = Pools.randomUpstream(hostLimitedProd);
@@ -173,7 +173,7 @@ class PostBindBonusPoolSpecTest {
         throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         int virtLimit = 4;
         ProductDTO limitVirtProd = createLimitedVirtProduct(adminClient, ownerKey, virtLimit);
@@ -201,7 +201,7 @@ class PostBindBonusPoolSpecTest {
     void shouldUpdateBonusPoolQuantityWhenExportEntitlementQuantityIsUpdated() throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         int virtLimit = 4;
         ProductDTO limitVirtProd = createLimitedVirtProduct(adminClient, ownerKey, virtLimit);
@@ -239,7 +239,7 @@ class PostBindBonusPoolSpecTest {
         throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         ProductDTO unlimitedVirtProd = createUnlimitedVirtProduct(adminClient, ownerKey);
         PoolDTO unlimitedMasterPool = Pools.randomUpstream(unlimitedVirtProd);
@@ -263,7 +263,7 @@ class PostBindBonusPoolSpecTest {
         throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         ProductDTO unlimitedVirtProd = createUnlimitedVirtProduct(adminClient, ownerKey);
         int masterPoolQuantity = 10;
@@ -293,13 +293,13 @@ class PostBindBonusPoolSpecTest {
         guest.setUuid(StringUtil.random("guest"));
         guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
         guest = adminClient.consumers().createConsumer(guest);
-        ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+        ApiClient guestClient = ApiClients.ssl(guest);
 
         ConsumerDTO systemUser = Consumers.random(owner, ConsumerTypes.System);
         systemUser.setUsername("admin");
         systemUser = adminClient.consumers().createConsumer(systemUser, "admin",
         owner.getKey(), null, true);
-        ApiClient systemClient = ApiClients.trustedConsumer(systemUser.getUuid());
+        ApiClient systemClient = ApiClients.ssl(systemUser);
 
         ProductDTO unlimitedVirtProd = createUnlimitedVirtProduct(adminClient, ownerKey);
         PoolDTO unlimitedMasterPool = Pools.randomUpstream(unlimitedVirtProd);
@@ -330,7 +330,7 @@ class PostBindBonusPoolSpecTest {
         systemUser.setUsername("admin");
         systemUser = adminClient.consumers().createConsumer(systemUser, "admin",
         owner.getKey(), null, true);
-        ApiClient systemClient = ApiClients.trustedConsumer(systemUser.getUuid());
+        ApiClient systemClient = ApiClients.ssl(systemUser);
 
         ProductDTO hostLimitedProd = createHostLimitedProduct(adminClient, ownerKey);
         PoolDTO hostLimitedMasterPool = Pools.randomUpstream(hostLimitedProd);
@@ -371,7 +371,7 @@ class PostBindBonusPoolSpecTest {
         systemUser.setUsername("admin");
         systemUser = adminClient.consumers().createConsumer(systemUser, "admin",
         owner.getKey(), null, true);
-        ApiClient systemClient = ApiClients.trustedConsumer(systemUser.getUuid());
+        ApiClient systemClient = ApiClients.ssl(systemUser);
 
         ProductDTO unlimitedVirtProd = createUnlimitedVirtProduct(adminClient, ownerKey);
         PoolDTO unlimitedMasterPool = Pools.randomUpstream(unlimitedVirtProd);
@@ -412,7 +412,7 @@ class PostBindBonusPoolSpecTest {
         systemUser.setUsername("admin");
         systemUser = adminClient.consumers().createConsumer(systemUser, "admin",
         owner.getKey(), null, true);
-        ApiClient systemClient = ApiClients.trustedConsumer(systemUser.getUuid());
+        ApiClient systemClient = ApiClients.ssl(systemUser);
 
         int virtLimit = 4;
         ProductDTO limitedVirtProd = createLimitedVirtProduct(adminClient, ownerKey, virtLimit);
@@ -451,13 +451,13 @@ class PostBindBonusPoolSpecTest {
     void shouldRevokeExcessEntitlementsWhenFiniteVirtLimitedMasterPoolIsExported() throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         ConsumerDTO guest = Consumers.random(owner, ConsumerTypes.System);
         guest.setUuid(StringUtil.random("guest"));
         guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
         guest = adminClient.consumers().createConsumer(guest);
-        ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+        ApiClient guestClient = ApiClients.ssl(guest);
 
         int virtLimit = 4;
         ProductDTO limitVirtProd = createLimitedVirtProduct(adminClient, ownerKey, virtLimit);
@@ -491,19 +491,19 @@ class PostBindBonusPoolSpecTest {
     void shouldRevokeOnlySufficientEntitlementsWhenFiniteVirtLimitedMasterPoolIsExported() throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         ConsumerDTO guest = Consumers.random(owner, ConsumerTypes.System);
         guest.setUuid(StringUtil.random("guest"));
         guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
         guest = adminClient.consumers().createConsumer(guest);
-        ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+        ApiClient guestClient = ApiClients.ssl(guest);
 
         ConsumerDTO guest2 = Consumers.random(owner, ConsumerTypes.System);
         guest2.setUuid(StringUtil.random("guest"));
         guest2.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest2.getUuid()));
         guest2 = adminClient.consumers().createConsumer(guest2);
-        ApiClient guestClient2 = ApiClients.trustedConsumer(guest2.getUuid());
+        ApiClient guestClient2 = ApiClients.ssl(guest2);
 
         int virtLimit = 4;
         int masterPoolQuant = 10;
@@ -561,13 +561,13 @@ class PostBindBonusPoolSpecTest {
     void shouldRevokeSufficientEntitlementsWhenEntitlementQuantityIsUpdated() throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         ConsumerDTO guest = Consumers.random(owner, ConsumerTypes.System);
         guest.setUuid(StringUtil.random("guest"));
         guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
         guest = adminClient.consumers().createConsumer(guest);
-        ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+        ApiClient guestClient = ApiClients.ssl(guest);
 
         int virtLimit = 4;
         int masterPoolQuant = 10;
@@ -618,13 +618,13 @@ class PostBindBonusPoolSpecTest {
         throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         ConsumerDTO guest = Consumers.random(owner, ConsumerTypes.System);
         guest.setUuid(StringUtil.random("guest"));
         guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
         guest = adminClient.consumers().createConsumer(guest);
-        ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+        ApiClient guestClient = ApiClients.ssl(guest);
 
         ProductDTO unlimitedVirtProd = createUnlimitedVirtProduct(adminClient, ownerKey);
         PoolDTO unlimitedMasterPool = Pools.randomUpstream(unlimitedVirtProd);
@@ -656,19 +656,19 @@ class PostBindBonusPoolSpecTest {
         throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         ConsumerDTO guest = Consumers.random(owner, ConsumerTypes.System);
         guest.setUuid(StringUtil.random("guest"));
         guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
         guest = adminClient.consumers().createConsumer(guest);
-        ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+        ApiClient guestClient = ApiClients.ssl(guest);
 
         ConsumerDTO guest2 = Consumers.random(owner, ConsumerTypes.System);
         guest2.setUuid(StringUtil.random("guest"));
         guest2.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest2.getUuid()));
         guest2 = adminClient.consumers().createConsumer(guest2);
-        ApiClient guestClient2 = ApiClients.trustedConsumer(guest2.getUuid());
+        ApiClient guestClient2 = ApiClients.ssl(guest2);
 
         ProductDTO unlimitedVirtProd = createUnlimitedVirtProduct(adminClient, ownerKey);
         PoolDTO unlimitedMasterPool = Pools.randomUpstream(unlimitedVirtProd);
@@ -706,7 +706,7 @@ class PostBindBonusPoolSpecTest {
         guest.setUuid(StringUtil.random("guest"));
         guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
         guest = adminClient.consumers().createConsumer(guest);
-        ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+        ApiClient guestClient = ApiClients.ssl(guest);
 
         ProductDTO unlimitedProd = createUnlimitedProduct(adminClient, ownerKey, 4);
         PoolDTO unlimitedProdMasterPool = Pools.randomUpstream(unlimitedProd).quantity(-1L);
@@ -737,7 +737,7 @@ class PostBindBonusPoolSpecTest {
         throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         ProductDTO unlimitedProd = createUnlimitedProduct(adminClient, ownerKey, 4);
         PoolDTO unlimitedProdMasterPool = Pools.randomUpstream(unlimitedProd).quantity(-1L);
@@ -772,7 +772,7 @@ class PostBindBonusPoolSpecTest {
         guest.setUuid(StringUtil.random("guest"));
         guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
         guest = adminClient.consumers().createConsumer(guest);
-        ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+        ApiClient guestClient = ApiClients.ssl(guest);
 
         ProductDTO hostLimitedUnlimitedVirtProduct =
             createHostLimitedUnlimitedVirtProduct(adminClient, ownerKey);
@@ -797,13 +797,13 @@ class PostBindBonusPoolSpecTest {
         throws Exception {
         ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
         cpUser = adminClient.consumers().createConsumer(cpUser);
-        ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+        ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
         ConsumerDTO guest = Consumers.random(owner, ConsumerTypes.System);
         guest.setUuid(StringUtil.random("guest"));
         guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
         guest = adminClient.consumers().createConsumer(guest);
-        ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+        ApiClient guestClient = ApiClients.ssl(guest);
 
         ProductDTO hostLimitedUnlimitedVirtProd =
             createHostLimitedUnlimitedVirtProduct(adminClient, ownerKey);
@@ -866,7 +866,7 @@ class PostBindBonusPoolSpecTest {
             guest.setUuid(StringUtil.random("guest"));
             guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
             guest = adminClient.consumers().createConsumer(guest);
-            ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+            ApiClient guestClient = ApiClients.ssl(guest);
 
             PoolDTO unlimitedProdBonusPool =
                 getBonusPool(adminClient, ownerKey, unlimitedProdMasterPool.getSubscriptionId());
@@ -907,7 +907,7 @@ class PostBindBonusPoolSpecTest {
             throws Exception {
             ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
             cpUser = adminClient.consumers().createConsumer(cpUser);
-            ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+            ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
             PoolDTO unlimitedProductBonusPool =
                 getBonusPool(adminClient, ownerKey, unlimitedProdMasterPool.getSubscriptionId());
@@ -950,13 +950,13 @@ class PostBindBonusPoolSpecTest {
             throws Exception {
             ConsumerDTO cpUser = Consumers.random(owner, ConsumerTypes.Candlepin);
             cpUser = adminClient.consumers().createConsumer(cpUser);
-            ApiClient candlepinClient = ApiClients.trustedConsumer(cpUser.getUuid());
+            ApiClient candlepinClient = ApiClients.ssl(cpUser);
 
             ConsumerDTO guest = Consumers.random(owner, ConsumerTypes.System);
             guest.setUuid(StringUtil.random("guest"));
             guest.setFacts(Map.of("virt.is_guest", "true", "virt.uuid", guest.getUuid()));
             guest = adminClient.consumers().createConsumer(guest);
-            ApiClient guestClient = ApiClients.trustedConsumer(guest.getUuid());
+            ApiClient guestClient = ApiClients.ssl(guest);
 
             PoolDTO hostLimitedUnlimitedVirtBonusPool =
                 getBonusPool(adminClient, ownerKey, hostAndVirtLimitedProdMasterPool.getSubscriptionId());


### PR DESCRIPTION
- While porting spec tests from ruby to java, there has been a heavy use of ApiClients.trustedConsumer and ApiClients.trustedUser auth methods which are using the 'magic' headers (cp-consumer/cp-user). The ruby tests never used those, and instead use the identity cert + key and username + password for authentication. This change switches all existing java spec tests to use the ApiClients.basic(username, password) and ApiClients.ssl(consumer) which are the more realistic authentication use cases.