### PR TITLE
[M] CANDLEPIN-480: Fixed product and content attribute referencing

### DIFF
--- a/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
@@ -246,8 +246,8 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
                 // Impl note:
                 // We've already implicitly checked the ID above by how we're pulling candidate
                 // entities from the map
-                log.error("Entity version collision detected; attempting resolution... {} != {}",
-                    entity, candidate);
+                log.error("Entity version collision detected; attempting resolution..." +
+                    "\nConflicting entities:\n{}\n{}", entity, candidate);
 
                 this.ownerContentCurator.clearContentEntityVersion(candidate);
                 break;

--- a/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
@@ -354,10 +354,11 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
                 // Impl note:
                 // We've already implicitly checked the ID above by how we're pulling candidate
                 // entities from the map
-                log.error("Entity version collision detected; attempting resolution... {} != {}",
-                    entity, candidate);
+                log.error("Entity version collision detected; attempting resolution..." +
+                    "\nConflicting entities:\n{}\n{}", entity, candidate);
 
                 this.ownerProductCurator.clearProductEntityVersion(candidate);
+                break;
             }
         }
 

--- a/src/main/java/org/candlepin/model/AbstractHibernateObject.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateObject.java
@@ -16,76 +16,176 @@ package org.candlepin.model;
 
 import org.candlepin.model.dto.CandlepinDTO;
 
-import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
 import java.io.Serializable;
 import java.util.Date;
 
 import javax.persistence.MappedSuperclass;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
-import javax.xml.bind.annotation.XmlType;
 
 
 
 /**
- * Abstract class for hibernate entities
+ * Abstract base class for Hibernate entities.
+ * <p>
+ * Due to the nature of model/entity classes and how Hibernate works internally, subclasses -- and
+ * Hibernate entities in general -- should adhere to certain behavioral patterns to avoid problems
+ * with the persistence engine, or a given subclass or proxy's ability to fetch accurate data.
+ * <ul>
+ *   <li>
+ *   <strong>Avoid directly referencing an entity attribute directly outside of the constructors,
+ *   accessors, and mutators</strong><br>
+ *   Since entity classes tend to be non-final and are often fetched from Hibernate as proxy
+ *   instances, doing so could lead to a case where a non-overloaded utility method could be
+ *   operating on stale or invalid data, rather than the actual data the entity may contain.
+ *   </li>
+ *   <li>
+ *   <strong>Fully encapsulate collections, and disallow external modification</strong><br>
+ *   Similar to proxy objects, collections are often fetched as proxy objects and may have explicit
+ *   behavior required for functionality in the persistence engine, such as cascades. By
+ *   encapsulating such collections and ensuring modification is done through the class, certain
+ *   issues with data consistency can be avoided.<br>
+ *   Additionally, this avoids a class of issue surrounding validation or normalization being
+ *   skipped due to direct modification of an entity's collection(s).
+ *   </li>
+ *   <li>
+ *   <strong>Avoid non-default constructors as a requirement for instantiation</strong><br>
+ *   Due to the high probability that entity classes will be subclasses by generated code, it is
+ *   likely that parameterized constructors won't be called and cannot be relied upon for a global
+ *   invocation.
+ *   </li>
+ * </ul>
+ * As with all guidelines, there may be cases where one or more rules need to be violated for proper
+ * functionality or more maintable code. In such cases, it should be documented in code at the very
+ * least to explain why such a deviation is necessary and to avoid future maintenance pains or
+ * confusion.
  *
  * @param <T>
  *  Entity type extending this class; should be the name of the subclass
  */
 @MappedSuperclass
-@XmlType(name = "CandlepinObject")
-@JsonFilter("DefaultFilter")
 public abstract class AbstractHibernateObject<T extends AbstractHibernateObject>
     implements Persisted, Serializable, TimestampedEntity<T> {
 
     private static final long serialVersionUID = 6677558844288404862L;
 
+    /**
+     * The name of the field to sort by when no sort field is specified by the client.
+     *
+     * @deprecated
+     *  Declared as part of the v1 paging framework. This field will be moved to the paging
+     *  interfaces once implemented.
+     */
+    @Deprecated
     public static final String DEFAULT_SORT_FIELD = "created";
+
 
     private Date created;
     private Date updated;
 
+    /**
+     * Performs data normalization when this entity is initially persisted to the underlying
+     * persistence engine. This method is called automatically, and is not necessary to invoke
+     * directly.
+     * <p>
+     * <strong>Note</strong>: subclasses overriding this method should ensure the parent
+     * implementation is called by calling <tt>super.onCreate()</tt> at the head of the override.
+     */
     @PrePersist
     protected void onCreate() {
         Date now = new Date();
 
-        if (this.created == null) {
-            setCreated(now);
+        if (this.getCreated() == null) {
+            this.setCreated(now);
         }
 
-        setUpdated(now);
+        this.setUpdated(now);
     }
 
+    /**
+     * Performs data normalization when changes to this entity are persisted to the underlying
+     * persistence engine. This method is called automatically, and is not necessary to invoke
+     * directly.
+     * <p>
+     * <strong>Note</strong>: subclasses overriding this method should ensure the parent
+     * implementation is called by calling <tt>super.onUpdate()</tt> at the head of the override.
+     */
     @PreUpdate
     protected void onUpdate() {
-        setUpdated(new Date());
+        this.setUpdated(new Date());
     }
 
-    @JsonInclude(Include.NON_NULL)
+    /**
+     * Fetches the date this entity was created, generally indicating the time at which it was first
+     * persisted to the database. If the entity has not yet been persisted, or the creation date has
+     * not yet been set, this method returns null.
+     *
+     * @return
+     *  the date this entity was initially persisted
+     */
     public Date getCreated() {
+        // TODO: FIXME: Change this and setCreated to use the java.time classes instead of Date
         return created;
     }
 
-    public void setCreated(Date created) {
+    /**
+     * Sets or clears the creation date of this entity. If the given date is null, any existing
+     * date will be cleared.
+     * <p>
+     * <strong>Note:</strong> this method will be called automatically on initial persist if the
+     * creation date is not already explicitly set. It <strong>will not</strong> be called on
+     * subsequent persists, even if the creation date is cleared.
+     *
+     * @param created
+     *  the creation date to set for this entity, or null to clear the existing value
+     *
+     * @return
+     *  a reference to this entity instance
+     */
+    public T setCreated(Date created) {
         this.created = created;
+        return (T) this;
     }
 
-    @JsonInclude(Include.NON_NULL)
+    /**
+     * Fetches the date this entity was last updated, generally indicating the time at which it was
+     * last persisted to the database. If the entity has not yet bene persisted or the last-update
+     * date has not yet been set, this method returns null.
+     *
+     * @return
+     *  the date this entity was last persisted
+     */
     public Date getUpdated() {
         return updated;
     }
 
-    public void setUpdated(Date updated) {
+    /**
+     * Sets or clears the last-update date of this entity. If the given date is null, any existing
+     * last-updated date will be cleared.
+     * <p>
+     * <strong>Note:</strong> this method will be called automatically on persist, even if the
+     * last-updated date is explicitly set.
+     *
+     * @param updated
+     *  the last-updated date to set for this entity, or null to clear the existing value
+     *
+     * @return
+     *  a reference to this entity instance
+     */
+    public T setUpdated(Date updated) {
         this.updated = updated;
+        return (T) this;
     }
 
     /**
      * Populates this entity with the data contained in the source DTO. Unpopulated values within
      * the DTO will be ignored.
+     *
+     * @deprecated
+     *  The DTO integrations have not been maintained and are no longer supported directly on the
+     *  model, as it conflates the responsibilities of the DTO and model layers. Newer translation
+     *  logic should occur on a case-by-case basis, or in a translation framework. This method will
+     *  eventually be removed entirely.
      *
      * @param source
      *  The source DTO containing the data to use to update this entity
@@ -96,7 +196,8 @@ public abstract class AbstractHibernateObject<T extends AbstractHibernateObject>
      * @return
      *  A reference to this entity
      */
-    public AbstractHibernateObject populate(CandlepinDTO source) {
+    @Deprecated
+    public T populate(CandlepinDTO source) {
         if (source == null) {
             throw new IllegalArgumentException("source is null");
         }
@@ -109,6 +210,6 @@ public abstract class AbstractHibernateObject<T extends AbstractHibernateObject>
             this.setUpdated(source.getUpdated());
         }
 
-        return this;
+        return (T) this;
     }
 }

--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -1216,7 +1216,8 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
     @Override
     public String toString() {
-        return String.format("Product [uuid: %s, id: %s, name: %s]", this.uuid, this.id, this.name);
+        return String.format("Product [uuid: %s, id: %s, name: %s, entity_version: %s]",
+            this.getUuid(), this.getId(), this.getName(), this.getEntityVersion());
     }
 
     public Product setLocked(boolean locked) {
@@ -1254,10 +1255,10 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             }
 
             equals = new EqualsBuilder()
-                .append(this.id, that.id)
-                .append(this.name, that.name)
-                .append(this.multiplier, that.multiplier)
-                .append(this.attributes, that.attributes)
+                .append(this.getId(), that.getId())
+                .append(this.getName(), that.getName())
+                .append(this.getMultiplier(), that.getMultiplier())
+                .append(this.getAttributes(), that.getAttributes())
                 .isEquals();
 
             // Check derived product
@@ -1267,13 +1268,14 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
             // Impl note: We can't use .equals here on the collections, as Hibernate's special
             // collections explicitly state that they break the contract on .equals. As such, we
             // have to step through each collection and do a manual comparison. Ugh.
-            equals = equals && Util.collectionsAreEqual(this.dependentProductIds, that.dependentProductIds);
+            equals = equals && Util.collectionsAreEqual(this.getDependentProductIds(),
+                that.getDependentProductIds());
 
             // Compare our content
-            equals = equals && Util.collectionsAreEqual(this.productContent, that.productContent);
+            equals = equals && Util.collectionsAreEqual(this.getProductContent(), that.getProductContent());
 
             // Compare branding collections
-            equals = equals && Util.collectionsAreEqual(this.branding, that.branding);
+            equals = equals && Util.collectionsAreEqual(this.getBranding(), that.getBranding());
 
             // Compare provided products
             equals = equals && Util.collectionsAreEqual(this.getProvidedProducts(),

--- a/src/main/resources/db/changelog/20230207161633-clear_entity_versions-1.xml
+++ b/src/main/resources/db/changelog/20230207161633-clear_entity_versions-1.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20230207161633-1" author="crog">
+        <comment>
+            Clear existing entity versions to prevent accidental collisions due to the
+            algorithm change
+        </comment>
+
+        <sql>
+            UPDATE cp2_products SET entity_version = NULL;
+            UPDATE cp2_content SET entity_version = NULL;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-create.xml
+++ b/src/main/resources/db/changelog/changelog-create.xml
@@ -1275,4 +1275,5 @@
     <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
     <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
     <include file="db/changelog/20221212140215-remove_prodcont_fk_delete_cascade.xml"/>
+    <include file="db/changelog/20230207161633-clear_entity_versions-1.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-testing.xml
+++ b/src/main/resources/db/changelog/changelog-testing.xml
@@ -2365,4 +2365,5 @@
     <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
     <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
     <include file="db/changelog/20221212140215-remove_prodcont_fk_delete_cascade.xml"/>
+    <include file="db/changelog/20230207161633-clear_entity_versions-1.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -182,4 +182,5 @@
     <include file="db/changelog/20221003160605-remove_direct_ak_product_reference.xml"/>
     <include file="db/changelog/20221003160623-remove_direct_env_content_reference.xml"/>
     <include file="db/changelog/20221212140215-remove_prodcont_fk_delete_cascade.xml"/>
+    <include file="db/changelog/20230207161633-clear_entity_versions-1.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- Added entity class guidelines and documentation to the
  AbstractHibernateObject
- Changed several methods in Product and Content to no longer
  reference model attributes outside of mutators and accessors
- Added entity version to the string representation of Product
  and Content
- Improved output of entity version collision error message in
  ProductNodeVisitor and ContentNodeVisitor
- Changed how content processes modified product IDs during
  entity version calculation
- Removed XML serialization annotations from AbstractHibernateObject,
  Content, and Product
- AbstractHibernateObject now returns a typed self-reference from
  its mutators
- Deprecated the AbstractHibernateObject.populate method, and the
  AbstractHibernateObject.DEFAULT_SORT_FIELD property