### PR TITLE
Limit bundler version to 2.3.26

### DIFF
--- a/ansible/roles/candlepin/tasks/el8/el8_ruby.yml
+++ b/ansible/roles/candlepin/tasks/el8/el8_ruby.yml
@@ -6,7 +6,12 @@
     rvm1_rubies:
       - "{{ ruby_version }}"
     rvm1_user: "{{ candlepin_user | default('candlepin') }}"
-    rvm1_bundler_install: true
+    rvm1_bundler_install: false
   tags:
     - molecule-idempotence-notest
+    - ruby
+
+- name: Ensure bundler is installed
+  ansible.builtin.command: "bash -lc 'gem install bundler -v 2.3.26'"
+  tags:
     - ruby

--- a/ansible/roles/candlepin/tasks/el9/el9_ruby.yml
+++ b/ansible/roles/candlepin/tasks/el9/el9_ruby.yml
@@ -43,6 +43,6 @@
     - ruby
 
 - name: Ensure bundler is installed
-  ansible.builtin.command: "bash -lc 'gem install bundler'"
+  ansible.builtin.command: "bash -lc 'gem install bundler -v 2.3.26'"
   tags:
     - ruby


### PR DESCRIPTION
- Bundler 2.4 dropped support of our ruby version. Bundler 2.3.26 is the last version that supports it.