### PR TITLE
[M] Upgrade maven openapi plugin to be in line with gradle

### DIFF
--- a/buildSrc/src/main/groovy/PomToolkit.groovy
+++ b/buildSrc/src/main/groovy/PomToolkit.groovy
@@ -151,7 +151,7 @@ class PomToolkit implements Plugin<Project> {
         def plugin = parentNode.appendNode('plugin')
         plugin.appendNode('groupId', 'org.openapitools')
         plugin.appendNode('artifactId', 'openapi-generator-maven-plugin')
-        plugin.appendNode('version', '5.4.0')
+        plugin.appendNode('version', '6.3.0')
         def executionsNode = plugin.appendNode('executions')
         def executionNode = executionsNode.appendNode('execution')
         def goalsNode = executionNode.appendNode('goals')

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-servlet-filter-adapter</artifactId>
-      <version>20.0.4</version>
+      <version>21.0.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -411,7 +411,7 @@
       <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
-        <version>5.4.0</version>
+        <version>6.3.0</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
- Openapi-generator was upgraded to 6.3.0 in gradle, but the maven plugin needs to also be upgraded.