### PR TITLE
Fix vagrant up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,7 +78,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define("el8", primary: true) do |vm_config|
-    vm_config.vm.box = "centos/stream8"
+    vm_config.vm.box = "generic/centos8s"
     vm_config.vm.host_name = "candlepin-el8.example.com"
 
     # Vagrant allows to create a forwarded port mapping which allows access to a specific port

--- a/ansible/roles/candlepin/tasks/el8/el8_base_deps.yml
+++ b/ansible/roles/candlepin/tasks/el8/el8_base_deps.yml
@@ -7,12 +7,12 @@
     - system
     - candlepin
 
-# FIXME: Update this task to use the dnf module once Ansible 2.10 or newer is readily available
 - name: "Update system packages"
   become: true
-  ansible.builtin.command:
-    cmd: dnf update -y --allowerasing
-  changed_when: false
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest
+    allowerasing: true
   tags:
     - system
     - system_update


### PR DESCRIPTION
- Switched to generic/centos8s box. The box we currently use, which got it's last update two years ago seems no longer updatable.
- Updated dnf update task to use dnf module instead of command.