### PR TITLE
[4.1] CANDLEPIN-331: Jenkins: Reuse result of unit test stage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -370,6 +370,8 @@ test {
 }
 
 jacocoTestReport {
+    dependsOn test
+
     reports {
         xml.enabled true
     }
@@ -380,12 +382,17 @@ jacocoTestReport {
 }
 
 // User-friendly alias for jacocoTestReport task
-task coverage {
+tasks.register("coverage") {
     dependsOn jacocoTestReport
 }
 
-project.tasks["sonarqube"].dependsOn "test"
 project.tasks["sonarqube"].dependsOn "coverage"
+sonarqube{
+    properties{
+        property "sonar.sourceEncoding","Utf-8"
+        property "sonar.exclusions","**/*generated*"
+    }
+}
 
 wrapper {
     distributionType = Wrapper.DistributionType.ALL

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -6,12 +6,9 @@ library identifier: 'fh-pipeline-library@master', retriever: modernSCM(
 pipeline {
     agent none
     options {
-        skipDefaultCheckout true
+        skipDefaultCheckout()
         timeout(time: 16, unit: 'HOURS')
         disableConcurrentBuilds(abortPrevious: true)
-    }
-    environment {
-        CANDLEPIN_QUAY_BOT = credentials("candlepin-quay-bot")
     }
     stages {
         stage('Trust') {
@@ -22,141 +19,55 @@ pipeline {
         }
         stage('Test') {
             parallel {
-                stage('unit') {
-                    // ensures that this stage will get assigned its own workspace
-                    agent { label 'candlepin' }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/unit-tests.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
+                stage('Unit tests and Sonar') {
+                    stages {
+                        stage('Unit tests') {
+                            agent { label 'candlepin' }
+                            steps {
+                                checkout scm
+                                sh './gradlew test coverage'
+                            }
+                            post {
+                                always {
+                                    stash name: 'jacocoReports', includes: 'build/**/*'
+                                    junit '**/build/test-results/**/*.xml'
+                                }
+                            }
                         }
-                    }
-                }
-                stage('Upload-PR-to-SonarQube') {
-                    agent { label 'candlepin' }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/upload-on-sonarqube.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
+                        stage('Upload-PR-to-SonarQube') {
+                            agent { label 'candlepin' }
+                            when {
+                                changeRequest()
+                            }
+                            steps {
+                                checkout scm
+                                unstash 'jacocoReports'
+                                sh "./gradlew sonar -x coverage -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.projectKey=chainsaw:candlepin-server"
+                            }
                         }
-                    }
-                }
-                stage('Upload-Branch-to-SonarQube') {
-                    agent { label 'candlepin' }
-                    environment {
-                        BRANCH_UPLOAD = 'true'
-                    }
-                    when {
-                        not {
-                            changeRequest()
-                        }
-                    }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/upload-on-sonarqube.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
+                        stage('Upload-Branch-to-SonarQube') {
+                            agent { label 'candlepin' }
+                            environment {
+                                BRANCH_UPLOAD = 'true'
+                            }
+                            when {
+                                not {
+                                    changeRequest()
+                                }
+                            }
+                            steps {
+                                checkout scm
+                                unstash 'jacocoReports'
+                                sh "./gradlew sonar -x coverage -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.projectKey=chainsaw:candlepin-server"
+                            }
                         }
                     }
                 }
                 stage('checkstyle') {
                     agent { label 'candlepin' }
                     steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
                         checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/lint.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
-                        }
-                    }
-                }
-                stage('rspec-postgresql') {
-                    agent { label 'candlepin' }
-                    environment {
-                        CANDLEPIN_DATABASE = 'postgresql'
-                        CP_TEST_ARGS = '-r'
-                    }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/rspec-tests.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
-                        }
-                    }
-                }
-                stage('rspec-mysql') {
-                    agent { label 'candlepin' }
-                    environment {
-                        CANDLEPIN_DATABASE = 'mysql'
-                        CP_TEST_ARGS = '-r'
-                    }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/rspec-tests.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
-                        }
-                    }
-                }
-                stage('rspec-postgres-hosted') {
-                    agent { label 'candlepin' }
-                    environment {
-                        CANDLEPIN_DATABASE = 'postgresql'
-                        CP_TEST_ARGS = '-H -k'
-                    }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/rspec-tests.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
-                        }
-                    }
-                }
-                stage('rspec-mysql-hosted') {
-                    agent { label 'candlepin' }
-                    environment {
-                        CANDLEPIN_DATABASE = 'mysql'
-                        CP_TEST_ARGS = '-H -k'
-                    }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/rspec-tests.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
-                        }
+                        sh './gradlew checkstyle'
                     }
                 }
                 stage('bugzilla-reference') {
@@ -166,19 +77,78 @@ pipeline {
                         BUGZILLA_TOKEN = credentials('BUGZILLA_API_TOKEN')
                     }
                     steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
                         checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
                         sh 'python jenkins/check_pr_branch.py $CHANGE_ID'
                     }
                 }
                 stage('validate-translation') {
                     agent { label 'candlepin' }
                     steps {
+                        checkout scm
+                        sh './gradlew validate_translation'
+                    }
+                }
+                stage('spec-postgresql') {
+                    agent { label 'candlepin' }
+                    environment {
+                        CANDLEPIN_DATABASE = 'postgresql'
+                        CP_TEST_ARGS = '-r'
+                    }
+                    steps {
                         sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
                         checkout scm
-                        sh 'docker login -u "$CANDLEPIN_QUAY_BOT_USR" -p "$CANDLEPIN_QUAY_BOT_PSW" quay.io'
-                        sh 'sh jenkins/candlepin-validate-text.sh'
+                        sh 'sh jenkins/rspec-tests.sh'
+                    }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
+                    }
+                }
+                stage('spec-mysql') {
+                    agent { label 'candlepin' }
+                    environment {
+                        CANDLEPIN_DATABASE = 'mysql'
+                        CP_TEST_ARGS = '-r'
+                    }
+                    steps {
+                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
+                        checkout scm
+                        sh 'sh jenkins/rspec-tests.sh'
+                    }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
+                    }
+                }
+                stage('spec-postgres-hosted') {
+                    agent { label 'candlepin' }
+                    environment {
+                        CANDLEPIN_DATABASE = 'postgresql'
+                        CP_TEST_ARGS = '-H -k'
+                    }
+                    steps {
+                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
+                        checkout scm
+                        sh 'sh jenkins/rspec-tests.sh'
+                    }
+                    post {
+                        always {
+                            sh 'sh jenkins/cleanup.sh'
+                        }
+                    }
+                }
+                stage('spec-mysql-hosted') {
+                    agent { label 'candlepin' }
+                    environment {
+                        CANDLEPIN_DATABASE = 'mysql'
+                        CP_TEST_ARGS = '-H -k'
+                    }
+                    steps {
+                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
+                        checkout scm
+                        sh 'sh jenkins/rspec-tests.sh'
                     }
                     post {
                         always {

--- a/src/test/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitorTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitorTest.java
@@ -893,7 +893,8 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
 
         OwnerProduct updated = this.ownerProductCurator.getOwnerProduct(owner.getId(), existing.getId());
         assertNotNull(updated);
-        assertEquals(orphanedDate, updated.getOrphanedDate());
+        assertEquals(orphanedDate.truncatedTo(ChronoUnit.MILLIS),
+            updated.getOrphanedDate().truncatedTo(ChronoUnit.MILLIS));
     }
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")

--- a/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -27,8 +27,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.opentest4j.AssertionFailedError;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -831,12 +833,12 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
 
         for (Map.Entry<String, Instant> entry : expected.entrySet()) {
             assertTrue(output.containsKey(entry.getKey()));
-            assertEquals(entry.getValue(), output.get(entry.getKey()));
+            assertInstantEqualsMillis(entry.getValue(), output.get(entry.getKey()));
         }
 
         for (Map.Entry<String, Instant> entry : output.entrySet()) {
             assertTrue(expected.containsKey(entry.getKey()));
-            assertEquals(entry.getValue(), expected.get(entry.getKey()));
+            assertInstantEqualsMillis(entry.getValue(), expected.get(entry.getKey()));
         }
     }
 
@@ -864,7 +866,7 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         assertNull(output.get(product1.getId()));
 
         assertTrue(output.containsKey(product2.getId()));
-        assertEquals(op2.getOrphanedDate(), output.get(product2.getId()));
+        assertInstantEqualsMillis(op2.getOrphanedDate(), output.get(product2.getId()));
     }
 
     @Test
@@ -891,7 +893,7 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         assertNull(output.get(product1.getId()));
 
         assertTrue(output.containsKey(product2.getId()));
-        assertEquals(op2.getOrphanedDate(), output.get(product2.getId()));
+        assertInstantEqualsMillis(op2.getOrphanedDate(), output.get(product2.getId()));
     }
 
     @Test
@@ -929,12 +931,12 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
 
         for (Map.Entry<String, Instant> entry : expected.entrySet()) {
             assertTrue(output.containsKey(entry.getKey()));
-            assertEquals(entry.getValue(), output.get(entry.getKey()));
+            assertInstantEqualsMillis(entry.getValue(), output.get(entry.getKey()));
         }
 
         for (Map.Entry<String, Instant> entry : output.entrySet()) {
             assertTrue(expected.containsKey(entry.getKey()));
-            assertEquals(entry.getValue(), expected.get(entry.getKey()));
+            assertInstantEqualsMillis(entry.getValue(), expected.get(entry.getKey()));
         }
     }
 
@@ -962,7 +964,7 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         assertNull(output.get(product1.getId()));
 
         assertTrue(output.containsKey(product2.getId()));
-        assertEquals(op2.getOrphanedDate(), output.get(product2.getId()));
+        assertInstantEqualsMillis(op2.getOrphanedDate(), output.get(product2.getId()));
     }
 
     @Test
@@ -989,7 +991,7 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         assertNull(output.get(product1.getId()));
 
         assertTrue(output.containsKey(product2.getId()));
-        assertEquals(op2.getOrphanedDate(), output.get(product2.getId()));
+        assertInstantEqualsMillis(op2.getOrphanedDate(), output.get(product2.getId()));
     }
 
     @Test
@@ -1036,10 +1038,10 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
             assertNotNull(refreshed);
 
             if (expected.contains(op)) {
-                assertEquals(update, refreshed.getOrphanedDate());
+                assertInstantEqualsMillis(update, refreshed.getOrphanedDate());
             }
             else {
-                assertEquals(op.getOrphanedDate(), refreshed.getOrphanedDate());
+                assertInstantEqualsMillis(op.getOrphanedDate(), refreshed.getOrphanedDate());
             }
         }
     }
@@ -1069,12 +1071,12 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         OwnerProduct refreshedOp1 = this.ownerProductCurator
             .getOwnerProduct(op1.getOwner().getId(), op1.getProduct().getId());
         assertNotNull(refreshedOp1);
-        assertEquals(update, refreshedOp1.getOrphanedDate());
+        assertInstantEqualsMillis(update, refreshedOp1.getOrphanedDate());
 
         OwnerProduct refreshedOp2 = this.ownerProductCurator
             .getOwnerProduct(op2.getOwner().getId(), op2.getProduct().getId());
         assertNotNull(refreshedOp2);
-        assertEquals(op2.getOrphanedDate(), refreshedOp2.getOrphanedDate());
+        assertInstantEqualsMillis(op2.getOrphanedDate(), refreshedOp2.getOrphanedDate());
     }
 
     @Test
@@ -1117,10 +1119,10 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
             assertNotNull(refreshed);
 
             if (expected.contains(op)) {
-                assertEquals(update, refreshed.getOrphanedDate());
+                assertInstantEqualsMillis(update, refreshed.getOrphanedDate());
             }
             else {
-                assertEquals(op.getOrphanedDate(), refreshed.getOrphanedDate());
+                assertInstantEqualsMillis(op.getOrphanedDate(), refreshed.getOrphanedDate());
             }
         }
     }
@@ -1150,12 +1152,12 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
         OwnerProduct refreshedOp1 = this.ownerProductCurator
             .getOwnerProduct(op1.getOwner().getId(), op1.getProduct().getId());
         assertNotNull(refreshedOp1);
-        assertEquals(update, refreshedOp1.getOrphanedDate());
+        assertInstantEqualsMillis(update, refreshedOp1.getOrphanedDate());
 
         OwnerProduct refreshedOp2 = this.ownerProductCurator
             .getOwnerProduct(op2.getOwner().getId(), op2.getProduct().getId());
         assertNotNull(refreshedOp2);
-        assertEquals(op2.getOrphanedDate(), refreshedOp2.getOrphanedDate());
+        assertInstantEqualsMillis(op2.getOrphanedDate(), refreshedOp2.getOrphanedDate());
     }
 
     @Test
@@ -1319,6 +1321,23 @@ public class OwnerProductCuratorTest extends DatabaseTestFixture {
 
         assertNotNull(fetched2);
         assertEquals(version2, fetched2);
+    }
+
+    /**
+     * Equivalency of dates down to milliseconds is sufficient
+     * @param date1
+     * @param date2
+     */
+    private void assertInstantEqualsMillis(Instant date1, Instant date2) {
+        if (date1 == null && date2 == null) {
+            return;
+        }
+        else if (date1 == null || date2 == null) {
+            throw new AssertionFailedError();
+        }
+        else {
+            assertEquals(date1.truncatedTo(ChronoUnit.MILLIS), date2.truncatedTo(ChronoUnit.MILLIS));
+        }
     }
 
 }


### PR DESCRIPTION
- Undockerize stages that do not have to run in a container. Only spec test stages need to run in docker.
- Reuse junit test reports in sonar to avoid running unit tests twice.