### PR TITLE
[M] CANDLEPIN-480: Fixed incorrect variable reference in Content.getEntityVersion

### DIFF
--- a/src/main/java/org/candlepin/model/Content.java
+++ b/src/main/java/org/candlepin/model/Content.java
@@ -640,8 +640,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
                 modifiedProductIds.stream() :
                 Stream.empty();
 
-            modifiedProductIds.stream()
-                .filter(Objects::nonNull)
+            mpistream.filter(Objects::nonNull)
                 .sorted()
                 .forEach(builder::append);
 


### PR DESCRIPTION
- Updated Content.getEntityVersion to reference the correct variable when adding modified product IDs to the hash