### PR TITLE
[M] 2134502: Satellite cannot enable or sync satellite-tools repo

### DIFF
--- a/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -589,7 +589,8 @@ public class X509V3ExtensionUtil extends X509Util {
                     // all grandparents with name now point to merged node
                     for (PathNode pn : toRemove.getParents()) {
                         for (NodePair child : pn.getChildren()) {
-                            if (child.getName().equals(name)) {
+                            if (child.getName().equals(name) &&
+                                child.getConnection().isEquivalentTo(merged)) {
                                 child.setConnection(merged);
                             }
                         }


### PR DESCRIPTION
- The path tree condensing algorithm was dropping nodes in some specific cases
- This code was untouched for 10 years and only after a change was made to the
  hashing of content did it surface.
- Included are sets of data, where it previously did and did not work correctly,
  in unit tests so that we will see any future problems sooner.
- The urls in the files should all be compressed and decompressed correctly
  if the algorithm is operating properly.