### PR TITLE
[M] Log different types of token auth usage

### DIFF
--- a/src/main/java/org/candlepin/auth/CloudRegistrationAuth.java
+++ b/src/main/java/org/candlepin/auth/CloudRegistrationAuth.java
@@ -173,6 +173,7 @@ public class CloudRegistrationAuth implements AuthProvider {
                     throw new VerificationException("Token contains an invalid audience: " + ownerKey);
                 }
 
+                log.info("Token type used for authentication: {}", TOKEN_TYPE);
                 return this.createCloudUserPrincipal(subject, ownerKey);
             }
         }

--- a/src/main/java/org/candlepin/auth/KeycloakAuth.java
+++ b/src/main/java/org/candlepin/auth/KeycloakAuth.java
@@ -111,6 +111,7 @@ public class KeycloakAuth extends UserAuth implements AuthProvider {
 
             if (keycloakSecurityContext != null && keycloakSecurityContext.getToken() != null) {
                 String userName = keycloakSecurityContext.getToken().getPreferredUsername();
+                log.info("Token type used for authentication: Bearer");
                 return createPrincipal(userName);
             }
         }


### PR DESCRIPTION
- This is for stats purposes, to differantiate between cloud auto-registration token and generic 'keycloak' token usage.