### PR TITLE
Draft: Add provided tags as product attribute

### DIFF
--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -103,6 +103,9 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
          *  to the value "ALL" to specify all architectures */
         public static final String ARCHITECTURE = "arch";
 
+        /** Attribute to specify the provided tags of a product */
+        public static final String PROVIDED_TAGS = "provided_tags";
+
         /** Attribute for specifying the type of branding to apply to a marketing product (SKU) */
         public static final String BRANDING_TYPE = "brand_type";
 

--- a/src/main/java/org/candlepin/util/X509ExtensionUtil.java
+++ b/src/main/java/org/candlepin/util/X509ExtensionUtil.java
@@ -182,6 +182,10 @@ public class X509ExtensionUtil  extends X509Util{
         toReturn.add(new X509ExtensionWrapper(productOid + "." +
             OIDUtil.ORDER_PRODUCT_OIDS.get(OIDUtil.OP_ARCH_KEY), false, arch != null ? arch : ""));
 
+        String provides = product.getAttributeValue(Product.Attributes.PROVIDED_TAGS);
+        toReturn.add(new X509ExtensionWrapper(productOid + "." +
+            OIDUtil.ORDER_PRODUCT_OIDS.get(OIDUtil.OP_PROVIDES_KEY), false, provides != null ? provides : ""));
+
         String version = product.getAttributeValue(Product.Attributes.VERSION);
         toReturn.add(new X509ExtensionWrapper(productOid + "." +
             OIDUtil.ORDER_PRODUCT_OIDS.get(OIDUtil.OP_VERSION_KEY), false, version != null ? version : ""));

--- a/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -946,6 +946,20 @@ public class DefaultEntitlementCertServiceAdapterTest {
             cont.getId() + "." + contentType + ".1");
     }
 
+    private Boolean extMapHasProductProvidedTags(Product product, Map<String, String> extMap) {
+        return extMap.containsKey("1.3.6.1.4.1.2312.9.1." +
+            product.getId() + "." + "4");
+    }
+
+    private Boolean extMapProductProvidedTagsMatches(Product product, Map<String, String> extMap,
+        String providedTags) {
+        String providedTagsOid = "1.3.6.1.4.1.2312.9.1." +
+            product.getId() + "." + "4";
+        String extBrandType = extMap.get(providedTagsOid);
+
+        return extBrandType.equals(providedTags);
+    }
+
     private Boolean extMapHasProductBrandType(Product product, Map<String, String> extMap) {
         return extMap.containsKey("1.3.6.1.4.1.2312.9.1." +
             product.getId() + "." + "5");
@@ -979,6 +993,25 @@ public class DefaultEntitlementCertServiceAdapterTest {
         // do we have a yum content type oid
         assertTrue(extMapHasContentType(content, extMap, "1"));
         assertFalse(extMapHasContentType(content, extMap, "2"));
+    }
+
+    @Test
+    public void testPrepareV1ExtensionsProvidedTags() {
+        Set<Product> products = new HashSet<>();
+
+        product.setAttribute(Product.Attributes.PROVIDED_TAGS, "centos_8.9");
+        products.add(product);
+        setupEntitlements(ARCH_LABEL, "1.0");
+
+        Set<X509ExtensionWrapper> extensions =
+            certServiceAdapter.prepareV1Extensions(products, pool, consumer,
+            entitlement.getQuantity(), new PromotedContent(prefix("")), new HashSet<>());
+        Map<String, X509ExtensionWrapper> map = getEncodedContent(extensions);
+        Map<String, String> extMap = getEncodedContentMap(extensions);
+
+        assertTrue(isEncodedContentValid(map));
+        assertTrue(extMapHasProductProvidedTags(product, extMap));
+        assertTrue(extMapProductProvidedTagsMatches(product, extMap, "centos_8.9"));
     }
 
     @Test


### PR DESCRIPTION
This extension is necessary to enable product-based filtering of repositories for non-RHEL operating systems in the Katello/subscription-manager context.

Currently, the Katello "restrict-to os" feature is only possible for RHEL. This checks whether the required-tags of a repository are fulfilled for the operating system used on the basis of the provided-tags.

In the case of RHEL, the provided tags are delivered with the product certificate.
This procedure is not possible for other operating systems, which is why "Restrict to OS" cannot be used at all.

The idea behind this PR is that you can 
- that you can extend Katello so that you can set provided tags for custom products yourself. 
- These provided tags are then transferred to Candlepin as cp2_product_attributes via API.
- via product/<id>/certificate the certificate can be downloaded, which then contains the provided-tags
- when deploying a host or attaching a existing host to Katello, the product certificate is stored on the host itself
- so the subscription-manager can use the product-certificate and check if the required-tags of a repository are fulfilled by the product-tags. 

Another approch would be:
https://github.com/candlepin/subscription-manager/pull/3188
(The change would then only be in sub-man and Katello - feature wise, the same would be possible)

The PR is marked as draft because we should discuss, which solution we now prefer. Thanks.

CC @jeremylenz & @ptoscano 
