### PR TITLE
CANDLEPIN-509: [4.2] Link to source cp-test

### DIFF
--- a/docker/candlepin-base-cs8/Dockerfile
+++ b/docker/candlepin-base-cs8/Dockerfile
@@ -17,7 +17,10 @@ RUN /bin/bash /root/setup-supervisord.sh
 # Script for actually running the tests, could theoretically move to candlepin
 # checkout for easier updating.
 COPY /base-scripts/setup-db.sh /root/
-COPY cp-test /usr/bin/
+
+# This allows the cp-test file in the branch to be used instead of one baked into the docker image.
+RUN ln -s /candlepin-dev/docker/cp-test /usr/bin/cp-test
+
 
 # Centos Streams 8 uses Python3 so we must create alias to not break existing scripts.
 RUN echo 'alias python="python3"' >> ~/.bashrc

--- a/docker/candlepin-base/Dockerfile
+++ b/docker/candlepin-base/Dockerfile
@@ -17,7 +17,9 @@ RUN /bin/bash /root/setup-supervisord.sh
 # Script for actually running the tests, could theoretically move to candlepin
 # checkout for easier updating.
 COPY /base-scripts/setup-db.sh /root/
-COPY cp-test /usr/bin/
+
+# This allows the cp-test file in the branch to be used instead of one baked into the docker image.
+RUN ln -s /candlepin-dev/docker/cp-test /usr/bin/cp-test
 
 EXPOSE 8443 22
 


### PR DESCRIPTION
This allows the cp-test file in the branch to be used instead of one baked into
 the docker image.

Brought here so that images can be created and tested solely in this branch.