### PR TITLE
[4.0] Fix workspace ownership

### DIFF
--- a/jenkins/candlepin-validate-text.sh
+++ b/jenkins/candlepin-validate-text.sh
@@ -13,5 +13,5 @@ chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
 # Run the validation on translations
 ./docker/test -p -c "cp-test -i -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
 RETVAL=$?
-sudo chown -R jenkins:jenkins $WORKSPACE/artifacts
+sudo chown -R jenkins:jenkins $WORKSPACE
 exit $RETVAL

--- a/jenkins/lint.sh
+++ b/jenkins/lint.sh
@@ -13,5 +13,5 @@ chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
 # Run the linter
 ./docker/test -p -c "cp-test -l -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
 RETVAL=$?
-sudo chown -R jenkins:jenkins $WORKSPACE/artifacts
+sudo chown -R jenkins:jenkins $WORKSPACE
 exit $RETVAL

--- a/jenkins/rspec-tests.sh
+++ b/jenkins/rspec-tests.sh
@@ -19,5 +19,5 @@ esac
 
 ./docker/test $TEST_DB -c "cp-test ${CP_TEST_ARGS} -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
 RETVAL=$?
-sudo chown -R jenkins:jenkins $WORKSPACE/artifacts
+sudo chown -R jenkins:jenkins $WORKSPACE
 exit $RETVAL

--- a/jenkins/unit-tests.sh
+++ b/jenkins/unit-tests.sh
@@ -13,5 +13,5 @@ chcon -Rt svirt_sandbox_file_t $WORKSPACE//artifacts/
 # Run the Candlepin unit tests
 ./docker/test -p -c "cp-test -uuu -c ${CHANGE_BRANCH}" -n "${STAGE_NAME}-${BUILD_TAG}"
 RETVAL=$?
-sudo chown -R jenkins:jenkins $WORKSPACE/artifacts
+sudo chown -R jenkins:jenkins $WORKSPACE
 exit $RETVAL


### PR DESCRIPTION
When Jenkins stage runs in docker, all build output is created under root user which prevents unprivileged staages from working.

This change returns ownership of workspace to jenkins user after each such stage.