### PR TITLE
[M] CANDLEPIN-459: Updated Util.getHostname to no longer use reflection

### DIFF
--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -255,6 +255,7 @@ public class ConfigProperties {
     public static final String KEYCLOAK_FILEPATH = "candlepin.keycloak.config";
 
     // Async Job Properties and utilities
+    public static final String ASYNC_JOBS_NODE_NAME = "candlepin.async.node_name";
     public static final String ASYNC_JOBS_THREADS = "candlepin.async.threads";
     public static final String ASYNC_JOBS_SCHEDULER_ENABLED = "candlepin.async.scheduler.enabled";
 

--- a/src/main/java/org/candlepin/util/Util.java
+++ b/src/main/java/org/candlepin/util/Util.java
@@ -31,8 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -503,14 +501,10 @@ public class Util {
      */
     public static String getHostname() {
         try {
-            Field implField = InetAddress.class.getDeclaredField("impl");
-            implField.setAccessible(true);
-
-            Object impl = implField.get(null);
-            Method method = impl.getClass().getDeclaredMethod("getLocalHostName");
-            method.setAccessible(true);
-
-            return (String) method.invoke(impl);
+            // Hoping for the best here, as reflection rules in Java17 prevent us from
+            // jumping directly to the getLocalHostName call without even more shenanigans
+            // that are worse than just dealing with the shortcomings this method has.
+            return InetAddress.getLocalHost().getHostName();
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -510,6 +510,37 @@ public class JobManagerTest {
     }
 
     @Test
+    public void testJobManagerUsesHostnameAsDefaultNodeName() throws JobException {
+        this.config.clearProperty(ConfigProperties.ASYNC_JOBS_NODE_NAME);
+
+        JobManager manager = this.createJobManager();
+        manager.initialize();
+        manager.start();
+
+        AsyncJobStatus result = manager.queueJob(JobConfig.forJob(TestJob.JOB_KEY));
+        assertNotNull(result);
+
+        String origin = result.getOrigin();
+        assertEquals(Util.getHostname(), origin);
+    }
+
+    @Test
+    public void testJobManagerUsesConfiguredNameAsNodeNameWhenPresent() throws JobException {
+        String nodeName = "custom node name";
+        this.config.setProperty(ConfigProperties.ASYNC_JOBS_NODE_NAME, nodeName);
+
+        JobManager manager = this.createJobManager();
+        manager.initialize();
+        manager.start();
+
+        AsyncJobStatus result = manager.queueJob(JobConfig.forJob(TestJob.JOB_KEY));
+        assertNotNull(result);
+
+        String origin = result.getOrigin();
+        assertEquals(nodeName, origin);
+    }
+
+    @Test
     public void shouldSendEvents() throws JobException {
         AsyncJobStatus status = this.createJobStatus(JOB_ID)
             .setJobKey(TestJob.JOB_KEY)
@@ -1795,6 +1826,7 @@ public class JobManagerTest {
         verify(this.scheduler, times(1))
             .unscheduleJobs(Arrays.asList(dummyTrigger.getKey()));
         verify(this.scheduler, times(1)).deleteJob(eq(jobkey4));
-
     }
+
+
 }

--- a/src/test/java/org/candlepin/util/UtilTest.java
+++ b/src/test/java/org/candlepin/util/UtilTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import org.candlepin.dto.api.server.v1.AttributeDTO;
@@ -323,14 +322,9 @@ public class UtilTest {
     }
 
     @Test
-    public void testGetHostname() {
-        try {
-            String hostname = Util.getHostname();
-            assertNotNull(hostname);
-        }
-        catch (Exception e) {
-            fail("getHostname should not throw an exception");
-        }
+    public void testGetHostname() throws Exception {
+        String hostname = Util.getHostname();
+        assertNotNull(hostname);
     }
 
     @Test


### PR DESCRIPTION
- Updated Util.getHostname to drop the use of reflection, as this method has been blocked with new restrictions as of Java 17
- Added a new configuration for specifying the name of a node to use while setting the origin and executor for jobs within the job system