### PR TITLE
[4.1] 2134480: Satellite cannot enable or sync satellite-tools repo

### DIFF
--- a/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -593,7 +593,8 @@ public class X509V3ExtensionUtil extends X509Util {
                     // all grandparents with name now point to merged node
                     for (PathNode pn : toRemove.getParents()) {
                         for (NodePair child : pn.getChildren()) {
-                            if (child.getName().equals(name)) {
+                            if (child.getName().equals(name) &&
+                                child.getConnection().isEquivalentTo(merged)) {
                                 child.setConnection(merged);
                             }
                         }

--- a/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyString;
@@ -83,6 +84,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -112,6 +116,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.stream.Stream;
 import java.util.zip.InflaterOutputStream;
 
 import javax.inject.Inject;
@@ -2033,6 +2038,55 @@ public class DefaultEntitlementCertServiceAdapterTest {
             Object found = v3extensionUtil.findHuffNodeValueByBits(trieParent, paths[idx++]);
             assertEquals(o, found);
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("pathTreeCondensationProvider")
+    public void testPathTreeCondensation(List<String> paths) {
+        List<org.candlepin.model.dto.Content> contentList = new ArrayList<>();
+        for (String path : paths) {
+            org.candlepin.model.dto.Content content = new org.candlepin.model.dto.Content();
+            content.setPath(path);
+            contentList.add(content);
+        }
+
+        PathNode location = v3extensionUtil.makePathTree(contentList, v3extensionUtil.new PathNode());
+        for (org.candlepin.model.dto.Content c : contentList) {
+            List<String> path = Arrays.asList(c.getPath().split("/"));
+            assertTrue(checkPath(location, path.subList(1, path.size())), "failed path " + c.getPath());
+        }
+    }
+
+    boolean checkPath(PathNode location, List<String> path) {
+        if (path.size() == 0) {
+            return true;
+        }
+        for (NodePair pn : location.getChildren()) {
+            if (path.get(0).equals(pn.getName())) {
+                if (path.size() == 1) {
+                    return true;
+                }
+                return checkPath(pn.getConnection(), path.subList(1, path.size()));
+            }
+        }
+        return false;
+    }
+
+    public static Stream<Arguments> pathTreeCondensationProvider() {
+        // BZ 2131312
+        Arguments block1 = arguments(List.of(
+            "/content/dist/rhel/server/6/$releasever/$basearch/satellite/6.0/os",
+            "/content/dist/rhel/server/6/$releasever/$basearch/satellite/6.0/source/SRPMS",
+            "/content/dist/layered/rhel9/x86_64/sat-client/6/source/SRPMS",
+            "/content/beta/layered/rhel8/x86_64/sat-tools/6/source/SRPMS",
+            "/content/beta/layered/rhel8/x86_64/sat-tools/6/os",
+            "/content/dist/layered/rhel8/x86_64/sat-tools/6.8/os",
+            "/content/dist/layered/rhel8/x86_64/sat-client/6/os",
+            "/content/dist/layered/rhel9/x86_64/sat-client/6/os",
+            "/content/dist/layered/rhel8/x86_64/sat-client/6/source/SRPMS"));
+        // add additional blocks if other test scenarios arrive
+
+        return Stream.of(block1);
     }
 
     private String processPayload(byte[] payload) throws IOException {


### PR DESCRIPTION
- The path tree condensing algorithm was dropping nodes in some specific cases
- This code was untouched for 10 years and only after a change was made to the hashing of content did it surface.
- Included is a set of data from the BZ where the condensation did not work.
- The urls should be compressed and decompressed correctly if the algorithm is operating properly.