### PR TITLE
test_data_importer: fix invalid content_url

### DIFF
--- a/bin/deployment/test_data_importer.py
+++ b/bin/deployment/test_data_importer.py
@@ -549,16 +549,16 @@ def map_content_to_product(cp, owner_key, product_data, content_data):
         for content_id, enabled in product_data['content']:
             # Create a unique content specifically for this product-content pairing.
             content = find_content(content_id).copy()
-            content_id = '{pid}{cid}'.format(pid=product_data['id'], cid=content_id)
+            candlepin_content_id = '{pid}{cid}'.format(pid=product_data['id'], cid=content_id)
 
             # Modify the base content data so that it is unique for this product
-            content['id'] = content_id
+            content['id'] = candlepin_content_id
             content['name'] = '{name}-{uid}'.format(name=content['name'], uid=product_data['id'])
             content['label'] = '{label}-{uid}'.format(label=content['label'], uid=product_data['id'])
-            content['content_url'] = '{url}/{uid}'.format(url=content['content_url'], uid=content_id)
+            content['content_url'] = '{url}/{pid}-{cid}'.format(url=content['content_url'], pid=product_data['id'], cid=content_id)
 
             product_content.append(content)
-            content_map[content_id] = enabled
+            content_map[candlepin_content_id] = enabled
 
     if product_content:
         for content_data in product_content:


### PR DESCRIPTION
The actual paths for content have the directory named as "$PID-$CID" (with a dash), and the "content_url" stored for the products did not have it. Fix it by:
- rename the "content_id" variable in the loop to "candlepin_content_id": this way it does not shadow the "content_id" loop variable
- compose "content_url" using the expected format

Fixes commit 7dff0036b805cbdba392a0139666d3ccf0a4e12a.