### PR TITLE
[M] Removed DELETE-CASCADE from content side of product-content link

### DIFF
--- a/src/main/java/org/candlepin/async/tasks/OrphanCleanupJob.java
+++ b/src/main/java/org/candlepin/async/tasks/OrphanCleanupJob.java
@@ -79,8 +79,10 @@ public class OrphanCleanupJob implements AsyncJob  {
         this.filterOrphanedContent(orphanedContentUuids, orphanedProductUuids);
 
         log.debug("Deleting orphaned entities...");
-        int orphanedContentRemoved = this.deleteOrphanedContent(orphanedContentUuids);
+        // Impl note: again, process/delete products first, so we don't fail out trying to delete
+        // a content that's used by a product we're also removing
         int orphanedProductsRemoved = this.deleteOrphanedProducts(orphanedProductUuids);
+        int orphanedContentRemoved = this.deleteOrphanedContent(orphanedContentUuids);
 
         String format = "Orphan cleanup completed;" +
             "\n  %d orphaned content deleted" +

--- a/src/main/resources/db/changelog/20221212140215-remove_prodcont_fk_delete_cascade.xml
+++ b/src/main/resources/db/changelog/20221212140215-remove_prodcont_fk_delete_cascade.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20221212140215-1" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <foreignKeyConstraintExists foreignKeyName="cp2_product_content_fk2"/>
+        </preConditions>
+
+        <dropForeignKeyConstraint
+            baseTableName="cp2_product_content"
+            constraintName="cp2_product_content_fk2"/>
+    </changeSet>
+
+    <changeSet id="20221212140215-2" author="crog">
+        <addForeignKeyConstraint
+            baseTableName="cp2_product_content"
+            baseColumnNames="content_uuid"
+            referencedTableName="cp2_content"
+            referencedColumnNames="uuid"
+            constraintName="cp2_product_content_fk2"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1274,4 +1274,5 @@
     <include file="db/changelog/20221117125815-prime_system_locks.xml"/>
     <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
     <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
+    <include file="db/changelog/20221212140215-remove_prodcont_fk_delete_cascade.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2364,4 +2364,5 @@
     <include file="db/changelog/20221117125815-prime_system_locks.xml"/>
     <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
     <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
+    <include file="db/changelog/20221212140215-remove_prodcont_fk_delete_cascade.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -181,4 +181,5 @@
     <include file="db/changelog/20221117125815-prime_system_locks.xml"/>
     <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
     <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
+    <include file="db/changelog/20221212140215-remove_prodcont_fk_delete_cascade.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -76,6 +76,34 @@ public class ContentCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testDeleteCannotDeleteContentReferencedByProducts() {
+        Owner owner = this.createOwner();
+        Content content = this.createContent(owner);
+        Product product = this.createProductWithContent(owner, content);
+
+        this.contentCurator.flush();
+
+        assertThrows(PersistenceException.class, () -> {
+            this.contentCurator.delete(content);
+            this.contentCurator.flush();
+        });
+    }
+
+    @Test
+    public void testDeleteCannotDeleteOrphanedContentReferencedByProducts() {
+        Owner owner = this.createOwner();
+        Content content = this.createOrphanedContent();
+        Product product = this.createProductWithContent(owner, content);
+
+        this.contentCurator.flush();
+
+        assertThrows(PersistenceException.class, () -> {
+            this.contentCurator.delete(content);
+            this.contentCurator.flush();
+        });
+    }
+
+    @Test
     public void testBulkDeleteByUuids() {
         Content content1 = this.createContent();
         Content content2 = this.createContent();
@@ -131,6 +159,30 @@ public class ContentCuratorTest extends DatabaseTestFixture {
 
         assertNull(this.contentCurator.get(content1.getUuid()));
         assertNull(this.contentCurator.get(content2.getUuid()));
+    }
+
+    @Test
+    public void testBulkDeleteByUuidsCannotDeleteContentReferencedByProducts() {
+        Owner owner = this.createOwner();
+        Content content = this.createContent(owner);
+        Product product = this.createProductWithContent(owner, content);
+
+        this.contentCurator.flush();
+
+        assertThrows(PersistenceException.class, () ->
+            this.contentCurator.bulkDeleteByUuids(Set.of(content.getUuid())));
+    }
+
+    @Test
+    public void testBulkDeleteByUuidsCannotDeleteOrphanedContentReferencedByProducts() {
+        Owner owner = this.createOwner();
+        Content content = this.createOrphanedContent();
+        Product product = this.createProductWithContent(owner, content);
+
+        this.contentCurator.flush();
+
+        assertThrows(PersistenceException.class, () ->
+            this.contentCurator.bulkDeleteByUuids(Set.of(content.getUuid())));
     }
 
     @Test


### PR DESCRIPTION
- Removed the ON DELETE CASCADE on the foreign key for the content on the product-content link object
  This should help avoid a desync that can occur in some situations where a content is removed that is referenced by a product whose product-content collection is still in the Hibernate L2 cache.