### PR TITLE
CANDLEPIN-209: Enable RPM build on RHEL 9

### DIFF
--- a/bin/scripts/code/setup/cpdb
+++ b/bin/scripts/code/setup/cpdb
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2017 Red Hat, Inc.
 #

--- a/bin/scripts/code/setup/cpsetup
+++ b/bin/scripts/code/setup/cpsetup
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2010 Red Hat, Inc.
 #

--- a/build.gradle
+++ b/build.gradle
@@ -477,7 +477,6 @@ publishing {
             pom.withXml {
                 PomToolkit.generatePomDependencies(
                     asNode(),
-                    configurations.annotationProcessor.dependencies,
                     configurations.compileOnly.dependencies,
                     configurations.implementation.dependencies,
                     configurations.providedCompile.dependencies,
@@ -487,7 +486,7 @@ publishing {
                 )
 
                 PomToolkit.generateRepositories(asNode())
-                PomToolkit.generateBuild(asNode())
+                PomToolkit.generateBuild(asNode(), configurations.annotationProcessor.dependencies)
                 PomToolkit.generateProfiles(asNode())
                 PomToolkit.generateDependencyManagement(asNode())
             }

--- a/candlepin.spec.tmpl
+++ b/candlepin.spec.tmpl
@@ -4,7 +4,6 @@
 %global _source_payload w9.gzdio
 
 %global selinux_variants mls minimum targeted
-%global selinux_policyver %(%{__sed} -e 's,.*selinux-policy-\\([^/]*\\)/.*,\\1,' /usr/share/selinux/devel/policyhelp || echo 0.0.0)
 %global modulename candlepin
 
 ## If you follow the Java packaging guidelines, you

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,6 @@
       <systemPath>${jssLocation}</systemPath>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-jpamodelgen</artifactId>
-      <version>5.6.12.Final</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.15</version>
@@ -262,7 +256,7 @@
     <dependency>
       <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
-      <version>3.10.4</version>
+      <version>3.10.5</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -274,7 +268,7 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-server</artifactId>
-      <version>2.26.0</version>
+      <version>2.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -322,7 +316,7 @@
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
-      <version>3.0.9</version>
+      <version>3.1.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -529,6 +523,13 @@
           <debug>true</debug>
           <debuglevel>lines,vars,source</debuglevel>
           <compilerArgument>-proc:none</compilerArgument>
+          <annotationProcessorPaths>
+            <annotationProcessorPath>
+              <groupId>org.hibernate</groupId>
+              <artifactId>hibernate-jpamodelgen</artifactId>
+              <version>5.6.12.Final</version>
+            </annotationProcessorPath>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
- Update pom generation to generate annotation processor paths
- Update script headers to fix python version ambiguity
- Remove unuser selinux_policyver