### PR TITLE
[M] Remove argument requirement for build-images -c flag

### DIFF
--- a/containers/build-images
+++ b/containers/build-images
@@ -33,7 +33,7 @@ OPTIONS:
 HELP
 }
 
-while getopts ":pd:c:v" opt; do
+while getopts ":pd:cv" opt; do
   case $opt in
   h)
     usage


### PR DESCRIPTION
- Due to a regression running 'build-images -c' now fails with 'Option -c requires an argument.'. This should not be the case since -c does not need an argument.