### PR TITLE
CANDLEPIN-541: Spec test improvements for Jenkins runs

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
-networkTimeout=10000
+networkTimeout=60000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/spec-tests/build.gradle
+++ b/spec-tests/build.gradle
@@ -45,6 +45,10 @@ test {
     enabled = false
 }
 
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
+}
+
 task spec(type: Test) {
     description = 'Run Java based spec tests'
     group = 'Verification'


### PR DESCRIPTION
- Extended the network timeout in the gradle-wrapper.properties to
  fix the issue of retrieving the gradle zip and Java dependencies
    
- Updated the build.gradle for the spec tests to force the use of
  UTF-8 encoding for compiling
