### PR TITLE
[M] Reverted product/content link from activation key and environments (CANDLEPIN-437)

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -8805,8 +8805,8 @@ components:
     EnvironmentContentDTO:
       description: EnvironmentContent represents the promotion of content into a particular environment.
       properties:
-        content:
-          $ref: "#/components/schemas/ContentDTO"
+        contentId:
+          type: string
         enabled:
           type: boolean
 

--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
@@ -421,7 +421,8 @@ public class ContentAccessSpecTest {
         env = adminClient.environments().getEnvironment(env.getId());
         assertThat(env.getEnvironmentContent())
             .singleElement()
-            .returns(content, EnvironmentContentDTO::getContent);
+            .returns(content.getId(), EnvironmentContentDTO::getContentId);
+
         certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
         assertThat(certs).singleElement();
         prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));

--- a/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentSpecTest.java
@@ -955,8 +955,7 @@ class OwnerContentSpecTest {
         assertThat(env.getEnvironmentContent())
             .isNotNull()
             .hasSize(contentMap.size())
-            .map(EnvironmentContentDTO::getContent)
-            .map(ContentDTO::getId)
+            .map(EnvironmentContentDTO::getContentId)
             .containsExactlyInAnyOrderElementsOf(contentMap.keySet());
 
         // Verify that the products still link to valid instances of the content we just modified

--- a/src/main/java/org/candlepin/async/tasks/EntitleByProductsJob.java
+++ b/src/main/java/org/candlepin/async/tasks/EntitleByProductsJob.java
@@ -70,8 +70,9 @@ public class EntitleByProductsJob implements AsyncJob {
             final String[] prodIds = arguments.getAs(PROD_IDS_KEY, String[].class);
             final String[] pools = arguments.getAs(FROM_POOLS_KEY, String[].class);
 
-            final List<Entitlement> ents = this.entitler.bindByProducts(
-                prodIds, consumerUuid, entitleDate, Arrays.asList(pools));
+            final List<Entitlement> ents = this.entitler
+                .bindByProducts(Arrays.asList(prodIds), consumerUuid, entitleDate, Arrays.asList(pools));
+
             entitler.sendEvents(ents);
 
             context.setJobResult("%d entitlements created for owner", ents.size());
@@ -108,12 +109,12 @@ public class EntitleByProductsJob implements AsyncJob {
             return this;
         }
 
-        public EntitleByProductsJobConfig setProductIds(final String[] prodIds) {
+        public EntitleByProductsJobConfig setProductIds(final Collection<String> prodIds) {
             if (prodIds == null) {
                 throw new IllegalArgumentException("Product ids is null");
             }
 
-            this.setJobArgument(PROD_IDS_KEY, prodIds);
+            this.setJobArgument(PROD_IDS_KEY, prodIds.toArray());
 
             return this;
         }

--- a/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
+++ b/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
@@ -149,7 +149,10 @@ public class HealEntireOrgJob implements AsyncJob {
         Owner owner = (Owner) args[1];
         Date date = (Date) args[2];
 
-        List<Entitlement> ents = entitler.bindByProducts(AutobindData.create(consumer, owner).on(date), true);
+        AutobindData autobindData = new AutobindData(consumer, owner)
+            .on(date);
+
+        List<Entitlement> ents = entitler.bindByProducts(autobindData, true);
         entitler.sendEvents(ents);
 
         return String.format("Successfully healed consumer with UUID: %s\n", consumer.getUuid());

--- a/src/main/java/org/candlepin/async/tasks/OrphanCleanupJob.java
+++ b/src/main/java/org/candlepin/async/tasks/OrphanCleanupJob.java
@@ -201,23 +201,6 @@ public class OrphanCleanupJob implements AsyncJob  {
                 }
             }
         }
-
-        // Ensure no other environments are still (erroneously) referencing the orphaned content...
-        Map<String, Set<String>> contentEnvironmentReferences = this.contentCurator
-            .getEnvironmentsReferencingContent(orphanedContentUuids);
-
-        if (contentEnvironmentReferences != null && !contentEnvironmentReferences.isEmpty()) {
-            log.warn("Found {} orphaned content referenced by one or more environments; " +
-                "omitting content from cleanup:",
-                contentEnvironmentReferences.size());
-
-            for (Map.Entry<String, Set<String>> entry : contentEnvironmentReferences.entrySet()) {
-                log.warn("  Content UUID: {}, Referenced by environments: {}", entry.getKey(),
-                    entry.getValue());
-
-                orphanedContentUuids.remove(entry.getKey());
-            }
-        }
     }
 
     /**

--- a/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/src/main/java/org/candlepin/controller/PoolManager.java
@@ -116,7 +116,7 @@ public interface PoolManager {
     List<Entitlement> entitleByProducts(AutobindData data)
         throws EntitlementRefusedException;
 
-    List<PoolQuantity> getBestPools(Consumer consumer, String[] productIds,
+    List<PoolQuantity> getBestPools(Consumer consumer, Collection<String> productIds,
         Date entitleDate, String ownerId, String serviceLevelOverride, Collection<String> fromPools)
         throws EntitlementRefusedException;
 

--- a/src/main/java/org/candlepin/controller/util/PromotedContent.java
+++ b/src/main/java/org/candlepin/controller/util/PromotedContent.java
@@ -67,9 +67,9 @@ public class PromotedContent {
 
         log.debug("Checking for promoted content in environment: {}", environment.getName());
         for (EnvironmentContent envContent : environment.getEnvironmentContent()) {
-            log.debug("  promoted content: {}", envContent.getContent());
+            log.debug("  promoted content: {}", envContent);
 
-            this.contents.putIfAbsent(envContent.getContent().getId(), envContent);
+            this.contents.putIfAbsent(envContent.getContentId(), envContent);
         }
 
         return this;

--- a/src/main/java/org/candlepin/dto/api/v1/ActivationKeyTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ActivationKeyTranslator.java
@@ -24,7 +24,6 @@ import org.candlepin.dto.api.server.v1.NestedOwnerDTO;
 import org.candlepin.dto.api.server.v1.ReleaseVerDTO;
 import org.candlepin.model.ContentOverride;
 import org.candlepin.model.Owner;
-import org.candlepin.model.Product;
 import org.candlepin.model.Release;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyPool;
@@ -33,6 +32,7 @@ import org.candlepin.util.Util;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 
 
 /**
@@ -90,22 +90,13 @@ public class ActivationKeyTranslator implements ObjectTranslator<ActivationKey, 
             .role(source.getRole());
 
         // Set activation key product IDs
-        Set<Product> products = source.getProducts();
-        if (products != null) {
-            Set<String> productIds = new HashSet<>();
+        Set<String> productIds = source.getProductIds();
+        if (productIds != null) {
+            Set<ActivationKeyProductDTO> akpdtos = productIds.stream()
+                .map(pid -> new ActivationKeyProductDTO().productId(pid))
+                .collect(Collectors.toSet());
 
-            for (Product prod : products) {
-                if (prod != null && prod.getId() != null && !prod.getId().isEmpty()) {
-                    productIds.add(prod.getId());
-                }
-            }
-            Set<ActivationKeyProductDTO> productIdObjects = productIds.stream().map(productId ->  {
-                ActivationKeyProductDTO newProduct = new ActivationKeyProductDTO();
-                newProduct.setProductId(productId);
-                return newProduct;
-            }).collect(Collectors.toSet());
-
-            dest.setProducts(productIdObjects);
+            dest.setProducts(akpdtos);
         }
         else {
             dest.setProducts(null);

--- a/src/main/java/org/candlepin/dto/api/v1/EnvironmentTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/EnvironmentTranslator.java
@@ -16,18 +16,18 @@ package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.ObjectTranslator;
-import org.candlepin.dto.api.server.v1.ContentDTO;
 import org.candlepin.dto.api.server.v1.EnvironmentContentDTO;
 import org.candlepin.dto.api.server.v1.EnvironmentDTO;
 import org.candlepin.dto.api.server.v1.NestedOwnerDTO;
-import org.candlepin.model.Content;
 import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.Owner;
 import org.candlepin.util.Util;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+
 
 /**
  * The EnvironmentTranslator provides translation from Environment model objects to EnvironmentDTOs
@@ -85,24 +85,18 @@ public class EnvironmentTranslator implements ObjectTranslator<Environment, Envi
 
             Set<EnvironmentContent> envContents = source.getEnvironmentContent();
             if (envContents != null) {
-                Set<EnvironmentContentDTO> setOfEnvironmentContents = new HashSet<>();
+                Set<EnvironmentContentDTO> ecdtos = envContents.stream()
+                    .map(ec -> {
+                        return new EnvironmentContentDTO()
+                            .contentId(ec.getContentId())
+                            .enabled(ec.getEnabled());
+                    })
+                    .collect(Collectors.toSet());
 
-                ObjectTranslator<Content, ContentDTO> contentTranslator = translator
-                    .findTranslatorByClass(Content.class, ContentDTO.class);
-
-                for (EnvironmentContent ec : envContents) {
-                    if (ec != null) {
-                        ContentDTO dto = contentTranslator.translate(translator, ec.getContent());
-
-                        if (dto != null) {
-                            setOfEnvironmentContents.add(new EnvironmentContentDTO()
-                                .content(dto)
-                                .enabled(ec.getEnabled()));
-                        }
-                    }
-                }
-
-                dest.setEnvironmentContent(setOfEnvironmentContents);
+                dest.setEnvironmentContent(ecdtos);
+            }
+            else {
+                dest.setEnvironmentContent(null);
             }
         }
         else {

--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -191,8 +191,12 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @NotNull
     private String typeId;
 
-    @Column(name = "owner_id")
+    @Column(name = "owner_id", nullable = false)
     private String ownerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", insertable = false, updatable = false)
+    private Owner owner;
 
     @Column(name = "entitlement_count")
     @NotNull
@@ -264,10 +268,6 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     @Basic(fetch = FetchType.LAZY)
     @Column(name = "annotations", length = 4194304)
     private String annotations;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_id", insertable = false, updatable = false)
-    private Owner owner;
 
     @Column(name = "rh_cloud_profile_modified")
     private Date rhCloudProfileModified;
@@ -471,12 +471,10 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
      *  The owner of this consumer, if the owner ID is populated; null otherwise.
      */
     @Override
-    @JsonIgnore
     public Owner getOwner() {
         return this.owner;
     }
 
-    @JsonIgnore
     public Consumer setOwner(Owner owner) {
         if (owner == null || owner.getId() == null) {
             throw new IllegalArgumentException("owner is null or lacks an ID");

--- a/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/src/main/java/org/candlepin/model/ContentCurator.java
@@ -156,41 +156,4 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
         return output;
     }
 
-    /**
-     * Returns a mapping of content UUIDs to collections of environments referencing them. That is,
-     * for a given entry in the returned map, the key will be one of the input content UUIDs, and
-     * the value will be the set of product UUIDs which reference it. If no environments reference
-     * any of the specified contents by UUID, this method returns an empty map.
-     *
-     * @param contentUuids
-     *  a collection content UUIDs for which to fetch referencing environments
-     *
-     * @return
-     *  a mapping of content UUIDs to sets of UUIDs of the environments referencing them
-     */
-    public Map<String, Set<String>> getEnvironmentsReferencingContent(Collection<String> contentUuids) {
-        Map<String, Set<String>> output = new HashMap<>();
-
-        if (contentUuids != null && !contentUuids.isEmpty()) {
-            String jpql = "SELECT ec.content.uuid, env.id FROM Environment env " +
-                "JOIN env.environmentContent ec " +
-                "WHERE ec.content.uuid IN (:content_uuids)";
-
-            Query query = this.getEntityManager()
-                .createQuery(jpql);
-
-            for (List<String> block : this.partition(contentUuids)) {
-                List<Object[]> rows = query.setParameter("content_uuids", block)
-                    .getResultList();
-
-                for (Object[] row : rows) {
-                    output.computeIfAbsent((String) row[0], (key) -> new HashSet<>())
-                        .add((String) row[1]);
-                }
-            }
-        }
-
-        return output;
-    }
-
 }

--- a/src/main/java/org/candlepin/model/EnvironmentContent.java
+++ b/src/main/java/org/candlepin/model/EnvironmentContent.java
@@ -20,13 +20,16 @@ import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
-import javax.xml.bind.annotation.XmlTransient;
+
+// TODO: This should be made to be immutable.
+
 
 /**
  * EnvironmentContent represents the promotion of content into a particular environment.
@@ -39,7 +42,7 @@ import javax.xml.bind.annotation.XmlTransient;
 public class EnvironmentContent extends AbstractHibernateObject {
 
     /** Name of the table backing this object in the database */
-    public static final String DB_TABLE = "cp2_environment_content";
+    public static final String DB_TABLE = "cp_environment_content";
 
     @Id
     @GeneratedValue(generator = "system-uuid")
@@ -48,15 +51,18 @@ public class EnvironmentContent extends AbstractHibernateObject {
     @NotNull
     private String id;
 
-    @ManyToOne
-    @JoinColumn(name = "environment_id", nullable = false)
-    @NotNull
+    @Column(name = "environment_id", nullable = false)
+    private String environmentId;
+
+    // Convenience value for performing lazy environment lookups off this object, but will not be
+    // pulled until fetched via getEnvironment; should be avoided to reduce the frequency of N+1
+    // perf issues
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "environment_id", updatable = false, insertable = false)
     private Environment environment;
 
-    @ManyToOne
-    @JoinColumn(name = "content_uuid", nullable = false)
-    @NotNull
-    private Content content;
+    @Column(name = "content_id", nullable = false)
+    private String contentId;
 
     private Boolean enabled;
 
@@ -64,72 +70,119 @@ public class EnvironmentContent extends AbstractHibernateObject {
         // Intentionally left empty
     }
 
-    public EnvironmentContent(Environment env, Content content, Boolean enabled) {
-        this.setEnvironment(env);
-        this.setContent(content);
-        this.setEnabled(enabled);
-        env.getEnvironmentContent().add(this);
-    }
-
     public String getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public EnvironmentContent setId(String id) {
         this.id = id;
+        return this;
     }
 
-    public void setContent(Content content) {
-        this.content = content;
+    public String getEnvironmentId() {
+        return this.environmentId;
     }
 
-    public Content getContent() {
-        return content;
-    }
-
-    public void setEnvironment(Environment env) {
-        this.environment = env;
-    }
-
-    @XmlTransient
+    /**
+     * Fetches the environment this EnvironmentContent instance belongs to, if the environment ID
+     * has been set. This may perform a lazy lookup of the environment, and should generally be
+     * avoided in cases where the environment ID is sufficient.
+     *
+     * @return
+     *  the environment for this environment content, or null if the environment has not yet been
+     *  set
+     */
     public Environment getEnvironment() {
         return environment;
     }
 
-    public void setEnabled(Boolean enabled) {
-        this.enabled = enabled;
+    /**
+     * Sets the environment for this environment content. The environment cannot be null and must
+     * have a valid ID.
+     *
+     * @param environment
+     *  the environment with which to associate this environment content
+     *
+     * @return
+     *  a reference to this environment content instance
+     */
+    public EnvironmentContent setEnvironment(Environment environment) {
+        if (environment == null || environment.getId() == null) {
+            throw new IllegalArgumentException("environment is null or lacks an ID");
+        }
+
+        this.environment = environment;
+        this.environmentId = environment.getId();
+
+        return this;
     }
 
+    public String getContentId() {
+        return this.contentId;
+    }
+
+    public EnvironmentContent setContentId(String contentId) {
+        this.contentId = contentId;
+        return this;
+    }
+
+    public EnvironmentContent setContent(Content content) {
+        if (content == null || content.getId() == null) {
+            throw new IllegalArgumentException("content is null or lacks an ID");
+        }
+
+        this.contentId = content.getId();
+        return this;
+    }
+
+    /**
+     * Returns a boolean value indicating the content's enablement if the default enablement has
+     * been overridden in this environment. If the content's enablement should use the default set
+     * on the product, this method returns null.
+     *
+     * @return
+     *  a boolean value indicating the content's enablement if overridden in the environment; null
+     *  if it should use the content's default enablement from the product
+     */
     public Boolean getEnabled() {
-        return enabled;
+        return this.enabled;
+    }
+
+    public EnvironmentContent setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+        return this;
     }
 
     @Override
     public int hashCode() {
-        HashCodeBuilder hcBuilder = new HashCodeBuilder(3, 23)
-            .append(this.content.hashCode());
-        return hcBuilder.toHashCode();
+        return new HashCodeBuilder(3, 23)
+            .append(this.id)
+            .toHashCode();
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (this == other) {
+    public boolean equals(Object obj) {
+        if (this == obj) {
             return true;
         }
-        if (other instanceof EnvironmentContent) {
-            EnvironmentContent that = (EnvironmentContent) other;
-            return new EqualsBuilder().append(this.enabled, that.enabled)
-                .isEquals() && this.content.equals(that.content);
+
+        if (!(obj instanceof EnvironmentContent)) {
+            return false;
         }
-        return false;
+
+        EnvironmentContent that = (EnvironmentContent) obj;
+
+        return new EqualsBuilder()
+            .append(this.getEnvironmentId(), that.getEnvironmentId())
+            .append(this.getContentId(), that.getContentId())
+            .append(this.getEnabled(), that.getEnabled())
+            .isEquals();
     }
 
     @Override
     public String toString() {
-        return "EnvironmentContent [id=" + id + ", environment=" +
-                 (environment != null ?  environment.getId() : "") +
-                 ", content=" +
-                 (content != null ? content.getId() : "" + "]");
+        return String.format("EnvironmentContent [environment: %s, content: %s, enabled: %s]",
+            this.getEnvironmentId(), this.getContentId(), this.getEnabled());
     }
 
 }

--- a/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
+++ b/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
@@ -14,17 +14,16 @@
  */
 package org.candlepin.model;
 
-import com.google.common.collect.Iterables;
-
-import org.hibernate.criterion.Restrictions;
-
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Singleton;
+import javax.persistence.NoResultException;
 import javax.persistence.Query;
+
 
 
 /**
@@ -36,67 +35,79 @@ public class EnvironmentContentCurator extends AbstractHibernateCurator<Environm
         super(EnvironmentContent.class);
     }
 
-    public EnvironmentContent getByEnvironmentAndContent(Environment e, String contentId) {
-        return (EnvironmentContent) this.currentSession().createCriteria(EnvironmentContent.class)
-            .createAlias("content", "content")
-            .add(Restrictions.eq("environment", e))
-            .add(Restrictions.eq("content.id", contentId))
-            .uniqueResult();
+    public EnvironmentContent getByEnvironmentAndContent(Environment env, String contentId) {
+        if (env == null || contentId == null) {
+            return null;
+        }
+
+        try {
+            String jpql = "SELECT ec FROM Environment env JOIN env.environmentContent ec " +
+                "WHERE env.id = :env_id AND ec.contentId = :content_id";
+
+            return this.getEntityManager()
+                .createQuery(jpql, EnvironmentContent.class)
+                .setParameter("env_id", env.getId())
+                .setParameter("content_id", contentId)
+                .getSingleResult();
+        }
+        catch (NoResultException e) {
+            // intentionally left empty
+        }
+
+        return null;
     }
 
-    public EnvironmentContent getByEnvironmentAndContent(Environment e, Content content) {
-        return (EnvironmentContent) this.currentSession().createCriteria(EnvironmentContent.class)
-            .add(Restrictions.eq("environment", e))
-            .add(Restrictions.eq("content", content))
-            .uniqueResult();
+    public EnvironmentContent getByEnvironmentAndContent(Environment env, Content content) {
+        if (env == null || content == null) {
+            return null;
+        }
+
+        return this.getByEnvironmentAndContent(env, content.getId());
     }
 
     public List<EnvironmentContent> getByContent(Owner owner, String contentId) {
-        return this.currentSession().createCriteria(EnvironmentContent.class)
-            .createAlias("environment", "environment")
-            .createAlias("content", "content")
-            .add(Restrictions.eq("environment.owner", owner))
-            .add(Restrictions.eq("content.id", contentId))
-            .list();
+        String jpql = "SELECT ec FROM Environment env JOIN env.environmentContent ec " +
+            "WHERE env.owner.id = :owner_id AND ec.contentId = :content_id";
+
+        return this.getEntityManager()
+            .createQuery(jpql, EnvironmentContent.class)
+            .setParameter("owner_id", owner.getId())
+            .setParameter("content_id", contentId)
+            .getResultList();
     }
 
     /**
-     * Returns the map of environment ID & its respective content UUIDs
+     * Returns a mapping of environment IDs to the content IDs promoted to the environment. If none
+     * of the specified environments exist or none have content, this method returns an empty map.
      *
-     * @params environmentIds
-     *  List of environment IDs
+     * @param environmentIds
+     *  a collection of environment IDs for which to fetch content IDs
      *
      * @return
-     *  Map of environmentIds & respective contentUUIDs
+     *  a mapping of environment IDs to content IDs
      */
-    public Map<String, List<String>> getEnvironmentContentUUIDs(Iterable<String> environmentIds) {
-        Map<String, List<String>> contentUUIDMap = new HashMap<>();
+    public Map<String, Set<String>> getEnvironmentContentIdMap(Iterable<String> environmentIds) {
+        Map<String, Set<String>> envContentIdMap = new HashMap<>();
 
-        String jpql = "SELECT e.id, ec.content.uuid FROM EnvironmentContent ec " +
-            "JOIN Environment e ON ec.environment.id = e.id " +
-            "WHERE e.id IN (:envIDs)";
+        if (environmentIds != null) {
+            String jpql = "SELECT ec.environmentId, ec.contentId FROM EnvironmentContent ec " +
+                "WHERE ec.environmentId IN (:env_ids)";
 
-        Query query = this.getEntityManager().createQuery(jpql, Object[].class);
-        int blockSize = Math.min(this.getInBlockSize(), this.getQueryParameterLimit() - 1);
+            Query query = this.getEntityManager()
+                .createQuery(jpql);
 
-        for (List<String> block : Iterables.partition(environmentIds, blockSize)) {
-            query.setParameter("envIDs", block);
-            processData(contentUUIDMap, query.getResultList());
+            for (List<String> block : this.partition(environmentIds)) {
+                List<Object[]> rows = query.setParameter("env_ids", block)
+                    .getResultList();
+
+                for (Object[] row : rows) {
+                    envContentIdMap.computeIfAbsent((String) row[0], (key) -> new HashSet<>())
+                        .add((String) row[1]);
+                }
+            }
         }
 
-        return contentUUIDMap;
+        return envContentIdMap;
     }
 
-    /**
-     * Process the result list (row) which contains entitlement ID & content UUID to
-     * build a map.
-     */
-    private void processData(Map<String, List<String>> contentUUIDMap, List<Object[]> resultList) {
-        for (Object[] result : resultList) {
-            String envId = result[0].toString();
-            List<String> ids = contentUUIDMap.getOrDefault(envId, new ArrayList<>());
-            ids.add(result[1].toString());
-            contentUUIDMap.put(envId, ids);
-        }
-    }
 }

--- a/src/main/java/org/candlepin/model/EnvironmentCurator.java
+++ b/src/main/java/org/candlepin/model/EnvironmentCurator.java
@@ -23,11 +23,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Singleton;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
+
 
 
 @Singleton
@@ -121,15 +121,6 @@ public class EnvironmentCurator extends AbstractHibernateCurator<Environment> {
             .add(Restrictions.eq("name", envName));
 
         return this.cpQueryFactory.buildQuery(this.currentSession(), criteria);
-    }
-
-    @SuppressWarnings("unchecked")
-    public List<Environment> listWithContent(Set<String> contentIds) {
-        return currentSession().createCriteria(Environment.class)
-            .createCriteria("environmentContent")
-            .createCriteria("content")
-            .add(Restrictions.in("id", contentIds))
-            .list();
     }
 
     /**

--- a/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
+++ b/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
@@ -33,17 +33,17 @@ import org.hibernate.annotations.GenericGenerator;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -80,21 +80,21 @@ public class ActivationKey extends AbstractHibernateObject<ActivationKey> implem
     @Size(max = 255)
     private String description;
 
-    @ManyToOne
-    @JoinColumn(nullable = false)
-    @NotNull
+    @Column(name = "owner_id", nullable = false)
+    private String ownerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", insertable = false, updatable = false)
     private Owner owner;
 
-    @OneToMany(mappedBy = "key")
+    @OneToMany(mappedBy = "activationKey")
     @Cascade({CascadeType.ALL, CascadeType.DELETE_ORPHAN})
     private Set<ActivationKeyPool> pools = new HashSet<>();
 
-    @ManyToMany
-    @JoinTable(
-        name = "cp2_activation_key_products",
-        joinColumns = {@JoinColumn(name = "key_id")},
-        inverseJoinColumns = {@JoinColumn(name = "product_uuid")})
-    private Set<Product> products = new HashSet<>();
+    @ElementCollection
+    @CollectionTable(name = "cp_activation_key_products", joinColumns = @JoinColumn(name = "key_id"))
+    @Column(name = "product_id")
+    private Set<String> productIds = new HashSet<>();
 
     @OneToMany(targetEntity = ActivationKeyContentOverride.class, mappedBy = "key")
     @Cascade({CascadeType.ALL, CascadeType.DELETE_ORPHAN})
@@ -130,211 +130,105 @@ public class ActivationKey extends AbstractHibernateObject<ActivationKey> implem
     }
 
     public ActivationKey(String name, Owner owner) {
-        this.name = name;
-        this.owner = owner;
+        this.setName(name);
+
+        if (owner != null) {
+            this.setOwner(owner);
+        }
     }
 
     public ActivationKey(String name, Owner owner, String description) {
-        this.name = name;
-        this.owner = owner;
-        this.description = description;
+        this(name, owner);
+
+        this.setDescription(description);
     }
 
     public String getId() {
         return this.id;
     }
 
-    public void setId(String id) {
+    public ActivationKey setId(String id) {
         this.id = id;
+        return this;
     }
 
-    /**
-     * @return the name
-     */
     public String getName() {
         return name;
     }
 
-    /**
-     * @param name the name to set
-     */
-    public void setName(String name) {
+    public ActivationKey setName(String name) {
         this.name = name;
+        return this;
     }
 
     /**
-     * @return the set of Pools
-     */
-    public Set<ActivationKeyPool> getPools() {
-        return pools;
-    }
-
-    /**
-     * @param pools the set of Pools to set
-     */
-    public void setPools(Set<ActivationKeyPool> pools) {
-        this.pools = pools;
-    }
-
-    /**
-     * @return the products
-     */
-    public Set<Product> getProducts() {
-        return products;
-    }
-
-    /**
-     * @param products the set of product to set
-     */
-    public void setProducts(Set<Product> products) {
-        this.products = products;
-    }
-
-    /**
-     * @return the owner
-     */
-    public Owner getOwner() {
-        return owner;
-    }
-
-    /**
-     * @return the owner Id of this Consumer.
+     * {@inheritDoc}
      */
     @Override
     public String getOwnerId() {
-        return (owner == null) ? null : owner.getId();
+        return this.ownerId;
     }
 
     /**
-     * @param owner the owner to set
-     */
-    public void setOwner(Owner owner) {
-        this.owner = owner;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String toString() {
-        return String.format("ActivationKey [id: %s, name: %s, description: %s]",
-                this.getId(), this.getName(), this.getDescription());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
-        }
-
-        boolean equals = false;
-
-        if (obj instanceof ActivationKey && super.equals(obj)) {
-            ActivationKey that = (ActivationKey) obj;
-
-            // Pull the owner IDs, as we're not interested in verifying that the owners
-            // themselves are equal; just so long as they point to the same owner.
-            String thisOwnerId = this.getOwner() != null ? this.getOwner().getId() : null;
-            String thatOwnerId = that.getOwner() != null ? that.getOwner().getId() : null;
-
-            equals = new EqualsBuilder()
-                .append(this.getId(), that.getId())
-                .append(this.getName(), that.getName())
-                .append(this.getDescription(), that.getDescription())
-                .append(thisOwnerId, thatOwnerId)
-                .append(this.getReleaseVer(), that.getReleaseVer())
-                .append(this.getServiceLevel(), that.getServiceLevel())
-                .append(this.isAutoAttach(), that.isAutoAttach())
-                .isEquals();
-
-            equals = equals && Util.collectionsAreEqual(this.getPools(), that.getPools(),
-                new Comparator<ActivationKeyPool>() {
-                    public int compare(ActivationKeyPool akp1, ActivationKeyPool akp2) {
-                        return akp1 == akp2 || (akp1 != null && akp1.equals(akp2)) ? 0 : 1;
-                    }
-                });
-
-            equals = equals && Util.collectionsAreEqual(this.getProducts(), that.getProducts(),
-                new Comparator<Product>() {
-                    public int compare(Product prod1, Product prod2) {
-                        return prod1 == prod2 || (prod1 != null && prod1.equals(prod2)) ? 0 : 1;
-                    }
-                });
-
-            return equals;
-        }
-
-        return false;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder(7, 17)
-            .append(this.id);
-        return builder.toHashCode();
-    }
-
-    public void addProduct(Product product) {
-        this.getProducts().add(product);
-    }
-
-    public void removeProduct(Product product) {
-        for (Product candidate : this.getProducts()) {
-            if (product.getId().equals(candidate.getId())) {
-                this.getProducts().remove(candidate);
-                break;
-            }
-        }
-    }
-
-    /**
-     * Checks if the specified product has been added to this activation key.
-     *
-     * @param product
-     *  The product to check
-     *
-     * @throws IllegalArgumentException
-     *  if product is null
+     * Fetches the owner of this activation key, if the owner ID is set. This may perform a lazy
+     * lookup of the owner, and should generally be avoided if the owner ID is sufficient.
      *
      * @return
-     *  true if the product has been added to this activation key; false otherwise.
+     *  The owner of this key, if the owner ID is populated; null otherwise.
      */
-    public boolean hasProduct(Product product) {
-        if (product == null) {
-            throw new IllegalArgumentException("product is null");
+    public Owner getOwner() {
+        return this.owner;
+    }
+
+    public ActivationKey setOwner(Owner owner) {
+        if (owner == null || owner.getId() == null) {
+            throw new IllegalArgumentException("owner is null or lacks an ID");
         }
 
-        for (Product candidate : this.getProducts()) {
-            if (product.getId().equals(candidate.getId())) {
-                return true;
+        this.owner = owner;
+        this.ownerId = owner.getId();
+
+        return this;
+    }
+
+    public Set<ActivationKeyPool> getPools() {
+        return this.pools;
+    }
+
+    public ActivationKey setPools(Collection<ActivationKeyPool> pools) {
+        this.pools.clear();
+
+        if (pools != null) {
+            this.pools.addAll(pools);
+        }
+
+        return this;
+    }
+
+    public ActivationKey addPool(Pool pool, Long quantity) {
+        ActivationKeyPool akpool = new ActivationKeyPool()
+            .setKey(this)
+            .setPool(pool)
+            .setQuantity(quantity);
+
+        this.pools.add(akpool);
+        return this;
+    }
+
+    public ActivationKey removePool(Pool pool) {
+        if (pool != null && pool.getId() != null) {
+            String poolId = pool.getId();
+            Iterator<ActivationKeyPool> iterator = this.pools.iterator();
+
+            while (iterator.hasNext()) {
+                ActivationKeyPool akp = iterator.next();
+                if (poolId.equals(akp.getPoolId())) {
+                    iterator.remove();
+                }
             }
         }
 
-        return false;
-    }
-
-    public void addPool(Pool pool, Long quantity) {
-        ActivationKeyPool akp = new ActivationKeyPool(this, pool, quantity);
-        this.getPools().add(akp);
-    }
-
-    public void removePool(Pool pool) {
-        ActivationKeyPool toRemove = null;
-
-        for (ActivationKeyPool akp : this.getPools()) {
-            if (akp.getPool().getId().equals(pool.getId())) {
-                toRemove = akp;
-                break;
-            }
-        }
-
-        this.getPools().remove(toRemove);
+        return this;
     }
 
     /**
@@ -354,38 +248,116 @@ public class ActivationKey extends AbstractHibernateObject<ActivationKey> implem
             throw new IllegalArgumentException("pool is null");
         }
 
-        for (ActivationKeyPool akp : this.getPools()) {
-            if (akp.getPool().getId().equals(pool.getId())) {
-                return true;
-            }
+        return this.pools.stream()
+            .map(ActivationKeyPool::getPoolId)
+            .anyMatch(pid -> pid.equals(pool.getId()));
+    }
+
+    public Set<String> getProductIds() {
+        return this.productIds;
+    }
+
+    public ActivationKey setProductIds(Collection<String> productIds) {
+        this.productIds.clear();
+
+        if (productIds != null) {
+            this.productIds.addAll(productIds);
         }
 
-        return false;
+        return this;
     }
 
     /**
-     * @return the contentOverrides
+     * Adds the specified product ID to this activation key. If the productId is null or empty, this
+     * method throws an exception.
+     *
+     * @param productId
+     *  the Red Hat ID of the product to add to this activation key; cannot be null or empty
+     *
+     * @throws IllegalArgumentException
+     *  if productId is null or empty
+     *
+     * @return
+     *  a reference to this activation key
      */
+    public ActivationKey addProductId(String productId) {
+        if (productId == null || productId.isEmpty()) {
+            throw new IllegalArgumentException("productId is null or empty");
+        }
+
+        this.productIds.add(productId);
+        return this;
+    }
+
+    /**
+     * Adds the specified product to this activation key, using its Red Hat product ID. If the
+     * product is null, or lacks a product ID, this method throws an exception.
+     *
+     * @param product
+     *  the product to add to this activation key; cannot be null and must have a valid product ID
+     *
+     * @throws IllegalArgumentException
+     *  if product is null or lacks a valid Red Hat product ID
+     *
+     * @return
+     *  a reference to this activation key
+     */
+    public ActivationKey addProduct(Product product) {
+        if (product == null) {
+            throw new IllegalArgumentException("product is null");
+        }
+
+        this.addProductId(product.getId());
+        return this;
+    }
+
+    public boolean removeProductId(String productId) {
+        return this.productIds.remove(productId);
+    }
+
+    public boolean removeProduct(Product product) {
+        return product != null && this.removeProductId(product.getId());
+    }
+
+    public boolean hasProductId(String productId) {
+        return this.productIds.contains(productId);
+    }
+
+    /**
+     * Checks if the specified product has been added to this activation key.
+     *
+     * @param product
+     *  The product to check
+     *
+     * @return
+     *  true if the product has been added to this activation key; false otherwise.
+     */
+    public boolean hasProduct(Product product) {
+        return product != null && this.hasProductId(product.getId());
+    }
+
     public Set<ActivationKeyContentOverride> getContentOverrides() {
         return contentOverrides;
     }
 
-    /**
-     * @param contentOverrides the contentOverrides to set
-     */
-    public void setContentOverrides(Set<ActivationKeyContentOverride> contentOverrides) {
+    public ActivationKey setContentOverrides(Set<ActivationKeyContentOverride> contentOverrides) {
         this.contentOverrides.clear();
         this.addContentOverrides(contentOverrides);
+
+        return this;
     }
 
-    public void addContentOverride(ActivationKeyContentOverride override) {
+    public ActivationKey addContentOverride(ActivationKeyContentOverride override) {
         this.addOrUpdate(override);
+        return this;
     }
 
-    public void addContentOverrides(Collection<ActivationKeyContentOverride> overrides) {
+    public ActivationKey addContentOverrides(Collection<ActivationKeyContentOverride> overrides) {
         for (ActivationKeyContentOverride newOverride : overrides) {
             this.addContentOverride(newOverride);
         }
+
+        return this;
     }
 
     public ActivationKeyContentOverride removeContentOverride(String overrideId) {
@@ -404,95 +376,66 @@ public class ActivationKey extends AbstractHibernateObject<ActivationKey> implem
         return toRemove;
     }
 
-    public void removeAllContentOverrides() {
+    public ActivationKey removeAllContentOverrides() {
         this.contentOverrides.clear();
+        return this;
     }
 
-    /**
-     * @return the releaseVer
-     */
     public Release getReleaseVer() {
         return new Release(releaseVer);
     }
 
-    /**
-     * @param releaseVer the releaseVer to set
-     */
-    public void setReleaseVer(Release releaseVer) {
+    public ActivationKey setReleaseVer(Release releaseVer) {
         this.releaseVer = releaseVer.getReleaseVer();
+        return this;
     }
 
-    /**
-     * @return the service level
-     */
     public String getServiceLevel() {
         return serviceLevel;
     }
 
-    /**
-     * @param serviceLevel the service level to set
-     */
-    public void setServiceLevel(String serviceLevel) {
+    public ActivationKey setServiceLevel(String serviceLevel) {
         this.serviceLevel = serviceLevel;
+        return this;
     }
 
-    /**
-     * @return the usage
-     */
     public String getUsage() {
         return usage;
     }
 
-    /**
-     * @param usage the usage to set
-     */
-    public void setUsage(String usage) {
+    public ActivationKey setUsage(String usage) {
         this.usage = usage;
+        return this;
     }
 
-    /**
-     * @return the role
-     */
     public String getRole() {
         return role;
     }
 
-    /**
-     * @param role the role to set
-     */
-    public void setRole(String role) {
+    public ActivationKey setRole(String role) {
         this.role = role;
+        return this;
     }
 
-    /**
-     * @return the addons
-     */
     public Set<String> getAddOns() {
         return addOns;
     }
 
-    /**
-     * @param addOns the addOns to set
-     */
-    public void setAddOns(Set<String> addOns) {
+    public ActivationKey setAddOns(Set<String> addOns) {
         this.addOns = addOns;
+        return this;
     }
 
-    /**
-     * @return the description
-     */
     public String getDescription() {
         return description;
     }
 
-    /**
-     * @param description
-     */
-    public void setDescription(String description) {
+    public ActivationKey setDescription(String description) {
         this.description = description;
+        return this;
     }
 
-    private void addOrUpdate(ActivationKeyContentOverride override) {
+    private ActivationKey addOrUpdate(ActivationKeyContentOverride override) {
         boolean found = false;
         for (ActivationKeyContentOverride existing : this.getContentOverrides()) {
             if (existing.getContentLabel().equalsIgnoreCase(override.getContentLabel()) &&
@@ -507,14 +450,75 @@ public class ActivationKey extends AbstractHibernateObject<ActivationKey> implem
             override.setKey(this);
             this.getContentOverrides().add(override);
         }
+
+        return this;
     }
 
-    public void setAutoAttach(Boolean autoAttach) {
+    public ActivationKey setAutoAttach(Boolean autoAttach) {
         this.autoAttach = autoAttach;
+        return this;
     }
 
     public Boolean isAutoAttach() {
         return autoAttach;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(7, 17)
+            .append(this.id)
+            .toHashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+
+        boolean equals = false;
+
+        if (obj instanceof ActivationKey && super.equals(obj)) {
+            ActivationKey that = (ActivationKey) obj;
+
+            equals = new EqualsBuilder()
+                .append(this.getId(), that.getId())
+                .append(this.getName(), that.getName())
+                .append(this.getDescription(), that.getDescription())
+                .append(this.getOwnerId(), that.getOwnerId())
+                .append(this.getReleaseVer(), that.getReleaseVer())
+                .append(this.getServiceLevel(), that.getServiceLevel())
+                .append(this.isAutoAttach(), that.isAutoAttach())
+                .isEquals();
+
+            equals = equals && Util.collectionsAreEqual(this.getPools(), that.getPools(),
+                new Comparator<ActivationKeyPool>() {
+                    public int compare(ActivationKeyPool akp1, ActivationKeyPool akp2) {
+                        return akp1 == akp2 || (akp1 != null && akp1.equals(akp2)) ? 0 : 1;
+                    }
+                });
+
+            equals = equals && Util.collectionsAreEqual(this.getProductIds(), that.getProductIds());
+
+            return equals;
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return String.format("ActivationKey [id: %s, name: %s, description: %s]",
+            this.getId(), this.getName(), this.getDescription());
     }
 
 }

--- a/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
+++ b/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
@@ -47,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,7 @@ public class AutobindRules {
         jsRules.init("autobind_name_space");
     }
 
-    public List<PoolQuantity> selectBestPools(Consumer consumer, String[] productIds,
+    public List<PoolQuantity> selectBestPools(Consumer consumer, Collection<String> productIds,
         List<Pool> pools, ComplianceStatus compliance, String serviceLevelOverride,
         Set<String> exemptLevels, boolean considerDerived) {
 
@@ -146,7 +147,7 @@ public class AutobindRules {
         args.put("owner", this.translator.translate(owner, OwnerDTO.class));
         args.put("serviceLevelOverride", serviceLevelOverride);
         args.put("pools", poolDTOs.toArray());
-        args.put("products", productIds);
+        args.put("products", productIds.toArray());
         args.put("log", log, false);
         args.put("compliance", this.translator.translate(compliance, ComplianceStatusDTO.class));
         args.put("exemptList", exemptLevels);
@@ -191,7 +192,9 @@ public class AutobindRules {
         return bestPools;
     }
 
-    private void logProducts(String message, String[] productIds, Consumer consumer, boolean debug) {
+    private void logProducts(String message, Collection<String> productIds, Consumer consumer,
+        boolean debug) {
+
         List<String> consumerProducts = new LinkedList<>();
         if (consumer != null && consumer.getInstalledProducts() != null) {
             for (ConsumerInstalledProduct product: consumer.getInstalledProducts()) {

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -40,7 +40,6 @@ import org.candlepin.controller.PoolManager;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.server.v1.ActivationKeyDTO;
 import org.candlepin.dto.api.server.v1.ActivationKeyPoolDTO;
-import org.candlepin.dto.api.server.v1.ActivationKeyProductDTO;
 import org.candlepin.dto.api.server.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.server.v1.ConsumerDTOArrayElement;
 import org.candlepin.dto.api.server.v1.ContentAccessDTO;
@@ -648,21 +647,13 @@ public class OwnerResource implements OwnerApi {
         }
 
         if (dto.getProducts() != null) {
-            if (dto.getProducts().isEmpty()) {
-                entity.setProducts(new HashSet<>());
-            }
-            else {
-                Set<String> productIds = dto.getProducts().stream()
-                    .map(ActivationKeyProductDTO::getProductId)
-                    .collect(Collectors.toSet());
+            Set<String> pids = new HashSet<>();
 
-                for (String productId : productIds) {
-                    if (productId != null) {
-                        Product product = findProduct(entity.getOwner(), productId);
-                        entity.addProduct(product);
-                    }
-                }
-            }
+            dto.getProducts().stream()
+                .map(keyprod -> this.findProduct(entity.getOwner(), keyprod.getProductId()).getId())
+                .forEach(pids::add);
+
+            entity.setProductIds(pids);
         }
     }
 

--- a/src/main/java/org/candlepin/resource/util/EnvironmentUpdates.java
+++ b/src/main/java/org/candlepin/resource/util/EnvironmentUpdates.java
@@ -34,9 +34,11 @@ public class EnvironmentUpdates {
     private final Map<String, List<String>> current = new HashMap<>();
     private final Map<String, List<String>> updated = new HashMap<>();
 
-    public void put(String consumerId, List<String> currentEnvs, List<String> updatedEnvs) {
+    public EnvironmentUpdates put(String consumerId, List<String> currentEnvs, List<String> updatedEnvs) {
         this.current.put(consumerId, currentEnvs);
         this.updated.put(consumerId, updatedEnvs);
+
+        return this;
     }
 
     /**

--- a/src/main/resources/db/changelog/20221003160605-remove_direct_ak_product_reference.xml
+++ b/src/main/resources/db/changelog/20221003160605-remove_direct_ak_product_reference.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20221003160605-1" author="crog">
+        <createTable tableName="cp_activation_key_products">
+            <column name="key_id" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="product_id" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="20221003160605-2" author="crog">
+        <addPrimaryKey tableName="cp_activation_key_products" columnNames="key_id, product_id"
+            constraintName="cp_akproducts_pkey"/>
+
+        <addForeignKeyConstraint constraintName="cp_akproducts_fk1"
+            baseTableName="cp_activation_key_products"
+            baseColumnNames="key_id"
+            referencedTableName="cp_activation_key"
+            referencedColumnNames="id"
+            deleteCascade="true"/>
+    </changeSet>
+
+    <changeSet id="20221003160605-3" author="crog">
+        <createIndex indexName="cp_akproducts_idx1" tableName="cp_activation_key_products">
+            <column name="key_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20221003160605-4" author="crog">
+        <sql dbms="postgresql, mysql">
+            INSERT INTO cp_activation_key_products
+                SELECT akp2.key_id, prod.product_id
+                    FROM cp2_activation_key_products akp2
+                    JOIN cp2_products prod ON prod.uuid = akp2.product_uuid;
+        </sql>
+    </changeSet>
+
+<!--
+    <changeSet id="20221003160605-5" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="cp2_activation_key_products"/>
+        </preConditions>
+
+        <dropTable tableName="cp2_activation_key_products"/>
+    </changeSet>
+-->
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/20221003160623-remove_direct_env_content_reference.xml
+++ b/src/main/resources/db/changelog/20221003160623-remove_direct_env_content_reference.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20221003160623-1" author="crog">
+        <createTable tableName="cp_environment_content">
+            <column name="id" type="varchar(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="${timestamp.type}"/>
+            <column name="updated" type="${timestamp.type}"/>
+            <column name="environment_id" type="varchar(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="content_id" type="varchar(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="enabled" type="boolean"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="20221003160623-2" author="crog">
+        <addPrimaryKey tableName="cp_environment_content" columnNames="id" constraintName="cp_envcontent_pkey"/>
+
+        <addForeignKeyConstraint constraintName="cp_envcontent_fk1"
+            baseTableName="cp_environment_content"
+            baseColumnNames="environment_id"
+            referencedTableName="cp_environment"
+            referencedColumnNames="id"
+            deleteCascade="true"/>
+
+        <addUniqueConstraint constraintName="cp_envcontent_uidx1"
+            tableName="cp_environment_content"
+            columnNames="environment_id, content_id"/>
+    </changeSet>
+
+    <changeSet id="20221003160623-3" author="crog">
+        <createIndex indexName="cp_envcontent_idx1" tableName="cp_environment_content">
+            <column name="environment_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20221003160623-4" author="crog">
+        <sql dbms="postgresql, mysql">
+            INSERT INTO cp_environment_content
+                SELECT ec.id, ec.created, ec.updated, ec.environment_id, c.content_id, ec.enabled
+                    FROM cp2_environment_content ec
+                    JOIN cp2_content c ON c.uuid = ec.content_uuid;
+        </sql>
+    </changeSet>
+
+<!--
+    <changeSet id="20221003160623-5" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="cp2_environment_content"/>
+        </preConditions>
+
+        <dropTable tableName="cp2_environment_content"/>
+    </changeSet>
+-->
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1272,4 +1272,6 @@
     <include file="db/changelog/20220901113942-delete_unused_table_and_columns.xml"/>
     <include file="db/changelog/20221114152236-add_delete_cascade_to_content_modified_products.xml"/>
     <include file="db/changelog/20221117125815-prime_system_locks.xml"/>
+    <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
+    <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2362,4 +2362,6 @@
     <include file="db/changelog/20220901113942-delete_unused_table_and_columns.xml"/>
     <include file="db/changelog/20221114152236-add_delete_cascade_to_content_modified_products.xml"/>
     <include file="db/changelog/20221117125815-prime_system_locks.xml"/>
+    <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
+    <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -179,4 +179,6 @@
     <include file="db/changelog/20220901113942-delete_unused_table_and_columns.xml"/>
     <include file="db/changelog/20221114152236-add_delete_cascade_to_content_modified_products.xml"/>
     <include file="db/changelog/20221117125815-prime_system_locks.xml"/>
+    <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
+    <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/async/tasks/OrphanCleanupJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/OrphanCleanupJobTest.java
@@ -22,8 +22,6 @@ import static org.mockito.Mockito.*;
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.model.AsyncJobStatus;
 import org.candlepin.model.Content;
-import org.candlepin.model.Environment;
-import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
@@ -272,39 +270,4 @@ public class OrphanCleanupJobTest extends DatabaseTestFixture {
         assertNull(this.contentCurator.get(orphanedContent3.getUuid()));
     }
 
-    @Test
-    public void testCleanupDoesNotRemoveOrphanedContentReferencedByEnvironments() throws Exception {
-        Owner owner1 = this.createOwner();
-        Owner owner2 = this.createOwner();
-
-        Content orphanedContent1 = this.createOrphanedContent();
-        Content orphanedContent2 = this.createOrphanedContent();
-        Content orphanedContent3 = this.createOrphanedContent();
-
-        Environment refEnv1 = new Environment("ref_env_1", "ref environment 1", owner1);
-        refEnv1.setEnvironmentContent(Set.of(new EnvironmentContent(refEnv1, orphanedContent1, true)));
-
-        Environment refEnv2 = new Environment("ref_env_2", "ref environment 2", owner2);
-        refEnv2.setEnvironmentContent(Set.of(new EnvironmentContent(refEnv2, orphanedContent2, true)));
-
-        refEnv1 = this.environmentCurator.create(refEnv1);
-        refEnv2 = this.environmentCurator.create(refEnv2);
-
-        // Execute job
-        OrphanCleanupJob job = this.createJobInstance();
-        AsyncJobStatus status = mock(AsyncJobStatus.class);
-        JobExecutionContext context = new JobExecutionContext(status);
-
-        job.execute(context);
-
-        this.ownerCurator.flush();
-        this.ownerCurator.clear();
-
-        // Verify referenced orphans were not removed
-        assertNotNull(this.contentCurator.get(orphanedContent1.getUuid()));
-        assertNotNull(this.contentCurator.get(orphanedContent2.getUuid()));
-
-        // Verify unreferenced orphans were
-        assertNull(this.contentCurator.get(orphanedContent3.getUuid()));
-    }
 }

--- a/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -122,7 +122,11 @@ public class EventSinkImplTest {
         this.eventFilter = new EventFilter(new CandlepinCommonTestConfig());
 
         this.eventSinkImpl = createEventSink(mockSessionFactory);
-        o = new Owner("test owner");
+
+        this.o = new Owner()
+            .setId("test_owner")
+            .setKey("test_owner")
+            .setDisplayName("Test Owner");
     }
 
     /**
@@ -206,7 +210,7 @@ public class EventSinkImplTest {
 
     @Test
     public void emptyKeyShouldEmitSuccessfully() throws Exception {
-        ActivationKey key = TestUtil.createActivationKey(new Owner("deadbeef"), null);
+        ActivationKey key = TestUtil.createActivationKey(this.o, null);
         eventSinkImpl.emitActivationKeyCreated(key);
         eventSinkImpl.sendEvents();
         verify(mockClientProducer).send(any(ClientMessage.class));
@@ -217,7 +221,7 @@ public class EventSinkImplTest {
         ArrayList<Pool> pools = new ArrayList<>();
         pools.add(TestUtil.createPool(o, TestUtil.createProduct()));
         pools.add(TestUtil.createPool(o, TestUtil.createProduct()));
-        ActivationKey key = TestUtil.createActivationKey(new Owner("deadbeef"), pools);
+        ActivationKey key = TestUtil.createActivationKey(this.o, pools);
         eventSinkImpl.emitActivationKeyCreated(key);
         eventSinkImpl.sendEvents();
         verify(mockClientProducer).send(any(ClientMessage.class));

--- a/src/test/java/org/candlepin/auth/ActivationKeyAuthTest.java
+++ b/src/test/java/org/candlepin/auth/ActivationKeyAuthTest.java
@@ -153,7 +153,7 @@ class ActivationKeyAuthTest {
 
     private void mockKey(String owner, String key) {
         when(this.activationKeyCurator.findByKeyNames(eq(owner), anyCollection()))
-            .thenReturn(List.of(new ActivationKey(key, new Owner())));
+            .thenReturn(List.of(new ActivationKey(key, new Owner().setId("test_owner"))));
     }
 
     private ActivationKeyAuth createActivationKeyAuth() {

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -292,8 +292,19 @@ public class ContentAccessManagerTest {
     }
 
     private Environment mockEnvironment(Owner owner, Consumer consumer, Content content) {
-        Environment environment = new Environment("test_environment", "test_environment", owner);
-        environment.setEnvironmentContent(Util.asSet(new EnvironmentContent(environment, content, true)));
+        int rnd = TestUtil.randomInt();
+
+        Environment environment = new Environment()
+            .setId("test_environment-" + rnd)
+            .setName("test_environment-" + rnd)
+            .setOwner(owner);
+
+        EnvironmentContent ec = new EnvironmentContent()
+            .setEnvironment(environment)
+            .setContent(content)
+            .setEnabled(true);
+
+        environment.addEnvironmentContent(ec);
 
         consumer.addEnvironment(environment);
 

--- a/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -231,8 +231,10 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     public void testQuantityCheck() throws Exception {
         Pool monitoringPool = poolCurator.listByOwnerAndProduct(o, monitoring.getId()).get(0);
         assertEquals(Long.valueOf(5), monitoringPool.getQuantity());
-        AutobindData data = AutobindData.create(parentSystem, o).on(new Date())
-            .forProducts(new String[] { monitoring.getId() });
+        AutobindData data = new AutobindData(parentSystem, o)
+            .on(new Date())
+            .forProducts(Set.of(monitoring.getId()));
+
         for (int i = 0; i < 5; i++) {
             List<Entitlement> entitlements = poolManager.entitleByProducts(data);
             assertEquals(1, entitlements.size());
@@ -264,8 +266,10 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
     @Test
     public void testRevocation() throws Exception {
-        AutobindData data = AutobindData.create(parentSystem, o).on(new Date())
-            .forProducts(new String[] { monitoring.getId() });
+        AutobindData data = new AutobindData(parentSystem, o)
+            .on(new Date())
+            .forProducts(Set.of(monitoring.getId()));
+
         Entitlement e = poolManager.entitleByProducts(data).get(0);
         poolManager.revokeEntitlement(e);
 
@@ -294,10 +298,11 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testRegenerateEntitlementCertificatesWithSingleEntitlement()
-        throws Exception {
-        AutobindData data = AutobindData.create(childVirtSystem, o).on(new Date())
-            .forProducts(new String[] { provisioning.getId() });
+    public void testRegenerateEntitlementCertificatesWithSingleEntitlement() throws Exception {
+        AutobindData data = new AutobindData(childVirtSystem, o)
+            .on(new Date())
+            .forProducts(Set.of(provisioning.getId()));
+
         this.entitlementCurator.refresh(poolManager.entitleByProducts(data).get(0));
         regenerateECAndAssertNotSameCertificates();
     }
@@ -336,8 +341,11 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
     @Test
     public void testRegenerateEntitlementCertificatesWithMultipleEntitlements()
         throws EntitlementRefusedException {
-        AutobindData data = AutobindData.create(childVirtSystem, o).on(new Date())
-            .forProducts(new String[] { provisioning.getId() });
+
+        AutobindData data = new AutobindData(childVirtSystem, o)
+            .on(new Date())
+            .forProducts(Set.of(provisioning.getId()));
+
         this.entitlementCurator.refresh(poolManager.entitleByProducts(data).get(0));
         this.entitlementCurator.refresh(poolManager.entitleByProducts(data).get(0));
         regenerateECAndAssertNotSameCertificates();
@@ -390,14 +398,16 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         // this ends up causing a hibernate failure (the old cert is asked to be deleted,
         // but it hasn't been saved yet). Since getting the pool ordering right is tricky
         // inside an entitleByProducts call, we do it in two singular calls here.
-        AutobindData data = AutobindData.create(parentSystem, o).on(new Date())
-            .forProducts(new String[] { "modifier" });
+        AutobindData data = new AutobindData(parentSystem, o)
+            .on(new Date())
+            .forProducts(Set.of("modifier"));
 
         poolManager.entitleByProducts(data);
 
         try {
-            data = AutobindData.create(parentSystem, o).on(new Date())
-                .forProducts(new String[] { PRODUCT_VIRT_HOST });
+            data = new AutobindData(parentSystem, o)
+                .on(new Date())
+                .forProducts(Set.of(PRODUCT_VIRT_HOST));
 
             poolManager.entitleByProducts(data);
         }
@@ -942,8 +952,10 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
 
     @Test
     public void testRevocationRevokesEntitlementCertSerial() throws Exception {
-        AutobindData data = AutobindData.create(parentSystem, o).on(new Date())
-            .forProducts(new String[] { monitoring.getId() });
+        AutobindData data = new AutobindData(parentSystem, o)
+            .on(new Date())
+            .forProducts(Set.of(monitoring.getId()));
+
         Entitlement e = poolManager.entitleByProducts(data).get(0);
         CertificateSerial serial = e.getCertificates().iterator().next().getSerial();
         poolManager.revokeEntitlement(e);

--- a/src/test/java/org/candlepin/controller/util/PromotedContentTest.java
+++ b/src/test/java/org/candlepin/controller/util/PromotedContentTest.java
@@ -247,7 +247,7 @@ class PromotedContentTest {
         Owner owner = this.mockOwner();
         Consumer consumer = this.mockConsumer(owner);
         Environment environment = this.mockEnvironment(owner, consumer, content);
-        environment.getEnvironmentContent().add(new EnvironmentContent(environment, content, true));
+
         return environment;
     }
 
@@ -309,8 +309,19 @@ class PromotedContentTest {
     }
 
     private Environment mockEnvironment(Owner owner, Consumer consumer, Content content) {
-        Environment environment = new Environment("test_environment", "test_environment", owner);
-        environment.setEnvironmentContent(Util.asSet(new EnvironmentContent(environment, content, true)));
+        int rnd = (int) (Math.random() * 10000);
+
+        Environment environment = new Environment()
+            .setId("test_environment-" + rnd)
+            .setName("test environment " + rnd)
+            .setOwner(owner);
+
+        EnvironmentContent ec = new EnvironmentContent()
+            .setEnvironment(environment)
+            .setContent(content)
+            .setEnabled(true);
+
+        environment.addEnvironmentContent(ec);
 
         consumer.addEnvironment(environment);
 
@@ -327,9 +338,20 @@ class PromotedContentTest {
     }
 
     private PromotedContent createPromotedContent(String prefix) {
-        Environment environment = new Environment(ENV_ID, "env1", new Owner());
-        environment.getEnvironmentContent()
-            .add(new EnvironmentContent(environment, new Content(CONTENT_ID), true));
+        Owner owner = new Owner()
+            .setId("owner-1");
+
+        Environment environment = new Environment()
+            .setId(ENV_ID)
+            .setName("env1")
+            .setOwner(owner);
+
+        EnvironmentContent envcontent = new EnvironmentContent()
+            .setEnvironment(environment)
+            .setContent(new Content().setId(CONTENT_ID))
+            .setEnabled(true);
+
+        environment.addEnvironmentContent(envcontent);
 
         return new PromotedContent(prefix(prefix))
             .with(environment);

--- a/src/test/java/org/candlepin/dto/api/v1/ActivationKeyTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ActivationKeyTranslatorTest.java
@@ -80,9 +80,6 @@ public class ActivationKeyTranslatorTest extends
         source.setServiceLevel("key-service-level");
         source.setAutoAttach(true);
 
-
-        Set<Product> products = new HashSet<>();
-        Set<ActivationKeyPool> akpools = new HashSet<>();
         Set<ActivationKeyContentOverride> overrides = new HashSet<>();
 
         for (int i = 0; i < 3; ++i) {
@@ -92,21 +89,17 @@ public class ActivationKeyTranslatorTest extends
             Pool pool = new Pool();
             pool.setId("test_pool-" + i);
 
-            ActivationKeyPool akp = new ActivationKeyPool(source, pool, 1L);
-
             ActivationKeyContentOverride override = new ActivationKeyContentOverride();
             override.setKey(source);
             override.setContentLabel("test_content_label-" + i);
             override.setName("test_name-" + i);
             override.setValue("test_value-" + i);
 
-            products.add(product);
-            akpools.add(akp);
+            source.addProduct(product);
+            source.addPool(pool, 1L);
             overrides.add(override);
         }
 
-        source.setProducts(products);
-        source.setPools(akpools);
         source.setContentOverrides(overrides);
 
         return source;
@@ -127,22 +120,20 @@ public class ActivationKeyTranslatorTest extends
             assertEquals(source.isAutoAttach(), dest.getAutoAttach());
 
             // Check product IDs
-            Collection<Product> products = source.getProducts();
+            Collection<String> productIds = source.getProductIds();
             Collection<ActivationKeyProductDTO> productDTOs = dest.getProducts();
 
-            if (products != null) {
+            if (productIds != null) {
                 assertNotNull(productDTOs);
-                assertEquals(products.size(), productDTOs.size());
+                assertEquals(productIds.size(), productDTOs.size());
 
-                for (Product product : products) {
-                    assertNotNull(product);
-                    assertNotNull(product.getId());
+                Set<String> dtoProductIds = productDTOs.stream()
+                    .map(ActivationKeyProductDTO::getProductId)
+                    .collect(Collectors.toSet());
 
-                    Collection<String> productIds = productDTOs.stream()
-                        .map(ActivationKeyProductDTO::getProductId)
-                        .collect(Collectors.toSet());
-
-                    assertTrue(productIds.contains(product.getId()));
+                for (String pid : productIds) {
+                    assertNotNull(pid);
+                    assertTrue(dtoProductIds.contains(pid));
                 }
             }
             else {

--- a/src/test/java/org/candlepin/dto/rules/v1/ActivationKeyTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ActivationKeyTranslatorTest.java
@@ -67,9 +67,10 @@ public class ActivationKeyTranslatorTest extends
                 mktProduct.setAttribute("prod_attr-key" + j, "prod_attr-value" + j);
             }
 
-            ActivationKeyPool akp = new ActivationKeyPool(source, pool, 1L);
-
-            akpools.add(akp);
+            akpools.add(new ActivationKeyPool()
+                .setKey(source)
+                .setPool(pool)
+                .setQuantity(1L));
         }
 
         source.setPools(akpools);

--- a/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -21,7 +21,6 @@ import org.candlepin.test.TestUtil;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,23 +51,6 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         }
 
         return this.createProduct(product, owner);
-    }
-
-    private Environment createEnvironmentWithContent(Owner owner, Content... contents) {
-        String environmentId = "test-env-" + TestUtil.randomInt();
-        Environment environment = new Environment(environmentId, environmentId, owner);
-
-        if (contents != null && contents.length > 0) {
-            Set<EnvironmentContent> envContent = new HashSet<>();
-
-            for (Content content : contents) {
-                envContent.add(new EnvironmentContent(environment, content, true));
-            }
-
-            environment.setEnvironmentContent(envContent);
-        }
-
-        return this.environmentCurator.create(environment);
     }
 
     @Test
@@ -285,97 +267,6 @@ public class ContentCuratorTest extends DatabaseTestFixture {
     @Test
     public void testGetProductsReferencingContentHandlesNullInput() {
         Map<String, Set<String>> output = this.contentCurator.getProductsReferencingContent(null);
-        assertNotNull(output);
-        assertTrue(output.isEmpty());
-    }
-
-    @Test
-    public void testGetEnvironmentsReferencingContent() {
-        Owner owner1 = this.createOwner();
-        Owner owner2 = this.createOwner();
-
-        Content content1 = this.createContent(owner1);
-        Content content2 = this.createContent(owner2);
-        Content content3 = this.createContent(owner1);
-
-        Environment environment1 = this.createEnvironmentWithContent(owner1, content1);
-        Environment environment2 = this.createEnvironmentWithContent(owner2, content2, content3);
-        Environment environment3 = this.createEnvironmentWithContent(owner1);
-
-        Set<String> input = Set.of(content1.getUuid(), content2.getUuid(), content3.getUuid());
-
-        Map<String, Set<String>> output = this.contentCurator.getEnvironmentsReferencingContent(input);
-        assertNotNull(output);
-        assertEquals(3, output.size());
-
-        assertTrue(output.containsKey(content1.getUuid()));
-        assertEquals(Set.of(environment1.getId()), output.get(content1.getUuid()));
-
-        assertTrue(output.containsKey(content2.getUuid()));
-        assertEquals(Set.of(environment2.getId()), output.get(content2.getUuid()));
-
-        assertTrue(output.containsKey(content3.getUuid()));
-        assertEquals(Set.of(environment2.getId()), output.get(content3.getUuid()));
-    }
-
-    @Test
-    public void testGetEnvironmentsRefrencingContentWithMultipleReferences() {
-        Owner owner = this.createOwner();
-
-        Content content1 = this.createContent(owner);
-        Content content2 = this.createContent(owner);
-        Content content3 = this.createContent(owner);
-
-        Environment environment1 = this.createEnvironmentWithContent(owner, content1, content2);
-        Environment environment2 = this.createEnvironmentWithContent(owner, content2, content3);
-        Environment environment3 = this.createEnvironmentWithContent(owner, content3, content1);
-
-        Set<String> input = Set.of(content1.getUuid(), content2.getUuid(), content3.getUuid());
-
-        Map<String, Set<String>> output = this.contentCurator.getEnvironmentsReferencingContent(input);
-        assertNotNull(output);
-        assertEquals(3, output.size());
-
-        assertTrue(output.containsKey(content1.getUuid()));
-        assertEquals(Set.of(environment1.getId(), environment3.getId()), output.get(content1.getUuid()));
-
-        assertTrue(output.containsKey(content2.getUuid()));
-        assertEquals(Set.of(environment1.getId(), environment2.getId()), output.get(content2.getUuid()));
-
-        assertTrue(output.containsKey(content3.getUuid()));
-        assertEquals(Set.of(environment2.getId(), environment3.getId()), output.get(content3.getUuid()));
-    }
-
-    @Test
-    public void testGetEnvironmentsReferencingContentWithNoReferences() {
-        Owner owner1 = this.createOwner();
-        Owner owner2 = this.createOwner();
-
-        Content content1 = this.createContent(owner1);
-        Content content2 = this.createContent(owner2);
-        Content content3 = this.createContent(owner1);
-
-        Environment environment1 = this.createEnvironment(owner1);
-        Environment environment2 = this.createEnvironment(owner2);
-        Environment environment3 = this.createEnvironment(owner1);
-
-        Set<String> input = Set.of(content1.getUuid(), content2.getUuid(), content3.getUuid());
-
-        Map<String, Set<String>> output = this.contentCurator.getEnvironmentsReferencingContent(input);
-        assertNotNull(output);
-        assertTrue(output.isEmpty());
-    }
-
-    @Test
-    public void testGetEnvironmentsReferencingContentHandlesEmptyInput() {
-        Map<String, Set<String>> output = this.contentCurator.getEnvironmentsReferencingContent(Set.of());
-        assertNotNull(output);
-        assertTrue(output.isEmpty());
-    }
-
-    @Test
-    public void testGetEnvironmentsReferencingContentHandlesNullInput() {
-        Map<String, Set<String>> output = this.contentCurator.getEnvironmentsReferencingContent(null);
         assertNotNull(output);
         assertTrue(output.isEmpty());
     }

--- a/src/test/java/org/candlepin/model/EnvironmentContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EnvironmentContentCuratorTest.java
@@ -34,7 +34,7 @@ public class EnvironmentContentCuratorTest extends DatabaseTestFixture {
     private EnvironmentContent envContent;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws Exception {
         owner = this.createOwner("test-owner", "Test Owner");
 
         e = this.createEnvironment(owner, "env1", "Env 1");
@@ -44,8 +44,14 @@ public class EnvironmentContentCuratorTest extends DatabaseTestFixture {
         p.addContent(c, true);
         p = this.createProduct(p, owner);
 
-        envContent = new EnvironmentContent(e, c, true);
+        envContent = new EnvironmentContent()
+            .setEnvironment(e)
+            .setContent(c)
+            .setEnabled(true);
+
         envContent = environmentContentCurator.create(envContent);
+        environmentContentCurator.flush();
+        environmentContentCurator.clear();
     }
 
     @Test
@@ -68,7 +74,11 @@ public class EnvironmentContentCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void createDuplicate() {
-        envContent = new EnvironmentContent(e, c, true);
+        envContent = new EnvironmentContent()
+            .setEnvironment(e)
+            .setContent(c)
+            .setEnabled(true);
+
         assertThrows(PersistenceException.class, () -> environmentContentCurator.create(envContent));
     }
 

--- a/src/test/java/org/candlepin/model/EnvironmentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EnvironmentCuratorTest.java
@@ -23,10 +23,9 @@ import org.candlepin.test.DatabaseTestFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -53,39 +52,30 @@ public class EnvironmentCuratorTest extends DatabaseTestFixture {
         assertEquals(owner, e.getOwner());
     }
 
-    @Test public void delete() {
+    @Test
+    public void delete() {
         envCurator.delete(environment);
         assertEquals(0, envCurator.listAll().list().size());
     }
 
-    @Test public void listForOwner() {
+    @Test
+    public void listForOwner() {
         List<Environment> envs = envCurator.listForOwner(owner).list();
         assertEquals(1, envs.size());
         assertEquals(envs.get(0), environment);
     }
 
-    @Test public void listForOwnerByName() {
-        Environment e = envCurator.create(new Environment("env2", "Another Env", owner));
+    @Test
+    public void listForOwnerByName() {
+        Environment environment = new Environment()
+            .setId("env2")
+            .setName("Another Env")
+            .setOwner(owner);
+
+        this.envCurator.create(environment);
 
         List<Environment> envs = envCurator.listForOwnerByName(owner, "Another Env").list();
-        assertEquals(1, envs.size());
-        assertEquals(e, envs.get(0));
-    }
-
-    @Test
-    public void listWithContent() {
-        envCurator.create(new Environment("env2", "Another Env", owner));
-
-        final String contentId = "contentId";
-        Content content = this.createContent(contentId, "test content", this.owner);
-
-        envContentCurator.create(new EnvironmentContent(environment, content, true));
-
-        Set<String> ids = new HashSet<>();
-        ids.add(contentId);
-
-        List<Environment> envs = envCurator.listWithContent(ids);
-
+        assertNotNull(envs);
         assertEquals(1, envs.size());
         assertEquals(environment, envs.get(0));
     }
@@ -98,17 +88,14 @@ public class EnvironmentCuratorTest extends DatabaseTestFixture {
         Content content2 = this.createContent("c2", "c2", owner1);
         Content content3 = this.createContent("c3", "c3", owner2);
 
-        Environment environment1 = this.createEnvironment(
-            owner1, "test_env-1", "test_env-1", null, null, List.of(content1)
-        );
+        Environment environment1 = this.createEnvironment(owner1, "test_env-1", "test_env-1", null, null,
+            List.of(content1));
 
-        Environment environment2 = this.createEnvironment(
-            owner1, "test_env-2", "test_env-2", null, null, List.of(content2)
-        );
+        Environment environment2 = this.createEnvironment(owner1, "test_env-2", "test_env-2", null, null,
+            List.of(content2));
 
-        Environment environment3 = this.createEnvironment(
-            owner2, "test_env-3", "test_env-3", null, null, List.of(content3)
-        );
+        Environment environment3 = this.createEnvironment(owner2, "test_env-3", "test_env-3", null, null,
+            List.of(content3));
 
         int output = this.environmentCurator.deleteEnvironmentsForOwner(owner1);
         assertEquals(2, output);
@@ -124,9 +111,9 @@ public class EnvironmentCuratorTest extends DatabaseTestFixture {
         assertNull(environment2);
         assertNotNull(environment3);
 
-        assertEquals(1, environment3.getEnvironmentContent().size());
-        assertEquals(content3.getUuid(), environment3.getEnvironmentContent().iterator().next().getContent()
-            .getUuid());
+        Collection<EnvironmentContent> envcontent = environment3.getEnvironmentContent();
+        assertEquals(1, envcontent.size());
+        assertEquals(content3.getId(), envcontent.iterator().next().getContentId());
     }
 
     @Test

--- a/src/test/java/org/candlepin/model/HibernateValidationAnnotationTest.java
+++ b/src/test/java/org/candlepin/model/HibernateValidationAnnotationTest.java
@@ -14,10 +14,12 @@
  */
 package org.candlepin.model;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.model.activationkeys.ActivationKey;
 
+import com.google.inject.matcher.AbstractMatcher;
 import com.google.inject.matcher.Matcher;
 import com.google.inject.matcher.Matchers;
 
@@ -28,6 +30,7 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.persistence.Column;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -38,9 +41,21 @@ import javax.validation.constraints.Size;
  */
 public class HibernateValidationAnnotationTest {
 
+    private static class NonNullColumnMatcher extends AbstractMatcher<AnnotatedElement> {
+
+        @Override
+        public boolean matches(AnnotatedElement elem) {
+            assertNotNull(elem);
+
+            Column annotation = elem.getAnnotation(Column.class);
+            return annotation != null && !annotation.nullable();
+        }
+    }
+
     private Matcher<AnnotatedElement> sizeAndNotNull = buildMatcher(Size.class, NotNull.class);
     private Matcher<AnnotatedElement> size = buildMatcher(Size.class);
     private Matcher<AnnotatedElement> notNull = buildMatcher(NotNull.class);
+    private Matcher<AnnotatedElement> nonNullableColumn = new NonNullColumnMatcher();
 
 
     @Test
@@ -56,7 +71,7 @@ public class HibernateValidationAnnotationTest {
         Map<Field, Matcher<AnnotatedElement>> fm = new HashMap<>();
         fm.put(ActivationKey.class.getDeclaredField("id"), notNull);
         fm.put(ActivationKey.class.getDeclaredField("name"), sizeAndNotNull);
-        fm.put(ActivationKey.class.getDeclaredField("owner"), notNull);
+        fm.put(ActivationKey.class.getDeclaredField("ownerId"), nonNullableColumn);
         fm.put(ActivationKey.class.getDeclaredField("releaseVer"), size);
         fm.put(ActivationKey.class.getDeclaredField("serviceLevel"), size);
         runMap(fm);
@@ -208,7 +223,7 @@ public class HibernateValidationAnnotationTest {
     public void environmentTest() throws Exception {
         Map<Field, Matcher<AnnotatedElement>> fm = new HashMap<>();
         fm.put(Environment.class.getDeclaredField("id"), notNull);
-        fm.put(Environment.class.getDeclaredField("owner"), notNull);
+        fm.put(Environment.class.getDeclaredField("ownerId"), nonNullableColumn);
         fm.put(Environment.class.getDeclaredField("name"), sizeAndNotNull);
         fm.put(Environment.class.getDeclaredField("description"), size);
         runMap(fm);
@@ -218,8 +233,8 @@ public class HibernateValidationAnnotationTest {
     public void environmentContentTest() throws Exception {
         Map<Field, Matcher<AnnotatedElement>> fm = new HashMap<>();
         fm.put(EnvironmentContent.class.getDeclaredField("id"), notNull);
-        fm.put(EnvironmentContent.class.getDeclaredField("environment"), notNull);
-        fm.put(EnvironmentContent.class.getDeclaredField("content"), notNull);
+        fm.put(EnvironmentContent.class.getDeclaredField("environmentId"), nonNullableColumn);
+        fm.put(EnvironmentContent.class.getDeclaredField("contentId"), nonNullableColumn);
         runMap(fm);
     }
 

--- a/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -153,7 +153,7 @@ public class AutobindRulesTest {
         List<Pool> pools = Arrays.asList(pool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         assertEquals(1, bestPools.size());
@@ -179,7 +179,7 @@ public class AutobindRulesTest {
         consumer.setFact("cpu.core(s)_per_socket", "1");
 
         final List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(), false);
+            Set.of(productId), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertEquals(6, bestPools.get(0).getQuantity().intValue());
@@ -191,13 +191,13 @@ public class AutobindRulesTest {
 
         List<Pool> pools = Arrays.asList(pool);
 
-        List<PoolQuantity> poolQs = autobindRules.selectBestPools(consumer, new String[]{ productId }, pools,
+        List<PoolQuantity> poolQs = autobindRules.selectBestPools(consumer, Set.of(productId), pools,
             compliance, null, new HashSet<>(), false);
         assertEquals(0, poolQs.size());
 
         // Try again with explicitly setting the consumer to cert v1:
         consumer.setFact("system.certificate_version", "1.0");
-        poolQs = autobindRules.selectBestPools(consumer, new String[]{ productId }, pools, compliance, null,
+        poolQs = autobindRules.selectBestPools(consumer, Set.of(productId), pools, compliance, null,
             new HashSet<>(), false);
         assertEquals(0, poolQs.size());
     }
@@ -207,13 +207,13 @@ public class AutobindRulesTest {
         Pool pool = createV3OnlyPool();
         List<Pool> pools = Arrays.asList(pool);
 
-        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer, new String[]{ productId },
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer, Set.of(productId),
             pools, compliance, null, new HashSet<>(), false);
         assertEquals(0, bestPools.size());
 
         // Shouldn't throw an exception as we do for certv1 clients.
         consumer.setFact("system.certificate_version", "2.5");
-        List<PoolQuantity> bestPoolsV2 = autobindRules.selectBestPools(consumer, new String[]{ productId },
+        List<PoolQuantity> bestPoolsV2 = autobindRules.selectBestPools(consumer, Set.of(productId),
             pools, compliance, null, new HashSet<>(), false);
         assertEquals(0, bestPoolsV2.size());
     }
@@ -236,7 +236,7 @@ public class AutobindRulesTest {
         doReturn(ctype).when(this.consumerTypeCurator).getByLabel(eq(ctype.getLabel()));
         doReturn(ctype).when(this.consumerTypeCurator).getConsumerType(eq(consumer));
 
-        List<PoolQuantity> results = autobindRules.selectBestPools(consumer, new String[]{ productId },
+        List<PoolQuantity> results = autobindRules.selectBestPools(consumer, Set.of(productId),
             pools, compliance, null, new HashSet<>(), false);
         assertEquals(1, results.size());
     }
@@ -249,7 +249,7 @@ public class AutobindRulesTest {
 
         // Shouldn't throw an exception as we do for certv1 clients.
         consumer.setFact("system.certificate_version", "3.5");
-        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer, new String[]{ productId },
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer, Set.of(productId),
             pools, compliance, null, new HashSet<>(), false);
         assertEquals(1, bestPools.size());
     }
@@ -296,7 +296,7 @@ public class AutobindRulesTest {
         List<Pool> pools = Arrays.asList(pool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         assertEquals(1, bestPools.size());
@@ -343,7 +343,7 @@ public class AutobindRulesTest {
         pools.add(pool3);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ provided.getId() }, pools, compliance, null, new HashSet<>(),
+            Set.of(provided.getId()), pools, compliance, null, new HashSet<>(),
             false);
 
         assertEquals(1, bestPools.size());
@@ -388,7 +388,7 @@ public class AutobindRulesTest {
         List<Pool> pools = Arrays.asList(pool1, pool2, pool3);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ provided.getId() }, pools, compliance, null, new HashSet<>(), false);
+            Set.of(provided.getId()), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(2, bestPools.size());
         //higher quantity from this pool, as it is virt_only
@@ -431,7 +431,7 @@ public class AutobindRulesTest {
         // The consumer does not have any existing entitlements.
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId, slaPremiumProdId, slaStandardProdId},
+            Set.of(productId, slaPremiumProdId, slaStandardProdId),
             pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(3, bestPools.size());
@@ -481,7 +481,7 @@ public class AutobindRulesTest {
         // The consumer does not have any existing entitlements.
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId, slaPremiumProdId, slaStandardProdId},
+            Set.of(productId, slaPremiumProdId, slaStandardProdId),
             pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(3, bestPools.size());
@@ -531,7 +531,7 @@ public class AutobindRulesTest {
         // The consumer does not have any existing entitlements.
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId, slaPremiumProdId, slaStandardProdId},
+            Set.of(productId, slaPremiumProdId, slaStandardProdId),
             pools, compliance, slaOverride, new HashSet<>(), false);
 
         assertEquals(3, bestPools.size());
@@ -581,7 +581,7 @@ public class AutobindRulesTest {
         compliance.addPartiallyCompliantProduct("b4b4b4", entitlementWithStandardSLA);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId, slaStandardProdId}, pools, compliance, null,
+            Set.of(productId, slaStandardProdId), pools, compliance, null,
             new HashSet<>(), false);
 
         // Pool will get prioritized by SLA matching Consumer SLA preference.
@@ -648,7 +648,7 @@ public class AutobindRulesTest {
         // In this case, the productIds array also includes a marketing product id (requiredMktProduct).
         // This scenario comes up when an activation key has auto-attach set to true, and a marketing
         // product id specified.
-        String[] requiredProducts = new String[]{"requiredEngProduct", "requiredMktProduct"};
+        Set<String> requiredProducts = Set.of("requiredEngProduct", "requiredMktProduct");
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer, requiredProducts,
             pools, compliance, null, new HashSet<>(), false);
@@ -946,7 +946,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -1680,7 +1680,7 @@ public class AutobindRulesTest {
         pools.add(MCT_HA);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertEquals(RH00009.getId(), bestPools.get(0).getPool().getId());
@@ -1717,7 +1717,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
     }
@@ -1755,7 +1755,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
     }
@@ -1790,7 +1790,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -1829,7 +1829,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -1869,7 +1869,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -1906,7 +1906,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -1943,7 +1943,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -1980,7 +1980,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2032,7 +2032,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
         pools.add(MCT80);
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(2, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2087,7 +2087,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
         pools.add(MCT80);
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(2, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2136,7 +2136,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
         pools.add(MCT80);
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(2, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2182,7 +2182,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
         pools.add(MCT80);
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(2, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2220,7 +2220,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2259,7 +2259,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2295,7 +2295,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(0, bestPools.size());
     }
@@ -2330,7 +2330,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(0, bestPools.size());
     }
@@ -2416,7 +2416,7 @@ public class AutobindRulesTest {
         pools.add(poolWithServiceTypeOnly);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(3, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(poolWithInstalledProductOnly, 1)));
@@ -2517,7 +2517,7 @@ public class AutobindRulesTest {
         pools.add(poolWithServiceTypeOnly);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(3, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(poolWithInstalledProductOnly, 1)));
@@ -2569,7 +2569,7 @@ public class AutobindRulesTest {
         pools.add(genericPool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2619,7 +2619,7 @@ public class AutobindRulesTest {
         pools.add(genericPool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2669,7 +2669,7 @@ public class AutobindRulesTest {
         pools.add(genericPool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2716,7 +2716,7 @@ public class AutobindRulesTest {
         List<Pool> pools = Arrays.asList(MCT1650, genericPool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2768,7 +2768,7 @@ public class AutobindRulesTest {
         pools.add(genericPool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -2815,7 +2815,7 @@ public class AutobindRulesTest {
         pools.add(pool1);
         pools.add(pool2);
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         // Only one of the pools should have been attached.
         assertEquals(1, bestPools.size());
@@ -2868,7 +2868,7 @@ public class AutobindRulesTest {
         pools.add(pool1);
         pools.add(pool2);
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         // Only one of the pools should have been attached.
         assertEquals(1, bestPools.size());
@@ -2913,7 +2913,7 @@ public class AutobindRulesTest {
         pools.add(pool1);
         pools.add(pool2);
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         // Only one of the pools should have been attached.
         assertEquals(1, bestPools.size());
@@ -2955,7 +2955,7 @@ public class AutobindRulesTest {
         pools.add(pool1);
         pools.add(pool2);
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         // Only one of the pools should have been attached.
         assertEquals(1, bestPools.size());
@@ -3004,7 +3004,7 @@ public class AutobindRulesTest {
         pools.add(pool2);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(pool1, 1)));
@@ -3052,7 +3052,7 @@ public class AutobindRulesTest {
         pools.add(pool2);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(pool1, 1)));
@@ -3100,7 +3100,7 @@ public class AutobindRulesTest {
         pools.add(pool2);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(pool1, 1)));
@@ -3148,7 +3148,7 @@ public class AutobindRulesTest {
         pools.add(pool2);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(pool1, 1)));
@@ -3183,7 +3183,7 @@ public class AutobindRulesTest {
         candidatePools.add(pool1);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, candidatePools, compliance, null, new HashSet<>(),
+            Set.of(productId), candidatePools, compliance, null, new HashSet<>(),
             false);
 
         // pool1 should be removed from candidate pools during the 'validate' step,
@@ -3210,7 +3210,7 @@ public class AutobindRulesTest {
         pools.add(p1);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{}, pools, compliance, null, new HashSet<>(), false);
+            Set.of(), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(p1, 1)));
@@ -3237,7 +3237,7 @@ public class AutobindRulesTest {
         pools.add(p1);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{}, pools, compliance, null, new HashSet<>(), false);
+            Set.of(), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(p1, 1)));
@@ -3276,7 +3276,7 @@ public class AutobindRulesTest {
         pools.add(p2);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ "prod-69" }, pools, compliance, null, new HashSet<>(), false);
+            Set.of("prod-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
 
@@ -3318,7 +3318,7 @@ public class AutobindRulesTest {
         pools.add(p2);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ "prod-69" }, pools, compliance, null, new HashSet<>(), false);
+            Set.of("prod-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
 
@@ -3354,7 +3354,7 @@ public class AutobindRulesTest {
         pools.add(p1);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{}, pools, compliance, null, new HashSet<>(), false);
+            Set.of(), pools, compliance, null, new HashSet<>(), false);
 
         // We expect no pool to be attached since the specified role that is provided by p1 is already
         // compliant (even though it is a case-insensitive match).
@@ -3390,7 +3390,7 @@ public class AutobindRulesTest {
         pools.add(p1);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{}, pools, compliance, null, new HashSet<>(), false);
+            Set.of(), pools, compliance, null, new HashSet<>(), false);
 
         // We expect no pool to be attached since the specified addon that is provided by p1 is already
         // compliant (even though it is a case-insensitive match).
@@ -3429,7 +3429,7 @@ public class AutobindRulesTest {
         compliance.addPartialStack("1", entitlement);
 
         List<PoolQuantity> result = autobindRules.selectBestPools(consumer,
-            new String[]{ productId2, productId3 },
+            Set.of(productId2, productId3),
             pools, compliance, null, new HashSet<>(), false);
         assertNotNull(result);
         // We can make sure the partial stack wasn't completed
@@ -3453,9 +3453,11 @@ public class AutobindRulesTest {
     @Test
     public void testSelectBestPoolNoPools() {
         // There are no pools for the product in this case:
-        assertEquals(0, autobindRules.selectBestPools(consumer,
-            new String[] {HIGHEST_QUANTITY_PRODUCT}, new LinkedList<>(), compliance,
-            null, new HashSet<>(), false).size());
+        List<PoolQuantity> result = autobindRules.selectBestPools(consumer, Set.of(HIGHEST_QUANTITY_PRODUCT),
+            new LinkedList<>(), compliance, null, new HashSet<>(), false);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
     }
 
     @Test
@@ -3470,8 +3472,9 @@ public class AutobindRulesTest {
 
         List<Pool> availablePools = Arrays.asList(pool1, pool2);
 
-        List<PoolQuantity> result = autobindRules.selectBestPools(consumer,
-            new String[] {product.getId()}, availablePools, compliance, null, new HashSet<>(), false);
+        List<PoolQuantity> result = autobindRules.selectBestPools(consumer, Set.of(product.getId()),
+            availablePools, compliance, null, new HashSet<>(), false);
+
         assertNotNull(result);
         for (PoolQuantity pq : result) {
             assertEquals(1, pq.getQuantity());
@@ -3545,7 +3548,7 @@ public class AutobindRulesTest {
         String engProdId = "928";
         List<Pool> pools = createDerivedPool(engProdId);
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ engProdId }, pools, compliance, null, new HashSet<>(),
+            Set.of(engProdId), pools, compliance, null, new HashSet<>(),
             true);
         assertEquals(1, bestPools.size());
     }
@@ -3555,7 +3558,7 @@ public class AutobindRulesTest {
         List<Pool> pools = createInstanceBasedPool();
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         assertEquals(1, bestPools.size());
@@ -3569,7 +3572,7 @@ public class AutobindRulesTest {
         setupConsumer("8", false);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         assertEquals(1, bestPools.size());
@@ -3584,7 +3587,7 @@ public class AutobindRulesTest {
         setupConsumer("8", false);
 
         assertEquals(0, autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false).size());
     }
 
@@ -3595,7 +3598,7 @@ public class AutobindRulesTest {
         setupConsumer("8", false);
 
         assertEquals(0, autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false).size());
     }
 
@@ -3611,7 +3614,7 @@ public class AutobindRulesTest {
         compliance.addPartialStack("1", mockEnt);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         assertEquals(1, bestPools.size());
@@ -3632,7 +3635,7 @@ public class AutobindRulesTest {
         setupConsumer("8", true);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         assertEquals(1, bestPools.size());
@@ -3680,7 +3683,7 @@ public class AutobindRulesTest {
         setupConsumer("8", true);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         assertEquals(1, bestPools.size());
@@ -3724,7 +3727,7 @@ public class AutobindRulesTest {
         setupConsumer("8", false);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         assertEquals(1, bestPools.size());
@@ -3743,7 +3746,7 @@ public class AutobindRulesTest {
         pools.add(pool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ product.getId() }, pools, compliance, null, new HashSet<>(), false);
+            Set.of(product.getId()), pools, compliance, null, new HashSet<>(), false);
         assertEquals(1, bestPools.size());
         assertEquals(1, bestPools.get(0).getQuantity());
         assertEquals("POOL-ID", bestPools.get(0).getPool().getId());
@@ -3760,7 +3763,7 @@ public class AutobindRulesTest {
         pools.add(pool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ product.getId() }, pools, compliance, null, new HashSet<>(), false);
+            Set.of(product.getId()), pools, compliance, null, new HashSet<>(), false);
         assertEquals(1, bestPools.size());
         assertEquals(4, bestPools.get(0).getQuantity());
         assertEquals("POOL-ID", bestPools.get(0).getPool().getId());
@@ -3789,8 +3792,11 @@ public class AutobindRulesTest {
         pools.add(serverPool);
         pools.add(hyperPool);
 
-        assertEquals(0, autobindRules.selectBestPools(consumer,
-            new String[]{ server.getUuid() }, pools, compliance, null, new HashSet<>(), false).size());
+        List<PoolQuantity> output = autobindRules.selectBestPools(consumer, Set.of(server.getId()), pools,
+            compliance, null, new HashSet<>(), false);
+
+        assertNotNull(output);
+        assertTrue(output.isEmpty());
     }
 
     /*
@@ -3826,7 +3832,7 @@ public class AutobindRulesTest {
         pools.add(hyperPool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ server.getId() }, pools, compliance, null, new HashSet<>(), false);
+            Set.of(server.getId()), pools, compliance, null, new HashSet<>(), false);
         assertEquals(1, bestPools.size());
         assertEquals(4, bestPools.get(0).getQuantity());
         assertEquals("POOL-ID1", bestPools.get(0).getPool().getId());
@@ -3865,7 +3871,7 @@ public class AutobindRulesTest {
         pools.add(hyperPool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ server.getId() }, pools, compliance, null, new HashSet<>(), false);
+            Set.of(server.getId()), pools, compliance, null, new HashSet<>(), false);
         assertEquals(1, bestPools.size());
         assertEquals(1, bestPools.get(0).getQuantity());
         assertEquals("POOL-ID1", bestPools.get(0).getPool().getId());
@@ -3926,7 +3932,7 @@ public class AutobindRulesTest {
         setupConsumer("32", false);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         // Should always pick the 2 socket subscriptions because less are required
@@ -3943,7 +3949,7 @@ public class AutobindRulesTest {
         setupConsumer("8", false);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         // Should always pick the 2 socket subscriptions because there is no over-coverage
@@ -3960,7 +3966,7 @@ public class AutobindRulesTest {
         setupConsumer("8", false);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         // Should always pick the 3 socket subscription, becuase 3*3 gives 1 socket over-coverage,
@@ -3978,7 +3984,7 @@ public class AutobindRulesTest {
         setupConsumer("9", false);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         // Should always pick the 2 5 socket subscriptions over 9 1 socket subscriptions
@@ -3997,7 +4003,7 @@ public class AutobindRulesTest {
         setupConsumer("32", false);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         // Should always pick the 2 socket subscriptions because less are required
@@ -4014,7 +4020,7 @@ public class AutobindRulesTest {
         setupConsumer("8", false);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         // Should always pick the 2 socket subscriptions because there is no over-coverage
@@ -4031,7 +4037,7 @@ public class AutobindRulesTest {
         setupConsumer("8", false);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         // Should always pick the 3 socket subscription, becuase 3*3 gives 1 socket over-coverage,
@@ -4049,7 +4055,7 @@ public class AutobindRulesTest {
         setupConsumer("9", false);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ productId }, pools, compliance, null, new HashSet<>(),
+            Set.of(productId), pools, compliance, null, new HashSet<>(),
             false);
 
         // Should always pick the 2 5 socket subscriptions over 9 1 socket subscriptions
@@ -4078,7 +4084,7 @@ public class AutobindRulesTest {
         pools.add(p1);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{}, pools, compliance, null, new HashSet<>(), false);
+            Set.of(), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(p1, 1)));
@@ -4102,8 +4108,8 @@ public class AutobindRulesTest {
         List<Pool> pools = new ArrayList<>();
         pools.add(p1);
 
-        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{}, pools, compliance, null, new HashSet<>(), false);
+        List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer, Set.of(), pools, compliance,
+            null, Set.of(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(p1, 1)));
@@ -4343,7 +4349,7 @@ public class AutobindRulesTest {
         pools.add(p2);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{ "prod-69" }, pools, compliance, null, new HashSet<>(), false);
+            Set.of("prod-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
 
@@ -4395,7 +4401,7 @@ public class AutobindRulesTest {
         pools.add(genericPool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(MCT1650, 1)));
@@ -4445,7 +4451,7 @@ public class AutobindRulesTest {
         pools.add(pool2);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         assertTrue(bestPools.contains(new PoolQuantity(pool1, 1)));
@@ -4479,7 +4485,7 @@ public class AutobindRulesTest {
         pools.add(MCT1650);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(0, bestPools.size());
     }
@@ -4539,7 +4545,7 @@ public class AutobindRulesTest {
         pools.add(genericPool);
 
         List<PoolQuantity> bestPools = autobindRules.selectBestPools(consumer,
-            new String[]{"compliant-69"}, pools, compliance, null, new HashSet<>(), false);
+            Set.of("compliant-69"), pools, compliance, null, new HashSet<>(), false);
 
         assertEquals(1, bestPools.size());
         // We expect MCT1650 to be attached, because the fact that it covers the usage attribute, which is

--- a/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
@@ -36,7 +36,6 @@ import org.candlepin.model.Release;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyContentOverrideCurator;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
-import org.candlepin.model.activationkeys.ActivationKeyPool;
 import org.candlepin.policy.activationkey.ActivationKeyRules;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
@@ -255,9 +254,7 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
 
         akr.addPoolToKey("testKey", "testPool1", 1L);
         assertEquals(1, ak.getPools().size());
-        Set<ActivationKeyPool> akPools = new HashSet<>();
-        akPools.add(new ActivationKeyPool(ak, p1, 1L));
-        ak.setPools(akPools);
+
         akr.addPoolToKey("testKey", "testPool2", 1L);
         assertEquals(2, ak.getPools().size());
     }
@@ -344,9 +341,9 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
 
         assertNotNull(key.getId());
         activationKeyResource.addProductIdToKey(key.getId(), product.getId());
-        assertEquals(1, key.getProducts().size());
+        assertEquals(1, key.getProductIds().size());
         activationKeyResource.removeProductIdFromKey(key.getId(), product.getId());
-        assertEquals(0, key.getProducts().size());
+        assertEquals(0, key.getProductIds().size());
     }
 
     @Test
@@ -362,12 +359,11 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         assertNotNull(key.getId());
 
         activationKeyResource.addProductIdToKey(key.getId(), product.getId());
-        assertEquals(1, key.getProducts().size());
+        assertEquals(1, key.getProductIds().size());
 
         ActivationKey finalKey = key;
         assertThrows(BadRequestException.class, () ->
-            activationKeyResource.addProductIdToKey(finalKey.getId(), product.getId())
-        );
+            activationKeyResource.addProductIdToKey(finalKey.getId(), product.getId()));
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -569,23 +569,25 @@ public class ConsumerResourceTest {
 
     @Test
     public void futureHealing() throws Exception {
-        Owner o = createOwner();
-        Consumer c = createConsumer(o);
+        Owner owner = createOwner();
+        Consumer consumer = createConsumer(owner);
         ConsumerCurator cc = mock(ConsumerCurator.class);
         ConsumerInstalledProduct cip = mock(ConsumerInstalledProduct.class);
         Set<ConsumerInstalledProduct> products = new HashSet<>();
         products.add(cip);
 
-        when(ownerCurator.findOwnerById(eq(o.getId()))).thenReturn(o);
+        when(ownerCurator.findOwnerById(eq(owner.getId()))).thenReturn(owner);
         when(cip.getProductId()).thenReturn("product-foo");
-        when(subscriptionServiceAdapter.hasUnacceptedSubscriptionTerms(eq(o.getKey()))).thenReturn(false);
-        when(cc.verifyAndLookupConsumerWithEntitlements(eq(c.getUuid()))).thenReturn(c);
+        when(subscriptionServiceAdapter.hasUnacceptedSubscriptionTerms(eq(owner.getKey()))).thenReturn(false);
+        when(cc.verifyAndLookupConsumerWithEntitlements(eq(consumer.getUuid()))).thenReturn(consumer);
 
         String dtStr = "2011-09-26T18:10:50.184081+00:00";
         Date dt = ResourceDateParser.parseDateString(dtStr);
 
-        consumerResource.bind(c.getUuid(), null, null, null, null, null, false, dtStr, null);
-        AutobindData data = AutobindData.create(c, o).on(dt);
+        consumerResource.bind(consumer.getUuid(), null, null, null, null, null, false, dtStr, null);
+        AutobindData data = new AutobindData(consumer, owner)
+            .on(dt);
+
         verify(entitler).bindByProducts(eq(data));
     }
 

--- a/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -620,7 +620,7 @@ public class ConsumerResourceUpdateTest {
         );
 
         verify(poolManager).revokeEntitlement(eq(entitlement));
-        verify(entitler).bindByProducts(AutobindData.create(guest1, owner));
+        verify(entitler).bindByProducts(new AutobindData(guest1, owner));
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
@@ -147,8 +147,7 @@ class EnvironmentResourceTest {
             this.entCertGenerator
         );
 
-        this.owner = new Owner("owner1", "Owner 1");
-        owner.setId("owner1");
+        this.owner = TestUtil.createOwner("owner1");
         this.environment1 = createEnvironment(owner, ENV_ID_1);
     }
 
@@ -239,9 +238,13 @@ class EnvironmentResourceTest {
     void shouldThrowExceptionIfAnyOfEnvIdsDoesNotBelongToSameOwner() {
         ConsumerDTO dto = new ConsumerDTO();
         String envIds = "env1,env2,env3";
-        Environment env1 = createEnvironment(new Owner("Random_Owner_1", "Owner1"), "env1");
-        Environment env2 = createEnvironment(new Owner("Random_Owner_2", "Owner2"), "env2");
-        Environment env3 = createEnvironment(new Owner("Random_Owner_1", "Owner1"), "env3");
+
+        Owner owner1 = TestUtil.createOwner("owner1");
+        Owner owner2 = TestUtil.createOwner("owner2");
+
+        Environment env1 = createEnvironment(owner1, "env1");
+        Environment env2 = createEnvironment(owner2, "env2");
+        Environment env3 = createEnvironment(owner1, "env3");
         when(this.envCurator.get(anyString())).thenReturn(env2, env1, env3);
 
         assertThrows(BadRequestException.class, () -> this.environmentResource

--- a/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
@@ -231,19 +231,12 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
     public void deleteContent() {
         Owner owner = this.createOwner("test_owner");
         Content content = this.createContent("test_content", "test_content", owner);
-        Environment environment = this.createEnvironment(owner, "test_env", "test_env", null, null,
-            Arrays.asList(content));
 
         assertNotNull(this.ownerContentCurator.getContentById(owner, content.getId()));
 
         this.ownerContentResource.remove(owner.getKey(), content.getId());
 
         assertNull(this.ownerContentCurator.getContentById(owner, content.getId()));
-
-        this.environmentCurator.evict(environment);
-        environment = this.environmentCurator.get(environment.getId());
-
-        assertEquals(0, environment.getEnvironmentContent().size());
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -110,26 +110,28 @@ public class ConsumerBindUtilTest {
     @Test
     public void registerWithKeyWithPoolAndInstalledProductsAutoAttach() throws Exception {
         Product prod = TestUtil.createProduct();
-        String[] prodIds = new String[]{prod.getId()};
+        Set<String> prodIds = Set.of(prod.getId());
 
-        Pool pool = TestUtil.createPool(owner, prod);
-        pool.setId("id-string");
-        List<String> poolIds = new ArrayList<>();
-        poolIds.add(pool.getId());
+        Pool pool = TestUtil.createPool(owner, prod)
+            .setId("id-string");
 
-        List<ActivationKey> keys = new ArrayList<>();
-        ActivationKey key1 = new ActivationKey("key1", owner);
-        keys.add(key1);
-        key1.addPool(pool, 0L);
-        key1.setAutoAttach(true);
+        List<String> poolIds = List.of(pool.getId());
+
+        ActivationKey key1 = new ActivationKey("key1", owner)
+            .addPool(pool, 0L)
+            .setAutoAttach(true);
+
+        List<ActivationKey> keys = List.of(key1);
+
 
         Consumer consumer = new Consumer("sys.example.com", null, null, this.systemConsumerType);
-        Set<ConsumerInstalledProduct> cips = new HashSet<>();
         ConsumerInstalledProduct cip = new ConsumerInstalledProduct(consumer, prod);
-        cips.add(cip);
-        consumer.setInstalledProducts(cips);
+        consumer.setInstalledProducts(Set.of(cip));
 
-        AutobindData ad = new AutobindData(consumer, owner).withPools(poolIds).forProducts(prodIds);
+        AutobindData ad = new AutobindData(consumer, owner)
+            .withPools(poolIds)
+            .forProducts(prodIds);
+
         ConsumerBindUtil consumerBindUtil = this.buildConsumerBindUtil();
         consumerBindUtil.handleActivationKeys(consumer, keys, false);
         verify(entitler).bindByProducts(eq(ad));
@@ -138,7 +140,7 @@ public class ConsumerBindUtilTest {
     @Test
     public void registerWithKeyWithInstalledProductsAutoAttach() throws Exception {
         Product prod = TestUtil.createProduct();
-        String[] prodIds = new String[]{prod.getId()};
+        Set<String> prodIds = Set.of(prod.getId());
 
         List<ActivationKey> keys = new ArrayList<>();
         ActivationKey key1 = new ActivationKey("key1", owner);
@@ -151,7 +153,9 @@ public class ConsumerBindUtilTest {
         cips.add(cip);
         consumer.setInstalledProducts(cips);
 
-        AutobindData ad = new AutobindData(consumer, owner).forProducts(prodIds);
+        AutobindData ad = new AutobindData(consumer, owner)
+            .forProducts(prodIds);
+
         ConsumerBindUtil consumerBindUtil = this.buildConsumerBindUtil();
         consumerBindUtil.handleActivationKeys(consumer, keys, false);
         verify(entitler).bindByProducts(eq(ad));
@@ -163,7 +167,7 @@ public class ConsumerBindUtilTest {
         Product prod1 = TestUtil.createProduct();
         // key product
         Product prod2 = TestUtil.createProduct();
-        String[] prodIds = new String[]{prod1.getId(), prod2.getId()};
+        Set<String> prodIds = Set.of(prod1.getId(), prod2.getId());
 
         List<ActivationKey> keys = new ArrayList<>();
         ActivationKey key1 = new ActivationKey("key1", owner);
@@ -177,7 +181,9 @@ public class ConsumerBindUtilTest {
         cips.add(cip);
         consumer.setInstalledProducts(cips);
 
-        AutobindData ad = new AutobindData(consumer, owner).forProducts(prodIds);
+        AutobindData ad = new AutobindData(consumer, owner)
+            .forProducts(prodIds);
+
         ConsumerBindUtil consumerBindUtil = this.buildConsumerBindUtil();
         consumerBindUtil.handleActivationKeys(consumer, keys, false);
         verify(entitler).bindByProducts(eq(ad));

--- a/src/test/java/org/candlepin/resource/util/EntitlementEnvironmentFilterTest.java
+++ b/src/test/java/org/candlepin/resource/util/EntitlementEnvironmentFilterTest.java
@@ -14,322 +14,359 @@
  */
 package org.candlepin.resource.util;
 
-import static java.util.Map.entry;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyIterable;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-import org.candlepin.model.Consumer;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.EnvironmentContentCurator;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.mockito.stubbing.Answer;
 
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
+
+
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EntitlementEnvironmentFilterTest {
-    @Mock
-    private EntitlementCurator entitlementCurator;
-    @Mock
-    private EnvironmentContentCurator environmentContentCurator;
-    private Consumer consumer;
+    private EntitlementCurator mockEntitlementCurator;
+    private EnvironmentContentCurator mockEnvironmentContentCurator;
+
+    private final Map<String, Set<String>> consumerEntitlementIdMap = new HashMap<>();
+    private final Map<String, Set<String>> entitlementContentIdMap = new HashMap<>();
+    private final Map<String, Set<String>> environmentContentIdMap = new HashMap<>();
 
     @BeforeEach
-    void setUp() {
-        this.consumer = createConsumer(1);
+    public void setUp() {
+        this.consumerEntitlementIdMap.clear();
+        this.entitlementContentIdMap.clear();
+        this.environmentContentIdMap.clear();
+
+        this.mockEntitlementCurator = mock(EntitlementCurator.class);
+        this.mockEnvironmentContentCurator = mock(EnvironmentContentCurator.class);
+
+        doAnswer(iom -> {
+            Map<String, String> output = new HashMap<>();
+            Iterable<String> input = iom.getArgument(0);
+
+            for (String consumerId : input) {
+                this.consumerEntitlementIdMap.getOrDefault(consumerId, Set.of())
+                    .forEach(entitlementId -> output.put(entitlementId, consumerId));
+            }
+
+            return output;
+        }).when(this.mockEntitlementCurator).getEntitlementConsumerIdMap(anyIterable());
+
+        doAnswer(this.buildMapAnswer(this.entitlementContentIdMap))
+            .when(this.mockEntitlementCurator).getEntitlementContentIdMap(anyIterable());
+
+        doAnswer(this.buildMapAnswer(this.environmentContentIdMap))
+            .when(this.mockEnvironmentContentCurator).getEnvironmentContentIdMap(anyIterable());
     }
 
-    @ParameterizedTest
-    @MethodSource("addedDetectChange")
-    public void shouldDetectEntitlementOfAddedEnvironment(List<String> currentEnvs,
-        List<String> updatedEnvs) {
-        Map<String, Set<String>> contentUUIDsConsumerIds = Map.ofEntries(
-            entry("ent1", Set.of("c1", "c2", "c3"))
-        );
-        when(this.entitlementCurator.getEntitlementContentUUIDs(anyCollection()))
-            .thenReturn(contentUUIDsConsumerIds);
+    private Answer<Map<String, Set<String>>> buildMapAnswer(Map<String, Set<String>> source) {
+        return iom -> {
+            Map<String, Set<String>> output = new HashMap<>();
+            Iterable<String> input = iom.getArgument(0);
 
-        Map<String, List<String>> id = Map.ofEntries(
-            entry("envA", List.of("c1")),
-            entry("envB", List.of("c2")),
-            entry("envC", List.of("c1"))
-        );
-        when(this.environmentContentCurator.getEnvironmentContentUUIDs(anyIterable())).thenReturn(id);
+            for (String element : input) {
+                if (source.containsKey(element)) {
+                    output.put(element, source.get(element));
+                }
+            }
 
-        EnvironmentUpdates environmentUpdate = new EnvironmentUpdates();
-        environmentUpdate.put(consumer.getId(), currentEnvs, updatedEnvs);
-        Set<String> filteredEnt1 = createEntitlementFilter()
-            .filterEntitlements(environmentUpdate);
-
-        assertEquals(filteredEnt1.size(), 1);
-        assertTrue(filteredEnt1.contains("ent1"));
+            return output;
+        };
     }
 
-    public static Stream<Arguments> addedDetectChange() {
-        return Stream.of(
-            // EnvB added with Higher priority
-            // EnvA & EnvB both have different content
-            Arguments.of(List.of("envA"), List.of("envB", "envA")),
-            // EnvB added with Lower priority
-            // EnvA & EnvB both have different content
-            Arguments.of(List.of("envA"), List.of("envA", "envB")),
-            // EnvC is added with Higher priority
-            // EnvA (low) & EnvC (high) both have same content
-            Arguments.of(List.of("envA"), List.of("envC", "envA"))
-        );
+    private EntitlementEnvironmentFilter buildEEFilter() {
+        return new EntitlementEnvironmentFilter(this.mockEntitlementCurator,
+            this.mockEnvironmentContentCurator);
+    }
+
+    private void mapConsumerToEntitlements(String consumerId, String... entitlementIds) {
+        for (String entitlementId : entitlementIds) {
+            this.consumerEntitlementIdMap.computeIfAbsent(consumerId, (key) -> new HashSet<>())
+                .add(entitlementId);
+        }
+    }
+
+    private void mapEntitlementToContent(String entitlementId, String... contentIds) {
+        for (String contentId : contentIds) {
+            this.entitlementContentIdMap.computeIfAbsent(entitlementId, (key) -> new HashSet<>())
+                .add(contentId);
+        }
+    }
+
+    private void mapEnvironmentToContent(String environmentId, String... contentIds) {
+        for (String contentId : contentIds) {
+            this.environmentContentIdMap.computeIfAbsent(environmentId, (key) -> new HashSet<>())
+                .add(contentId);
+        }
+    }
+
+
+    @Test
+    public void testEEFRequiresNonNullInput() {
+        EntitlementEnvironmentFilter filter = this.buildEEFilter();
+
+        assertThrows(IllegalArgumentException.class, () -> filter.filterEntitlements(null));
     }
 
     @Test
-    public void shouldSkipEntitlementOfAddedEnvironmentWithSameContent() {
-        Map<String, Set<String>> contentUUIDsConsumerIds = Map.ofEntries(
-            entry("ent1", Set.of("c1", "c2", "c3"))
-        );
-        when(this.entitlementCurator.getEntitlementContentUUIDs(anyCollection()))
-            .thenReturn(contentUUIDsConsumerIds);
+    public void testEEFReturnsEmptySetOnEmptyInput() {
+        EntitlementEnvironmentFilter filter = this.buildEEFilter();
 
-        Map<String, List<String>> id = Map.ofEntries(
-            entry("envA", List.of("c1")),
-            entry("envB", List.of("c2")),
-            entry("envC", List.of("c1"))
-        );
-        when(this.environmentContentCurator.getEnvironmentContentUUIDs(anyIterable())).thenReturn(id);
+        Set<String> output = this.buildEEFilter().filterEntitlements(new EnvironmentUpdates());
 
-        // EnvC is added with lower priority
-        // EnvA (high) & EnvC (low) both have same content
-        EnvironmentUpdates environmentUpdate = new EnvironmentUpdates();
-        environmentUpdate.put(consumer.getId(), List.of("envA"), List.of("envA", "envC"));
-
-        Set<String> filteredEnt = createEntitlementFilter()
-            .filterEntitlements(environmentUpdate);
-        assertEquals(filteredEnt.size(), 0);
-
+        assertNotNull(output);
+        assertTrue(output.isEmpty());
     }
 
-    @ParameterizedTest
-    @MethodSource("removedDetectChange")
-    public void shouldDetectEntitlementOfRemovedEnvironment(List<String> currentEnvs,
-        List<String> updatedEnvs) {
-        Map<String, Set<String>> contentUUIDsConsumerIds = Map.ofEntries(
-            entry("ent1", Set.of("c1", "c2", "c3"))
-        );
-        when(entitlementCurator.getEntitlementContentUUIDs(anyCollection()))
-            .thenReturn(contentUUIDsConsumerIds);
+    // Tests for adding environments
+    @Test
+    public void testEEFReportsChangeWhenAddingEnvironmentWithNewEntitlementContent() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2");
+        this.mapEntitlementToContent("ent1", "c1", "c2", "c3");
+        this.mapEntitlementToContent("ent2", "c1", "c2");
+        this.mapEnvironmentToContent("env1", "c1");
+        this.mapEnvironmentToContent("env2", "c2");
+        this.mapEnvironmentToContent("env3", "c3");
 
-        Map<String, List<String>> id = Map.ofEntries(
-            entry("envA", List.of("c1")),
-            entry("envB", List.of("c2")),
-            entry("envC", List.of("c1"))
-        );
-        when(environmentContentCurator.getEnvironmentContentUUIDs(anyIterable())).thenReturn(id);
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2"), List.of("env1", "env2", "env3"));
 
-        EnvironmentUpdates environmentUpdate = new EnvironmentUpdates();
-        environmentUpdate.put(consumer.getId(), currentEnvs, updatedEnvs);
-        Set<String> filteredEnt = createEntitlementFilter()
-            .filterEntitlements(environmentUpdate);
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
 
-        assertEquals(filteredEnt.size(), 1);
-        assertTrue(filteredEnt.contains("ent1"));
-    }
-
-    public static Stream<Arguments> removedDetectChange() {
-        return Stream.of(
-            // EnvA of higher priority is being removed
-            // envA & envB have different content
-            Arguments.of(List.of("envA", "envB"), List.of("envB")),
-            // EnvB of lower priority is being removed
-            // envA & envB have different content
-            Arguments.of(List.of("envA", "envB"), List.of("envA")),
-            // EnvC of higher priority is being removed
-            // EnvC provides content same as envA
-            Arguments.of(List.of("envC", "envA"), List.of("envA"))
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("removedIgnoreChange")
-    public void shouldSkipEntitlementOfRemovedEnvironmentWithSameContent(
-        List<String> currentEnvs, List<String> updatedEnvs) {
-        Map<String, Set<String>> contentUUIDsConsumerIds = Map.ofEntries(
-            entry("ent1", Set.of("c1", "c2", "c3"))
-        );
-        when(entitlementCurator.getEntitlementContentUUIDs(anyCollection()))
-            .thenReturn(contentUUIDsConsumerIds);
-
-        Map<String, List<String>> id = Map.ofEntries(
-            entry("envA", List.of("c1")),
-            entry("envB", List.of("c2")),
-            entry("envC", List.of("c1"))
-        );
-        when(environmentContentCurator.getEnvironmentContentUUIDs(anyIterable())).thenReturn(id);
-
-        EnvironmentUpdates environmentUpdate = new EnvironmentUpdates();
-        environmentUpdate.put(consumer.getId(), currentEnvs, updatedEnvs);
-
-        Set<String> filteredEnt = createEntitlementFilter()
-            .filterEntitlements(environmentUpdate);
-        assertEquals(filteredEnt.size(), 0);
-    }
-
-    public static Stream<Arguments> removedIgnoreChange() {
-        return Stream.of(
-            // EnvC of lower priority is being removed
-            // EnvC provides content same as envA
-            Arguments.of(List.of("envA", "envB", "envC"), List.of("envA", "envB")),
-            // EnvC of Lower priority is being removed
-            // EnvC provides content same as envA
-            Arguments.of(List.of("envA", "envC"), List.of("envA"))
-        );
+        assertNotNull(output);
+        assertEquals(1, output.size());
+        assertTrue(output.contains("ent1"));
     }
 
     @Test
-    public void testWhenLowerPriorityEnvsReorderedProvidingSameContent() {
-        Map<String, Set<String>> contentUUIDsConsumerIds = Map.ofEntries(
-            entry("ent1", Set.of("c1", "c2", "c3"))
-        );
-        when(entitlementCurator.getEntitlementContentUUIDs(anyCollection()))
-            .thenReturn(contentUUIDsConsumerIds);
+    public void testEEFReportsChangeWhenAddingEnvironmentProvidingExistingContentAtHigherPriority() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2");
+        this.mapEntitlementToContent("ent1", "c1", "c2");
+        this.mapEntitlementToContent("ent2", "c3");
+        this.mapEnvironmentToContent("env1", "c1", "c2");
+        this.mapEnvironmentToContent("env2", "c3");
+        this.mapEnvironmentToContent("env3", "c2");
 
-        Map<String, List<String>> id = Map.ofEntries(
-            entry("envA", List.of("c1")),
-            entry("envB", List.of("c1")),
-            entry("envC", List.of("c1"))
-        );
-        when(environmentContentCurator.getEnvironmentContentUUIDs(anyIterable())).thenReturn(id);
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2"), List.of("env3", "env1", "env2"));
 
-        EnvironmentUpdates environmentUpdate = new EnvironmentUpdates();
-        environmentUpdate.put(consumer.getId(),
-            List.of("envA", "envB", "envC"), List.of("envA", "envC", "envB"));
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
 
-        // Reordering lower priority (envB & envC) environments
-        // providing same contents
-        Set<String> filteredEnt = createEntitlementFilter()
-            .filterEntitlements(environmentUpdate);
-        assertEquals(filteredEnt.size(), 0);
+        assertNotNull(output);
+        assertEquals(1, output.size());
+        assertTrue(output.contains("ent1"));
     }
 
     @Test
-    public void testWhenEnvsAreReorderedProvidingDifferentContent() {
-        Map<String, Set<String>> contentUUIDsConsumerIds = Map.ofEntries(
-            entry("ent1", Set.of("c1", "c2", "c3"))
-        );
-        when(entitlementCurator.getEntitlementContentUUIDs(anyCollection()))
-            .thenReturn(contentUUIDsConsumerIds);
+    public void testEEFIgnoresChangeWhenAddingEnvironmentProvidingExistingContentAtLowerPriority() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2");
+        this.mapEntitlementToContent("ent1", "c1", "c2");
+        this.mapEntitlementToContent("ent2", "c3");
+        this.mapEnvironmentToContent("env1", "c1", "c2");
+        this.mapEnvironmentToContent("env2", "c3");
+        this.mapEnvironmentToContent("env3", "c2");
 
-        Map<String, List<String>> id = Map.ofEntries(
-            entry("envA", List.of("c1")),
-            entry("envB", List.of("c2"))
-        );
-        when(environmentContentCurator.getEnvironmentContentUUIDs(anyIterable())).thenReturn(id);
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2"), List.of("env1", "env2", "env3"));
 
-        EnvironmentUpdates environmentUpdate = new EnvironmentUpdates();
-        environmentUpdate.put(consumer.getId(), List.of("envA", "envB"), List.of("envB", "envA"));
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
 
-        // Priority of envB & envA are reversed
-        Set<String> filteredEnt = createEntitlementFilter()
-            .filterEntitlements(environmentUpdate);
-        assertEquals(filteredEnt.size(), 1);
-        assertTrue(filteredEnt.contains("ent1"));
+        assertNotNull(output);
+        assertTrue(output.isEmpty());
     }
 
     @Test
-    public void testWhenHigherPriorityEnvironmentIsDeleted() {
-        Map<String, Set<String>> contentUUIDsConsumerIds = Map.ofEntries(
-            entry("ent1", Set.of("c1", "c2"))
-        );
-        when(entitlementCurator.getEntitlementContentUUIDs(anyCollection()))
-            .thenReturn(contentUUIDsConsumerIds);
+    public void testEEFIgnoresChangeWhenAddingEnvironmentProvidingNoEntitlementContent() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2");
+        this.mapEntitlementToContent("ent1", "c1", "c2");
+        this.mapEntitlementToContent("ent2", "c3");
+        this.mapEnvironmentToContent("env1", "c1", "c2");
+        this.mapEnvironmentToContent("env2", "c3");
+        this.mapEnvironmentToContent("env3", "c4");
 
-        Map<String, List<String>> id = Map.ofEntries(
-            entry("envA", List.of("c1", "c2")),
-            entry("envB", List.of("c1", "c2"))
-        );
-        when(environmentContentCurator.getEnvironmentContentUUIDs(anyIterable())).thenReturn(id);
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2"), List.of("env3", "env1", "env2"));
 
-        EnvironmentUpdates environmentUpdate = new EnvironmentUpdates();
-        environmentUpdate.put(consumer.getId(), List.of("envA", "envB"), List.of("envB"));
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
 
-        Set<String> filteredEnt = createEntitlementFilter()
-            .filterEntitlements(environmentUpdate);
-        assertEquals(filteredEnt.size(), 1);
-        assertTrue(filteredEnt.contains("ent1"));
+        assertNotNull(output);
+        assertTrue(output.isEmpty());
+    }
+
+    // Tests for changing environments (reordering/reprioritization)
+    @Test
+    public void testEEFReportsChangeWhenHighestPrioEnvProvidingContentChanges() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2");
+        this.mapEntitlementToContent("ent1", "c1", "c2");
+        this.mapEntitlementToContent("ent2", "c2", "c3");
+        this.mapEnvironmentToContent("env1", "c1");
+        this.mapEnvironmentToContent("env2", "c1");
+
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2"), List.of("env2", "env1"));
+
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
+
+        assertNotNull(output);
+        assertEquals(1, output.size());
+        assertTrue(output.contains("ent1"));
     }
 
     @Test
-    public void testEnvBeingAddedHasNoContent() {
-        Map<String, Set<String>> contentUUIDsConsumerIds = Map.ofEntries(
-            entry("ent1", Set.of("c1", "c2"))
-        );
-        when(entitlementCurator.getEntitlementContentUUIDs(anyCollection()))
-            .thenReturn(contentUUIDsConsumerIds);
+    public void testEEFIgnoresChangeWhenHighestPrioEnvProvidingNoEntitlementContentChanges() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2");
+        this.mapConsumerToEntitlements("consumer2", "ent1", "ent2");
+        this.mapEntitlementToContent("ent1", "c1", "c2");
+        this.mapEntitlementToContent("ent2", "c2", "c3");
+        this.mapEnvironmentToContent("env1", "c1", "c2");
+        this.mapEnvironmentToContent("env2", "c4");
+        this.mapEnvironmentToContent("env3", "c4");
 
-        Map<String, List<String>> id = Map.ofEntries(
-            entry("envA", List.of("c1", "c2")),
-            entry("envB", Collections.emptyList())
-        );
-        when(environmentContentCurator.getEnvironmentContentUUIDs(anyIterable())).thenReturn(id);
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2", "env3"), List.of("env1", "env3", "env2"))
+            .put("consumer2", List.of("env2", "env3", "env1"), List.of("env3", "env2", "env1"));
 
-        EnvironmentUpdates environmentUpdate = new EnvironmentUpdates();
-        environmentUpdate.put(consumer.getId(), List.of("envA"), List.of("envB", "envA"));
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
 
-        Set<String> filteredEnt = createEntitlementFilter()
-            .filterEntitlements(environmentUpdate);
-
-        assertEquals(filteredEnt.size(), 0);
+        assertNotNull(output);
+        assertTrue(output.isEmpty());
     }
 
     @Test
-    public void shouldHandleUpdateOfMultipleConsumersAtOnce() {
-        Consumer consumer2 = createConsumer(2);
-        Map<String, Set<String>> contentUUIDsConsumerIds = Map.ofEntries(
-            entry("ent1", Set.of("c1", "c2")),
-            entry("ent2", Set.of("c2", "c3")),
-            entry("ent3", Set.of("c4"))
-        );
-        when(entitlementCurator.getEntitlementContentUUIDs(anyCollection()))
-            .thenReturn(contentUUIDsConsumerIds);
+    public void testEEFIgnoresChangeWhenLowPriorityEnvsProvidingEntitlementContentChanges() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2");
+        this.mapConsumerToEntitlements("consumer2", "ent1", "ent2");
+        this.mapEntitlementToContent("ent1", "c1", "c2");
+        this.mapEntitlementToContent("ent2", "c2", "c3");
+        this.mapEnvironmentToContent("env1", "c1", "c2");
+        this.mapEnvironmentToContent("env2", "c2");
+        this.mapEnvironmentToContent("env3", "c2");
 
-        Map<String, List<String>> envContent = Map.ofEntries(
-            entry("envA", List.of("c1")),
-            entry("envB", List.of("c2")),
-            entry("envC", List.of("c3", "c4"))
-        );
-        when(environmentContentCurator.getEnvironmentContentUUIDs(anyIterable()))
-            .thenReturn(envContent);
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2", "env3"), List.of("env1", "env3", "env2"));
 
-        EnvironmentUpdates environmentUpdate = new EnvironmentUpdates();
-        environmentUpdate.put(consumer.getId(), List.of("envA", "envB"), List.of("envB"));
-        environmentUpdate.put(consumer2.getId(), List.of("envA", "envB"), List.of("envA"));
-        environmentUpdate.put(consumer2.getId(), List.of("envC"), List.of("envA"));
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
 
-        Set<String> filteredEnt = createEntitlementFilter()
-            .filterEntitlements(environmentUpdate);
-        assertEquals(filteredEnt.size(), 3);
+        assertNotNull(output);
+        assertTrue(output.isEmpty());
     }
 
-    private EntitlementEnvironmentFilter createEntitlementFilter() {
-        return new EntitlementEnvironmentFilter(this.entitlementCurator,
-            this.environmentContentCurator);
+    @Test
+    public void testEEFIgnoresChangeWhenLowPriorityEnvsProvidingNoEntitlementContentChanges() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2");
+        this.mapConsumerToEntitlements("consumer2", "ent1", "ent2");
+        this.mapEntitlementToContent("ent1", "c1", "c2");
+        this.mapEntitlementToContent("ent2", "c2", "c3");
+        this.mapEnvironmentToContent("env1", "c1", "c2");
+        this.mapEnvironmentToContent("env2", "c4");
+        this.mapEnvironmentToContent("env3", "c4");
+
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2", "env3"), List.of("env1", "env3", "env2"));
+
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
+
+        assertNotNull(output);
+        assertTrue(output.isEmpty());
     }
 
-    private Consumer createConsumer(int id) {
-        Consumer consumer = new Consumer();
-        consumer.setUuid("test_consumer_" + id);
-        consumer.setId("test_consumer_" + id);
-        return consumer;
+    // Tests for removing environments
+    @Test
+    public void testEEFReportsChangeWhenOnlyEnvironmentProvidingEntitlementContentIsRemoved() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2", "ent3");
+        this.mapConsumerToEntitlements("consumer2", "ent1", "ent2");
+        this.mapConsumerToEntitlements("consumer3", "ent1");
+        this.mapEntitlementToContent("ent1", "c1");
+        this.mapEntitlementToContent("ent2", "c2");
+        this.mapEntitlementToContent("ent3", "c3");
+        this.mapEnvironmentToContent("env1", "c1", "c2");
+        this.mapEnvironmentToContent("env2", "c1", "c2");
+        this.mapEnvironmentToContent("env3", "c3");
+
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2", "env3"), List.of("env1", "env2"));
+
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
+
+        assertNotNull(output);
+        assertEquals(1, output.size());
+        assertTrue(output.contains("ent3"));
     }
 
+    @Test
+    public void testEEFReportsChangeWhenHighestPriorityEnvProvidingContentIsRemoved() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2", "ent3");
+        this.mapConsumerToEntitlements("consumer2", "ent1", "ent2");
+        this.mapConsumerToEntitlements("consumer3", "ent1");
+        this.mapEntitlementToContent("ent1", "c1");
+        this.mapEntitlementToContent("ent2", "c2");
+        this.mapEntitlementToContent("ent3", "c3");
+        this.mapEnvironmentToContent("env1", "c1", "c2", "c3");
+        this.mapEnvironmentToContent("env2", "c1", "c2");
+        this.mapEnvironmentToContent("env3", "c3");
+
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2", "env3"), List.of("env2", "env3"));
+
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
+
+        assertNotNull(output);
+        assertEquals(3, output.size());
+        assertEquals(Set.of("ent1", "ent2", "ent3"), output);
+    }
+
+    @Test
+    public void testEEFIgnoresChangeWhenLowPriorityEnvProvidingContentIsRemoved() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2");
+        this.mapConsumerToEntitlements("consumer2", "ent1", "ent2");
+        this.mapEntitlementToContent("ent1", "c1", "c2");
+        this.mapEntitlementToContent("ent2", "c2", "c3");
+        this.mapEnvironmentToContent("env1", "c1", "c2");
+        this.mapEnvironmentToContent("env2", "c3");
+        this.mapEnvironmentToContent("env3", "c1", "c2", "c3");
+
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2", "env3"), List.of("env1", "env2"))
+            .put("consumer2", List.of("env3", "env2", "env1"), List.of("env3"));
+
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
+
+        assertNotNull(output);
+        assertTrue(output.isEmpty());
+    }
+
+    @Test
+    public void testEEFIgnoresChangeWhenEnvironmentProvidingNoEntitlementContentIsRemoved() {
+        this.mapConsumerToEntitlements("consumer1", "ent1", "ent2");
+        this.mapConsumerToEntitlements("consumer2", "ent1", "ent2");
+        this.mapEntitlementToContent("ent1", "c1", "c2");
+        this.mapEntitlementToContent("ent2", "c2", "c3");
+        this.mapEnvironmentToContent("env1", "c1", "c2");
+        this.mapEnvironmentToContent("env2", "c3");
+        this.mapEnvironmentToContent("env3", "c4");
+
+        EnvironmentUpdates updates = new EnvironmentUpdates()
+            .put("consumer1", List.of("env1", "env2", "env3"), List.of("env1", "env2"));
+
+        Set<String> output = this.buildEEFilter().filterEntitlements(updates);
+
+        assertNotNull(output);
+        assertTrue(output.isEmpty());
+    }
 }

--- a/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -527,9 +527,9 @@ public class DefaultEntitlementCertServiceAdapterTest {
         throws CertificateSizeException {
 
         // Environment, with promoted content:
-        Environment e = this.mockEnvironment(new Environment("env1", "Env 1", owner));
+        Environment e = this.mockEnvironment(new Environment("env1", "Env 1", owner))
+            .addContent(content, true);
 
-        e.getEnvironmentContent().add(new EnvironmentContent(e, content, true));
         this.consumer.addEnvironment(e);
 
         PromotedContent promotedContent = new PromotedContent(prefix(""))
@@ -546,11 +546,13 @@ public class DefaultEntitlementCertServiceAdapterTest {
     public void testContentExtensionIncludesPromotedContentFromMultipleEnvs()
         throws CertificateSizeException {
 
-        Environment e1 = this.mockEnvironment(new Environment("env1", "Env 1", owner));
-        Environment e2 = this.mockEnvironment(new Environment("env2", "Env 2", owner));
-        e1.getEnvironmentContent().add(new EnvironmentContent(e1, content, true));
+        Environment e1 = this.mockEnvironment(new Environment("env1", "Env 1", owner))
+            .addContent(content, true);
+
+        Environment e2 = this.mockEnvironment(new Environment("env2", "Env 2", owner))
+            .addContent(noArchContent, true);
+
         this.consumer.addEnvironment(e1);
-        e2.getEnvironmentContent().add(new EnvironmentContent(e2, noArchContent, true));
         this.consumer.addEnvironment(e2);
 
         PromotedContent promotedContent = new PromotedContent(prefix(""))
@@ -662,7 +664,12 @@ public class DefaultEntitlementCertServiceAdapterTest {
 
         // Make sure that we filter by environment when asked.
         Environment environment = this.mockEnvironment(new Environment());
-        environment.getEnvironmentContent().add(new EnvironmentContent(environment, normalContent, true));
+
+        environment.addEnvironmentContent(new EnvironmentContent()
+            .setEnvironment(environment)
+            .setContent(normalContent)
+            .setEnabled(true));
+
         consumer.addEnvironment(environment);
 
         promotedContent.with(environment);

--- a/src/test/java/org/candlepin/test/CollectionMatcher.java
+++ b/src/test/java/org/candlepin/test/CollectionMatcher.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2009 - 2022 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.test;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+
+/**
+ * An arbitrary collection matcher that allows verifying if two collections are equal strictly by
+ * their unordered contents. This permits matching across ordered and restricted collections like
+ * sets and lists.
+ *
+ * Two collections will be considered equal if they contain exactly the same elements, without
+ * respect to order. The elements of the collections must properly implement equality checking, or
+ * the result of this matcher will be undefined. Null collections are permitted, and will only match
+ * another null collection, regardless of the declared type.
+ */
+public class CollectionMatcher<T> implements ArgumentMatcher<Collection<T>> {
+
+    private final Collection<T> expected;
+
+    public CollectionMatcher(Collection<T> expected) {
+        this.expected = expected;
+    }
+
+    public boolean matches(Collection<T> input) {
+        if (input == this.expected || input == null) {
+            return input == expected;
+        }
+
+        if (this.expected == null || this.expected.size() != input.size()) {
+            return false;
+        }
+
+        // Move the expected value to a mutable container so we can do a comparison via collection
+        // subtraction without attempting to modify it in any way. This isn't the most efficient way
+        // of doing it, but it's easy to maintain and good enough for testing.
+        List<T> container = new ArrayList<>(this.expected);
+
+        // Impl note: we can't use removeAll here, as that will remove duplicates for us, which we
+        // absolutely do not want. We need to make sure there's a 1:1 removal of items. If any
+        // removal fails, we can immediately return false.
+        for (T element : input) {
+            if (!container.remove(element)) {
+                return false;
+            }
+        }
+
+        return container.isEmpty();
+    }
+
+}

--- a/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -52,7 +52,6 @@ import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Environment;
-import org.candlepin.model.EnvironmentContent;
 import org.candlepin.model.EnvironmentContentCurator;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.IdentityCertificateCurator;
@@ -539,21 +538,17 @@ public class DatabaseTestFixture {
     protected Environment createEnvironment(Owner owner, String id, String name, String description,
         Collection<Consumer> consumers, Collection<Content> content) {
 
-        Environment environment = new Environment(id, name, owner);
-        environment.setDescription(description);
+        Environment environment = new Environment()
+            .setId(id)
+            .setName(name)
+            .setOwner(owner)
+            .setDescription(description);
 
         if (content != null) {
-            for (Content elem : content) {
-                EnvironmentContent envContent = new EnvironmentContent(environment, elem, true);
-
-                // Impl note:
-                // At the time of writing, this line is redundant. But if we ever fix environment,
-                // this will be good to have as a backup.
-                environment.getEnvironmentContent().add(envContent);
-            }
+            content.forEach(elem -> environment.addContent(elem, true));
         }
 
-        environment = this.environmentCurator.create(environment);
+        this.environmentCurator.create(environment);
 
         // Update consumers to point to the new environment
         if (consumers != null) {

--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -46,7 +46,6 @@ import org.candlepin.model.RulesCurator;
 import org.candlepin.model.SourceSubscription;
 import org.candlepin.model.User;
 import org.candlepin.model.activationkeys.ActivationKey;
-import org.candlepin.model.activationkeys.ActivationKeyPool;
 import org.candlepin.model.dto.ContentData;
 import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.model.dto.ProductData;
@@ -765,17 +764,14 @@ public class TestUtil {
     }
 
     public static ActivationKey createActivationKey(Owner owner, List<Pool> pools) {
-        ActivationKey key = new ActivationKey();
-        key.setOwner(owner);
-        key.setName("A Test Key");
-        key.setServiceLevel("TestLevel");
-        key.setDescription("A test description for the test key.");
+        ActivationKey key = new ActivationKey()
+            .setOwner(owner)
+            .setName("A Test Key")
+            .setServiceLevel("TestLevel")
+            .setDescription("A test description for the test key.");
+
         if (pools != null) {
-            Set<ActivationKeyPool> akPools = new HashSet<>();
-            for (Pool p : pools) {
-                akPools.add(new ActivationKeyPool(key, p, (long) 1));
-            }
-            key.setPools(akPools);
+            pools.forEach(pool -> key.addPool(pool, 1L));
         }
 
         return key;


### PR DESCRIPTION
- ActivationKey no longer references products directly, instead referencing products by Red Hat product ID
- Environment no longer references content directly, instead referencing content by Red Hat content ID
- Removed the ActivationKey and Environment entity remapping logic from org refresh and product/content update flows
- Internal entity model API improvements, cleanup, and changes
- Removed some long-unused code