### PR TITLE
[4.1] 1931923: API-level product/content updates no longer occur in parallel (CANDLEPIN-440)

### DIFF
--- a/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/src/main/java/org/candlepin/controller/ContentManager.java
@@ -137,11 +137,11 @@ public class ContentManager {
             throw new IllegalArgumentException("contentData is incomplete");
         }
 
+        this.ownerContentCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_WRITE);
+
         if (this.ownerContentCurator.contentExists(owner, contentData.getId())) {
             throw new IllegalStateException("content has already been created: " + contentData.getId());
         }
-
-        this.ownerContentCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_READ);
 
         log.debug("Creating new content for org: {}, {}", contentData, owner);
 
@@ -237,6 +237,8 @@ public class ContentManager {
             throw new IllegalArgumentException("contentData is incomplete");
         }
 
+        this.ownerContentCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_WRITE);
+
         // Resolve the entity to ensure we're working with the merged entity, and to ensure it's
         // already been created.
         Content entity = this.ownerContentCurator.getContentById(owner, contentData.getId());
@@ -250,8 +252,6 @@ public class ContentManager {
         if (!isChangedBy(entity, contentData)) {
             return entity;
         }
-
-        this.ownerContentCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_READ);
 
         log.debug("Applying content update for org: {} => {}, {}", contentData, entity, owner);
 
@@ -384,6 +384,8 @@ public class ContentManager {
         if (contentId == null) {
             throw new IllegalArgumentException("contentId is null");
         }
+
+        this.ownerContentCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_WRITE);
 
         Content entity = this.ownerContentCurator.getContentById(owner, contentId);
         if (entity == null) {

--- a/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/src/main/java/org/candlepin/controller/ProductManager.java
@@ -163,7 +163,7 @@ public class ProductManager {
      */
     private Map<String, Content> resolveContentRefs(Owner owner, ProductInfo pinfo) {
         Set<String> cids = new HashSet<>();
-        Map<String, Content> output;
+        Map<String, Content> output = new HashMap<>();
 
         Collection<? extends ProductContentInfo> productContent = pinfo.getProductContent();
         if (productContent != null) {
@@ -185,17 +185,13 @@ public class ProductManager {
         }
 
         if (!cids.isEmpty()) {
-            output = this.ownerContentCurator.getContentByIds(owner, cids).list().stream()
-                .collect(Collectors.toMap(c -> c.getId(), Function.identity()));
+            output = this.ownerContentCurator.getContentByIds(owner, cids);
 
             cids.removeAll(output.keySet());
             if (!cids.isEmpty()) {
                 throw new MalformedEntityReferenceException(
                     "product references one or more content which do not exist: " + cids);
             }
-        }
-        else {
-            output = new HashMap<>();
         }
 
         return output;
@@ -233,11 +229,11 @@ public class ProductManager {
             throw new IllegalArgumentException("productData is incomplete");
         }
 
+        this.ownerProductCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_WRITE);
+
         if (this.ownerProductCurator.productExists(owner, productData.getId())) {
             throw new IllegalStateException("product has already been created: " + productData.getId());
         }
-
-        this.ownerProductCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_READ);
 
         Map<String, Product> productMap = this.resolveProductRefs(owner, productData);
         Map<String, Content> contentMap = this.resolveContentRefs(owner, productData);
@@ -335,6 +331,8 @@ public class ProductManager {
             throw new IllegalArgumentException("productData is incomplete");
         }
 
+        this.ownerProductCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_WRITE);
+
         // Resolve the entity to ensure we're working with the merged entity, and to ensure it's
         // already been created.
         Product entity = this.ownerProductCurator.getProductById(owner, productData.getId());
@@ -348,8 +346,6 @@ public class ProductManager {
         if (!isChangedBy(entity, productData)) {
             return entity;
         }
-
-        this.ownerProductCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_READ);
 
         Map<String, Product> productMap = this.resolveProductRefs(owner, productData);
         Map<String, Content> contentMap = this.resolveContentRefs(owner, productData);
@@ -485,7 +481,7 @@ public class ProductManager {
             throw new IllegalArgumentException("entity is null");
         }
 
-        this.ownerProductCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_READ);
+        this.ownerProductCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_WRITE);
 
         Map<String, Product> productMap = this.resolveProductRefs(owner, entity);
         Map<String, Content> contentMap = this.resolveContentRefs(owner, entity);
@@ -601,6 +597,8 @@ public class ProductManager {
         if (productId == null) {
             throw new IllegalArgumentException("productId is null");
         }
+
+        this.ownerProductCurator.getSystemLock(SYSTEM_LOCK, LockModeType.PESSIMISTIC_WRITE);
 
         // Make sure the entity actually exists to be removed
         Product entity = this.ownerProductCurator.getProductById(owner, productId);

--- a/src/main/java/org/candlepin/model/Content.java
+++ b/src/main/java/org/candlepin/model/Content.java
@@ -124,6 +124,10 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     @Column(nullable = true)
     private Long metadataExpire;
 
+    // Impl note:
+    // As of 2022-11-14, the FK for this table has a delete cascade for automated cleanup. It should
+    // be removed if the ridiculous limitations placed on @elementcollections are ever sorted at the
+    // JPA spec level.
     @BatchSize(size = 128)
     @ElementCollection
     @CollectionTable(name = "cp2_content_modified_products", joinColumns = @JoinColumn(name = "content_uuid"))

--- a/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/src/main/java/org/candlepin/model/ContentCurator.java
@@ -17,17 +17,19 @@ package org.candlepin.model;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 
-import org.hibernate.Session;
-import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Singleton;
+import javax.persistence.Query;
 
 
 
@@ -36,8 +38,7 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class ContentCurator extends AbstractHibernateCurator<Content> {
-
-    private static Logger log = LoggerFactory.getLogger(ContentCurator.class);
+    private static final Logger log = LoggerFactory.getLogger(ContentCurator.class);
 
     private ProductCurator productCurator;
 
@@ -74,35 +75,122 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
     }
 
     /**
-     * Fetches a collection of content used by the given products
+     * Performs a bulk deletion of content specified by the given collection of content UUIDs.
      *
-     * @param products
-     *  The products for which to fetch content
+     * @param contentUuids
+     *  the UUIDs of the content to delete
      *
      * @return
-     *  A collection of content used by the specified products
+     *  the number of content deleted as a result of this operation
      */
-    @SuppressWarnings("unchecked")
-    public CandlepinQuery<Content> getContentByProducts(Collection<Product> products) {
-        if (products != null && !products.isEmpty()) {
-            // We're doing this in two queries because (a) that's what Hibernate's doing already due
-            // to the projection and (b) DISTINCT_ROOT_ENTITY only works when listing, not when
-            // scrolling.
-            Session session = this.currentSession();
+    public int bulkDeleteByUuids(Collection<String> contentUuids) {
+        int count = 0;
 
-            List<String> uuids = session.createCriteria(ProductContent.class)
-                .add(CPRestrictions.in("product", products))
-                .setProjection(Projections.distinct(Projections.property("content.uuid")))
-                .list();
+        if (contentUuids != null && !contentUuids.isEmpty()) {
+            Query query = this.getEntityManager()
+                .createQuery("DELETE Content c WHERE c.uuid IN (:content_uuids)");
 
-            if (uuids != null && !uuids.isEmpty()) {
-                DetachedCriteria criteria = this.createSecureDetachedCriteria()
-                    .add(CPRestrictions.in("uuid", uuids));
-
-                return this.cpQueryFactory.<Content>buildQuery(session, criteria);
+            for (List<String> block : this.partition(contentUuids)) {
+                count += query.setParameter("content_uuids", block)
+                    .executeUpdate();
             }
         }
 
-        return this.cpQueryFactory.<Content>buildQuery();
+        return count;
     }
+
+    /**
+     * Fetches a list of content UUIDs representing content which are no longer used by any
+     * organization. If no such contents exist, this method returns an empty list.
+     * <p></p>
+     * <strong>Warning:</strong> Due to the nature of this query, it is highly advised that
+     * this it be run within a transaction, with a pessimistic lock held.
+     *
+     * @return
+     *  a list of UUIDs of content no longer used by any organization
+     */
+    public List<String> getOrphanedContentUuids() {
+        String sql = "SELECT c.uuid " +
+            "FROM cp2_content c LEFT JOIN cp2_owner_content oc ON c.uuid = oc.content_uuid " +
+            "WHERE oc.owner_id IS NULL";
+
+        return this.getEntityManager()
+            .createNativeQuery(sql)
+            .getResultList();
+    }
+
+    /**
+     * Returns a mapping of content UUIDs to collections of products referencing them. That is, for
+     * a given entry in the returned map, the key will be one of the input content UUIDs, and the
+     * value will be the set of product UUIDs which reference it. If no products reference any of
+     * the specified contents by UUID, this method returns an empty map.
+     *
+     * @param contentUuids
+     *  a collection content UUIDs for which to fetch referencing products
+     *
+     * @return
+     *  a mapping of content UUIDs to sets of UUIDs of the products referencing them
+     */
+    public Map<String, Set<String>> getProductsReferencingContent(Collection<String> contentUuids) {
+        Map<String, Set<String>> output = new HashMap<>();
+
+        if (contentUuids != null && !contentUuids.isEmpty()) {
+            String jpql = "SELECT pc.content.uuid, prod.uuid FROM Product prod " +
+                "JOIN prod.productContent pc " +
+                "WHERE pc.content.uuid IN (:content_uuids)";
+
+            Query query = this.getEntityManager()
+                .createQuery(jpql);
+
+            for (List<String> block : this.partition(contentUuids)) {
+                List<Object[]> rows = query.setParameter("content_uuids", block)
+                    .getResultList();
+
+                for (Object[] row : rows) {
+                    output.computeIfAbsent((String) row[0], (key) -> new HashSet<>())
+                        .add((String) row[1]);
+                }
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * Returns a mapping of content UUIDs to collections of environments referencing them. That is,
+     * for a given entry in the returned map, the key will be one of the input content UUIDs, and
+     * the value will be the set of product UUIDs which reference it. If no environments reference
+     * any of the specified contents by UUID, this method returns an empty map.
+     *
+     * @param contentUuids
+     *  a collection content UUIDs for which to fetch referencing environments
+     *
+     * @return
+     *  a mapping of content UUIDs to sets of UUIDs of the environments referencing them
+     */
+    public Map<String, Set<String>> getEnvironmentsReferencingContent(Collection<String> contentUuids) {
+        Map<String, Set<String>> output = new HashMap<>();
+
+        if (contentUuids != null && !contentUuids.isEmpty()) {
+            String jpql = "SELECT ec.content.uuid, env.id FROM Environment env " +
+                "JOIN env.environmentContent ec " +
+                "WHERE ec.content.uuid IN (:content_uuids)";
+
+            Query query = this.getEntityManager()
+                .createQuery(jpql);
+
+            for (List<String> block : this.partition(contentUuids)) {
+                List<Object[]> rows = query.setParameter("content_uuids", block)
+                    .getResultList();
+
+                for (Object[] row : rows) {
+                    output.computeIfAbsent((String) row[0], (key) -> new HashSet<>())
+                        .add((String) row[1]);
+                }
+            }
+        }
+
+        return output;
+    }
+
 }

--- a/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -16,9 +16,7 @@ package org.candlepin.model;
 
 import com.google.inject.persist.Transactional;
 
-import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.slf4j.Logger;
@@ -173,34 +171,59 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
         return this.cpQueryFactory.<Content>buildQuery();
     }
 
-    public CandlepinQuery<Content> getContentByIds(Owner owner, Collection<String> contentIds) {
-        return this.getContentByIds(owner.getId(), contentIds);
+    /**
+     * Fetches content within the given organization by content ID as a mapping of content ID to
+     * content entity. If the organization or specified content cannot be found, this method returns
+     * an empty map. If the lookup finds only a subset of the requested content, the map will only
+     * contain entries for the existing content.
+     *
+     * @param ownerId
+     *  the ID of the organization in which to lookup content
+     *
+     * @param contentIds
+     *  a collection of content IDs (not UUID) by which to lookup content
+     *
+     * @return
+     *  a mapping of content ID to content entity for matching content in the given organization
+     */
+    public Map<String, Content> getContentByIds(String ownerId, Collection<String> contentIds) {
+        Map<String, Content> output = new HashMap<>();
+
+        if (contentIds != null && !contentIds.isEmpty()) {
+            String jpql = "SELECT oc.content FROM OwnerContent oc JOIN oc.content content " +
+                "WHERE oc.ownerId = :owner_id AND content.id IN (:content_ids)";
+
+            TypedQuery<Content> query = this.getEntityManager()
+                .createQuery(jpql, Content.class)
+                .setParameter("owner_id", ownerId);
+
+            for (List<String> block : this.partition(contentIds)) {
+                query.setParameter("content_ids", block)
+                    .getResultList()
+                    .forEach(elem -> output.put(elem.getId(), elem));
+            }
+        }
+
+        return output;
     }
 
-    public CandlepinQuery<Content> getContentByIds(String ownerId, Collection<String> contentIds) {
-        if (contentIds == null || contentIds.isEmpty()) {
-            return this.cpQueryFactory.<Content>buildQuery();
-        }
-
-        // Impl note: See getOwnersByContent for details on why we're doing this in two queries
-        Session session = this.currentSession();
-
-        List<String> uuids = session.createCriteria(OwnerContent.class)
-            .createAlias("owner", "owner")
-            .createAlias("content", "content")
-            .add(Restrictions.eq("owner.id", ownerId))
-            .add(CPRestrictions.in("content.id", contentIds))
-            .setProjection(Projections.property("content.uuid"))
-            .list();
-
-        if (uuids != null && !uuids.isEmpty()) {
-            DetachedCriteria criteria = this.createSecureDetachedCriteria(Content.class, null)
-                .add(CPRestrictions.in("uuid", uuids));
-
-            return this.cpQueryFactory.<Content>buildQuery(session, criteria);
-        }
-
-        return this.cpQueryFactory.<Content>buildQuery();
+    /**
+     * Fetches content within the given organization by content ID as a mapping of content ID to
+     * content entity. If the organization or specified content cannot be found, this method returns
+     * an empty map. If the lookup finds only a subset of the requested content, the map will only
+     * contain entries for the existing content.
+     *
+     * @param owner
+     *  the owner instance representing the organization in which to lookup content
+     *
+     * @param contentIds
+     *  a collection of content IDs (not UUID) by which to lookup content
+     *
+     * @return
+     *  a mapping of content ID to content entity for matching content in the given organization
+     */
+    public Map<String, Content> getContentByIds(Owner owner, Collection<String> contentIds) {
+        return this.getContentByIds(owner != null ? owner.getId() : null, contentIds);
     }
 
     @Transactional
@@ -361,39 +384,6 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
 
         return result;
     }
-
-    /**
-     * Builds a query which can be used to fetch the current collection of orphaned content. Due
-     * to the nature of this request, it is highly advised that this query be run within a
-     * transaction, with a pessimistic lock mode set.
-     *
-     * @return
-     *  A CandlepinQuery for fetching the orphaned content
-     */
-    public CandlepinQuery<Content> getOrphanedContent() {
-        // As with many of the owner=>content lookups, we have to do this in two queries. Since
-        // we need to start from content and do a left join back to owner content, we have to use
-        // a native query instead of any of the ORM query languages
-
-        String sql = "SELECT c.uuid " +
-            "FROM cp2_content c LEFT JOIN cp2_owner_content oc ON c.uuid = oc.content_uuid " +
-            "WHERE oc.owner_id IS NULL";
-
-        List<String> uuids = this.getEntityManager()
-            .createNativeQuery(sql)
-            .getResultList();
-
-        if (uuids != null && !uuids.isEmpty()) {
-            DetachedCriteria criteria = DetachedCriteria.forClass(Content.class)
-                .add(CPRestrictions.in("uuid", uuids))
-                .addOrder(Order.asc("uuid"));
-
-            return this.cpQueryFactory.<Content>buildQuery(this.currentSession(), criteria);
-        }
-
-        return this.cpQueryFactory.<Content>buildQuery();
-    }
-
 
     /**
      * Updates the content references currently pointing to the original content to instead point to

--- a/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -20,7 +20,6 @@ import com.google.inject.persist.Transactional;
 
 import org.hibernate.Session;
 import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.slf4j.Logger;
@@ -97,7 +96,7 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
      * Determines if a productId exists for a given owner while attempting to gain a lock on it
      *
      * @param owner
-     *  The organization whose product we are looking for
+     *  The organization in which to lock the product
      *
      * @param productId
      *  The ID of the product
@@ -106,7 +105,7 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
      *  The lock mode to use
      *
      * @return
-     *  boolean to show that the product exists and that a lock was achieved
+     *  true if the product exists and the lock was obtained; false otherwise
      */
     public boolean lockOwnerProduct(Owner owner, String productId, LockModeType lockMode) {
         if (owner == null) {
@@ -508,49 +507,6 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
             .createQuery(jpql, String.class)
             .setParameter("owner_id", ownerId)
             .setParameter("pool_type", PoolType.DEVELOPMENT)
-            .getResultList();
-    }
-
-    /**
-     * Builds a query which can be used to fetch the current collection of orphaned products. Due
-     * to the nature of this request, it is highly advised that this query be run within a
-     * transaction, with a pessimistic lock mode set.
-     *
-     * @return
-     *  A CandlepinQuery for fetching the orphaned products
-     */
-    public CandlepinQuery<Product> getOrphanedProducts() {
-        // As with many of the owner=>product lookups, we have to do this in two queries. Since
-        // we need to start from product and do a left join back to owner products, we have to use
-        // a native query instead of any of the ORM query languages
-
-        List<String> uuids = this.getOrphanedProductUuids();
-
-        if (uuids != null && !uuids.isEmpty()) {
-            DetachedCriteria criteria = DetachedCriteria.forClass(Product.class)
-                .add(CPRestrictions.in("uuid", uuids))
-                .addOrder(Order.asc("uuid"));
-
-            return this.cpQueryFactory.<Product>buildQuery(this.currentSession(), criteria);
-        }
-
-        return this.cpQueryFactory.<Product>buildQuery();
-    }
-
-    /**
-     * Fetches a list of product UUIDs representing products which are no longer used by any owner.
-     * If no such products exist, this method returns an empty list.
-     *
-     * @return
-     *  a list of UUIDs of products no longer used by any organization
-     */
-    public List<String> getOrphanedProductUuids() {
-        String sql = "SELECT p.uuid " +
-            "FROM cp2_products p LEFT JOIN cp2_owner_products op ON p.uuid = op.product_uuid " +
-            "WHERE op.owner_id IS NULL";
-
-        return this.getEntityManager()
-            .createNativeQuery(sql)
             .getResultList();
     }
 

--- a/src/main/resources/db/changelog/20221114152236-add_delete_cascade_to_content_modified_products.xml
+++ b/src/main/resources/db/changelog/20221114152236-add_delete_cascade_to_content_modified_products.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20221114152236-1" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <foreignKeyConstraintExists foreignKeyName="cp2_cmp_fk1"/>
+        </preConditions>
+
+        <dropForeignKeyConstraint baseTableName="cp2_content_modified_products" constraintName="cp2_cmp_fk1"/>
+    </changeSet>
+
+    <changeSet id="20221114152236-2" author="crog">
+        <comment>
+            Add delete cascading on the foreign key to work around a limitation element collections
+            have with JPA-level cascading when their parent is manipulated with JPA bulk deletions.
+        </comment>
+
+        <addForeignKeyConstraint baseTableName="cp2_content_modified_products"
+            baseColumnNames="content_uuid"
+            referencedTableName="cp2_content"
+            referencedColumnNames="uuid"
+            constraintName="cp2_cmp_fk1"
+            onDelete="CASCADE" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/20221117125815-prime_system_locks.xml
+++ b/src/main/resources/db/changelog/20221117125815-prime_system_locks.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20221117125815-1" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(id) FROM cp_system_locks WHERE id = 'content'
+            </sqlCheck>
+        </preConditions>
+
+        <insert tableName="cp_system_locks">
+            <column name="id" value="content"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="20221117125815-2" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(id) FROM cp_system_locks WHERE id = 'products'
+            </sqlCheck>
+        </preConditions>
+
+        <insert tableName="cp_system_locks">
+            <column name="id" value="products"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1261,4 +1261,6 @@
     <include file="db/changelog/20220329154201-owner-product-key-change.xml"/>
     <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
     <include file="db/changelog/20220517162755-add_owner_product_orphaned_date.xml"/>
+    <include file="db/changelog/20221114152236-add_delete_cascade_to_content_modified_products.xml"/>
+    <include file="db/changelog/20221117125815-prime_system_locks.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2353,4 +2353,6 @@
     <include file="db/changelog/20220329154201-owner-product-key-change.xml"/>
     <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
     <include file="db/changelog/20220517162755-add_owner_product_orphaned_date.xml"/>
+    <include file="db/changelog/20221114152236-add_delete_cascade_to_content_modified_products.xml"/>
+    <include file="db/changelog/20221117125815-prime_system_locks.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -170,4 +170,6 @@
     <include file="db/changelog/20220329154201-owner-product-key-change.xml"/>
     <include file="db/changelog/20220420165513-drop_pool_derived_product_constraint.xml"/>
     <include file="db/changelog/20220517162755-add_owner_product_orphaned_date.xml"/>
+    <include file="db/changelog/20221114152236-add_delete_cascade_to_content_modified_products.xml"/>
+    <include file="db/changelog/20221117125815-prime_system_locks.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -183,13 +183,19 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         this.createOwnerContentMapping(owner, content2);
 
         Collection<String> ids = Arrays.asList(content1.getId(), content2.getId(), content3.getId(), "dud");
-        Collection<Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids).list();
-        Collection<Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids).list();
+        Map<String, Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids);
+        Map<String, Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids);
 
         assertEquals(2, contentA.size());
-        assertTrue(contentA.contains(content1));
-        assertTrue(contentA.contains(content2));
-        assertFalse(contentA.contains(content3));
+
+        assertTrue(contentA.containsKey(content1.getId()));
+        assertEquals(content1, contentA.get(content1.getId()));
+
+        assertTrue(contentA.containsKey(content2.getId()));
+        assertEquals(content2, contentA.get(content2.getId()));
+
+        assertFalse(contentA.containsKey(content3.getId()));
+
         assertEquals(contentA, contentB);
     }
 
@@ -203,8 +209,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         this.createOwnerContentMapping(owner, content2);
 
         Collection<String> ids = null;
-        Collection<Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids).list();
-        Collection<Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids).list();
+        Map<String, Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids);
+        Map<String, Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids);
 
         assertTrue(contentA.isEmpty());
         assertTrue(contentB.isEmpty());
@@ -220,8 +226,8 @@ public class OwnerContentCuratorTest extends DatabaseTestFixture {
         this.createOwnerContentMapping(owner, content2);
 
         Collection<String> ids = Collections.<String>emptyList();
-        Collection<Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids).list();
-        Collection<Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids).list();
+        Map<String, Content> contentA = this.ownerContentCurator.getContentByIds(owner, ids);
+        Map<String, Content> contentB = this.ownerContentCurator.getContentByIds(owner.getId(), ids);
 
         assertTrue(contentA.isEmpty());
         assertTrue(contentB.isEmpty());

--- a/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -33,8 +33,6 @@ import org.candlepin.util.PropertyValidationException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.HibernateException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +52,8 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.persistence.PersistenceException;
 import javax.validation.ConstraintViolationException;
+
+
 
 public class ProductCuratorTest extends DatabaseTestFixture {
     private static Logger log = LoggerFactory.getLogger(ProductCuratorTest.class);
@@ -515,13 +515,13 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     @Test
     public void testPoolProvidedProducts() {
         Set<String> uuids = productCurator.getPoolProvidedProductUuids(pool.getId());
-        assertEquals(new HashSet<>(Arrays.asList(providedProduct.getUuid())), uuids);
+        assertEquals(Set.of(providedProduct.getUuid()), uuids);
     }
 
     @Test
     public void testDerivedPoolProvidedProducts() {
         Set<String> uuids = productCurator.getDerivedPoolProvidedProductUuids(pool.getId());
-        assertEquals(new HashSet<>(Arrays.asList(derivedProvidedProduct.getUuid())), uuids);
+        assertEquals(Set.of(derivedProvidedProduct.getUuid()), uuids);
     }
 
     @Test
@@ -659,14 +659,17 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Pool pool2 = this.createPool(owner1, product2);
         Pool pool3 = this.createPool(owner2, product3);
 
-        Set<Pair<String, String>> output = this.productCurator.getPoolsReferencingProducts(
+        Map<String, Set<String>> output = this.productCurator.getPoolsReferencingProducts(
             Arrays.asList(product1.getUuid(), product2.getUuid()));
 
         assertNotNull(output);
         assertEquals(2, output.size());
-        assertThat(output, containsInAnyOrder(
-            new ImmutablePair<String, String>(product1.getUuid(), pool1.getId()),
-            new ImmutablePair<String, String>(product2.getUuid(), pool2.getId())));
+
+        assertTrue(output.containsKey(product1.getUuid()));
+        assertEquals(Set.of(pool1.getId()), output.get(product1.getUuid()));
+
+        assertTrue(output.containsKey(product2.getUuid()));
+        assertEquals(Set.of(pool2.getId()), output.get(product2.getUuid()));
     }
 
     @Test
@@ -682,7 +685,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Pool pool2 = this.createPool(owner1, product2);
         Pool pool3 = this.createPool(owner2, product3);
 
-        Set<Pair<String, String>> output = this.productCurator.getPoolsReferencingProducts(
+        Map<String, Set<String>> output = this.productCurator.getPoolsReferencingProducts(
             Arrays.asList("bad uuid", "another bad uuid"));
 
         assertNotNull(output);
@@ -691,7 +694,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testGetPoolsReferencingProductsWithEmptyInput() {
-        Set<Pair<String, String>> output = this.productCurator.getPoolsReferencingProducts(
+        Map<String, Set<String>> output = this.productCurator.getPoolsReferencingProducts(
             Collections.emptyList());
 
         assertNotNull(output);
@@ -700,7 +703,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testGetPoolsReferencingProductsWithNullInput() {
-        Set<Pair<String, String>> output = this.productCurator.getPoolsReferencingProducts(null);
+        Map<String, Set<String>> output = this.productCurator.getPoolsReferencingProducts(null);
 
         assertNotNull(output);
         assertEquals(0, output.size());
@@ -728,14 +731,17 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         refProduct2 = this.createProduct(refProduct2, owner1);
         refProduct3 = this.createProduct(refProduct3, owner2);
 
-        Set<Pair<String, String>> output = this.productCurator.getProductsReferencingProducts(
+        Map<String, Set<String>> output = this.productCurator.getProductsReferencingProducts(
             Arrays.asList(product1.getUuid(), product2.getUuid()));
 
         assertNotNull(output);
         assertEquals(2, output.size());
-        assertThat(output, containsInAnyOrder(
-            new ImmutablePair<String, String>(product1.getUuid(), refProduct1.getUuid()),
-            new ImmutablePair<String, String>(product2.getUuid(), refProduct2.getUuid())));
+
+        assertTrue(output.containsKey(product1.getUuid()));
+        assertEquals(Set.of(refProduct1.getUuid()), output.get(product1.getUuid()));
+
+        assertTrue(output.containsKey(product2.getUuid()));
+        assertEquals(Set.of(refProduct2.getUuid()), output.get(product2.getUuid()));
     }
 
     @Test
@@ -760,7 +766,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         refProduct2 = this.createProduct(refProduct2, owner1);
         refProduct3 = this.createProduct(refProduct3, owner2);
 
-        Set<Pair<String, String>> output = this.productCurator.getProductsReferencingProducts(
+        Map<String, Set<String>> output = this.productCurator.getProductsReferencingProducts(
             Arrays.asList("bad uuid", "another bad uuid"));
 
         assertNotNull(output);
@@ -769,7 +775,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testGetProductsReferencingProductsWithEmptyInput() {
-        Set<Pair<String, String>> output = this.productCurator.getProductsReferencingProducts(
+        Map<String, Set<String>> output = this.productCurator.getProductsReferencingProducts(
             Collections.emptyList());
 
         assertNotNull(output);
@@ -778,7 +784,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testGetProductsReferencingProductsWithNullInput() {
-        Set<Pair<String, String>> output = this.productCurator.getProductsReferencingProducts(null);
+        Map<String, Set<String>> output = this.productCurator.getProductsReferencingProducts(null);
 
         assertNotNull(output);
         assertEquals(0, output.size());

--- a/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -419,7 +419,10 @@ public class DatabaseTestFixture {
 
     protected Content createContent(Content content, Owner... owners) {
         content = this.contentCurator.create(content);
-        this.ownerContentCurator.mapContentToOwners(content, owners);
+
+        if (owners != null & owners.length > 0) {
+            this.ownerContentCurator.mapContentToOwners(content, owners);
+        }
 
         return content;
     }


### PR DESCRIPTION
- Changed the ProductManager and ContentManager to obtain pessimistic write locks before making any change or removal of products or content
- Moved several org-less content and product queries from the OwnerContentCurator or OwnerProductCurator to the ContentCurator or ProductCurator as appropriate
- Changed the output from several curator methods from lists of tuples to maps of collections to better convey exactly what was being returned and to make it easier to follow during analysis
- The OrphanCleanupJob no longer removes content that is referenced by a non-orphaned product or an environment, even in cases where the content is technically orphaned (bad content mapping)
- Added a DB-level delete cascade on Content.modifiedProductIds, as JPA is inexplicably unwilling or unable to cascade a deletion on the parent entity to an element collection when using JPA bulk deletions
- Removed some unused curator methods