### PR TITLE
[M] CANDLEPIN-538: Disabled FIPS mode for dev Tomcat setup

### DIFF
--- a/bin/deployment/deploy
+++ b/bin/deployment/deploy
@@ -120,6 +120,28 @@ update_legacy_keystore() {
     fi
 }
 
+configure_tomcat() {
+    if [ "$FORCECERT" == "1" ]; then
+        GEN_CERTS_ARGS="-f"
+    fi
+
+    # generate SSL certs and keystores as needed
+    $SUDO bash $SELF_DIR/gen_certs.sh $GEN_CERTS_ARGS
+
+    # Update symlink to legacy keystore if we're on an old version of TC
+    update_legacy_keystore
+
+    # update server.xml
+    $SUDO python $PROJECT_DIR/bin/deployment/update-server-xml.py --tomcat-version $TC_VERSION $CONTAINER_CONF_DIR
+
+    # create conf.d file to disable FIPS for our TC instance
+    local CONTAINER_CONFD_DIR="${CONTAINER_CONF_DIR}/conf.d"
+    local FIPS_CONF_FILE="${CONTAINER_CONFD_DIR}/candlepin_disable_fips.conf"
+
+    $SUDO sh -c "echo 'JAVA_OPTS=\"\$JAVA_OPTS -Dcom.redhat.fips=false\"' > $FIPS_CONF_FILE"
+    $SUDO sh -c "echo >> $FIPS_CONF_FILE"
+}
+
 upload_products() {
   if [ "$TESTDATA" = "1" ]; then
       $SELF_DIR/test_data_importer.py $SELF_DIR/test_data.json
@@ -365,18 +387,7 @@ fi
 # generate the DB
 gendb
 
-if [ "$FORCECERT" == "1" ]; then
-    GEN_CERTS_ARGS="-f"
-fi
-
-# generate SSL certs and keystores as needed
-$SUDO bash $SELF_DIR/gen_certs.sh $GEN_CERTS_ARGS
-
-# Update symlink to legacy keystore if we're on an old version of TC
-update_legacy_keystore
-
-# update server.xml
-$SUDO python $PROJECT_DIR/bin/deployment/update-server-xml.py --tomcat-version $TC_VERSION $CONTAINER_CONF_DIR
+configure_tomcat
 
 create_var_lib_candlepin
 configure_tomcat_root_dir

--- a/bin/scripts/code/setup/cpsetup
+++ b/bin/scripts/code/setup/cpsetup
@@ -117,6 +117,14 @@ class TomcatSetup(object):
         regex = re.compile(self.main_comment_pattern, re.MULTILINE)
         return regex.sub(self.new_java_home, original, 1)
 
+    def _write_disable_fips_conf(self):
+        filename = "candlepin_disable_fips.conf"
+        confd_dir = os.path.join(self.conf_dir, "conf.d")
+        target_file = os.path.join(confd_dir, filename)
+
+        with open(target_file, 'w') as file:
+            file.write("JAVA_OPTS=\"$JAVA_OPTS -Dcom.redhat.fips=false\"\n")
+
     def update_config(self):
         # Edit server.xml
         self._backup_config(self.conf_dir)
@@ -149,6 +157,9 @@ class TomcatSetup(object):
 
         with open(self.main_conf, 'w') as main_config:
             main_config.write(updated_main)
+
+        # Write extra config file to conf.d to disable FIPS in this TC instance:
+        self._write_disable_fips_conf()
 
     def fix_perms(self):
         run_command("chmod g+x /var/log/" + TOMCAT)
@@ -363,7 +374,6 @@ def main(argv):
     certsetup = CertSetup()
     certsetup.generate()
 
-    tsetup = TomcatSetup('/etc/' + TOMCAT, options.keystorepwd)
     tsetup.update_config()
 
     if not options.skip_service:


### PR DESCRIPTION
- The cpsetup and the deploy scripts will now create an additional config file in Tomcat's conf.d directory to set the com.redhat.fips property to false to disable FIPS mode in Candlepin's Tomcat instance