### PR TITLE
[M] Set default compose file in docker/test script

### DIFF
--- a/docker/test
+++ b/docker/test
@@ -2,7 +2,8 @@
 
 TEST_CMD="/usr/bin/cp-test -t -u -r"
 DIR="$(git rev-parse --show-toplevel)/docker/"
-OPERATING_SYSTEM="cs8" # Changing this variable, change default OS
+OPERATING_SYSTEM="cs8" # Default OS/image
+COMPOSE_ARGS="-f $DIR/docker-compose-postgres"; # Default compose file
 
 usage() {
   cat << USAGE


### PR DESCRIPTION
- This solves an error when the user does not explicitly set -m, -p, -q, -x to choose a compose profile. The default is now set to postgresql on Centos Stream 8.