### PR TITLE
[M] RPM spec file cleanup

### DIFF
--- a/candlepin.spec.tmpl
+++ b/candlepin.spec.tmpl
@@ -26,25 +26,21 @@ License: GPLv2
 Source0: %{name}-%{version}-complete.tar.gz
 Source1: %{name}-%{version}.war
 
-Obsoletes: candlepin-tomcat
-Obsoletes: candlepin-tomcat6
-Obsoletes: candlepin-devel
-Obsoletes: candlepin-certgen-lib
 Suggests: %{name}-selinux = %{version}-%{release}
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 BuildArch: noarch
 
 BuildRequires: selinux-policy-doc
-%if 0%{?rhel} == 8 || 0%{?fedora} > 29
-BuildRequires: /usr/bin/pathfix.py
-%endif
 
 Requires: java-11 >= 1:11.0.0
 Requires: wget
-## tomcatjss itself depends on jss and tomcat/pki-servlet-container/pki-servlet-engine
-## without having to worry about about the renaming of those packages.
-Requires: tomcatjss >= 7.2.1-7.1
+%if 0%{?fedora}
+Requires: tomcat
+%else
+Requires: pki-servlet-engine
+%endif
+Requires: jss
 Requires: javapackages-tools
 
 %description
@@ -93,9 +89,6 @@ SELinux policy module supporting candlepin
 
 %prep
 %setup -q %{SOURCE0}
-%if 0%{?rhel} == 8 || 0%{?fedora} > 29
-pathfix.py -pni "%{__python3} %{py3_shbang_opts}" bin/scripts/code/setup/cpdb bin/scripts/code/setup/cpsetup
-%endif
 
 %build
 cd selinux
@@ -119,14 +112,8 @@ rm -rf %{buildroot}
 
 %{__install} -d 755 %{buildroot}%{_sysconfdir}/logrotate.d/
 %{__install} -m 644 config/candlepin/logrotate.conf %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
-## logrotate 3.8 requires the su directive,
-## where as prior versions do not recognize it.
-%if 0%{?fedora} || 0%{?rhel} > 6
-sed -i 's/#LOGROTATE-3.8#//' %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
-%endif
 
 %{__install} -d -m 755 %{buildroot}/%{_datadir}/%{name}/
-
 %{__install} -m 755 bin/scripts/code/setup/cpsetup %{buildroot}/%{_datadir}/%{name}/cpsetup
 %{__install} -m 755 bin/scripts/code/setup/cpdb %{buildroot}/%{_datadir}/%{name}/cpdb
 %{__install} -m 755 bin/deployment/liquibase.sh %{buildroot}/%{_datadir}/%{name}/liquibase.sh

--- a/config/candlepin/logrotate.conf
+++ b/config/candlepin/logrotate.conf
@@ -1,9 +1,7 @@
 #1520502: Only access.log requires logrotate. Other logs are rotated by logback
 #1344469: cant use * here cause not all logs in this folder will be owned by tomcat
 /var/log/candlepin/access.log {
-# logrotate 3.8 requires the su directive,
-# where as prior versions do not recognize it.
-#LOGROTATE-3.8#    su tomcat tomcat
+    su tomcat tomcat
     copytruncate
     daily
     rotate 52


### PR DESCRIPTION
- Remove conditional statements used for RHEL 7 or earlier since now candlepin supports RHEL 8 as the minimum.
- Remove long unneeded obsoletes directives.
- Don't depend on tomcatjss, but instead directly on pki-servlet-engine and jss. The tomcatjss dependency was a hack to work around the renaming of the tomcat package from pki-servlet-container to pki-servlet-engine on RHEL 8.1.