### PR TITLE
CANDLEPIN-509: [M] Link to source cp-test

### DIFF
--- a/docker/candlepin-base-cs8/Dockerfile
+++ b/docker/candlepin-base-cs8/Dockerfile
@@ -16,7 +16,9 @@ RUN /bin/bash /root/setup-devel-env.sh
 # Script for actually running the tests, could theoretically move to candlepin
 # checkout for easier updating.
 COPY /base-scripts/setup-db.sh /root/
-COPY cp-test /usr/bin/
+
+# This allows the cp-test file in the branch to be used instead of one baked into the docker image.
+RUN ln -s /candlepin-dev/docker/cp-test /usr/bin/cp-test
 
 # Centos Streams 8 uses Python3 so we must create alias to not break existing scripts.
 RUN echo 'alias python="python3"' >> ~/.bashrc

--- a/docker/candlepin-base-cs9/Dockerfile
+++ b/docker/candlepin-base-cs9/Dockerfile
@@ -15,7 +15,9 @@ RUN /bin/bash /root/setup-devel-env.sh
 # Script for actually running the tests, could theoretically move to candlepin
 # checkout for easier updating.
 COPY /base-scripts/setup-db.sh /root/
-COPY cp-test /usr/bin/
+
+# This allows the cp-test file in the branch to be used instead of one baked into the docker image.
+RUN ln -s /candlepin-dev/docker/cp-test /usr/bin/cp-test
 
 EXPOSE 8443
 

--- a/docker/candlepin-base/Dockerfile
+++ b/docker/candlepin-base/Dockerfile
@@ -17,7 +17,9 @@ RUN /bin/bash /root/setup-supervisord.sh
 # Script for actually running the tests, could theoretically move to candlepin
 # checkout for easier updating.
 COPY /base-scripts/setup-db.sh /root/
-COPY cp-test /usr/bin/
+
+# This allows the cp-test file in the branch to be used instead of one baked into the docker image.
+RUN ln -s /candlepin-dev/docker/cp-test /usr/bin/cp-test
 
 EXPOSE 8443 22
 


### PR DESCRIPTION
This allows the cp-test file in the branch to be used instead of one baked into
 the docker image.

to test, build locally and then run the test command against it. See https://github.com/candlepin/candlepin/pull/3876 if you need the full instructions.

Note that once this makes it into the images on quay.io, none of the branches prior to 4.2 will run CI correctly until they have the change in PR https://github.com/candlepin/candlepin/pull/3876