### PR TITLE
CANDLEPIN-509: [4.1] Link to cp-test file in branch

### DIFF
--- a/docker/candlepin-base/Dockerfile.template
+++ b/docker/candlepin-base/Dockerfile.template
@@ -15,7 +15,9 @@ RUN /bin/bash /root/setup-supervisord.sh
 # Script for actually running the tests, could theoretically move to candlepin
 # checkout for easier updating.
 COPY setup-db.sh /root/
-COPY cp-test /usr/bin/
+
+# This allows the cp-test file in the branch to be used instead of one baked into the docker image.
+RUN ln -s /candlepin-dev/docker/cp-test /usr/bin/cp-test
 
 EXPOSE 8443 22
 

--- a/docker/cp-test
+++ b/docker/cp-test
@@ -1,0 +1,1 @@
+candlepin-base/cp-test


### PR DESCRIPTION
    This will allow the version of the cp-test file in the test branch
     to be used. The previous means was to use the cp-test file in the
     master branch that would get baked into the docker image.

The reason for the symlink to cp-test is that the location of the cp-test file was different in later branches. 
The symlink in the Dockerfile.template file matches the one in later branches to allow a uniform setup when an image is produced from this branch instead of master and then tested.

To test [from the docker directory in this branch]: 
./build-images 
take the hash output at the end of the process. Copy to the docker-compose-[postgres|mysql].yml file in place of "candlepin: image: **${REGISTRY}/candlepin-base**". 
run "./test -[p|m] -c '/usr/bin/cp-test -u'"

WE NEED TO WAIT ON THE MASTER CHANGE https://github.com/candlepin/candlepin/pull/3875 TO ENSURE THAT THE CI WORKS CORRECTLY ON JENKINS WITH THE MASTER IMAGE.
