### PR TITLE
CANDLEPIN-509: [4.0-SAT] Link to cp-test file in branch

### DIFF
--- a/docker/candlepin-base/Dockerfile.template
+++ b/docker/candlepin-base/Dockerfile.template
@@ -15,7 +15,9 @@ RUN /bin/bash /root/setup-supervisord.sh
 # Script for actually running the tests, could theoretically move to candlepin
 # checkout for easier updating.
 COPY setup-db.sh /root/
-COPY cp-test /usr/bin/
+
+# This allows the cp-test file in the branch to be used instead of one baked into the docker image.
+RUN ln -s /candlepin-dev/docker/cp-test /usr/bin/cp-test
 
 EXPOSE 8443 22
 

--- a/docker/cp-test
+++ b/docker/cp-test
@@ -1,0 +1,1 @@
+candlepin-base/cp-test


### PR DESCRIPTION
This will allow the version of the cp-test file in the test branch
 to be used. The previous means was to use the cp-test file in the
 master branch that would get baked into the docker image.

See description on https://github.com/candlepin/candlepin/pull/3876 for the details that apply here as well