### PR TITLE
[M] CANDLEPIN-456: Fixed input validation on content creation endpoint

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -8566,26 +8566,36 @@ components:
         - $ref: '#/components/schemas/TimestampedEntity'
         - type: object
           required:
-            - id
+            - type
+            - label
+            - name
+            - vendor
           properties:
             uuid:
               type: string
               example: "ff808081554a3e4101554a3e9033005d"
             id:
               type: string
-              minLength: 1
               example: "5001"
             type:
               type: string
+              minLength: 1
+              maxLength: 255
               example: "yum"
             label:
               type: string
+              minLength: 1
+              maxLength: 255
               example: "content_label"
             name:
               type: string
+              minLength: 1
+              maxLength: 255
               example: "content_name"
             vendor:
               type: string
+              minLength: 1
+              maxLength: 255
               example: "example-vendor"
             contentUrl:
               type: string

--- a/buildSrc/src/main/resources/templates/api.mustache
+++ b/buildSrc/src/main/resources/templates/api.mustache
@@ -24,7 +24,8 @@ import javax.validation.Valid;{{/useBeanValidation}}
 @Api(description = "the {{{baseName}}} API"){{/useSwaggerAnnotations}}{{#hasConsumes}}
 @Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}
 @Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}
-{{>generatedAnnotation}}public {{#interfaceOnly}}interface{{/interfaceOnly}}{{^interfaceOnly}}class{{/interfaceOnly}} {{classname}} {
+{{>generatedAnnotation}}
+public {{#interfaceOnly}}interface{{/interfaceOnly}}{{^interfaceOnly}}class{{/interfaceOnly}} {{classname}} {
 {{#operations}}
 {{#operation}}
 

--- a/buildSrc/src/main/resources/templates/pojo.mustache
+++ b/buildSrc/src/main/resources/templates/pojo.mustache
@@ -12,7 +12,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
  **/{{/description}}
 {{#useSwaggerAnnotations}}{{#description}}@ApiModel(description = "{{{.}}}"){{/description}}{{/useSwaggerAnnotations}}
 @JsonTypeName("{{name}}")
-{{>generatedAnnotation}}{{>additionalModelTypeAnnotations}}public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+{{>generatedAnnotation}}{{>additionalModelTypeAnnotations}}
+public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
   {{#vars}}{{#isEnum}}{{^isContainer}}
 
 {{>enumClass}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}

--- a/src/main/java/org/candlepin/validation/CandlepinMessageInterpolator.java
+++ b/src/main/java/org/candlepin/validation/CandlepinMessageInterpolator.java
@@ -20,7 +20,6 @@ import com.google.inject.Provider;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -89,7 +88,6 @@ public class CandlepinMessageInterpolator implements MessageInterpolator {
         msgs.put("{org.hibernate.validator.constraints.URL.message}",
             new ValidationMessage(I18n.marktr("must be a valid URL")));
 
-
         MESSAGES = Collections.<String, ValidationMessage>unmodifiableMap(msgs);
     }
 
@@ -99,12 +97,11 @@ public class CandlepinMessageInterpolator implements MessageInterpolator {
      */
     public static class ValidationMessage {
         private String message;
-
         private List<String> paramNames;
 
         public ValidationMessage(String message, String... paramNames) {
             this.message = message;
-            this.paramNames = Collections.unmodifiableList(Arrays.asList(paramNames));
+            this.paramNames = List.of(paramNames);
         }
 
         public String getMessage() {
@@ -126,7 +123,7 @@ public class CandlepinMessageInterpolator implements MessageInterpolator {
 
     // You must use the Provider here otherwise you will end up with a stale
     // I18n object!
-    private Provider<I18n> i18nProvider;
+    private final Provider<I18n> i18nProvider;
 
     @Inject
     public CandlepinMessageInterpolator(Provider<I18n> i18nProvider) {
@@ -134,14 +131,14 @@ public class CandlepinMessageInterpolator implements MessageInterpolator {
     }
 
     @Override
-    public String interpolate(String message, Context context) {
-        return interpolate(message, context, i18nProvider.get().getLocale());
+    public String interpolate(String msgTemplate, Context context) {
+        return interpolate(msgTemplate, context, i18nProvider.get().getLocale());
     }
 
     @Override
-    public String interpolate(String messageTemplate, Context context, Locale locale) {
+    public String interpolate(String msgTemplate, Context context, Locale locale) {
         Map<String, Object> attrs = context.getConstraintDescriptor().getAttributes();
-        ValidationMessage validationMessage = MESSAGES.get(messageTemplate);
+        ValidationMessage validationMessage = MESSAGES.get(msgTemplate);
         List<Object> paramList = new ArrayList<>();
 
         for (String param : validationMessage.getParamNames()) {


### PR DESCRIPTION
- Corrected the input validation on the POST /owners/{key}/content endpoint to match the request handler's logic: the id field is no longer required, but the label, name, type, and vendor fields are
- Updated the ValidationExceptionMapper to separate constraint violations when building the response error message
- Updated a few older bits of code with to fit with modern practices and stylistic choices
- Updated a couple of the OpenAPI generator templates to produce slightly more readable code