### PR TITLE
[4.2] CANDLEPIN-331: Jenkins: Reuse result of unit test stage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,7 @@ test {
         host = '*'
     }
 
-    useJUnitPlatform ()
+    useJUnitPlatform()
 
     // Sometimes causes out of memory on vagrant
     maxHeapSize = "2g"
@@ -324,6 +324,8 @@ test {
 }
 
 jacocoTestReport {
+    dependsOn test
+
     reports {
         xml.enabled true
     }
@@ -334,12 +336,17 @@ jacocoTestReport {
 }
 
 // User-friendly alias for jacocoTestReport task
-task coverage {
+tasks.register("coverage") {
     dependsOn jacocoTestReport
 }
 
-project.tasks["sonarqube"].dependsOn "test"
-project.tasks["sonarqube"].dependsOn "coverage"
+project.tasks["sonar"].dependsOn "coverage"
+sonarqube{
+    properties{
+        property "sonar.sourceEncoding","Utf-8"
+        property "sonar.exclusions","**/*generated*"
+    }
+}
 
 wrapper {
     distributionType = Wrapper.DistributionType.ALL

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -6,7 +6,7 @@ library identifier: 'fh-pipeline-library@master', retriever: modernSCM(
 pipeline {
     agent none
     options {
-        skipDefaultCheckout true
+        skipDefaultCheckout()
         timeout(time: 16, unit: 'HOURS')
         disableConcurrentBuilds(abortPrevious: true)
     }
@@ -19,68 +19,73 @@ pipeline {
         }
         stage('Test') {
             parallel {
-                stage('unit') {
-                    // ensures that this stage will get assigned its own workspace
-                    agent { label 'candlepin' }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'sh jenkins/unit-tests.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
-                            archiveArtifacts artifacts: 'unit-artifacts/**',
-                                             fingerprint: true,
-                                             onlyIfSuccessful: false
+                stage('Unit tests and Sonar') {
+                    stages {
+                        stage('Unit tests') {
+                            agent { label 'candlepin' }
+                            steps {
+                                checkout scm
+                                sh './gradlew test coverage'
+                            }
+                            post {
+                                always {
+                                    stash name: 'jacocoReports', includes: 'build/**/*'
+                                    junit '**/build/test-results/**/*.xml'
+                                }
+                            }
                         }
-                    }
-                }
-                stage('Upload-PR-to-SonarQube') {
-                    agent { label 'candlepin' }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'sh jenkins/upload-on-sonarqube.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
+                        stage('Upload-PR-to-SonarQube') {
+                            agent { label 'candlepin' }
+                            when {
+                                changeRequest()
+                            }
+                            steps {
+                                checkout scm
+                                unstash 'jacocoReports'
+                                sh "./gradlew sonar -x coverage -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.pullrequest.key=${CHANGE_ID} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.projectKey=chainsaw:candlepin-server"
+                            }
                         }
-                    }
-                }
-                stage('Upload-Branch-to-SonarQube') {
-                    agent { label 'candlepin' }
-                    environment {
-                        BRANCH_UPLOAD = 'true'
-                    }
-                    when {
-                        not {
-                            changeRequest()
-                        }
-                    }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'sh jenkins/upload-on-sonarqube.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
+                        stage('Upload-Branch-to-SonarQube') {
+                            agent { label 'candlepin' }
+                            environment {
+                                BRANCH_UPLOAD = 'true'
+                            }
+                            when {
+                                not {
+                                    changeRequest()
+                                }
+                            }
+                            steps {
+                                checkout scm
+                                unstash 'jacocoReports'
+                                sh "./gradlew sonar -x coverage -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.projectKey=chainsaw:candlepin-server"
+                            }
                         }
                     }
                 }
                 stage('checkstyle') {
                     agent { label 'candlepin' }
                     steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
                         checkout scm
-                        sh 'sh jenkins/lint.sh'
+                        sh './gradlew checkstyle'
                     }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
-                        }
+                }
+                stage('bugzilla-reference') {
+                    agent { label 'candlepin' }
+                    environment {
+                        GITHUB_TOKEN = credentials('github-api-token-as-username-password')
+                        BUGZILLA_TOKEN = credentials('BUGZILLA_API_TOKEN')
+                    }
+                    steps {
+                        checkout scm
+                        sh 'python jenkins/check_pr_branch.py $CHANGE_ID'
+                    }
+                }
+                stage('validate-translation') {
+                    agent { label 'candlepin' }
+                    steps {
+                        checkout scm
+                        sh './gradlew validate_translation'
                     }
                 }
                 stage('spec-postgresql') {
@@ -160,31 +165,6 @@ pipeline {
                             archiveArtifacts artifacts: 'spec-mysql-hosted-artifacts/**',
                                              fingerprint: true,
                                              onlyIfSuccessful: false
-                        }
-                    }
-                }
-                stage('bugzilla-reference') {
-                    agent { label 'candlepin' }
-                    environment {
-                        GITHUB_TOKEN = credentials('github-api-token-as-username-password')
-                        BUGZILLA_TOKEN = credentials('BUGZILLA_API_TOKEN')
-                    }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'python jenkins/check_pr_branch.py $CHANGE_ID'
-                    }
-                }
-                stage('validate-translation') {
-                    agent { label 'candlepin' }
-                    steps {
-                        sh 'sudo chown -R jenkins:jenkins $WORKSPACE'
-                        checkout scm
-                        sh 'sh jenkins/candlepin-validate-text.sh'
-                    }
-                    post {
-                        always {
-                            sh 'sh jenkins/cleanup.sh'
                         }
                     }
                 }


### PR DESCRIPTION
- Undockerize stages that do not have to run in a container. Only spec test stages need to run in docker.
- Reuse junit test reports in sonar to avoid running unit tests twice.