### PR TITLE
CANDLEPIN-476: Updated Pools model to avoid immutability warning

### DIFF
--- a/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -746,9 +746,13 @@ public class OwnerContentCurator extends AbstractHibernateCurator<OwnerContent> 
             return;
         }
 
+        String sql = "UPDATE " + Content.DB_TABLE + " SET entity_version = NULL " +
+            "WHERE uuid = :content_uuid";
+
         this.getEntityManager()
-            .createQuery("UPDATE Content SET entityVersion = NULL WHERE uuid = :content_uuid")
+            .createNativeQuery(sql)
             .setParameter("content_uuid", contentUuid)
+            .setHint(QueryHints.NATIVE_SPACES, Content.class.getName())
             .executeUpdate();
     }
 

--- a/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -1148,9 +1148,13 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
             return;
         }
 
+        String sql = "UPDATE " + Product.DB_TABLE + " SET entity_version = NULL " +
+            "WHERE uuid = :product_uuid";
+
         this.getEntityManager()
-            .createQuery("UPDATE Product SET entityVersion = NULL WHERE uuid = :product_uuid")
+            .createNativeQuery(sql)
             .setParameter("product_uuid", productUuid)
+            .setHint(QueryHints.NATIVE_SPACES, Product.class.getName())
             .executeUpdate();
     }
 


### PR DESCRIPTION
- Updated OwnerProductCurator.clearProductEntityVersion to use native query

The Hibernate warning messages that this PR addresses are the following:
1. HHH000502: The [product] property of the [org.candlepin.model.Pool] entity was modified, but it won't be updated because the property is immutable.
2. HHH000487: The query: [UPDATE Product SET entityVersion = NULL WHERE uuid = :product_uuid] attempts to update an immutable entity: [cp2_products]

The first error message is reproduced by running the spec tests in the RefreshPoolsSpecTest suite. I ran the same tests to validate that the changes cause the warning messages to no longer occur. The issue is that the annotation parameters `insertable = false` and `updatable = false` was marking the Pool.Product field as non updatable, but we are updating that field in the in refresh pools job.

I used the `RefreshPoolsSpecTest.shouldRegenerateEntsWhenModifiedProductIdsOfContentChange` spec test to remote debug the field access of the Pool's product uuid in the RefreshWorker.mapExistingPools method. I verified that the productuuid field is properly used instead of hydrating the whole product field. I also verified no additional database calls are made by `Hibernate.isInitialized` in Pools.getProductUuid by turning on the Hibernate debug logging and stepping over check while tailing the logs.

https://github.com/candlepin/candlepin/blob/f1fa1dbaef691029495ca893e42aed1d5c0b36dd/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java#L394

I wasn't able to recreate the second error regarding the update statement, but looking at where the hibernate error message is thrown, changing our OwnerProductCurator.clearProductEntityVersion method to use native sql instead of hsql should resolve the issue.

https://github.com/hibernate/hibernate-orm/blob/7d30b57f15617f679a20aa1389c9385433e45b2c/hibernate-core/src/main/java/org/hibernate/query/sqm/internal/QuerySqmImpl.java#L428-L434