### PR TITLE
CANDLEPIN-544: Run liquibase update on startup [POC]

### DIFF
--- a/bin/deployment/deploy
+++ b/bin/deployment/deploy
@@ -26,7 +26,6 @@ gendb() {
 
     if [ "$GENDB" == "1" ]; then
         MESSAGE="Generating New Database"
-        CHANGELOG="changelog-create.xml"
         if [ "$USE_MYSQL" == "1" ]; then
             recreate_mysql $APP_DB_NAME $DBUSER
         else
@@ -38,32 +37,7 @@ gendb() {
         info_msg "Cleaning hornetq journal"
         $SUDO rm -rf /var/lib/candlepin/hornetq/*
         $SUDO rm -rf /var/lib/candlepin/activemq-artemis/*
-    else
-        MESSAGE="Updating Database"
-        CHANGELOG="changelog-update.xml"
     fi
-
-    info_msg "$MESSAGE"
-    LQCOMMAND="${PROJECT_DIR}/bin/deployment/liquibase.sh --driver=${JDBC_DRIVER} \
-      --classpath=build/classes/java/main/:${JDBC_JAR} --changelog-file=db/changelog/$CHANGELOG \
-      --url=${JDBC_URL} --username=candlepin --hub-mode=OFF "
-
-    if [ -n "$DBPASSWORD" ] ; then
-        LQCOMMAND="$LQCOMMAND --password=$DBPASSWORD "
-    fi
-
-    LQCOMMAND="$LQCOMMAND update -Dcommunity=True"
-
-    # At the time of writing, Liquibase does not respect any log-level parameter for reasons.
-    # So unless we're running with verbose mode set to on, we'll just pipe everything to the void.
-    if [ "$VERBOSE" == "1" ]; then
-        LQOUT=/dev/stdout
-    else
-        LQOUT=/dev/null
-    fi
-
-    (cd $PROJECT_DIR && $LQCOMMAND >$LQOUT 2>&1)
-    evalrc $? "Liquibase command failed"
 }
 
 deploy() {

--- a/config/candlepin/candlepin.conf.template
+++ b/config/candlepin/candlepin.conf.template
@@ -34,7 +34,7 @@ candlepin.pretty_print=true
 candlepin.async.scheduler.enabled=<%= candlepin.async_scheduler_enabled %>
 
 candlepin.hidden_resources=
-candlepin.db.halt_on_liquibase_desync=true
+candlepin.db.database_manage_on_startup=Manage
 
 <% if (candlepin.hidden_capabilities) { %>\
 candlepin.hidden_capabilities=<%= candlepin.hidden_capabilities %>

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -25,6 +25,7 @@ import org.candlepin.async.tasks.JobCleaner;
 import org.candlepin.async.tasks.ManifestCleanerJob;
 import org.candlepin.async.tasks.OrphanCleanupJob;
 import org.candlepin.async.tasks.UnmappedGuestEntitlementCleanerJob;
+import org.candlepin.guice.CandlepinContextListener;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -128,7 +129,7 @@ public class ConfigProperties {
     // Space separated list of resources to hide in GET /status
     public static final String HIDDEN_CAPABILITIES = "candlepin.hidden_capabilities";
 
-    public static final String HALT_ON_LIQUIBASE_DESYNC = "candlepin.db.halt_on_liquibase_desync";
+    public static final String DB_MANAGE_ON_START = "candlepin.db.database_manage_on_startup";
 
     // Authentication
     public static final String TRUSTED_AUTHENTICATION = "candlepin.auth.trusted.enable";
@@ -405,7 +406,7 @@ public class ConfigProperties {
             // submit one when registering.
             this.put(HIDDEN_RESOURCES, "environments");
             this.put(HIDDEN_CAPABILITIES, "");
-            this.put(HALT_ON_LIQUIBASE_DESYNC, "true");
+            this.put(DB_MANAGE_ON_START, CandlepinContextListener.DBManageLevel.NONE.getName());
             this.put(SSL_VERIFY, "false");
 
             this.put(FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");

--- a/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -359,49 +359,7 @@ public class CandlepinContextListenerTest {
     }
 
     @Test
-    public void hasMissingChangesets() throws Exception {
-        // needs a listener that allows checkDbChangelog()
-        listener = new CandlepinContextListener() {
-            @Override
-            protected List<Module> getModules(ServletContext context) {
-                List<Module> modules = new LinkedList<>();
-                modules.add(new TestingModules.JpaModule());
-                modules.add(new TestingModules.StandardTest(config));
-                modules.add(new ContextListenerTestModule());
-                return modules;
-            }
-
-            @Override
-            protected Configuration readConfiguration(ServletContext context) {
-                configRead.verify(context);
-                return config;
-            }
-        };
-
-        LiquibaseExtension le = new LiquibaseExtension();
-        le.createLiquibaseSchema();
-        le.runUpdate();
-        Liquibase l = le.getLiquibase();
-        ChangeSet cs = new ChangeSet("21220101",
-            "tester",
-            true,
-            true,
-            "db/changelog/21220101-test.xml",
-            null,
-            null,
-            l.getDatabaseChangeLog());
-        l.getDatabaseChangeLog().addChangeSet(cs);
-        CandlepinContextListener spy = Mockito.spy(listener);
-        doReturn(l).when(spy).getLiquibase();
-
-        // Runtime exception for changeset that is not in db
-        prepareForInitialization();
-        RuntimeException re = assertThrows(RuntimeException.class, () -> spy.contextInitialized(evt));
-        assertEquals("The database is missing Liquibase changeset(s)", re.getMessage());
-    }
-
-    @Test
-    public void hasMissingChangesetsConfigFalse() throws Exception {
+    public void hasMissingChangesetsNone() throws Exception {
         // needs a listener that allows checkDbChangelog()
         listener = new CandlepinContextListener() {
             @Override
@@ -437,9 +395,143 @@ public class CandlepinContextListenerTest {
         doReturn(l).when(spy).getLiquibase();
 
         // no Runtime exception because of config override
-        this.config.setProperty(ConfigProperties.HALT_ON_LIQUIBASE_DESYNC, "false");
+        this.config.setProperty(ConfigProperties.DB_MANAGE_ON_START,
+            CandlepinContextListener.DBManageLevel.NONE.getName());
         prepareForInitialization();
         spy.contextInitialized(evt);
+    }
+
+    @Test
+    public void hasMissingChangesetsReport() throws Exception {
+        // needs a listener that allows checkDbChangelog()
+        listener = new CandlepinContextListener() {
+            @Override
+            protected List<Module> getModules(ServletContext context) {
+                List<Module> modules = new LinkedList<>();
+                modules.add(new TestingModules.JpaModule());
+                modules.add(new TestingModules.StandardTest(config));
+                modules.add(new ContextListenerTestModule());
+                return modules;
+            }
+
+            @Override
+            protected Configuration readConfiguration(ServletContext context) {
+                configRead.verify(context);
+                return config;
+            }
+        };
+
+        LiquibaseExtension le = new LiquibaseExtension();
+        le.createLiquibaseSchema();
+        le.runUpdate();
+        Liquibase l = le.getLiquibase();
+        ChangeSet cs = new ChangeSet("21220101",
+            "tester",
+            true,
+            true,
+            "db/changelog/21220101-test.xml",
+            null,
+            null,
+            l.getDatabaseChangeLog());
+        l.getDatabaseChangeLog().addChangeSet(cs);
+        CandlepinContextListener spy = Mockito.spy(listener);
+        doReturn(l).when(spy).getLiquibase();
+
+        // no Runtime exception because of config override
+        this.config.setProperty(ConfigProperties.DB_MANAGE_ON_START,
+            CandlepinContextListener.DBManageLevel.REPORT.getName());
+        prepareForInitialization();
+        spy.contextInitialized(evt);
+    }
+
+    @Test
+    public void hasMissingChangesetsHalt() throws Exception {
+        // needs a listener that allows checkDbChangelog()
+        listener = new CandlepinContextListener() {
+            @Override
+            protected List<Module> getModules(ServletContext context) {
+                List<Module> modules = new LinkedList<>();
+                modules.add(new TestingModules.JpaModule());
+                modules.add(new TestingModules.StandardTest(config));
+                modules.add(new ContextListenerTestModule());
+                return modules;
+            }
+
+            @Override
+            protected Configuration readConfiguration(ServletContext context) {
+                configRead.verify(context);
+                return config;
+            }
+        };
+
+        LiquibaseExtension le = new LiquibaseExtension();
+        le.createLiquibaseSchema();
+        le.runUpdate();
+        Liquibase l = le.getLiquibase();
+        ChangeSet cs = new ChangeSet("21220101",
+            "tester",
+            true,
+            true,
+            "db/changelog/21220101-test.xml",
+            null,
+            null,
+            l.getDatabaseChangeLog());
+        l.getDatabaseChangeLog().addChangeSet(cs);
+        CandlepinContextListener spy = Mockito.spy(listener);
+        doReturn(l).when(spy).getLiquibase();
+
+        // Runtime exception for changeset that is not in db
+        this.config.setProperty(ConfigProperties.DB_MANAGE_ON_START,
+            CandlepinContextListener.DBManageLevel.HALT.getName());
+        prepareForInitialization();
+        RuntimeException re = assertThrows(RuntimeException.class, () -> spy.contextInitialized(evt));
+        assertEquals("The database is missing Liquibase changeset(s)", re.getMessage());
+    }
+
+    @Test
+    public void hasMissingChangesetManage() throws Exception {
+        // needs a listener that allows checkDbChangelog()
+        listener = new CandlepinContextListener() {
+            @Override
+            protected List<Module> getModules(ServletContext context) {
+                List<Module> modules = new LinkedList<>();
+                modules.add(new TestingModules.JpaModule());
+                modules.add(new TestingModules.StandardTest(config));
+                modules.add(new ContextListenerTestModule());
+                return modules;
+            }
+
+            @Override
+            protected Configuration readConfiguration(ServletContext context) {
+                configRead.verify(context);
+                return config;
+            }
+        };
+
+        LiquibaseExtension le = new LiquibaseExtension();
+        le.createLiquibaseSchema();
+        le.runUpdate();
+        Liquibase l = le.getLiquibase();
+        ChangeSet cs = new ChangeSet("21220101",
+            "tester",
+            true,
+            true,
+            "db/changelog/21220101-test.xml",
+            null,
+            null,
+            l.getDatabaseChangeLog());
+        l.getDatabaseChangeLog().addChangeSet(cs);
+        CandlepinContextListener spy = Mockito.spy(listener);
+        doReturn(l).when(spy).getLiquibase();
+
+        // no Runtime exception because update is enabled
+        this.config.setProperty(ConfigProperties.DB_MANAGE_ON_START,
+            CandlepinContextListener.DBManageLevel.MANAGE.getName());
+        prepareForInitialization();
+        spy.contextInitialized(evt);
+
+        assertEquals(1, l.getDatabaseChangeLog()
+            .getChangeSets("db/changelog/21220101-test.xml", "tester", "21220101").size());
     }
 
     private void registerDrivers(Enumeration<Driver> drivers) {


### PR DESCRIPTION
- Uses the existing lookup for unrun liquibase change sets to determine the need for executing the update.