### PR TITLE
[M] Fix flaky activation key list test

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/activationkey/ActivationKeySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/activationkey/ActivationKeySpecTest.java
@@ -115,6 +115,7 @@ public class ActivationKeySpecTest {
             .hasSize(3)
             .usingRecursiveComparison()
             .ignoringFields("created", "updated")
+            .ignoringCollectionOrder()
             .isEqualTo(activationKeys);
     }
 


### PR DESCRIPTION
- The test would sometimes fail because the comparison of the activation key lists was taking into account the order of the returned list, which shouldn't matter.