### PR TITLE
CANDLEPIN-536: Update JSON time serializer for ISO-8601

### DIFF
--- a/src/main/java/org/candlepin/jackson/OffsetDateTimeSerializer.java
+++ b/src/main/java/org/candlepin/jackson/OffsetDateTimeSerializer.java
@@ -36,7 +36,7 @@ public class OffsetDateTimeSerializer extends JsonSerializer<OffsetDateTime> {
 
     public OffsetDateTimeSerializer() {
         // This DateTimeFormatter pattern is ISO 8601 without milliseconds
-        this.dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
+        this.dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssxxx");
     }
 
     @Override

--- a/src/main/java/org/candlepin/resource/StatusResource.java
+++ b/src/main/java/org/candlepin/resource/StatusResource.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -158,7 +159,7 @@ public class StatusResource implements StatusApi {
             .modeReason(mcr != null ? mcr.toString() : null)
             .modeChangeTime(Util.toDateTime(mcr != null ? mcr.getTime() : null))
             .managerCapabilities(caps)
-            .timeUTC(OffsetDateTime.now());
+            .timeUTC(OffsetDateTime.now(ZoneOffset.UTC));
 
         if (keycloakEnabled) {
             AdapterConfig adapterConfig = keycloakConfig.getAdapterConfig();

--- a/src/test/java/org/candlepin/jackson/OffsetDateTimeSerializerTest.java
+++ b/src/test/java/org/candlepin/jackson/OffsetDateTimeSerializerTest.java
@@ -40,6 +40,6 @@ public class OffsetDateTimeSerializerTest {
         OffsetDateTime dateTime = OffsetDateTime.parse("2021-01-24T13:30:30.382+01:00");
         serializer.serialize(dateTime, jsonGenerator, null);
         jsonGenerator.flush();
-        assertEquals("\"2021-01-24T13:30:30+0100\"", stringWriter.toString());
+        assertEquals("\"2021-01-24T13:30:30+01:00\"", stringWriter.toString());
     }
 }


### PR DESCRIPTION
Update JSON time serializer to follow more strict ISO-8601 derivatives
- When we specify the format as date-time for a given field, the OpenAPI spec
 expects it to be an RFC-3339 date-time, which while close to the basic
 ISO-8601 format, does not permit omitting the colon in the offset.
- This is handled in code with the DateTimeFormatter.ISO_OFFSET_DATE_TIME
 which claims to be ISO-8601 lenient, but still has a requirement of the
 colon in the zone offset.

Ensure Status output has proper UTC time
- Previously we relied on the value to come from a system set to
  UTC already. This will ensure it is in UTC regardless of the system
  setting.