### PR TITLE
[M] Added remote debug configurations for Gradle

### DIFF
--- a/ansible/roles/candlepin/tasks/common/cp_debugging.yml
+++ b/ansible/roles/candlepin/tasks/common/cp_debugging.yml
@@ -15,13 +15,16 @@
         - candlepin
         - debugging
 
-    - name: "Enable Tomcat debugging port in firewalld"
+    - name: "Enable debugging ports in firewalld"
       become: true
       ansible.posix.firewalld:
-        port: "8000/tcp"
+        port: "{{ item }}/tcp"
         state: enabled
         permanent: true
         offline: false
+      with_items:
+        - 8000 # Tomcat remote debugging port
+        - 5005 # Gradle remote debugging port
       when:
         - "'services' in ansible_facts"
         - "'firewalld.service' in ansible_facts.services"

--- a/build.gradle
+++ b/build.gradle
@@ -307,6 +307,10 @@ msgfmt {
 }
 
 test {
+    debugOptions {
+        host = '*'
+    }
+
     useJUnitPlatform ()
 
     // Sometimes causes out of memory on vagrant

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/spec-tests/build.gradle
+++ b/spec-tests/build.gradle
@@ -53,6 +53,10 @@ task spec(type: Test) {
     group = 'Verification'
     outputs.upToDateWhen { false }
 
+    debugOptions {
+        host = '*'
+    }
+
     useJUnitPlatform()
 
     // We have to propagate the -D params if we want them available in tests


### PR DESCRIPTION
- Added a block in the cp_debugging task that forwards port 8001
- Added a check for the 'remote-debug' system property in the spec gradle task

Running `vagrant up` with ansible.roles.candlepin.defaults.cp_configure_debugging set to 'true' will now forward the port 8001 that can be attached to for remote debugging Java spec tests. I also added a check for the system property 'remote-debug' in the 'spec' gradle task that will enable the remote debugging.

I figured that we should use a different port than what is already being forwarded for Candlepin debugging (8000) so you don't have to remove the debug arguments from Tomcat and restart the service so that port 8000 is open before trying to debug a spec test.

Example of running a spec test for remote debugging:
`./gradlew clean spec -Dremote-debug=true --tests OwnerResourceSpecTest.shouldCreateScaOwner`