### PR TITLE
[M] CANDLEPIN-551: Moved default user creation to DefaultUserServiceAdapter

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -35,20 +35,17 @@ paths:
 
   /admin/init:
     get:
+      deprecated: true
       description: |
-        Initializes the Candlepin database. Currently this just
-        creates the admin user for standalone deployments using the
-        default user service adapter. It must be called once after
-        candlepin is installed, repeat calls are not required, but
-        will be harmless. The String returned is the description if
-        the db was or already is initialized.
+        Deprecated. Formerly used to finish deployment by creating a default admin user in select
+        environments, but no longer performs any action. Will be removed entirely in a future release.
       tags:
         - admin
       operationId: initialize
       security: [ ]
       responses:
         200:
-          description: Candlepin successfully initialized.
+          description: always returns a 200
           content:
             text/plain:
               schema:

--- a/src/main/java/org/candlepin/resource/AdminResource.java
+++ b/src/main/java/org/candlepin/resource/AdminResource.java
@@ -15,21 +15,15 @@
 package org.candlepin.resource;
 
 import org.candlepin.audit.EventSink;
-import org.candlepin.auth.Principal;
 import org.candlepin.auth.SecurityHole;
-import org.candlepin.auth.SystemPrincipal;
 import org.candlepin.dto.api.server.v1.QueueStatus;
-import org.candlepin.model.User;
-import org.candlepin.model.UserCurator;
 import org.candlepin.resource.server.v1.AdminApi;
-import org.candlepin.service.UserServiceAdapter;
-import org.candlepin.service.impl.DefaultUserServiceAdapter;
 
-import org.jboss.resteasy.core.ResteasyContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -39,45 +33,30 @@ import javax.inject.Inject;
  * Candlepin server administration REST calls.
  */
 public class AdminResource implements AdminApi {
+    private static final Logger log = LoggerFactory.getLogger(AdminResource.class);
 
-    private static Logger log = LoggerFactory.getLogger(AdminResource.class);
-
-    private UserServiceAdapter userService;
-    private UserCurator userCurator;
-    private EventSink sink;
+    private final EventSink sink;
 
     @Inject
-    public AdminResource(UserServiceAdapter userService, UserCurator userCurator,
-        EventSink dispatcher) {
-        this.userService = userService;
-        this.userCurator = userCurator;
-        this.sink = dispatcher;
+    public AdminResource(EventSink dispatcher) {
+        this.sink = Objects.requireNonNull(dispatcher);
     }
 
+    /**
+     * Endpoint originally intended to complete a Candlepin deployment by initializing any of its
+     * services. As of 4.3.2, this endpoint should no longer be used as it no longer performs any
+     * actions and will eventually be removed.
+     *
+     * @deprecated
+     *  As of Candlepin 4.3.2, this endpoint is no longer used, and will be removed in a future
+     *  release
+     */
     @Override
     @SecurityHole(noAuth = true)
+    @Deprecated
     public String initialize() {
-        log.debug("Called initialize()");
-
-        log.info("Initializing Candlepin database.");
-
-        // All we really need to do here is create the initial admin user, if we're using
-        // the default user service adapter, and no other users exist already:
-        if (userService instanceof DefaultUserServiceAdapter &&
-            userCurator.getUserCount() == 0) {
-            // Push the system principal so we can create all these entries as a
-            // superuser:
-            ResteasyContext.pushContext(Principal.class, new SystemPrincipal());
-
-            log.info("Creating default super admin.");
-            User defaultAdmin = new User("admin", "admin", true);
-            userService.createUser(defaultAdmin);
-            return "Initialized!";
-        }
-        else {
-            // Any other user service adapter and we really have nothing to do:
-            return "Already initialized.";
-        }
+        log.warn("The init endpoint has been deprecated and will be removed in a future Candlepin release");
+        return "Already initialized.";
     }
 
     @Override

--- a/src/main/java/org/candlepin/service/impl/DefaultUserServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultUserServiceAdapter.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -52,7 +53,7 @@ import javax.inject.Inject;
  * for user creation and persistence.
  */
 public class DefaultUserServiceAdapter implements UserServiceAdapter {
-    private static Logger log = LoggerFactory.getLogger(DefaultUserServiceAdapter.class);
+    private static final Logger log = LoggerFactory.getLogger(DefaultUserServiceAdapter.class);
 
     private UserCurator userCurator;
     private RoleCurator roleCurator;
@@ -65,11 +66,26 @@ public class DefaultUserServiceAdapter implements UserServiceAdapter {
         PermissionBlueprintCurator permissionCurator, OwnerCurator ownerCurator,
         PermissionFactory permissionFactory) {
 
-        this.userCurator = userCurator;
-        this.roleCurator = roleCurator;
-        this.permissionCurator = permissionCurator;
-        this.ownerCurator = ownerCurator;
-        this.permissionFactory = permissionFactory;
+        this.userCurator = Objects.requireNonNull(userCurator);
+        this.roleCurator = Objects.requireNonNull(roleCurator);
+        this.permissionCurator = Objects.requireNonNull(permissionCurator);
+        this.ownerCurator = Objects.requireNonNull(ownerCurator);
+        this.permissionFactory = Objects.requireNonNull(permissionFactory);
+
+        this.createDefaultAdminUser();
+    }
+
+    /**
+     * Creates the default super-admin user "admin" if no other users exist in the backing user data
+     * store.
+     */
+    private void createDefaultAdminUser() {
+        if (this.userCurator.getUserCount() == 0) {
+            log.info("Creating default super-admin user");
+
+            User adminUser = new User("admin", "admin", true);
+            this.createUser(adminUser);
+        }
     }
 
     /**

--- a/src/test/java/org/candlepin/resource/AdminResourceTest.java
+++ b/src/test/java/org/candlepin/resource/AdminResourceTest.java
@@ -15,17 +15,11 @@
 package org.candlepin.resource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.audit.EventSink;
 import org.candlepin.dto.api.server.v1.QueueStatus;
-import org.candlepin.model.User;
-import org.candlepin.model.UserCurator;
-import org.candlepin.service.UserServiceAdapter;
-import org.candlepin.service.impl.DefaultUserServiceAdapter;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,41 +27,26 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+
+
 /**
  * AdminResourceTest
  */
 public class AdminResourceTest {
 
-    private UserServiceAdapter usa;
     private AdminResource ar;
-    private UserCurator uc;
     private EventSink sink;
 
     @BeforeEach
     public void init() {
-        usa = mock(DefaultUserServiceAdapter.class);
-        uc = mock(UserCurator.class);
         sink = mock(EventSink.class);
-        ar = new AdminResource(usa, uc, sink);
+        ar = new AdminResource(sink);
     }
 
     @Test
     public void initialize() {
-        when(uc.getUserCount()).thenReturn(0L);
-        assertEquals("Initialized!", ar.initialize());
-        verify(usa).createUser(any(User.class));
-    }
-
-    @Test
-    public void initWithNonDefaultUserService() {
-        ar = new AdminResource(mock(UserServiceAdapter.class), uc, null);
-        assertEquals("Already initialized.", ar.initialize());
-    }
-
-    @Test
-    public void alreadyInitialized() {
-        when(uc.getUserCount()).thenReturn(1000L);
-        assertEquals("Already initialized.", ar.initialize());
+        // Should always no-op and return the default "already initialized" string
+        assertEquals("Already initialized.", this.ar.initialize());
     }
 
     @Test

--- a/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -72,11 +73,23 @@ public class DefaultUserServiceAdapterTest extends DatabaseTestFixture {
 
     @Test
     public void testFindAllUsers() {
+        List<? extends UserInfo> users = this.service.listUsers();
+
+        // The default super-admin is always created by default, and should be present
+        assertEquals(1, users.size());
+        assertEquals("admin", users.get(0).getUsername());
+
         User user = new User("test_user", "mypassword");
         this.service.createUser(user);
-        List<? extends UserInfo> users = this.service.listUsers();
-        assertEquals(1, users.size());
-        assertEquals("test_user", users.get(0).getUsername());
+
+        users = this.service.listUsers();
+        assertEquals(2, users.size());
+
+        Set<String> usernames = users.stream()
+            .map(UserInfo::getUsername)
+            .collect(Collectors.toSet());
+
+        assertEquals(Set.of("admin", "test_user"), usernames);
     }
 
     @Test
@@ -107,10 +120,6 @@ public class DefaultUserServiceAdapterTest extends DatabaseTestFixture {
         Role adminRole = createAdminRole(owner);
         adminRole.addUser(user);
         roleCurator.create(adminRole);
-
-        //List<Owner> owners = this.service.getOwners("test_name");
-        //Assert.assertEquals(1, owners.size());
-        //Assert.assertEquals(owner, owners.get(0));
     }
 
     @Test

--- a/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -62,6 +62,7 @@ import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.OwnerInfoCurator;
 import org.candlepin.model.OwnerProductCurator;
 import org.candlepin.model.PermissionBlueprint;
+import org.candlepin.model.PermissionBlueprintCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
@@ -151,6 +152,7 @@ public class DatabaseTestFixture {
     @Inject protected OwnerCurator ownerCurator;
     @Inject protected OwnerInfoCurator ownerInfoCurator;
     @Inject protected OwnerProductCurator ownerProductCurator;
+    @Inject protected PermissionBlueprintCurator permissionBlueprintCurator;
     @Inject protected ProductCertificateCurator productCertificateCurator;
     @Inject protected ProductCurator productCurator;
     @Inject protected ContentAccessCertificateCurator caCertCurator;


### PR DESCRIPTION
- Moved the default super-admin user creation from the AdminResource.init endpoint to the DefaultUserServiceAdapter's construction step
- Marked the AdminResource.init endpoint deprecated; will remove in a future release