### PR TITLE
[M] Updated the gettext and msgfmt Gradle tasks

### DIFF
--- a/buildSrc/src/main/groovy/PomToolkit.groovy
+++ b/buildSrc/src/main/groovy/PomToolkit.groovy
@@ -203,22 +203,34 @@ class PomToolkit implements Plugin<Project> {
         def sourcesNode = configurationsNode.appendNode('sources')
         sourcesNode.appendNode('source', '${project.build.directory}/generated-sources/jpamodel/gen/java')
         sourcesNode.appendNode('source', '${project.build.directory}/generated-sources/openapi/src/gen/java')
+        sourcesNode.appendNode('source', '${project.build.directory}/generated-sources/msgfmt/gen/java')
         sourcesNode.appendNode('source', 'src/main/java')
     }
 
     private static void createGettextMavenPlugin(Node parentNode) {
         def plugin = parentNode.appendNode('plugin')
-        plugin.appendNode('groupId', 'com.googlecode.gettext-commons')
-        plugin.appendNode('artifactId', 'gettext-maven-plugin')
-        plugin.appendNode('version', '1.2.4')
+        plugin.appendNode('groupId', 'org.codehaus.mojo')
+        plugin.appendNode('artifactId', 'exec-maven-plugin')
+        plugin.appendNode('version', '3.1.0')
+
         def executionsNode = plugin.appendNode('executions')
         def executionNode = executionsNode.appendNode('execution')
-        executionNode.appendNode('phase', 'generate-resources')
+        executionNode.appendNode('phase', 'generate-sources')
+
         def goalsNode = executionNode.appendNode('goals')
-        goalsNode.appendNode('goal', 'dist')
+        goalsNode.appendNode('goal', 'exec')
+
         def configurationsNode = plugin.appendNode('configuration')
-        configurationsNode.appendNode('targetBundle', 'org.candlepin.common.i18n.Messages')
-        configurationsNode.appendNode('poDirectory', 'po')
+        configurationsNode.appendNode('executable', 'gradlew')
+        configurationsNode.appendNode('workingDirectory', '${project.basedir}')
+
+        def argumentsNode = configurationsNode.appendNode('arguments')
+        argumentsNode.appendNode('argument', 'msgfmt')
+        argumentsNode.appendNode('argument', '--no-daemon')
+        argumentsNode.appendNode('argument', '--input')
+        argumentsNode.appendNode('argument', '${project.basedir}/po')
+        argumentsNode.appendNode('argument', '--output')
+        argumentsNode.appendNode('argument', '${project.build.directory}/generated-sources/msgfmt/gen/java')
     }
 
     private static void createMavenResourcePlugin(Node parentNode) {

--- a/pom.xml
+++ b/pom.xml
@@ -468,6 +468,7 @@
               <sources>
                 <source>${project.build.directory}/generated-sources/jpamodel/gen/java</source>
                 <source>${project.build.directory}/generated-sources/openapi/src/gen/java</source>
+                <source>${project.build.directory}/generated-sources/msgfmt/gen/java</source>
                 <source>src/main/java</source>
               </sources>
             </configuration>
@@ -475,20 +476,28 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.googlecode.gettext-commons</groupId>
-        <artifactId>gettext-maven-plugin</artifactId>
-        <version>1.2.4</version>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
-            <phase>generate-resources</phase>
+            <phase>generate-sources</phase>
             <goals>
-              <goal>dist</goal>
+              <goal>exec</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <targetBundle>org.candlepin.common.i18n.Messages</targetBundle>
-          <poDirectory>po</poDirectory>
+          <executable>gradlew</executable>
+          <workingDirectory>${project.basedir}</workingDirectory>
+          <arguments>
+            <argument>msgfmt</argument>
+            <argument>--no-daemon</argument>
+            <argument>--input</argument>
+            <argument>${project.basedir}/po</argument>
+            <argument>--output</argument>
+            <argument>${project.build.directory}/generated-sources/msgfmt/gen/java</argument>
+          </arguments>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
- Added two parameters to allow specifying the input and output directories for the msgfmt Gradle task
- Added additional status output to the gettext and msgfmt tasks
- Minor refactors to the gettext task
- Updated the pom generator task to generate a pom.xml that no
  longer uses the gettest Maven plugin, and instead calls back
  into Gradle to generate source files