### PR TITLE
[M] CANDLEPIN-455: Normalized consumer fact constants and usage

### DIFF
--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -2034,11 +2034,15 @@ public class CandlepinPoolManager implements PoolManager {
             Consumer consumer = entitlement.getConsumer();
             Event event = eventFactory.entitlementDeleted(entitlement);
 
-            if (!entitlement.isValid() && entitlement.getPool().isUnmappedGuestPool() &&
-                consumerCurator.getHost(consumer.getFact("virt.uuid"), consumer.getOwnerId()) == null) {
-                event = eventFactory.entitlementExpired(entitlement);
-                event.setMessageText(event.getMessageText() + ": " +
-                    i18n.tr("Unmapped guest entitlement expired without establishing a host/guest mapping."));
+            if (!entitlement.isValid() && entitlement.getPool().isUnmappedGuestPool()) {
+                Consumer host = this.consumerCurator.getHost(consumer.getFact(Consumer.Facts.VIRT_UUID),
+                    consumer.getOwnerId());
+
+                if (host == null) {
+                    event = eventFactory.entitlementExpired(entitlement);
+                    event.setMessageText(event.getMessageText() + ": " + i18n.tr("Unmapped guest " +
+                        "entitlement expired without establishing a host/guest mapping."));
+                }
             }
 
             sink.queueEvent(event);

--- a/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -458,7 +458,7 @@ public class ContentAccessManager {
         }
 
         // Consumer isn't a special type, check their certificate_version fact
-        String entitlementVersion = consumer.getFact("system.certificate_version");
+        String entitlementVersion = consumer.getFact(Consumer.Facts.SYSTEM_CERTIFICATE_VERSION);
         return entitlementVersion != null && entitlementVersion.startsWith("3.");
     }
 

--- a/src/main/java/org/candlepin/controller/Entitler.java
+++ b/src/main/java/org/candlepin/controller/Entitler.java
@@ -253,8 +253,8 @@ public class Entitler {
         // If the consumer is a guest, and has a host, try to heal the host first
         // Dev consumers should not need to worry about the host or unmapped guest
         // entitlements based on the planned design of the subscriptions
-        if (consumer.hasFact("virt.uuid") && !consumer.isDev()) {
-            String guestUuid = consumer.getFact("virt.uuid");
+        if (consumer.hasFact(Consumer.Facts.VIRT_UUID) && !consumer.isDev()) {
+            String guestUuid = consumer.getFact(Consumer.Facts.VIRT_UUID);
             // Remove any expired unmapped guest entitlements
             revokeUnmappedGuestEntitlements(consumer);
 
@@ -311,7 +311,7 @@ public class Entitler {
             // Look up the dev pool for this consumer, and if not found
             // create one. If a dev pool already exists, remove it and
             // create a new one.
-            String sku = consumer.getFact("dev_sku");
+            String sku = consumer.getFact(Consumer.Facts.DEV_SKU);
             Pool devPool = poolCurator.findDevPool(consumer);
             if (devPool != null) {
                 poolManager.deletePool(devPool);
@@ -512,7 +512,7 @@ public class Entitler {
                 // Look up the dev pool for this consumer, and if not found
                 // create one. If a dev pool already exists, remove it and
                 // create a new one.
-                String sku = consumer.getFact("dev_sku");
+                String sku = consumer.getFact(Consumer.Facts.DEV_SKU);
                 Pool devPool = poolCurator.findDevPool(consumer);
                 if (devPool != null) {
                     poolManager.deletePool(devPool);

--- a/src/main/java/org/candlepin/model/CloudProfileFacts.java
+++ b/src/main/java/org/candlepin/model/CloudProfileFacts.java
@@ -16,23 +16,25 @@
 package org.candlepin.model;
 
 /**
- * The subscription profile time stamp should also get updated
- * on the specific Facts updates.
- * This Enum helps to configure more facts if required in the future.
+ * The CloudProfileFacts enum is a collection of consumer facts which are critical for maintaining
+ * a cloud profile in some client applications such as Subscription Watch.
+ *
+ * The facts in this enum come from the consumer facts, and are primarily used to determine whether
+ * or not to update a given consumer's cloud profile "last update" timestamp.
  */
 public enum CloudProfileFacts {
 
-    CPU_CORES_PERSOCKET("cpu.core(s)_per_socket"),
-    CPU_SOCKETS("cpu.cpu_socket(s)"),
-    DMI_BIOS_VENDOR("dmi.bios.vendor"),
-    DMI_BIOS_VERSION("dmi.bios.version"),
-    DMI_CHASSIS_ASSET_TAG("dmi.chassis.asset_tag"),
-    DMI_SYSTEM_MANUFACTURER("dmi.system.manufacturer"),
-    DMI_SYSTEM_UUID("dmi.system.uuid"),
-    MEMORY_MEMTOTAL("memory.memtotal"),
-    OCM_UNITS("ocm.units"),
-    UNAME_MACHINE("uname.machine"),
-    VIRT_IS_GUEST("virt.is_guest");
+    CPU_CORES_PER_SOCKET(Consumer.Facts.CPU_CORES_PER_SOCKET),
+    CPU_SOCKETS(Consumer.Facts.CPU_SOCKETS),
+    DMI_BIOS_VENDOR(Consumer.Facts.DMI_BIOS_VENDOR),
+    DMI_BIOS_VERSION(Consumer.Facts.DMI_BIOS_VERSION),
+    DMI_CHASSIS_ASSET_TAG(Consumer.Facts.DMI_CHASSIS_ASSET_TAG),
+    DMI_SYSTEM_MANUFACTURER(Consumer.Facts.DMI_SYSTEM_MANUFACTURER),
+    DMI_SYSTEM_UUID(Consumer.Facts.DMI_SYSTEM_UUID),
+    MEMORY_MEMTOTAL(Consumer.Facts.MEMORY_MEMTOTAL),
+    OCM_UNITS(Consumer.Facts.OCM_UNITS),
+    UNAME_MACHINE(Consumer.Facts.UNAME_MACHINE),
+    VIRT_IS_GUEST(Consumer.Facts.VIRT_IS_GUEST);
 
     private final String fact;
 
@@ -46,7 +48,7 @@ public enum CloudProfileFacts {
 
     @Override
     public String toString() {
-        return fact;
+        return this.fact;
     }
 
     public static boolean containsFact(String incomingFact) {
@@ -55,6 +57,7 @@ public enum CloudProfileFacts {
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -98,8 +98,50 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
      * Commonly used/recognized consumer facts
      */
     public static final class Facts {
-        public static final String SYSTEM_UUID = "dmi.system.uuid";
+        /** Used by the rules.js */
+        public static final String BAND_STORAGE_USAGE = "band.storage.usage";
+
+        /** The number of cores per socket on a given consumer; also part of the cloud profile and rules.js */
+        public static final String CPU_CORES_PER_SOCKET = "cpu.core(s)_per_socket";
+
+        /** The number of sockets on a given consumer; also part of the cloud profile and rules.js */
+        public static final String CPU_SOCKETS = "cpu.cpu_socket(s)";
+
+        /** The developer SKU for a given consumer */
+        public static final String DEV_SKU = "dev_sku";
+
+        /** */
+        public static final String DISTRIBUTOR_VERSION = "distributor_version";
+
+        /** The consumer's system/hardware UUID; also part of the cloud profile */
+        public static final String DMI_SYSTEM_UUID = "dmi.system.uuid";
+
+        /** The amount of memory on a given consumer; also part of the cloud profile and rules.js */
+        public static final String MEMORY_MEMTOTAL = "memory.memtotal";
+
+        /** The version of the Candlepin certificate system to use for this consumer */
+        public static final String SYSTEM_CERTIFICATE_VERSION = "system.certificate_version";
+
+        /** Used by the rules.js */
+        public static final String UNAME_MACHINE = "uname.machine";
+
+        /** Whether or not the consumer is a virtual/guest system; also part of the cloud profile */
+        public static final String VIRT_IS_GUEST = "virt.is_guest";
+
+        /** The consumer's guest UUID; used to match them to a hypervisor on virt-who checkin */
+        public static final String VIRT_UUID = "virt.uuid";
+
+        // Cloud profile facts
+        // These facts aren't used by Candlepin directly (other than to determine whether or not to
+        // update the "last cloud profile update" timestamp), but are critical to the function of
+        // some client applications, and must be maintained and passed through properly.
+        public static final String DMI_BIOS_VENDOR = "dmi.bios.vendor";
+        public static final String DMI_BIOS_VERSION = "dmi.bios.version";
+        public static final String DMI_CHASSIS_ASSET_TAG = "dmi.chassis.asset_tag";
+        public static final String DMI_SYSTEM_MANUFACTURER = "dmi.system.manufacturer";
+        public static final String OCM_UNITS = "ocm.units";
     }
+
 
     @Id
     @GeneratedValue(generator = "system-uuid")
@@ -904,12 +946,12 @@ public class Consumer extends AbstractHibernateObject implements Linkable, Owned
     }
 
     public boolean isDev() {
-        return !StringUtils.isEmpty(getFact("dev_sku"));
+        return !StringUtils.isEmpty(getFact(Facts.DEV_SKU));
     }
 
     @JsonIgnore
     public boolean isGuest() {
-        return "true".equalsIgnoreCase(this.getFact("virt.is_guest"));
+        return "true".equalsIgnoreCase(this.getFact(Facts.VIRT_IS_GUEST));
     }
 
     public String getContentAccessMode() {

--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -413,9 +413,9 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
                     this.addAttributeFilterSubquery(Pool.Attributes.VIRT_ONLY, Arrays.asList("true"))
                 ));
             }
-            else if (consumer.hasFact("virt.uuid")) {
+            else if (consumer.hasFact(Consumer.Facts.VIRT_UUID)) {
+                String uuidFact = consumer.getFact(Consumer.Facts.VIRT_UUID);
                 Consumer host = null;
-                String uuidFact = consumer.getFact("virt.uuid");
 
                 if (uuidFact != null) {
                     host = this.consumerCurator.getHost(uuidFact, ownerId);

--- a/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
+++ b/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
@@ -70,8 +70,9 @@ public class CriteriaRules  {
         // avoid passing in a consumerCurator just to get the host
         // consumer UUID
         Consumer hostConsumer = null;
-        if (consumer.getFact("virt.uuid") != null) {
-            hostConsumer = consumerCurator.getHost(consumer.getFact("virt.uuid"), consumer.getOwnerId());
+        if (consumer.getFact(Consumer.Facts.VIRT_UUID) != null) {
+            hostConsumer = this.consumerCurator.getHost(consumer.getFact(Consumer.Facts.VIRT_UUID),
+                consumer.getOwnerId());
         }
 
         List<Criterion> criteriaFilters = new LinkedList<>();
@@ -97,7 +98,7 @@ public class CriteriaRules  {
         else {
             // we are a virt guest
             // add criteria for filtering out pools that are not for this guest
-            if (consumer.hasFact("virt.uuid")) {
+            if (consumer.hasFact(Consumer.Facts.VIRT_UUID)) {
                 String hostUuid = ""; // need a default value in case there is no host
                 if (hostConsumer != null) {
                     hostUuid = hostConsumer.getUuid();

--- a/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
+++ b/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
@@ -291,7 +291,7 @@ public class AutobindRules {
         }
 
         // Consumer isn't a special type, check their certificate_version fact
-        String entitlementVersion = consumer.getFact("system.certificate_version");
+        String entitlementVersion = consumer.getFact(Consumer.Facts.SYSTEM_CERTIFICATE_VERSION);
         return entitlementVersion != null && entitlementVersion.startsWith("3.");
     }
 

--- a/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -253,8 +253,8 @@ public class EntitlementRules implements Enforcer {
     }
 
     private Consumer getHost(Consumer consumer) {
-        Consumer host = consumer.hasFact("virt.uuid") ? consumerCurator.getHost(
-            consumer.getFact("virt.uuid"), consumer.getOwnerId()) : null;
+        Consumer host = consumer.hasFact(Consumer.Facts.VIRT_UUID) ? consumerCurator.getHost(
+            consumer.getFact(Consumer.Facts.VIRT_UUID), consumer.getOwnerId()) : null;
         return host;
     }
 

--- a/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -251,7 +251,7 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
             }
 
             // Consumer isn't a special type, check their certificate_version fact
-            String entitlementVersion = consumer.getFact("system.certificate_version");
+            String entitlementVersion = consumer.getFact(Consumer.Facts.SYSTEM_CERTIFICATE_VERSION);
             return entitlementVersion != null && entitlementVersion.startsWith("3.");
         }
 

--- a/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
+++ b/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
@@ -136,7 +136,7 @@ public class HypervisorUpdateAction {
 
     public Consumer reconcileHost(Owner owner, Consumer incomingHost, HypervisorUpdateResultDTO result,
         boolean create, String principal, String jobReporterId) {
-        String systemUuid = incomingHost.getFact(Consumer.Facts.SYSTEM_UUID);
+        String systemUuid = incomingHost.getFact(Consumer.Facts.DMI_SYSTEM_UUID);
         String hypervisorId = incomingHost.getHypervisorId().getHypervisorId();
         Consumer resultHost = consumerCurator.getExistingConsumerByHypervisorIdOrUuid(owner.getId(),
             hypervisorId,

--- a/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
@@ -283,7 +283,7 @@ public class HypervisorUpdateJobTest {
         hypervisor.ensureUUID();
         hypervisor.setName("hyper-name");
         hypervisor.setOwner(owner);
-        hypervisor.setFact(Consumer.Facts.SYSTEM_UUID, "myUuid");
+        hypervisor.setFact(Consumer.Facts.DMI_SYSTEM_UUID, "myUuid");
         hypervisor.setId("the-id");
         String hypervisorId = "existing_hypervisor_id";
         hypervisor.setHypervisorId(new HypervisorId().setHypervisorId(hypervisorId));
@@ -323,7 +323,7 @@ public class HypervisorUpdateJobTest {
         hypervisor.ensureUUID();
         hypervisor.setName("hyper-name");
         hypervisor.setOwner(owner);
-        hypervisor.setFact(Consumer.Facts.SYSTEM_UUID, "myUuid");
+        hypervisor.setFact(Consumer.Facts.DMI_SYSTEM_UUID, "myUuid");
         String hypervisorId = "existing_hypervisor_id";
         hypervisor.setHypervisorId(new HypervisorId().setHypervisorId(hypervisorId));
         when(consumerCurator.getExistingConsumerByHypervisorIdOrUuid(any(String.class), any(String.class),
@@ -339,7 +339,7 @@ public class HypervisorUpdateJobTest {
                 "\"name\" : \"hypervisor_999\"," +
                 "\"hypervisorId\" : {\"hypervisorId\":\"expected_hypervisor_id\"}," +
                 "\"guestIds\" : [{\"guestId\" : \"guestId_1_999\"}]," +
-                "\"facts\" : {\"" + Consumer.Facts.SYSTEM_UUID + "\" : \"myUuid\"}" +
+                "\"facts\" : {\"" + Consumer.Facts.DMI_SYSTEM_UUID + "\" : \"myUuid\"}" +
                 "}]}";
 
         JobConfig config = createJobConfig(null);
@@ -438,7 +438,7 @@ public class HypervisorUpdateJobTest {
         hypervisor.ensureUUID();
         hypervisor.setName("hyper-name");
         hypervisor.setOwner(owner);
-        hypervisor.setFact(Consumer.Facts.SYSTEM_UUID, "myUuid");
+        hypervisor.setFact(Consumer.Facts.DMI_SYSTEM_UUID, "myUuid");
         hypervisor.setId("the-id");
         String hypervisorId = "existing_hypervisor_id";
         hypervisor.setHypervisorId(new HypervisorId().setHypervisorId(hypervisorId));

--- a/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -630,7 +630,7 @@ public class EntitlerTest {
 
         this.mockRefresh(owner, Arrays.asList(p1, p2, p3), null);
 
-        Pool created = entitler.assembleDevPool(devSystem, owner, devSystem.getFact("dev_sku"));
+        Pool created = entitler.assembleDevPool(devSystem, owner, devSystem.getFact(Consumer.Facts.DEV_SKU));
         Calendar cal = Calendar.getInstance();
         cal.setTime(created.getStartDate());
         cal.add(Calendar.DAY_OF_YEAR, 47);

--- a/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -1282,7 +1282,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     public void testGetHypervisorConsumerMapWithFacts() {
         String hypervisorId1 = "Hypervisor";
         Consumer consumer1 = new Consumer("testConsumer", "testUser", owner, ct);
-        consumer1.setFact(Consumer.Facts.SYSTEM_UUID, "blah");
+        consumer1.setFact(Consumer.Facts.DMI_SYSTEM_UUID, "blah");
         HypervisorId hid1 = new HypervisorId()
             .setOwner(owner)
             .setHypervisorId(hypervisorId1);
@@ -1301,7 +1301,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         // first consumer set with only the fact, not the hypervisor
         String hypervisorId1 = "Hypervisor";
         Consumer consumer1 = new Consumer("testConsumer", "testUser", owner, ct);
-        consumer1.setFact(Consumer.Facts.SYSTEM_UUID, "blah");
+        consumer1.setFact(Consumer.Facts.DMI_SYSTEM_UUID, "blah");
         consumer1 = consumerCurator.create(consumer1);
 
         // next consumer set with the hypervisor, not the fact

--- a/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -522,11 +522,11 @@ public class ConsumerTest extends DatabaseTestFixture {
     @Test
     public void testCloudProfileFactDidNotChange() {
         Consumer consumer = new Consumer();
-        consumer.setFact("dmi.bios.vendor", "vendorA");
+        consumer.setFact(Consumer.Facts.DMI_BIOS_VENDOR, "vendorA");
         consumer.setFact("lscpu.model", "78");
 
         Map<String, String> newFacts = new HashMap<>();
-        newFacts.put("dmi.bios.vendor", "vendorA");
+        newFacts.put(Consumer.Facts.DMI_BIOS_VENDOR, "vendorA");
         newFacts.put("lscpu.model", "100");
 
         // this should return false because the only cloud fact  the consumer has did not change
@@ -536,11 +536,11 @@ public class ConsumerTest extends DatabaseTestFixture {
     @Test
     public void testCloudProfileFactDidNotChangeWhenPassingSingleFact() {
         Consumer consumer = new Consumer();
-        consumer.setFact("dmi.bios.vendor", "vendorA");
+        consumer.setFact(Consumer.Facts.DMI_BIOS_VENDOR, "vendorA");
         consumer.setFact("lscpu.model", "78");
 
         Map<String, String> newFacts = new HashMap<>();
-        newFacts.put("dmi.bios.vendor", "vendorA");
+        newFacts.put(Consumer.Facts.DMI_BIOS_VENDOR, "vendorA");
 
         assertFalse(consumer.checkForCloudProfileFacts(newFacts));
     }
@@ -550,7 +550,7 @@ public class ConsumerTest extends DatabaseTestFixture {
         Consumer consumer = new Consumer();
 
         Map<String, String> newFacts = new HashMap<>();
-        newFacts.put("dmi.bios.vendor", "vendorA");
+        newFacts.put(Consumer.Facts.DMI_BIOS_VENDOR, "vendorA");
 
         assertTrue(consumer.checkForCloudProfileFacts(newFacts));
     }
@@ -558,7 +558,7 @@ public class ConsumerTest extends DatabaseTestFixture {
     @Test
     public void testCloudProfileFactOnEmptyIncomingFacts() {
         Consumer consumer = new Consumer();
-        consumer.setFact("dmi.bios.vendor", "vendorA");
+        consumer.setFact(Consumer.Facts.DMI_BIOS_VENDOR, "vendorA");
 
         Map<String, String> newFacts = null;
 
@@ -568,10 +568,10 @@ public class ConsumerTest extends DatabaseTestFixture {
     @Test
     public void testCloudProfileFactOnNullValueOfIncomingFacts() {
         Consumer consumer = new Consumer();
-        consumer.setFact("dmi.bios.vendor", "vendorA");
+        consumer.setFact(Consumer.Facts.DMI_BIOS_VENDOR, "vendorA");
 
         Map<String, String> newFacts = new HashMap<>();
-        newFacts.put("dmi.bios.vendor", null);
+        newFacts.put(Consumer.Facts.DMI_BIOS_VENDOR, null);
 
         assertTrue(consumer.checkForCloudProfileFacts(newFacts));
 
@@ -584,14 +584,13 @@ public class ConsumerTest extends DatabaseTestFixture {
     @Test
     public void testCloudProfileFactExistingIncomingFacts() {
         Consumer consumer = new Consumer();
-        consumer.setFact("dmi.bios.vendor", "vendorA");
+        consumer.setFact(Consumer.Facts.DMI_BIOS_VENDOR, "vendorA");
 
         Map<String, String> newFacts = new HashMap<>();
-        newFacts.put("dmi.bios.vendor", "vendorA");
+        newFacts.put(Consumer.Facts.DMI_BIOS_VENDOR, "vendorA");
 
         assertFalse(consumer.checkForCloudProfileFacts(newFacts));
     }
-
 
     @Test
     public void testServiceTypeConvertedToEmpty() {

--- a/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -825,7 +825,7 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         assertEquals(modifiedDateOnCreate, modifiedTSOnUnnecessaryFactUpdate);
 
         updatedConsumerDTO = new ConsumerDTO();
-        updatedConsumerDTO.putFactsItem(CloudProfileFacts.CPU_CORES_PERSOCKET.getFact(), "1");
+        updatedConsumerDTO.putFactsItem(CloudProfileFacts.CPU_CORES_PER_SOCKET.getFact(), "1");
         consumerResource.updateConsumer(consumer.getUuid(), updatedConsumerDTO);
         Date modifiedTSOnNecessaryFactUpdate = consumerCurator.get(consumer.getId())
             .getRHCloudProfileModified();


### PR DESCRIPTION
- Updated the Consumer.Facts pseudo-class to contain all of the facts Candlepin uses either directly or indirectly
- Updated the CloudProfileFacts to reference Consumer.Facts rather than hard-coding its own copies of the values
- Updated several places in Candlepin code which were using hard-coded strings for facts to use the new values in Consumer.Facts