### PR TITLE
Fix copyright header generation and checkstyle

### DIFF
--- a/.idea/copyright/GPLv2.xml
+++ b/.idea/copyright/GPLv2.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
     <option name="myName" value="GPLv2" />
-    <option name="notice" value=" Copyright (c) 2009 - &amp;#36;{YEAR} Red Hat, Inc.&#10; &#10; This software is licensed to you under the GNU General Public License,&#10; version 2 (GPLv2). There is NO WARRANTY for this software, express or&#10; implied, including the implied warranties of MERCHANTABILITY or FITNESS&#10; FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2&#10; along with this software; if not, see&#10; http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.&#10; &#10; Red Hat trademarks are not licensed under GPLv2. No permission is&#10; granted to use or replicate Red Hat trademarks that are incorporated&#10; in this software or its documentation." />
+    <option name="notice" value="Copyright (c) 2009 - &amp;#36;{today.year} Red Hat, Inc.&#10; &#10;This software is licensed to you under the GNU General Public License,&#10;version 2 (GPLv2). There is NO WARRANTY for this software, express or&#10;implied, including the implied warranties of MERCHANTABILITY or FITNESS&#10;FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2&#10;along with this software; if not, see&#10;http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.&#10;&#10;Red Hat trademarks are not licensed under GPLv2. No permission is&#10;granted to use or replicate Red Hat trademarks that are incorporated&#10;in this software or its documentation." />
   </copyright>
 </component>

--- a/config/checkstyle/HEADER.txt
+++ b/config/checkstyle/HEADER.txt
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -63,7 +63,7 @@
      ##########################################################################
    -->
   <module name="RegexpHeader">
-    <property name="header" value="^/\*\*$\n^ \* Copyright \(c\) 20\d\d - 20\d\d Red Hat, Inc.$"/>
+    <property name="header" value="^/\*$\n^ \* Copyright \(c\) 20\d\d - 20\d\d Red Hat, Inc.$"/>
   </module>
   <module name="Header">
     <property name="headerFile" value="${config_loc}/HEADER.txt" />

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,3 @@
 rootProject.name = "candlepin"
 include 'client'
 include 'spec-tests'
-

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/ApiExceptionAdapter.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/ApiExceptionAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import org.candlepin.invoker.client.ApiException;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CandlepinMode.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CandlepinMode.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import org.candlepin.dto.api.client.v1.StatusDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CandlepinStatusAssert.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CandlepinStatusAssert.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import org.candlepin.invoker.client.ApiException;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CapabilityEnable.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CapabilityEnable.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import org.candlepin.invoker.client.ApiException;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CertificateAssert.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CertificateAssert.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/ComplianceAssert.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/ComplianceAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/JobStatusAssert.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/JobStatusAssert.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import org.candlepin.dto.api.client.v1.AsyncJobStatusDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/OnlyInHosted.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/OnlyInHosted.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import org.junit.jupiter.api.Tag;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/OnlyInStandalone.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/OnlyInStandalone.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import org.junit.jupiter.api.Tag;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/OnlyWithCapability.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/OnlyWithCapability.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/ReasonAttributes.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/ReasonAttributes.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import java.util.Map;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/StatusCodeAssertions.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/StatusCodeAssertions.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClientFactory.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClientFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClients.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClients.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ConfigKey.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ConfigKey.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client;
 
 /**

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/DefaultProperties.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/DefaultProperties.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client;
 
 import java.io.IOException;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ExternalProperties.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ExternalProperties.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client;
 
 import org.slf4j.Logger;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/PropertiesConfiguration.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/PropertiesConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client;
 
 import org.slf4j.Logger;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/SpecTest.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/SpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client;
 
 import org.junit.jupiter.api.Tag;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/SystemProperties.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/SystemProperties.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client;
 
 import java.util.Properties;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/ConsumerClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/ConsumerClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client.api;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/EnvironmentClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/EnvironmentClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/JobsClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/JobsClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/OwnerClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/OwnerClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client.api;
 
 import org.candlepin.dto.api.client.v1.AsyncJobStatusDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/Paging.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/Paging.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client.api;
 
 /**

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/PoolsClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/PoolsClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client.api;
 
 import org.candlepin.dto.api.client.v1.PoolDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/RulesClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/RulesClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client.api;
 
 import org.candlepin.invoker.client.ApiClient;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/cert/CertificateParsingFailedException.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/cert/CertificateParsingFailedException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client.cert;
 
 public class CertificateParsingFailedException extends RuntimeException {

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/cert/X509Cert.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/cert/X509Cert.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client.cert;
 
 import org.candlepin.dto.api.client.v1.CertificateDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/JsonDeserializationException.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/JsonDeserializationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/JsonSerializationException.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/JsonSerializationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Request.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Request.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/RequestException.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/RequestException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Response.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Response.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/ResponseProcessingException.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/ResponseProcessingException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ActivationKeys.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ActivationKeys.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.ActivationKeyDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Branding.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Branding.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Cdns.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Cdns.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ConsumerTypes.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ConsumerTypes.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.ConsumerTypeDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Consumers.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Consumers.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.ConsumerDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ContentOverrides.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ContentOverrides.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.ConsumerDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Contents.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Contents.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Environments.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Environments.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Export.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Export.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.ConsumerDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ExportCdn.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ExportCdn.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 public class ExportCdn {

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ExportGenerator.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ExportGenerator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.CdnDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Facts.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Facts.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import java.util.Map;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/HypervisorTestData.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/HypervisorTestData.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.GuestIdDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/OID.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/OID.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.ContentDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Owners.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Owners.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import static java.util.Objects.requireNonNull;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Permissions.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Permissions.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.OwnerDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/PoolAttributes.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/PoolAttributes.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.AttributeDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Pools.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Pools.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.PoolDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ProductAttributes.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ProductAttributes.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.AttributeDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Products.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Products.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Roles.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Roles.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.OwnerDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Subscriptions.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Subscriptions.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.OwnerDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Users.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Users.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/CertificateUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/CertificateUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/DateUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/DateUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.util;
 
 import java.time.OffsetDateTime;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/ExportUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/ExportUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/StringUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/StringUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.util;
 
 import java.util.Random;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/UserUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/UserUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.util;
 
 import org.candlepin.dto.api.client.v1.OwnerDTO;

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/X509HuffmanDecodeUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/X509HuffmanDecodeUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.data.util;
 
 import org.slf4j.Logger;

--- a/spec-tests/src/test/java/org/candlepin/spec/AutobindDisabledForOwnerSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/AutobindDisabledForOwnerSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec;
 
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertBadRequest;

--- a/spec-tests/src/test/java/org/candlepin/spec/ContentDeliveryNetworkSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ContentDeliveryNetworkSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/ContentResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ContentResourceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/DistributorCapabilitySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/DistributorCapabilitySpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/EntitlementCertificateSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/EntitlementCertificateSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec;
 
 

--- a/spec-tests/src/test/java/org/candlepin/spec/ExportSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ExportSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/HostedTestSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/HostedTestSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/InstanceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/InstanceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/MultiplierSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/MultiplierSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/ResponseFilteringSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ResponseFilteringSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/RoleResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/RoleResourceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec;
 
 import static org.assertj.core.api.Assertions.as;

--- a/spec-tests/src/test/java/org/candlepin/spec/RulesImportSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/RulesImportSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/StatusSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/StatusSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/SubscriptionResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/SubscriptionResourceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/SystemAdminSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/SystemAdminSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/UserResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/UserResourceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/VirtSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/VirtSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/activationkey/ActivationKeySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/activationkey/ActivationKeySpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.activationkey;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/auth/ActivationKeyAuthSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/auth/ActivationKeyAuthSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/auth/BasicAuthSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/auth/BasicAuthSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/auth/NoAuthSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/auth/NoAuthSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/auth/OauthSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/auth/OauthSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/auth/SslAuthSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/auth/SslAuthSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/auth/TrustedConsumerAuthSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/auth/TrustedConsumerAuthSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/auth/TrustedUserAuthSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/auth/TrustedUserAuthSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/bootstrap/client/DefaultPropertiesTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/bootstrap/client/DefaultPropertiesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/bootstrap/client/ExternalPropertiesTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/bootstrap/client/ExternalPropertiesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.bootstrap.client;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerBonusPoolSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerBonusPoolSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerCheckinSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerCheckinSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerFactsSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerFactsSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceActivationKeySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceActivationKeySpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.consumers;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceContentAccessSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceContentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceContentSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.consumers;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceDevSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceDevSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.consumers;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceEntitlementSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceEntitlementSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceEnvironmentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceEnvironmentSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceHostGuestSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceHostGuestSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.consumers;
 
 import static java.lang.Thread.sleep;

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceHypervisorIdSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceHypervisorIdSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceSystemPurposeSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceSystemPurposeSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/DeletedConsumerSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/DeletedConsumerSpecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/DomainConsumerSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/DomainConsumerSpecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/IdentityCertificateSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/IdentityCertificateSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.consumers;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/LocalizationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/LocalizationSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.consumers;
 
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertThatStatus;

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/PersonConsumerSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/PersonConsumerSpecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,

--- a/spec-tests/src/test/java/org/candlepin/spec/content/ConditionalContentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ConditionalContentSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentVersioningSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentVersioningSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.content;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/content/SkuLevelEnableOverrideSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/SkuLevelEnableOverrideSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.content;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/AutobindSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/AutobindSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/CertRevocationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/CertRevocationSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -201,4 +201,3 @@ class CertRevocationSpecTest {
         return null;
     }
 }
-

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/ClientV1SizeSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/ClientV1SizeSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/CoreAndRamLimitingSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/CoreAndRamLimitingSpecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/CoreSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/CoreSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/DerivedProductSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/DerivedProductSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementCertificateV3SpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementCertificateV3SpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementComplianceReasonsSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementComplianceReasonsSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementMigrateSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementMigrateSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceConcurrentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceConcurrentSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceFilteringSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceFilteringSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -200,4 +200,3 @@ class EntitlementResourceSpecTest {
     }
 
 }
-

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.as;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/HealingSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/HealingSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/RamSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/RamSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/StackingComplianceReasonsSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/StackingComplianceReasonsSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/StorageBandSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/StorageBandSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/UeberCertSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/UeberCertSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/UnbindSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/UnbindSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/UnmappedGuestSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/UnmappedGuestSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/VcpuSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/VcpuSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/VirtOnlySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/VirtOnlySpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.entitlements;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentCertV3SpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentCertV3SpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.environments;
 
 import static org.assertj.core.api.Assertions.as;

--- a/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentPrioritySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentPrioritySpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.environments;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.environments;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/hypervisors/GuestsIdResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/hypervisors/GuestsIdResourceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.hypervisors;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/hypervisors/HypervisorCheckInSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/hypervisors/HypervisorCheckInSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.hypervisors;
 
 import static java.lang.Thread.sleep;

--- a/spec-tests/src/test/java/org/candlepin/spec/hypervisors/HypervisorHeartbeatSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/hypervisors/HypervisorHeartbeatSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.hypervisors;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/DerivedProductImportSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/DerivedProductImportSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.imports;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportCleanupSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportCleanupSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.imports;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportEnvironmentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportEnvironmentSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.imports;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportErrorSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportErrorSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.imports;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportSuccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportSuccessSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.imports;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportUndoSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportUndoSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.imports;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportUpdateSinglePoolSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportUpdateSinglePoolSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.imports;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportUpdateSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportUpdateSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.imports;
 
 import static java.lang.Thread.sleep;

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportWarningSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportWarningSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.imports;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/InactiveConsumerCleanerJobSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/InactiveConsumerCleanerJobSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.jobs;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/JobScheduleSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/JobScheduleSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.jobs;
 
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertForbidden;

--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/JobStatusSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/JobStatusSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.jobs;
 
 import static java.lang.Thread.sleep;

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceConsumerFactFilterSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceConsumerFactFilterSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.owners;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceCountingFeatureSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceCountingFeatureSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.owners;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceEntitlementListSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceEntitlementListSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.owners;
 
 import static org.assertj.core.api.Assertions.as;

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceFuturePoolSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceFuturePoolSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.owners;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceOwnerInfoSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceOwnerInfoSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.owners;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourcePoolFilterSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourcePoolFilterSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.owners;
 
 import static org.assertj.core.api.Assertions.as;

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/OneSubPoolPerStackSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/OneSubPoolPerStackSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.pools;
 
 import static java.lang.Thread.sleep;

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/PoolSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/PoolSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/PoolUnlimitedPrimarySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/PoolUnlimitedPrimarySpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.pools;
 
 

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/PostBindBonusPoolSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/PostBindBonusPoolSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/RefreshPoolsSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/RefreshPoolsSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/products/ProductCertSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/products/ProductCertSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.products;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/spec-tests/src/test/java/org/candlepin/spec/products/ProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/products/ProductResourceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/spec-tests/src/test/java/org/candlepin/spec/products/ProductVersioningSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/products/ProductVersioningSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.products;
 
 

--- a/spec-tests/src/test/java/org/candlepin/spec/system/SystemPurposeComplianceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/system/SystemPurposeComplianceSpecTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.spec.system;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/main/java/net/oauth/signature/CustomSigner.java
+++ b/src/main/java/net/oauth/signature/CustomSigner.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/ArgumentConversionException.java
+++ b/src/main/java/org/candlepin/async/ArgumentConversionException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/AsyncJob.java
+++ b/src/main/java/org/candlepin/async/AsyncJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobArguments.java
+++ b/src/main/java/org/candlepin/async/JobArguments.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobConfig.java
+++ b/src/main/java/org/candlepin/async/JobConfig.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobConfigValidationException.java
+++ b/src/main/java/org/candlepin/async/JobConfigValidationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobConstraint.java
+++ b/src/main/java/org/candlepin/async/JobConstraint.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobConstraints.java
+++ b/src/main/java/org/candlepin/async/JobConstraints.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobException.java
+++ b/src/main/java/org/candlepin/async/JobException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobExecutionContext.java
+++ b/src/main/java/org/candlepin/async/JobExecutionContext.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobExecutionException.java
+++ b/src/main/java/org/candlepin/async/JobExecutionException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobInitializationException.java
+++ b/src/main/java/org/candlepin/async/JobInitializationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobManager.java
+++ b/src/main/java/org/candlepin/async/JobManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobMessage.java
+++ b/src/main/java/org/candlepin/async/JobMessage.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobMessageDispatchException.java
+++ b/src/main/java/org/candlepin/async/JobMessageDispatchException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobMessageDispatcher.java
+++ b/src/main/java/org/candlepin/async/JobMessageDispatcher.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobMessageReceiver.java
+++ b/src/main/java/org/candlepin/async/JobMessageReceiver.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/JobStateManagementException.java
+++ b/src/main/java/org/candlepin/async/JobStateManagementException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/ResultSerializationException.java
+++ b/src/main/java/org/candlepin/async/ResultSerializationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/StateManagementException.java
+++ b/src/main/java/org/candlepin/async/StateManagementException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/impl/ActiveMQSessionFactory.java
+++ b/src/main/java/org/candlepin/async/impl/ActiveMQSessionFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/impl/ThrottledByJobKeyConstraint.java
+++ b/src/main/java/org/candlepin/async/impl/ThrottledByJobKeyConstraint.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/impl/UniqueByArgConstraint.java
+++ b/src/main/java/org/candlepin/async/impl/UniqueByArgConstraint.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/ActiveEntitlementJob.java
+++ b/src/main/java/org/candlepin/async/tasks/ActiveEntitlementJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/CertificateCleanupJob.java
+++ b/src/main/java/org/candlepin/async/tasks/CertificateCleanupJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/EntitleByProductsJob.java
+++ b/src/main/java/org/candlepin/async/tasks/EntitleByProductsJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/EntitlerJob.java
+++ b/src/main/java/org/candlepin/async/tasks/EntitlerJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.async.tasks;
 
 import org.candlepin.async.ArgumentConversionException;

--- a/src/main/java/org/candlepin/async/tasks/ExpiredPoolsCleanupJob.java
+++ b/src/main/java/org/candlepin/async/tasks/ExpiredPoolsCleanupJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/ExportJob.java
+++ b/src/main/java/org/candlepin/async/tasks/ExportJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
+++ b/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/HypervisorHeartbeatUpdateJob.java
+++ b/src/main/java/org/candlepin/async/tasks/HypervisorHeartbeatUpdateJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/HypervisorUpdateJob.java
+++ b/src/main/java/org/candlepin/async/tasks/HypervisorUpdateJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/ImportJob.java
+++ b/src/main/java/org/candlepin/async/tasks/ImportJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/ImportRecordCleanerJob.java
+++ b/src/main/java/org/candlepin/async/tasks/ImportRecordCleanerJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/InactiveConsumerCleanerJob.java
+++ b/src/main/java/org/candlepin/async/tasks/InactiveConsumerCleanerJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.async.tasks;
 
 import org.candlepin.async.AsyncJob;

--- a/src/main/java/org/candlepin/async/tasks/JobCleaner.java
+++ b/src/main/java/org/candlepin/async/tasks/JobCleaner.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.async.tasks;
 
 import org.candlepin.async.AsyncJob;

--- a/src/main/java/org/candlepin/async/tasks/ManifestCleanerJob.java
+++ b/src/main/java/org/candlepin/async/tasks/ManifestCleanerJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/OrphanCleanupJob.java
+++ b/src/main/java/org/candlepin/async/tasks/OrphanCleanupJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/RefreshPoolsForProductJob.java
+++ b/src/main/java/org/candlepin/async/tasks/RefreshPoolsForProductJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
+++ b/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/RegenEnvEntitlementCertsJob.java
+++ b/src/main/java/org/candlepin/async/tasks/RegenEnvEntitlementCertsJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/RegenProductEntitlementCertsJob.java
+++ b/src/main/java/org/candlepin/async/tasks/RegenProductEntitlementCertsJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/UndoImportsJob.java
+++ b/src/main/java/org/candlepin/async/tasks/UndoImportsJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/async/tasks/UnmappedGuestEntitlementCleanerJob.java
+++ b/src/main/java/org/candlepin/async/tasks/UnmappedGuestEntitlementCleanerJob.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/ActivationListener.java
+++ b/src/main/java/org/candlepin/audit/ActivationListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/ActiveMQContextListener.java
+++ b/src/main/java/org/candlepin/audit/ActiveMQContextListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/ActiveMQStatus.java
+++ b/src/main/java/org/candlepin/audit/ActiveMQStatus.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.audit;
 
 /**

--- a/src/main/java/org/candlepin/audit/ArtemisMessageSource.java
+++ b/src/main/java/org/candlepin/audit/ArtemisMessageSource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/ArtemisMessageSourceReceiverFactory.java
+++ b/src/main/java/org/candlepin/audit/ArtemisMessageSourceReceiverFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/DefaultEventMessageReceiver.java
+++ b/src/main/java/org/candlepin/audit/DefaultEventMessageReceiver.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/Event.java
+++ b/src/main/java/org/candlepin/audit/Event.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/EventAdapter.java
+++ b/src/main/java/org/candlepin/audit/EventAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/EventAdapterImpl.java
+++ b/src/main/java/org/candlepin/audit/EventAdapterImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/EventBuilder.java
+++ b/src/main/java/org/candlepin/audit/EventBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/src/main/java/org/candlepin/audit/EventFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/EventFilter.java
+++ b/src/main/java/org/candlepin/audit/EventFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/EventListener.java
+++ b/src/main/java/org/candlepin/audit/EventListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/EventMessageReceiver.java
+++ b/src/main/java/org/candlepin/audit/EventMessageReceiver.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/EventSink.java
+++ b/src/main/java/org/candlepin/audit/EventSink.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/EventSinkImpl.java
+++ b/src/main/java/org/candlepin/audit/EventSinkImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/LoggingListener.java
+++ b/src/main/java/org/candlepin/audit/LoggingListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/MessageAddress.java
+++ b/src/main/java/org/candlepin/audit/MessageAddress.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/audit/MessageReceiver.java
+++ b/src/main/java/org/candlepin/audit/MessageReceiver.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.audit;
 
 import org.candlepin.async.impl.ActiveMQSessionFactory;

--- a/src/main/java/org/candlepin/audit/MessageSource.java
+++ b/src/main/java/org/candlepin/audit/MessageSource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.audit;
 
 import org.candlepin.controller.ActiveMQStatusListener;

--- a/src/main/java/org/candlepin/audit/MessageSourceReceiverFactory.java
+++ b/src/main/java/org/candlepin/audit/MessageSourceReceiverFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.audit;
 
 

--- a/src/main/java/org/candlepin/audit/NoopEventSinkImpl.java
+++ b/src/main/java/org/candlepin/audit/NoopEventSinkImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/Access.java
+++ b/src/main/java/org/candlepin/auth/Access.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/ActivationKeyAuth.java
+++ b/src/main/java/org/candlepin/auth/ActivationKeyAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/ActivationKeyPrincipal.java
+++ b/src/main/java/org/candlepin/auth/ActivationKeyPrincipal.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/AuthProvider.java
+++ b/src/main/java/org/candlepin/auth/AuthProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/BasicAuth.java
+++ b/src/main/java/org/candlepin/auth/BasicAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/CandlepinKeycloakRequestAuthenticator.java
+++ b/src/main/java/org/candlepin/auth/CandlepinKeycloakRequestAuthenticator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,8 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
-
 package org.candlepin.auth;
 
 import org.jboss.resteasy.spi.HttpRequest;

--- a/src/main/java/org/candlepin/auth/CloudRegistrationAuth.java
+++ b/src/main/java/org/candlepin/auth/CloudRegistrationAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.auth;
 
 import org.candlepin.auth.permissions.OwnerPermission;

--- a/src/main/java/org/candlepin/auth/CloudRegistrationData.java
+++ b/src/main/java/org/candlepin/auth/CloudRegistrationData.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/ConsumerAuth.java
+++ b/src/main/java/org/candlepin/auth/ConsumerAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
+++ b/src/main/java/org/candlepin/auth/ConsumerPrincipal.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/ExternalSystemPrincipal.java
+++ b/src/main/java/org/candlepin/auth/ExternalSystemPrincipal.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/JobPrincipal.java
+++ b/src/main/java/org/candlepin/auth/JobPrincipal.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/KeycloakAuth.java
+++ b/src/main/java/org/candlepin/auth/KeycloakAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.auth;
 
 import org.candlepin.auth.permissions.PermissionFactory;

--- a/src/main/java/org/candlepin/auth/KeycloakConfiguration.java
+++ b/src/main/java/org/candlepin/auth/KeycloakConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.auth;
 
 

--- a/src/main/java/org/candlepin/auth/KeycloakOIDCFacade.java
+++ b/src/main/java/org/candlepin/auth/KeycloakOIDCFacade.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.auth;
 
 import org.candlepin.exceptions.CandlepinException;

--- a/src/main/java/org/candlepin/auth/NoAuthPrincipal.java
+++ b/src/main/java/org/candlepin/auth/NoAuthPrincipal.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/OAuth.java
+++ b/src/main/java/org/candlepin/auth/OAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/Principal.java
+++ b/src/main/java/org/candlepin/auth/Principal.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/PrincipalData.java
+++ b/src/main/java/org/candlepin/auth/PrincipalData.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/SSLAuth.java
+++ b/src/main/java/org/candlepin/auth/SSLAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/SecurityHole.java
+++ b/src/main/java/org/candlepin/auth/SecurityHole.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/SubResource.java
+++ b/src/main/java/org/candlepin/auth/SubResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/SystemPrincipal.java
+++ b/src/main/java/org/candlepin/auth/SystemPrincipal.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/TrustedConsumerAuth.java
+++ b/src/main/java/org/candlepin/auth/TrustedConsumerAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/TrustedExternalSystemAuth.java
+++ b/src/main/java/org/candlepin/auth/TrustedExternalSystemAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/TrustedUserAuth.java
+++ b/src/main/java/org/candlepin/auth/TrustedUserAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/TrustedUserPrincipal.java
+++ b/src/main/java/org/candlepin/auth/TrustedUserPrincipal.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/UpdateConsumerCheckIn.java
+++ b/src/main/java/org/candlepin/auth/UpdateConsumerCheckIn.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/UserAuth.java
+++ b/src/main/java/org/candlepin/auth/UserAuth.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/UserPrincipal.java
+++ b/src/main/java/org/candlepin/auth/UserPrincipal.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/Verify.java
+++ b/src/main/java/org/candlepin/auth/Verify.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/AsyncJobStatusPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/AsyncJobStatusPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/AttachPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/AttachPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/ConsumerEntitlementPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ConsumerEntitlementPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/ConsumerOrgHypervisorPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ConsumerOrgHypervisorPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/ConsumerPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ConsumerPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/ConsumerServiceLevelsPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ConsumerServiceLevelsPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/OwnerPoolsPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/OwnerPoolsPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/Permission.java
+++ b/src/main/java/org/candlepin/auth/permissions/Permission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/PermissionFactory.java
+++ b/src/main/java/org/candlepin/auth/permissions/PermissionFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/TypedPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/TypedPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/UserUserPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/UserUserPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/BindChain.java
+++ b/src/main/java/org/candlepin/bind/BindChain.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/BindChainFactory.java
+++ b/src/main/java/org/candlepin/bind/BindChainFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/BindContext.java
+++ b/src/main/java/org/candlepin/bind/BindContext.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/BindContextFactory.java
+++ b/src/main/java/org/candlepin/bind/BindContextFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/BindOperation.java
+++ b/src/main/java/org/candlepin/bind/BindOperation.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/CheckBonusPoolQuantitiesOp.java
+++ b/src/main/java/org/candlepin/bind/CheckBonusPoolQuantitiesOp.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/ComplianceOp.java
+++ b/src/main/java/org/candlepin/bind/ComplianceOp.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/HandleCertificatesOp.java
+++ b/src/main/java/org/candlepin/bind/HandleCertificatesOp.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/HandleEntitlementsOp.java
+++ b/src/main/java/org/candlepin/bind/HandleEntitlementsOp.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/PoolOperationCallback.java
+++ b/src/main/java/org/candlepin/bind/PoolOperationCallback.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/PostBindBonusPoolsOp.java
+++ b/src/main/java/org/candlepin/bind/PostBindBonusPoolsOp.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/PreEntitlementRulesCheckOp.java
+++ b/src/main/java/org/candlepin/bind/PreEntitlementRulesCheckOp.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/bind/PreEntitlementRulesCheckOpFactory.java
+++ b/src/main/java/org/candlepin/bind/PreEntitlementRulesCheckOpFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/cache/CandlepinCache.java
+++ b/src/main/java/org/candlepin/cache/CandlepinCache.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/cache/CandlepinCacheRegions.java
+++ b/src/main/java/org/candlepin/cache/CandlepinCacheRegions.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/cache/JCacheManagerProvider.java
+++ b/src/main/java/org/candlepin/cache/JCacheManagerProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/cache/StatusCache.java
+++ b/src/main/java/org/candlepin/cache/StatusCache.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/AbstractConfiguration.java
+++ b/src/main/java/org/candlepin/config/AbstractConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.config;
 
 import static org.candlepin.config.ConfigurationPrefixes.JPA_CONFIG_PREFIX;

--- a/src/main/java/org/candlepin/config/Configuration.java
+++ b/src/main/java/org/candlepin/config/Configuration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/ConfigurationException.java
+++ b/src/main/java/org/candlepin/config/ConfigurationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/ConfigurationFileLoader.java
+++ b/src/main/java/org/candlepin/config/ConfigurationFileLoader.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/ConfigurationPrefixes.java
+++ b/src/main/java/org/candlepin/config/ConfigurationPrefixes.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/ConversionException.java
+++ b/src/main/java/org/candlepin/config/ConversionException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/DatabaseConfigFactory.java
+++ b/src/main/java/org/candlepin/config/DatabaseConfigFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/EncryptedConfiguration.java
+++ b/src/main/java/org/candlepin/config/EncryptedConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/FileConfiguration.java
+++ b/src/main/java/org/candlepin/config/FileConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/MapConfiguration.java
+++ b/src/main/java/org/candlepin/config/MapConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/PropertiesFileConfiguration.java
+++ b/src/main/java/org/candlepin/config/PropertiesFileConfiguration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/config/PropertyConverter.java
+++ b/src/main/java/org/candlepin/config/PropertyConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/ActiveMQStatusListener.java
+++ b/src/main/java/org/candlepin/controller/ActiveMQStatusListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
+++ b/src/main/java/org/candlepin/controller/ActiveMQStatusMonitor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/AutobindDisabledForOwnerException.java
+++ b/src/main/java/org/candlepin/controller/AutobindDisabledForOwnerException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/AutobindHypervisorDisabledException.java
+++ b/src/main/java/org/candlepin/controller/AutobindHypervisorDisabledException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
+++ b/src/main/java/org/candlepin/controller/CandlepinPoolManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/CdnManager.java
+++ b/src/main/java/org/candlepin/controller/CdnManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/src/main/java/org/candlepin/controller/ContentManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/Entitler.java
+++ b/src/main/java/org/candlepin/controller/Entitler.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/ImportResult.java
+++ b/src/main/java/org/candlepin/controller/ImportResult.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/MalformedEntityReferenceException.java
+++ b/src/main/java/org/candlepin/controller/MalformedEntityReferenceException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/ManifestManager.java
+++ b/src/main/java/org/candlepin/controller/ManifestManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/OwnerContentAccess.java
+++ b/src/main/java/org/candlepin/controller/OwnerContentAccess.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller;
 
 import java.util.Objects;

--- a/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/src/main/java/org/candlepin/controller/PoolManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/src/main/java/org/candlepin/controller/ProductManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/Refresher.java
+++ b/src/main/java/org/candlepin/controller/Refresher.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/ScheduledExecutorServiceProvider.java
+++ b/src/main/java/org/candlepin/controller/ScheduledExecutorServiceProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/SuspendModeTransitioner.java
+++ b/src/main/java/org/candlepin/controller/SuspendModeTransitioner.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/mode/CandlepinModeManager.java
+++ b/src/main/java/org/candlepin/controller/mode/CandlepinModeManager.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/mode/ModeChangeListener.java
+++ b/src/main/java/org/candlepin/controller/mode/ModeChangeListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/mode/ModeChangeReason.java
+++ b/src/main/java/org/candlepin/controller/mode/ModeChangeReason.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/RefreshResult.java
+++ b/src/main/java/org/candlepin/controller/refresher/RefreshResult.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
+++ b/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/builders/ContentNodeBuilder.java
+++ b/src/main/java/org/candlepin/controller/refresher/builders/ContentNodeBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/builders/NodeBuilder.java
+++ b/src/main/java/org/candlepin/controller/refresher/builders/NodeBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/builders/NodeFactory.java
+++ b/src/main/java/org/candlepin/controller/refresher/builders/NodeFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/builders/PoolNodeBuilder.java
+++ b/src/main/java/org/candlepin/controller/refresher/builders/PoolNodeBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/builders/ProductNodeBuilder.java
+++ b/src/main/java/org/candlepin/controller/refresher/builders/ProductNodeBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/mappers/ContentMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/ContentMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/mappers/NodeMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/NodeMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/mappers/PoolMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/PoolMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/mappers/ProductMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/ProductMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/nodes/AbstractNode.java
+++ b/src/main/java/org/candlepin/controller/refresher/nodes/AbstractNode.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/nodes/ContentNode.java
+++ b/src/main/java/org/candlepin/controller/refresher/nodes/ContentNode.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/nodes/EntityNode.java
+++ b/src/main/java/org/candlepin/controller/refresher/nodes/EntityNode.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/nodes/PoolNode.java
+++ b/src/main/java/org/candlepin/controller/refresher/nodes/PoolNode.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/nodes/ProductNode.java
+++ b/src/main/java/org/candlepin/controller/refresher/nodes/ProductNode.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/visitors/NodeProcessor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/NodeProcessor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/visitors/NodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/NodeVisitor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/refresher/visitors/PoolNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/PoolNodeVisitor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -83,4 +83,3 @@ public class PoolNodeVisitor implements NodeVisitor<Pool, SubscriptionInfo> {
     }
 
 }
-

--- a/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/util/ContentPrefix.java
+++ b/src/main/java/org/candlepin/controller/util/ContentPrefix.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller.util;
 
 /**

--- a/src/main/java/org/candlepin/controller/util/EntitlementContentPrefix.java
+++ b/src/main/java/org/candlepin/controller/util/EntitlementContentPrefix.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller.util;
 
 import org.candlepin.model.Environment;

--- a/src/main/java/org/candlepin/controller/util/EntityVersioningRetryWrapper.java
+++ b/src/main/java/org/candlepin/controller/util/EntityVersioningRetryWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/controller/util/PromotedContent.java
+++ b/src/main/java/org/candlepin/controller/util/PromotedContent.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller.util;
 
 import org.candlepin.model.Environment;

--- a/src/main/java/org/candlepin/controller/util/ScaContainerContentPrefix.java
+++ b/src/main/java/org/candlepin/controller/util/ScaContainerContentPrefix.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller.util;
 
 import org.candlepin.model.Environment;

--- a/src/main/java/org/candlepin/controller/util/ScaContentPrefix.java
+++ b/src/main/java/org/candlepin/controller/util/ScaContentPrefix.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller.util;
 
 import org.candlepin.model.Environment;

--- a/src/main/java/org/candlepin/dto/CandlepinDTO.java
+++ b/src/main/java/org/candlepin/dto/CandlepinDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/ModelTranslator.java
+++ b/src/main/java/org/candlepin/dto/ModelTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/ObjectTranslator.java
+++ b/src/main/java/org/candlepin/dto/ObjectTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/SimpleModelTranslator.java
+++ b/src/main/java/org/candlepin/dto/SimpleModelTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/TimestampedCandlepinDTO.java
+++ b/src/main/java/org/candlepin/dto/TimestampedCandlepinDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/TimestampedEntityTranslator.java
+++ b/src/main/java/org/candlepin/dto/TimestampedEntityTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/TranslationException.java
+++ b/src/main/java/org/candlepin/dto/TranslationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ActivationKeyTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ActivationKeyTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/AsyncJobStatusTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/AsyncJobStatusTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/BrandingTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/BrandingTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/CapabilityTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/CapabilityTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/CdnTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/CdnTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/CertificateSerialTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/CertificateSerialTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/CertificateTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/CertificateTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ComplianceReasonTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ComplianceReasonTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ComplianceStatusTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ComplianceStatusTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ConsumerArrayElementTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ConsumerArrayElementTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ConsumerInstalledProductTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ConsumerInstalledProductTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ConsumerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ConsumerTypeTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ConsumerTypeTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ContentOverrideTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ContentOverrideTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ContentTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ContentTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/DeletedConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/DeletedConsumerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/DistributorVersionTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/DistributorVersionTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/EntitlementTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/EntitlementTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/EnvironmentTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/EnvironmentTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/GuestIdArrayElementTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/GuestIdArrayElementTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/GuestIdTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/GuestIdTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/HypervisorConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/HypervisorConsumerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/HypervisorIdTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/HypervisorIdTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ImportRecordTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ImportRecordTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ImportUpstreamConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ImportUpstreamConsumerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/LinkableDTO.java
+++ b/src/main/java/org/candlepin/dto/api/v1/LinkableDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/NestedOwnerDTOTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/NestedOwnerDTOTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.dto.api.v1;
 
 import org.candlepin.dto.ModelTranslator;

--- a/src/main/java/org/candlepin/dto/api/v1/NestedOwnerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/NestedOwnerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/OwnerInfoTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/OwnerInfoTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/OwnerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/OwnerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/PermissionBlueprintInfoTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/PermissionBlueprintInfoTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/PermissionBlueprintTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/PermissionBlueprintTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/PoolQuantityTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/PoolQuantityTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/PoolToSubscriptionTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/PoolToSubscriptionTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/PoolTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/PoolTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ProductCertificateTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ProductCertificateTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ProductContentTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ProductContentTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/ProductTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ProductTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/RoleInfoTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/RoleInfoTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/RoleTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/RoleTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/UeberCertificateTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/UeberCertificateTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/UpstreamConsumerArrayElementTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/UpstreamConsumerArrayElementTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/UpstreamConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/UpstreamConsumerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/UserInfoTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/UserInfoTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/api/v1/UserTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/UserTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/BrandingDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/BrandingDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/BrandingTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/BrandingTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/CdnDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/CdnDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/CdnTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/CdnTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/CertificateDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/CertificateDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/CertificateTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/CertificateTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/ConsumerDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/ConsumerDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/ConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/ConsumerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/ConsumerTypeDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/ConsumerTypeDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/ConsumerTypeTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/ConsumerTypeTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/ContentDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/ContentDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/ContentTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/ContentTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/DistributorVersionDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/DistributorVersionDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/DistributorVersionTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/DistributorVersionTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/EntitlementDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/EntitlementDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/EntitlementTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/EntitlementTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/OwnerDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/OwnerDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/OwnerTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/OwnerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/PoolDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/PoolDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/PoolTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/PoolTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/ProductDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/ProductDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/ProductTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/ProductTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/SubscriptionDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/SubscriptionDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/UpstreamConsumerDTO.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/UpstreamConsumerDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/manifest/v1/UpstreamConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/manifest/v1/UpstreamConsumerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/ActivationKeyDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/ActivationKeyDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/ActivationKeyTranslator.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/ActivationKeyTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/ComplianceReasonDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/ComplianceReasonDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/ComplianceReasonTranslator.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/ComplianceReasonTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/ComplianceStatusDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/ComplianceStatusDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/ComplianceStatusTranslator.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/ComplianceStatusTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/ConsumerDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/ConsumerDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/ConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/ConsumerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/ConsumerTypeDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/ConsumerTypeDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/ConsumerTypeTranslator.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/ConsumerTypeTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/EntitlementDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/EntitlementDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/EntitlementTranslator.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/EntitlementTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/GuestIdDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/GuestIdDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/GuestIdTranslator.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/GuestIdTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/OwnerDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/OwnerDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/OwnerTranslator.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/OwnerTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/PoolDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/PoolDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/PoolQuantityDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/PoolQuantityDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/PoolQuantityTranslator.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/PoolQuantityTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/PoolTranslator.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/PoolTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/rules/v1/SuggestedQuantityDTO.java
+++ b/src/main/java/org/candlepin/dto/rules/v1/SuggestedQuantityDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/shim/BrandingInfoTranslator.java
+++ b/src/main/java/org/candlepin/dto/shim/BrandingInfoTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/shim/CertificateInfoTranslator.java
+++ b/src/main/java/org/candlepin/dto/shim/CertificateInfoTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/shim/CertificateSerialInfoTranslator.java
+++ b/src/main/java/org/candlepin/dto/shim/CertificateSerialInfoTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/shim/ContentInfoTranslator.java
+++ b/src/main/java/org/candlepin/dto/shim/ContentInfoTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/shim/ProductInfoTranslator.java
+++ b/src/main/java/org/candlepin/dto/shim/ProductInfoTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/dto/shim/SubscriptionInfoTranslator.java
+++ b/src/main/java/org/candlepin/dto/shim/SubscriptionInfoTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/AcceptedRequestException.java
+++ b/src/main/java/org/candlepin/exceptions/AcceptedRequestException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/BadRequestException.java
+++ b/src/main/java/org/candlepin/exceptions/BadRequestException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/CandlepinException.java
+++ b/src/main/java/org/candlepin/exceptions/CandlepinException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/CandlepinJsonProcessingException.java
+++ b/src/main/java/org/candlepin/exceptions/CandlepinJsonProcessingException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/ConcurrentModificationException.java
+++ b/src/main/java/org/candlepin/exceptions/ConcurrentModificationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/ConflictException.java
+++ b/src/main/java/org/candlepin/exceptions/ConflictException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/DeletedConsumerExceptionMessage.java
+++ b/src/main/java/org/candlepin/exceptions/DeletedConsumerExceptionMessage.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/DuplicateEntryException.java
+++ b/src/main/java/org/candlepin/exceptions/DuplicateEntryException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.exceptions;
 
 /**

--- a/src/main/java/org/candlepin/exceptions/ExceptionMessage.java
+++ b/src/main/java/org/candlepin/exceptions/ExceptionMessage.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/ForbiddenException.java
+++ b/src/main/java/org/candlepin/exceptions/ForbiddenException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/GoneException.java
+++ b/src/main/java/org/candlepin/exceptions/GoneException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/IseException.java
+++ b/src/main/java/org/candlepin/exceptions/IseException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/NotAuthorizedException.java
+++ b/src/main/java/org/candlepin/exceptions/NotAuthorizedException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/NotFoundException.java
+++ b/src/main/java/org/candlepin/exceptions/NotFoundException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/NotImplementedException.java
+++ b/src/main/java/org/candlepin/exceptions/NotImplementedException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/NotModifiedException.java
+++ b/src/main/java/org/candlepin/exceptions/NotModifiedException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/ResourceMovedException.java
+++ b/src/main/java/org/candlepin/exceptions/ResourceMovedException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/ServiceUnavailableException.java
+++ b/src/main/java/org/candlepin/exceptions/ServiceUnavailableException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/SuspendedException.java
+++ b/src/main/java/org/candlepin/exceptions/SuspendedException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/ApplicationExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/ApplicationExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/BadRequestExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/BadRequestExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/CandlepinExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/CandlepinExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/DefaultOptionsMethodExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/DefaultOptionsMethodExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/FailureExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/FailureExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/InternalServerErrorExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/InternalServerErrorExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/JAXBMarshalExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/JAXBMarshalExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/JAXBUnmarshalExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/JAXBUnmarshalExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/NoLogWebApplicationExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/NoLogWebApplicationExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/NotAcceptableExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/NotAcceptableExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/NotAllowedExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/NotAllowedExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/NotAuthorizedExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/NotAuthorizedExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/NotFoundExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/NotFoundExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/NotSupportedExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/NotSupportedExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/ReaderExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/ReaderExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/RollbackExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/RollbackExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/RuntimeExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/RuntimeExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/ValidationExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/ValidationExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/WebApplicationExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/WebApplicationExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/mappers/WriterExceptionMapper.java
+++ b/src/main/java/org/candlepin/exceptions/mappers/WriterExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/exceptions/util/JaxRsExceptionResponseBuilder.java
+++ b/src/main/java/org/candlepin/exceptions/util/JaxRsExceptionResponseBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/CandlepinCapabilities.java
+++ b/src/main/java/org/candlepin/guice/CandlepinCapabilities.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/CandlepinFilterModule.java
+++ b/src/main/java/org/candlepin/guice/CandlepinFilterModule.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/CandlepinRequestScope.java
+++ b/src/main/java/org/candlepin/guice/CandlepinRequestScope.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/CandlepinRequestScoped.java
+++ b/src/main/java/org/candlepin/guice/CandlepinRequestScoped.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/CustomizableModules.java
+++ b/src/main/java/org/candlepin/guice/CustomizableModules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/DefaultConfig.java
+++ b/src/main/java/org/candlepin/guice/DefaultConfig.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/HttpMethodMatcher.java
+++ b/src/main/java/org/candlepin/guice/HttpMethodMatcher.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/I18nProvider.java
+++ b/src/main/java/org/candlepin/guice/I18nProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/JPAInitializer.java
+++ b/src/main/java/org/candlepin/guice/JPAInitializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/PrincipalProvider.java
+++ b/src/main/java/org/candlepin/guice/PrincipalProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/ScriptEngineProvider.java
+++ b/src/main/java/org/candlepin/guice/ScriptEngineProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/guice/ValidationListenerProvider.java
+++ b/src/main/java/org/candlepin/guice/ValidationListenerProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hibernate/AbstractJsonConverter.java
+++ b/src/main/java/org/candlepin/hibernate/AbstractJsonConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hibernate/EmptyStringInterceptor.java
+++ b/src/main/java/org/candlepin/hibernate/EmptyStringInterceptor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hibernate/EmptyStringUserType.java
+++ b/src/main/java/org/candlepin/hibernate/EmptyStringUserType.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hibernate/ResultDataUserType.java
+++ b/src/main/java/org/candlepin/hibernate/ResultDataUserType.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hibernate/TypeConversionException.java
+++ b/src/main/java/org/candlepin/hibernate/TypeConversionException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hostedtest/AdapterOverrideModule.java
+++ b/src/main/java/org/candlepin/hostedtest/AdapterOverrideModule.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hostedtest/HostedTestCloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestCloudRegistrationAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hostedtest/HostedTestDataStore.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestDataStore.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hostedtest/HostedTestProductServiceAdapter.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestProductServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hostedtest/HostedTestResource.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestSubscriptionServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/AsyncJobStatusAnnotationMixin.java
+++ b/src/main/java/org/candlepin/jackson/AsyncJobStatusAnnotationMixin.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.jackson;
 
 import com.fasterxml.jackson.annotation.JsonRawValue;

--- a/src/main/java/org/candlepin/jackson/AttributeDeserializer.java
+++ b/src/main/java/org/candlepin/jackson/AttributeDeserializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/CandlepinAttributeDeserializer.java
+++ b/src/main/java/org/candlepin/jackson/CandlepinAttributeDeserializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/CandlepinLegacyAttributeSerializer.java
+++ b/src/main/java/org/candlepin/jackson/CandlepinLegacyAttributeSerializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/CheckableBeanPropertyFilter.java
+++ b/src/main/java/org/candlepin/jackson/CheckableBeanPropertyFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/ConsumerTypeDeserializer.java
+++ b/src/main/java/org/candlepin/jackson/ConsumerTypeDeserializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/DateSerializer.java
+++ b/src/main/java/org/candlepin/jackson/DateSerializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/DynamicFilterData.java
+++ b/src/main/java/org/candlepin/jackson/DynamicFilterData.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/DynamicPropertyFilter.java
+++ b/src/main/java/org/candlepin/jackson/DynamicPropertyFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/DynamicPropertyFilterMixIn.java
+++ b/src/main/java/org/candlepin/jackson/DynamicPropertyFilterMixIn.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/GuestIdDeserializer.java
+++ b/src/main/java/org/candlepin/jackson/GuestIdDeserializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/HateoasArrayExclude.java
+++ b/src/main/java/org/candlepin/jackson/HateoasArrayExclude.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/HateoasBeanPropertyFilter.java
+++ b/src/main/java/org/candlepin/jackson/HateoasBeanPropertyFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/HateoasInclude.java
+++ b/src/main/java/org/candlepin/jackson/HateoasInclude.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/JsonBeanPropertyFilter.java
+++ b/src/main/java/org/candlepin/jackson/JsonBeanPropertyFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/MultiFilter.java
+++ b/src/main/java/org/candlepin/jackson/MultiFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/OffsetDateTimeDeserializer.java
+++ b/src/main/java/org/candlepin/jackson/OffsetDateTimeDeserializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/OffsetDateTimeSerializer.java
+++ b/src/main/java/org/candlepin/jackson/OffsetDateTimeSerializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/PoolAnnotationMixIn.java
+++ b/src/main/java/org/candlepin/jackson/PoolAnnotationMixIn.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/PoolEventFilter.java
+++ b/src/main/java/org/candlepin/jackson/PoolEventFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/ProductAttributesMixIn.java
+++ b/src/main/java/org/candlepin/jackson/ProductAttributesMixIn.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.jackson;
 
 import org.candlepin.dto.api.server.v1.AttributeDTO;

--- a/src/main/java/org/candlepin/jackson/ReleaseVersionWrapDeserializer.java
+++ b/src/main/java/org/candlepin/jackson/ReleaseVersionWrapDeserializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/SingleValueWrapDeserializer.java
+++ b/src/main/java/org/candlepin/jackson/SingleValueWrapDeserializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/SingleValueWrapSerializer.java
+++ b/src/main/java/org/candlepin/jackson/SingleValueWrapSerializer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/jackson/StringTrimmingConverter.java
+++ b/src/main/java/org/candlepin/jackson/StringTrimmingConverter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/katello/KatelloModule.java
+++ b/src/main/java/org/candlepin/katello/KatelloModule.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/katello/KatelloUserServiceAdapter.java
+++ b/src/main/java/org/candlepin/katello/KatelloUserServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/CustomTaskLogger.java
+++ b/src/main/java/org/candlepin/liquibase/CustomTaskLogger.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/FixDuplicatePoolsLiquibaseWrapper.java
+++ b/src/main/java/org/candlepin/liquibase/FixDuplicatePoolsLiquibaseWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/FixDuplicatePoolsTask.java
+++ b/src/main/java/org/candlepin/liquibase/FixDuplicatePoolsTask.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/LiquibaseCustomTask.java
+++ b/src/main/java/org/candlepin/liquibase/LiquibaseCustomTask.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskLogger.java
+++ b/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskLogger.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskWrapper.java
+++ b/src/main/java/org/candlepin/liquibase/LiquibaseCustomTaskWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationLiquibaseWrapper.java
+++ b/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationLiquibaseWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationTask.java
+++ b/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationTask.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationValidationLiquibaseWrapper.java
+++ b/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationValidationLiquibaseWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationValidationTask.java
+++ b/src/main/java/org/candlepin/liquibase/PerOrgProductsMigrationValidationTask.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/PoolTypeUpgradeLiquibaseWrapper.java
+++ b/src/main/java/org/candlepin/liquibase/PoolTypeUpgradeLiquibaseWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/PoolTypeUpgradeTask.java
+++ b/src/main/java/org/candlepin/liquibase/PoolTypeUpgradeTask.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/liquibase/SystemOutLogger.java
+++ b/src/main/java/org/candlepin/liquibase/SystemOutLogger.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/logging/LoggerAndMDCFilter.java
+++ b/src/main/java/org/candlepin/logging/LoggerAndMDCFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/logging/LoggerContextListener.java
+++ b/src/main/java/org/candlepin/logging/LoggerContextListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/logging/LoggingConfigurator.java
+++ b/src/main/java/org/candlepin/logging/LoggingConfigurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/logging/LoggingUtil.java
+++ b/src/main/java/org/candlepin/logging/LoggingUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMConsumer.java
+++ b/src/main/java/org/candlepin/messaging/CPMConsumer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMConsumerConfig.java
+++ b/src/main/java/org/candlepin/messaging/CPMConsumerConfig.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMContextListener.java
+++ b/src/main/java/org/candlepin/messaging/CPMContextListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMException.java
+++ b/src/main/java/org/candlepin/messaging/CPMException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMMessage.java
+++ b/src/main/java/org/candlepin/messaging/CPMMessage.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMMessageConfig.java
+++ b/src/main/java/org/candlepin/messaging/CPMMessageConfig.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMMessageListener.java
+++ b/src/main/java/org/candlepin/messaging/CPMMessageListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMProducer.java
+++ b/src/main/java/org/candlepin/messaging/CPMProducer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMProducerConfig.java
+++ b/src/main/java/org/candlepin/messaging/CPMProducerConfig.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMSession.java
+++ b/src/main/java/org/candlepin/messaging/CPMSession.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMSessionConfig.java
+++ b/src/main/java/org/candlepin/messaging/CPMSessionConfig.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/CPMSessionFactory.java
+++ b/src/main/java/org/candlepin/messaging/CPMSessionFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisConsumer.java
+++ b/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisConsumer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisContextListener.java
+++ b/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisContextListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisMessage.java
+++ b/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisMessage.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisProducer.java
+++ b/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisProducer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -129,4 +129,3 @@ public class ArtemisProducer implements CPMProducer {
         return ((ArtemisMessage) message).getClientMessage();
     }
 }
-

--- a/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisSession.java
+++ b/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisSession.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisSessionFactory.java
+++ b/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisSessionFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisUtil.java
+++ b/src/main/java/org/candlepin/messaging/impl/artemis/ArtemisUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/impl/noop/NoopContextListener.java
+++ b/src/main/java/org/candlepin/messaging/impl/noop/NoopContextListener.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/messaging/impl/noop/NoopSessionFactory.java
+++ b/src/main/java/org/candlepin/messaging/impl/noop/NoopSessionFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/AbstractCertificate.java
+++ b/src/main/java/org/candlepin/model/AbstractCertificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/AbstractHibernateObject.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateObject.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/AsyncJobStatus.java
+++ b/src/main/java/org/candlepin/model/AsyncJobStatus.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/AsyncJobStatusCurator.java
+++ b/src/main/java/org/candlepin/model/AsyncJobStatusCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Branding.java
+++ b/src/main/java/org/candlepin/model/Branding.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/CPRestrictions.java
+++ b/src/main/java/org/candlepin/model/CPRestrictions.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/CandlepinQuery.java
+++ b/src/main/java/org/candlepin/model/CandlepinQuery.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/CandlepinQueryFactory.java
+++ b/src/main/java/org/candlepin/model/CandlepinQueryFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Cdn.java
+++ b/src/main/java/org/candlepin/model/Cdn.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/CdnCertificate.java
+++ b/src/main/java/org/candlepin/model/CdnCertificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.model;
 
 

--- a/src/main/java/org/candlepin/model/CdnCurator.java
+++ b/src/main/java/org/candlepin/model/CdnCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Certificate.java
+++ b/src/main/java/org/candlepin/model/Certificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/CertificateSerial.java
+++ b/src/main/java/org/candlepin/model/CertificateSerial.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/CertificateSerialCurator.java
+++ b/src/main/java/org/candlepin/model/CertificateSerialCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/CertificateSerialIdGenerator.java
+++ b/src/main/java/org/candlepin/model/CertificateSerialIdGenerator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/CloudProfileFacts.java
+++ b/src/main/java/org/candlepin/model/CloudProfileFacts.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.model;
 
 /**

--- a/src/main/java/org/candlepin/model/ColumnarResultIterator.java
+++ b/src/main/java/org/candlepin/model/ColumnarResultIterator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ConsumerActivationKey.java
+++ b/src/main/java/org/candlepin/model/ConsumerActivationKey.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ConsumerCapability.java
+++ b/src/main/java/org/candlepin/model/ConsumerCapability.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ConsumerContentOverride.java
+++ b/src/main/java/org/candlepin/model/ConsumerContentOverride.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ConsumerContentOverrideCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerContentOverrideCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ConsumerInstalledProduct.java
+++ b/src/main/java/org/candlepin/model/ConsumerInstalledProduct.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ConsumerProperty.java
+++ b/src/main/java/org/candlepin/model/ConsumerProperty.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ConsumerType.java
+++ b/src/main/java/org/candlepin/model/ConsumerType.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ConsumerTypeCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerTypeCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Content.java
+++ b/src/main/java/org/candlepin/model/Content.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ContentAccessCertificate.java
+++ b/src/main/java/org/candlepin/model/ContentAccessCertificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ContentAccessCertificateCurator.java
+++ b/src/main/java/org/candlepin/model/ContentAccessCertificateCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/src/main/java/org/candlepin/model/ContentCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ContentOverride.java
+++ b/src/main/java/org/candlepin/model/ContentOverride.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ContentOverrideCurator.java
+++ b/src/main/java/org/candlepin/model/ContentOverrideCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/CuratorException.java
+++ b/src/main/java/org/candlepin/model/CuratorException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/DeletedConsumer.java
+++ b/src/main/java/org/candlepin/model/DeletedConsumer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/DeletedConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/DeletedConsumerCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/DetachedCandlepinQuery.java
+++ b/src/main/java/org/candlepin/model/DetachedCandlepinQuery.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/DistributorVersion.java
+++ b/src/main/java/org/candlepin/model/DistributorVersion.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/DistributorVersionCapability.java
+++ b/src/main/java/org/candlepin/model/DistributorVersionCapability.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/DistributorVersionCurator.java
+++ b/src/main/java/org/candlepin/model/DistributorVersionCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/EmptyCandlepinQuery.java
+++ b/src/main/java/org/candlepin/model/EmptyCandlepinQuery.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Entitlement.java
+++ b/src/main/java/org/candlepin/model/Entitlement.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/EntitlementCertificate.java
+++ b/src/main/java/org/candlepin/model/EntitlementCertificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/EntitlementCertificateCurator.java
+++ b/src/main/java/org/candlepin/model/EntitlementCertificateCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/EntitlementFilterBuilder.java
+++ b/src/main/java/org/candlepin/model/EntitlementFilterBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.model;
 
 /**

--- a/src/main/java/org/candlepin/model/Environment.java
+++ b/src/main/java/org/candlepin/model/Environment.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/EnvironmentContent.java
+++ b/src/main/java/org/candlepin/model/EnvironmentContent.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
+++ b/src/main/java/org/candlepin/model/EnvironmentContentCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/EnvironmentCurator.java
+++ b/src/main/java/org/candlepin/model/EnvironmentCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Eventful.java
+++ b/src/main/java/org/candlepin/model/Eventful.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ExpiredCertificate.java
+++ b/src/main/java/org/candlepin/model/ExpiredCertificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.model;
 
 import java.util.Objects;

--- a/src/main/java/org/candlepin/model/ExporterMetadata.java
+++ b/src/main/java/org/candlepin/model/ExporterMetadata.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ExporterMetadataCurator.java
+++ b/src/main/java/org/candlepin/model/ExporterMetadataCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/FactFilterBuilder.java
+++ b/src/main/java/org/candlepin/model/FactFilterBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/FilterBuilder.java
+++ b/src/main/java/org/candlepin/model/FilterBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/GuestId.java
+++ b/src/main/java/org/candlepin/model/GuestId.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/GuestIdCurator.java
+++ b/src/main/java/org/candlepin/model/GuestIdCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/HostCache.java
+++ b/src/main/java/org/candlepin/model/HostCache.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/HypervisorId.java
+++ b/src/main/java/org/candlepin/model/HypervisorId.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/IdentityCertificate.java
+++ b/src/main/java/org/candlepin/model/IdentityCertificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/IdentityCertificateCurator.java
+++ b/src/main/java/org/candlepin/model/IdentityCertificateCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ImportRecord.java
+++ b/src/main/java/org/candlepin/model/ImportRecord.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ImportRecordCurator.java
+++ b/src/main/java/org/candlepin/model/ImportRecordCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ImportUpstreamConsumer.java
+++ b/src/main/java/org/candlepin/model/ImportUpstreamConsumer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/InvalidOrderKeyException.java
+++ b/src/main/java/org/candlepin/model/InvalidOrderKeyException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/KeyPairData.java
+++ b/src/main/java/org/candlepin/model/KeyPairData.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/KeyPairDataCurator.java
+++ b/src/main/java/org/candlepin/model/KeyPairDataCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Linkable.java
+++ b/src/main/java/org/candlepin/model/Linkable.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ManifestFileRecord.java
+++ b/src/main/java/org/candlepin/model/ManifestFileRecord.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ManifestFileRecordCurator.java
+++ b/src/main/java/org/candlepin/model/ManifestFileRecordCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ModelEntity.java
+++ b/src/main/java/org/candlepin/model/ModelEntity.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Named.java
+++ b/src/main/java/org/candlepin/model/Named.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Owned.java
+++ b/src/main/java/org/candlepin/model/Owned.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Owner.java
+++ b/src/main/java/org/candlepin/model/Owner.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/OwnerContent.java
+++ b/src/main/java/org/candlepin/model/OwnerContent.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/OwnerContentCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerContentCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/OwnerContentKey.java
+++ b/src/main/java/org/candlepin/model/OwnerContentKey.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/OwnerCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/OwnerInfoBuilder.java
+++ b/src/main/java/org/candlepin/model/OwnerInfoBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.model;
 
 import org.candlepin.dto.api.server.v1.ConsumptionTypeCountsDTO;

--- a/src/main/java/org/candlepin/model/OwnerInfoCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerInfoCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/OwnerNotFoundException.java
+++ b/src/main/java/org/candlepin/model/OwnerNotFoundException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.model;
 
 public class OwnerNotFoundException extends RuntimeException {

--- a/src/main/java/org/candlepin/model/OwnerProduct.java
+++ b/src/main/java/org/candlepin/model/OwnerProduct.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/OwnerProductKey.java
+++ b/src/main/java/org/candlepin/model/OwnerProductKey.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/PermissionBlueprint.java
+++ b/src/main/java/org/candlepin/model/PermissionBlueprint.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/PermissionBlueprintCurator.java
+++ b/src/main/java/org/candlepin/model/PermissionBlueprintCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Persisted.java
+++ b/src/main/java/org/candlepin/model/Persisted.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Pool.java
+++ b/src/main/java/org/candlepin/model/Pool.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/PoolAttribute.java
+++ b/src/main/java/org/candlepin/model/PoolAttribute.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/PoolFilterBuilder.java
+++ b/src/main/java/org/candlepin/model/PoolFilterBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/PoolQuantity.java
+++ b/src/main/java/org/candlepin/model/PoolQuantity.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ProductCertificate.java
+++ b/src/main/java/org/candlepin/model/ProductCertificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ProductCertificateCurator.java
+++ b/src/main/java/org/candlepin/model/ProductCertificateCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ProductContent.java
+++ b/src/main/java/org/candlepin/model/ProductContent.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ProductContentKey.java
+++ b/src/main/java/org/candlepin/model/ProductContentKey.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/src/main/java/org/candlepin/model/ProductCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ProvidedProduct.java
+++ b/src/main/java/org/candlepin/model/ProvidedProduct.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/QueryArguments.java
+++ b/src/main/java/org/candlepin/model/QueryArguments.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Release.java
+++ b/src/main/java/org/candlepin/model/Release.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ResultIterator.java
+++ b/src/main/java/org/candlepin/model/ResultIterator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/ResultProcessor.java
+++ b/src/main/java/org/candlepin/model/ResultProcessor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/RevocableCertificate.java
+++ b/src/main/java/org/candlepin/model/RevocableCertificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Role.java
+++ b/src/main/java/org/candlepin/model/Role.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/RoleCurator.java
+++ b/src/main/java/org/candlepin/model/RoleCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/RowResultIterator.java
+++ b/src/main/java/org/candlepin/model/RowResultIterator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/Rules.java
+++ b/src/main/java/org/candlepin/model/Rules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/RulesCurator.java
+++ b/src/main/java/org/candlepin/model/RulesCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/SharedEntity.java
+++ b/src/main/java/org/candlepin/model/SharedEntity.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/SourceStack.java
+++ b/src/main/java/org/candlepin/model/SourceStack.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/SourceSubscription.java
+++ b/src/main/java/org/candlepin/model/SourceSubscription.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/SubscriptionsCertificate.java
+++ b/src/main/java/org/candlepin/model/SubscriptionsCertificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.model;
 
 

--- a/src/main/java/org/candlepin/model/SubscriptionsCertificateCurator.java
+++ b/src/main/java/org/candlepin/model/SubscriptionsCertificateCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/SystemLock.java
+++ b/src/main/java/org/candlepin/model/SystemLock.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/SystemPurposeAttributeType.java
+++ b/src/main/java/org/candlepin/model/SystemPurposeAttributeType.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/TimestampedEntity.java
+++ b/src/main/java/org/candlepin/model/TimestampedEntity.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/TransformedCandlepinQuery.java
+++ b/src/main/java/org/candlepin/model/TransformedCandlepinQuery.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/UeberCertificate.java
+++ b/src/main/java/org/candlepin/model/UeberCertificate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/UeberCertificateCurator.java
+++ b/src/main/java/org/candlepin/model/UeberCertificateCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
+++ b/src/main/java/org/candlepin/model/UeberCertificateGenerator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/UpstreamConsumer.java
+++ b/src/main/java/org/candlepin/model/UpstreamConsumer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/User.java
+++ b/src/main/java/org/candlepin/model/User.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/UserCurator.java
+++ b/src/main/java/org/candlepin/model/UserCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/VirtConsumerMap.java
+++ b/src/main/java/org/candlepin/model/VirtConsumerMap.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
+++ b/src/main/java/org/candlepin/model/activationkeys/ActivationKey.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/activationkeys/ActivationKeyContentOverride.java
+++ b/src/main/java/org/candlepin/model/activationkeys/ActivationKeyContentOverride.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/activationkeys/ActivationKeyContentOverrideCurator.java
+++ b/src/main/java/org/candlepin/model/activationkeys/ActivationKeyContentOverrideCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/activationkeys/ActivationKeyCurator.java
+++ b/src/main/java/org/candlepin/model/activationkeys/ActivationKeyCurator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/activationkeys/ActivationKeyPool.java
+++ b/src/main/java/org/candlepin/model/activationkeys/ActivationKeyPool.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/CandlepinDTO.java
+++ b/src/main/java/org/candlepin/model/dto/CandlepinDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/Content.java
+++ b/src/main/java/org/candlepin/model/dto/Content.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/ContentData.java
+++ b/src/main/java/org/candlepin/model/dto/ContentData.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/EntitlementBody.java
+++ b/src/main/java/org/candlepin/model/dto/EntitlementBody.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/Order.java
+++ b/src/main/java/org/candlepin/model/dto/Order.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/Pool.java
+++ b/src/main/java/org/candlepin/model/dto/Pool.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/PoolIdAndErrors.java
+++ b/src/main/java/org/candlepin/model/dto/PoolIdAndErrors.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/PoolIdAndQuantity.java
+++ b/src/main/java/org/candlepin/model/dto/PoolIdAndQuantity.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/Product.java
+++ b/src/main/java/org/candlepin/model/dto/Product.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/ProductContentData.java
+++ b/src/main/java/org/candlepin/model/dto/ProductContentData.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/ProductData.java
+++ b/src/main/java/org/candlepin/model/dto/ProductData.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/Service.java
+++ b/src/main/java/org/candlepin/model/dto/Service.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/Subscription.java
+++ b/src/main/java/org/candlepin/model/dto/Subscription.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/model/dto/TinySubscription.java
+++ b/src/main/java/org/candlepin/model/dto/TinySubscription.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/paging/Page.java
+++ b/src/main/java/org/candlepin/paging/Page.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/paging/PageRequest.java
+++ b/src/main/java/org/candlepin/paging/PageRequest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/CertificateReader.java
+++ b/src/main/java/org/candlepin/pki/CertificateReader.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/PKIUtility.java
+++ b/src/main/java/org/candlepin/pki/PKIUtility.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/PrivateKeyReader.java
+++ b/src/main/java/org/candlepin/pki/PrivateKeyReader.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
+++ b/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/X509ByteExtensionWrapper.java
+++ b/src/main/java/org/candlepin/pki/X509ByteExtensionWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/X509ExtensionWrapper.java
+++ b/src/main/java/org/candlepin/pki/X509ExtensionWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriter.java
+++ b/src/main/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/impl/JSSLoaderException.java
+++ b/src/main/java/org/candlepin/pki/impl/JSSLoaderException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/impl/JSSPKIUtility.java
+++ b/src/main/java/org/candlepin/pki/impl/JSSPKIUtility.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/impl/JSSPrivateKeyReader.java
+++ b/src/main/java/org/candlepin/pki/impl/JSSPrivateKeyReader.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/impl/JSSProviderLoader.java
+++ b/src/main/java/org/candlepin/pki/impl/JSSProviderLoader.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/impl/ProviderBasedPKIUtility.java
+++ b/src/main/java/org/candlepin/pki/impl/ProviderBasedPKIUtility.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/pki/impl/ProviderBasedPrivateKeyReader.java
+++ b/src/main/java/org/candlepin/pki/impl/ProviderBasedPrivateKeyReader.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/EntitlementRefusedException.java
+++ b/src/main/java/org/candlepin/policy/EntitlementRefusedException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/MissingFactException.java
+++ b/src/main/java/org/candlepin/policy/MissingFactException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/RulesValidationError.java
+++ b/src/main/java/org/candlepin/policy/RulesValidationError.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
+++ b/src/main/java/org/candlepin/policy/SystemPurposeComplianceRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/SystemPurposeComplianceStatus.java
+++ b/src/main/java/org/candlepin/policy/SystemPurposeComplianceStatus.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/ValidationError.java
+++ b/src/main/java/org/candlepin/policy/ValidationError.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/ValidationResult.java
+++ b/src/main/java/org/candlepin/policy/ValidationResult.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/ValidationWarning.java
+++ b/src/main/java/org/candlepin/policy/ValidationWarning.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/activationkey/ActivationKeyRules.java
+++ b/src/main/java/org/candlepin/policy/activationkey/ActivationKeyRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
+++ b/src/main/java/org/candlepin/policy/criteria/CriteriaRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/ArgumentJsContext.java
+++ b/src/main/java/org/candlepin/policy/js/ArgumentJsContext.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/JsContext.java
+++ b/src/main/java/org/candlepin/policy/js/JsContext.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/JsRunner.java
+++ b/src/main/java/org/candlepin/policy/js/JsRunner.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
+++ b/src/main/java/org/candlepin/policy/js/JsRunnerProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/JsRunnerRequestCache.java
+++ b/src/main/java/org/candlepin/policy/js/JsRunnerRequestCache.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/JsRunnerRequestCacheProvider.java
+++ b/src/main/java/org/candlepin/policy/js/JsRunnerRequestCacheProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/JsonJsContext.java
+++ b/src/main/java/org/candlepin/policy/js/JsonJsContext.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/RuleExecutionException.java
+++ b/src/main/java/org/candlepin/policy/js/RuleExecutionException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/RuleParseException.java
+++ b/src/main/java/org/candlepin/policy/js/RuleParseException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/RulesObjectMapper.java
+++ b/src/main/java/org/candlepin/policy/js/RulesObjectMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
+++ b/src/main/java/org/candlepin/policy/js/autobind/AutobindRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/compliance/ComplianceReason.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/ComplianceReason.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/ComplianceRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/compliance/ComplianceStatus.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/ComplianceStatus.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/StatusReasonMessageGenerator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/compliance/hash/ComplianceFacts.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/hash/ComplianceFacts.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.policy.js.compliance.hash;
 
 import org.candlepin.dto.api.server.v1.ConsumerDTO;

--- a/src/main/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasher.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasher.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.policy.js.compliance.hash;
 
 import org.candlepin.model.Consumer;

--- a/src/main/java/org/candlepin/policy/js/compliance/hash/HashableStringGenerator.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/hash/HashableStringGenerator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.policy.js.compliance.hash;
 
 

--- a/src/main/java/org/candlepin/policy/js/compliance/hash/HashableStringGenerators.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/hash/HashableStringGenerators.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.policy.js.compliance.hash;
 
 import org.candlepin.model.Consumer;

--- a/src/main/java/org/candlepin/policy/js/compliance/hash/Hasher.java
+++ b/src/main/java/org/candlepin/policy/js/compliance/hash/Hasher.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.policy.js.compliance.hash;
 
 import com.google.common.hash.HashCode;

--- a/src/main/java/org/candlepin/policy/js/consumer/ConsumerRules.java
+++ b/src/main/java/org/candlepin/policy/js/consumer/ConsumerRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/entitlement/Enforcer.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/Enforcer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/EntitlementRulesTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/entitlement/PreUnbindHelper.java
+++ b/src/main/java/org/candlepin/policy/js/entitlement/PreUnbindHelper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/export/ExportRules.java
+++ b/src/main/java/org/candlepin/policy/js/export/ExportRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
+++ b/src/main/java/org/candlepin/policy/js/pool/PoolHelper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
+++ b/src/main/java/org/candlepin/policy/js/pool/PoolRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/pool/PoolUpdate.java
+++ b/src/main/java/org/candlepin/policy/js/pool/PoolUpdate.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
+++ b/src/main/java/org/candlepin/policy/js/pool/StackedSubPoolValueAccumulator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
+++ b/src/main/java/org/candlepin/policy/js/quantity/QuantityRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/AdminResource.java
+++ b/src/main/java/org/candlepin/resource/AdminResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/CdnResource.java
+++ b/src/main/java/org/candlepin/resource/CdnResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/CertificateSerialResource.java
+++ b/src/main/java/org/candlepin/resource/CertificateSerialResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
+++ b/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/ConsumerTypeResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerTypeResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/src/main/java/org/candlepin/resource/ContentResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/CrlResource.java
+++ b/src/main/java/org/candlepin/resource/CrlResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/DeletedConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/DeletedConsumerResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/DistributorVersionResource.java
+++ b/src/main/java/org/candlepin/resource/DistributorVersionResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/EntitlementResource.java
+++ b/src/main/java/org/candlepin/resource/EntitlementResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/GuestIdResource.java
+++ b/src/main/java/org/candlepin/resource/GuestIdResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.resource;
 
 import org.candlepin.audit.EventFactory;

--- a/src/main/java/org/candlepin/resource/HypervisorResource.java
+++ b/src/main/java/org/candlepin/resource/HypervisorResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/JobResource.java
+++ b/src/main/java/org/candlepin/resource/JobResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.resource;
 
 import org.candlepin.auth.Verify;

--- a/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.resource;
 
 import org.candlepin.async.JobConfig;

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/src/main/java/org/candlepin/resource/PoolResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/src/main/java/org/candlepin/resource/ProductResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/RoleResource.java
+++ b/src/main/java/org/candlepin/resource/RoleResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/RootResource.java
+++ b/src/main/java/org/candlepin/resource/RootResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/RulesResource.java
+++ b/src/main/java/org/candlepin/resource/RulesResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/StatusResource.java
+++ b/src/main/java/org/candlepin/resource/StatusResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/SubscriptionResource.java
+++ b/src/main/java/org/candlepin/resource/SubscriptionResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/UserResource.java
+++ b/src/main/java/org/candlepin/resource/UserResource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/dto/AutobindData.java
+++ b/src/main/java/org/candlepin/resource/dto/AutobindData.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/dto/ContentAccessListing.java
+++ b/src/main/java/org/candlepin/resource/dto/ContentAccessListing.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/util/AttachedFile.java
+++ b/src/main/java/org/candlepin/resource/util/AttachedFile.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
+++ b/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/util/ConsumerEnricher.java
+++ b/src/main/java/org/candlepin/resource/util/ConsumerEnricher.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/util/ConsumerTypeValidator.java
+++ b/src/main/java/org/candlepin/resource/util/ConsumerTypeValidator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/util/EntitlementEnvironmentFilter.java
+++ b/src/main/java/org/candlepin/resource/util/EntitlementEnvironmentFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2021 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/util/EnvironmentUpdates.java
+++ b/src/main/java/org/candlepin/resource/util/EnvironmentUpdates.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.resource.util;
 
 import java.util.ArrayList;

--- a/src/main/java/org/candlepin/resource/util/GuestMigration.java
+++ b/src/main/java/org/candlepin/resource/util/GuestMigration.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/util/InfoAdapter.java
+++ b/src/main/java/org/candlepin/resource/util/InfoAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.resource.util;
 
 import org.candlepin.dto.api.server.v1.AttributeDTO;

--- a/src/main/java/org/candlepin/resource/util/JobStateMapper.java
+++ b/src/main/java/org/candlepin/resource/util/JobStateMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/util/KeyValueStringParser.java
+++ b/src/main/java/org/candlepin/resource/util/KeyValueStringParser.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/util/ResolverUtil.java
+++ b/src/main/java/org/candlepin/resource/util/ResolverUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resource/validation/DTOValidator.java
+++ b/src/main/java/org/candlepin/resource/validation/DTOValidator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/AnnotationLocator.java
+++ b/src/main/java/org/candlepin/resteasy/AnnotationLocator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/InfoProperty.java
+++ b/src/main/java/org/candlepin/resteasy/InfoProperty.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/JsonProvider.java
+++ b/src/main/java/org/candlepin/resteasy/JsonProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/MethodLocator.java
+++ b/src/main/java/org/candlepin/resteasy/MethodLocator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/ResourceLocatorMap.java
+++ b/src/main/java/org/candlepin/resteasy/ResourceLocatorMap.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/converter/OffsetDateTimeParamConverterProvider.java
+++ b/src/main/java/org/candlepin/resteasy/converter/OffsetDateTimeParamConverterProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/AbstractAuthorizationFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/AbstractAuthorizationFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/AuthUtil.java
+++ b/src/main/java/org/candlepin/resteasy/filter/AuthUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/AuthenticationFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/AuthorizationFeature.java
+++ b/src/main/java/org/candlepin/resteasy/filter/AuthorizationFeature.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptor.java
+++ b/src/main/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/CandlepinSecurityContext.java
+++ b/src/main/java/org/candlepin/resteasy/filter/CandlepinSecurityContext.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/CandlepinSuspendModeFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/CandlepinSuspendModeFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/ConsumerCheckInFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/ConsumerCheckInFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/DynamicJsonFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/DynamicJsonFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/EntityStore.java
+++ b/src/main/java/org/candlepin/resteasy/filter/EntityStore.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/LinkHeaderResponseFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/LinkHeaderResponseFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/LinkTooLongException.java
+++ b/src/main/java/org/candlepin/resteasy/filter/LinkTooLongException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/NoOpFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/NoOpFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/PageRequestFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/PageRequestFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/RestEasyOAuthMessage.java
+++ b/src/main/java/org/candlepin/resteasy/filter/RestEasyOAuthMessage.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/SecurityHoleAuthorizationFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/SecurityHoleAuthorizationFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
+++ b/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/SuperAdminAuthorizationFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/SuperAdminAuthorizationFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/resteasy/filter/VersionResponseFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/VersionResponseFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/EntitlementCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/EntitlementCertServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/IdentityCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/IdentityCertServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/OwnerServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/OwnerServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/ProductServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/ProductServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/SubscriptionServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/SubscriptionServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/UniqueIdGenerator.java
+++ b/src/main/java/org/candlepin/service/UniqueIdGenerator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/UserServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/UserServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/exception/CloudRegistrationAuthorizationException.java
+++ b/src/main/java/org/candlepin/service/exception/CloudRegistrationAuthorizationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/exception/MalformedCloudRegistrationException.java
+++ b/src/main/java/org/candlepin/service/exception/MalformedCloudRegistrationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/BaseEntitlementCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/BaseEntitlementCertServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/DefaultCloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultCloudRegistrationAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/DefaultOwnerServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultOwnerServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/DefaultProductServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultProductServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/DefaultUniqueIdGenerator.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultUniqueIdGenerator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/DefaultUserServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultUserServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
+++ b/src/main/java/org/candlepin/service/impl/HypervisorUpdateAction.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/ImportProductServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/ImportProductServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/BrandingInfo.java
+++ b/src/main/java/org/candlepin/service/model/BrandingInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/CdnInfo.java
+++ b/src/main/java/org/candlepin/service/model/CdnInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/CertificateInfo.java
+++ b/src/main/java/org/candlepin/service/model/CertificateInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/CertificateSerialInfo.java
+++ b/src/main/java/org/candlepin/service/model/CertificateSerialInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/CloudRegistrationInfo.java
+++ b/src/main/java/org/candlepin/service/model/CloudRegistrationInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/ConsumerInfo.java
+++ b/src/main/java/org/candlepin/service/model/ConsumerInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/ContentInfo.java
+++ b/src/main/java/org/candlepin/service/model/ContentInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/OwnerInfo.java
+++ b/src/main/java/org/candlepin/service/model/OwnerInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/PermissionBlueprintInfo.java
+++ b/src/main/java/org/candlepin/service/model/PermissionBlueprintInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/ProductContentInfo.java
+++ b/src/main/java/org/candlepin/service/model/ProductContentInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/ProductInfo.java
+++ b/src/main/java/org/candlepin/service/model/ProductInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/RoleInfo.java
+++ b/src/main/java/org/candlepin/service/model/RoleInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/ServiceAdapterModel.java
+++ b/src/main/java/org/candlepin/service/model/ServiceAdapterModel.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/SubscriptionInfo.java
+++ b/src/main/java/org/candlepin/service/model/SubscriptionInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/service/model/UserInfo.java
+++ b/src/main/java/org/candlepin/service/model/UserInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/servlet/filter/CandlepinContentTypeFilter.java
+++ b/src/main/java/org/candlepin/servlet/filter/CandlepinContentTypeFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/servlet/filter/CandlepinPersistFilter.java
+++ b/src/main/java/org/candlepin/servlet/filter/CandlepinPersistFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/servlet/filter/CandlepinScopeFilter.java
+++ b/src/main/java/org/candlepin/servlet/filter/CandlepinScopeFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/servlet/filter/EventFilter.java
+++ b/src/main/java/org/candlepin/servlet/filter/EventFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/servlet/filter/logging/BodyLogger.java
+++ b/src/main/java/org/candlepin/servlet/filter/logging/BodyLogger.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/servlet/filter/logging/LoggingFilter.java
+++ b/src/main/java/org/candlepin/servlet/filter/logging/LoggingFilter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/servlet/filter/logging/ServletLogger.java
+++ b/src/main/java/org/candlepin/servlet/filter/logging/ServletLogger.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/servlet/filter/logging/TeeHttpServletRequest.java
+++ b/src/main/java/org/candlepin/servlet/filter/logging/TeeHttpServletRequest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/servlet/filter/logging/TeeHttpServletResponse.java
+++ b/src/main/java/org/candlepin/servlet/filter/logging/TeeHttpServletResponse.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/servlet/filter/logging/TeeServletOutputStream.java
+++ b/src/main/java/org/candlepin/servlet/filter/logging/TeeServletOutputStream.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/CdnExporter.java
+++ b/src/main/java/org/candlepin/sync/CdnExporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/CdnImporter.java
+++ b/src/main/java/org/candlepin/sync/CdnImporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/CertificateExporter.java
+++ b/src/main/java/org/candlepin/sync/CertificateExporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ConflictExceptionMessage.java
+++ b/src/main/java/org/candlepin/sync/ConflictExceptionMessage.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ConflictOverrides.java
+++ b/src/main/java/org/candlepin/sync/ConflictOverrides.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ConsumerExporter.java
+++ b/src/main/java/org/candlepin/sync/ConsumerExporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ConsumerImporter.java
+++ b/src/main/java/org/candlepin/sync/ConsumerImporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ConsumerTypeExporter.java
+++ b/src/main/java/org/candlepin/sync/ConsumerTypeExporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ConsumerTypeImporter.java
+++ b/src/main/java/org/candlepin/sync/ConsumerTypeImporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/DistributorVersionExporter.java
+++ b/src/main/java/org/candlepin/sync/DistributorVersionExporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/DistributorVersionImporter.java
+++ b/src/main/java/org/candlepin/sync/DistributorVersionImporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/EntitlementExporter.java
+++ b/src/main/java/org/candlepin/sync/EntitlementExporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/EntitlementImporter.java
+++ b/src/main/java/org/candlepin/sync/EntitlementImporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ExportCreationException.java
+++ b/src/main/java/org/candlepin/sync/ExportCreationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ExportResult.java
+++ b/src/main/java/org/candlepin/sync/ExportResult.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/Exporter.java
+++ b/src/main/java/org/candlepin/sync/Exporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ImportConflictException.java
+++ b/src/main/java/org/candlepin/sync/ImportConflictException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ImportExtractionException.java
+++ b/src/main/java/org/candlepin/sync/ImportExtractionException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/Importer.java
+++ b/src/main/java/org/candlepin/sync/Importer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ImporterException.java
+++ b/src/main/java/org/candlepin/sync/ImporterException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ImporterUtils.java
+++ b/src/main/java/org/candlepin/sync/ImporterUtils.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/Meta.java
+++ b/src/main/java/org/candlepin/sync/Meta.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/MetaExporter.java
+++ b/src/main/java/org/candlepin/sync/MetaExporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ProductCertExporter.java
+++ b/src/main/java/org/candlepin/sync/ProductCertExporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ProductExporter.java
+++ b/src/main/java/org/candlepin/sync/ProductExporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/ProductImporter.java
+++ b/src/main/java/org/candlepin/sync/ProductImporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/RulesExporter.java
+++ b/src/main/java/org/candlepin/sync/RulesExporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/RulesImporter.java
+++ b/src/main/java/org/candlepin/sync/RulesImporter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/StringFromReader.java
+++ b/src/main/java/org/candlepin/sync/StringFromReader.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/SubscriptionReconciler.java
+++ b/src/main/java/org/candlepin/sync/SubscriptionReconciler.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/SyncDataFormatException.java
+++ b/src/main/java/org/candlepin/sync/SyncDataFormatException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/SyncException.java
+++ b/src/main/java/org/candlepin/sync/SyncException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/SyncUtils.java
+++ b/src/main/java/org/candlepin/sync/SyncUtils.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/file/DBManifestService.java
+++ b/src/main/java/org/candlepin/sync/file/DBManifestService.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/file/ManifestFile.java
+++ b/src/main/java/org/candlepin/sync/file/ManifestFile.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.sync.file;
 
 import java.io.InputStream;

--- a/src/main/java/org/candlepin/sync/file/ManifestFileService.java
+++ b/src/main/java/org/candlepin/sync/file/ManifestFileService.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/file/ManifestFileServiceException.java
+++ b/src/main/java/org/candlepin/sync/file/ManifestFileServiceException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/sync/file/ManifestFileType.java
+++ b/src/main/java/org/candlepin/sync/file/ManifestFileType.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/Arch.java
+++ b/src/main/java/org/candlepin/util/Arch.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/AttributeValidator.java
+++ b/src/main/java/org/candlepin/util/AttributeValidator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/CertificateSizeException.java
+++ b/src/main/java/org/candlepin/util/CertificateSizeException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/CollectionView.java
+++ b/src/main/java/org/candlepin/util/CollectionView.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/ContentOverrideValidator.java
+++ b/src/main/java/org/candlepin/util/ContentOverrideValidator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/DateSource.java
+++ b/src/main/java/org/candlepin/util/DateSource.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/DateSourceImpl.java
+++ b/src/main/java/org/candlepin/util/DateSourceImpl.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/ElementTransformer.java
+++ b/src/main/java/org/candlepin/util/ElementTransformer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/ExpiryDateFunction.java
+++ b/src/main/java/org/candlepin/util/ExpiryDateFunction.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/FactValidator.java
+++ b/src/main/java/org/candlepin/util/FactValidator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/ListView.java
+++ b/src/main/java/org/candlepin/util/ListView.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/LongHashCodeBuilder.java
+++ b/src/main/java/org/candlepin/util/LongHashCodeBuilder.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/MapView.java
+++ b/src/main/java/org/candlepin/util/MapView.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/OIDUtil.java
+++ b/src/main/java/org/candlepin/util/OIDUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/ObjectMapperFactory.java
+++ b/src/main/java/org/candlepin/util/ObjectMapperFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/PropertyUtil.java
+++ b/src/main/java/org/candlepin/util/PropertyUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/PropertyValidationException.java
+++ b/src/main/java/org/candlepin/util/PropertyValidationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/PropertyValidator.java
+++ b/src/main/java/org/candlepin/util/PropertyValidator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/RdbmsExceptionTranslator.java
+++ b/src/main/java/org/candlepin/util/RdbmsExceptionTranslator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/ServiceLevelValidator.java
+++ b/src/main/java/org/candlepin/util/ServiceLevelValidator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/SetView.java
+++ b/src/main/java/org/candlepin/util/SetView.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/Traceable.java
+++ b/src/main/java/org/candlepin/util/Traceable.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/TraceableParam.java
+++ b/src/main/java/org/candlepin/util/TraceableParam.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/TransactionExecutionException.java
+++ b/src/main/java/org/candlepin/util/TransactionExecutionException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/Transactional.java
+++ b/src/main/java/org/candlepin/util/Transactional.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/TransformedIterator.java
+++ b/src/main/java/org/candlepin/util/TransformedIterator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/Util.java
+++ b/src/main/java/org/candlepin/util/Util.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/X509ExtensionUtil.java
+++ b/src/main/java/org/candlepin/util/X509ExtensionUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/X509Util.java
+++ b/src/main/java/org/candlepin/util/X509Util.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/validation/CandlepinMessageInterpolator.java
+++ b/src/main/java/org/candlepin/validation/CandlepinMessageInterpolator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/version/CertVersionConflictException.java
+++ b/src/main/java/org/candlepin/version/CertVersionConflictException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/version/RpmVersionComparator.java
+++ b/src/main/java/org/candlepin/version/RpmVersionComparator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/main/java/org/candlepin/version/VersionUtil.java
+++ b/src/main/java/org/candlepin/version/VersionUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/TestingInterceptor.java
+++ b/src/test/java/org/candlepin/TestingInterceptor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/TestingModules.java
+++ b/src/test/java/org/candlepin/TestingModules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/JobManagerTest.java
+++ b/src/test/java/org/candlepin/async/JobManagerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/JobMessageDispatcherTest.java
+++ b/src/test/java/org/candlepin/async/JobMessageDispatcherTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/JobMessageReceiverTest.java
+++ b/src/test/java/org/candlepin/async/JobMessageReceiverTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/impl/ThrottledByJobKeyConstraintTest.java
+++ b/src/test/java/org/candlepin/async/impl/ThrottledByJobKeyConstraintTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.async.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/async/impl/UniqueByArgConstraintTest.java
+++ b/src/test/java/org/candlepin/async/impl/UniqueByArgConstraintTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/ActiveEntitlementJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/ActiveEntitlementJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.async.tasks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -137,4 +136,3 @@ public class ActiveEntitlementJobTest extends DatabaseTestFixture {
         assertFalse(entitlementCurator.get(ent.getId()).isUpdatedOnStart());
     }
 }
-

--- a/src/test/java/org/candlepin/async/tasks/BaseJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/BaseJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/CertificateCleanupJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/CertificateCleanupJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/EntitleByProductsJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/EntitleByProductsJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.async.tasks;
 
 

--- a/src/test/java/org/candlepin/async/tasks/EntitlerJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/EntitlerJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.async.tasks;
 
 

--- a/src/test/java/org/candlepin/async/tasks/ExpiredPoolsCleanupJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/ExpiredPoolsCleanupJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/ExportJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/HealEntireOrgJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/HealEntireOrgJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/HypervisorHeartbeatUpdateJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/HypervisorHeartbeatUpdateJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/HypervisorUpdateJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/ImportJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/ImportJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/ImportRecordCleanerJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/ImportRecordCleanerJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/InactiveConsumerCleanerJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/InactiveConsumerCleanerJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.async.tasks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/async/tasks/JobCleanerTest.java
+++ b/src/test/java/org/candlepin/async/tasks/JobCleanerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/ManifestCleanerJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/ManifestCleanerJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/OrphanCleanupJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/OrphanCleanupJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/RefreshPoolsJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/RefreshPoolsJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/RegenEnvEntitlementCertsJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/RegenEnvEntitlementCertsJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/RegenProductEntitlementCertsJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/RegenProductEntitlementCertsJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/async/tasks/UnmappedGuestEntitlementCleanerJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/UnmappedGuestEntitlementCleanerJobTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/audit/ActivationListenerTest.java
+++ b/src/test/java/org/candlepin/audit/ActivationListenerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/audit/ArtemisMessageSourceTest.java
+++ b/src/test/java/org/candlepin/audit/ArtemisMessageSourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/audit/DefaultEventMessageReceiverTest.java
+++ b/src/test/java/org/candlepin/audit/DefaultEventMessageReceiverTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/audit/EventAdapterTest.java
+++ b/src/test/java/org/candlepin/audit/EventAdapterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/audit/EventBuilderTest.java
+++ b/src/test/java/org/candlepin/audit/EventBuilderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/audit/EventFactoryTest.java
+++ b/src/test/java/org/candlepin/audit/EventFactoryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/audit/EventFilterTest.java
+++ b/src/test/java/org/candlepin/audit/EventFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/audit/EventSinkImplTest.java
+++ b/src/test/java/org/candlepin/audit/EventSinkImplTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/audit/TestingActiveMQSessionFactory.java
+++ b/src/test/java/org/candlepin/audit/TestingActiveMQSessionFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/ActivationKeyAuthTest.java
+++ b/src/test/java/org/candlepin/auth/ActivationKeyAuthTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.auth;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/org/candlepin/auth/AuthUtilTest.java
+++ b/src/test/java/org/candlepin/auth/AuthUtilTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/BasicAuthViaUserServiceTest.java
+++ b/src/test/java/org/candlepin/auth/BasicAuthViaUserServiceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/CloudRegistrationAuthTest.java
+++ b/src/test/java/org/candlepin/auth/CloudRegistrationAuthTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/ConsumerPrincipalTest.java
+++ b/src/test/java/org/candlepin/auth/ConsumerPrincipalTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/ExternalSystemPrincipalTest.java
+++ b/src/test/java/org/candlepin/auth/ExternalSystemPrincipalTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/FakeUriInfo.java
+++ b/src/test/java/org/candlepin/auth/FakeUriInfo.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.auth;
 
 import java.net.URI;

--- a/src/test/java/org/candlepin/auth/NoAuthPrincipalTest.java
+++ b/src/test/java/org/candlepin/auth/NoAuthPrincipalTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/SSLAuthTest.java
+++ b/src/test/java/org/candlepin/auth/SSLAuthTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/SSLCertTest.java
+++ b/src/test/java/org/candlepin/auth/SSLCertTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/SystemPrincipalTest.java
+++ b/src/test/java/org/candlepin/auth/SystemPrincipalTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/TrustedUserAuthTest.java
+++ b/src/test/java/org/candlepin/auth/TrustedUserAuthTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/TrustedUserPrincipalTest.java
+++ b/src/test/java/org/candlepin/auth/TrustedUserPrincipalTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/UserPrincipalTest.java
+++ b/src/test/java/org/candlepin/auth/UserPrincipalTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/permissions/AttachPermissionTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/AttachPermissionTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/permissions/ConsumerCuratorPermissionsTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/ConsumerCuratorPermissionsTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/permissions/OwnerCuratorPermissionsTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/OwnerCuratorPermissionsTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/auth/permissions/UsernameConsumersPermissionTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/UsernameConsumersPermissionTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/cache/StatusCacheTest.java
+++ b/src/test/java/org/candlepin/cache/StatusCacheTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.cache;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/config/CandlepinCommonTestConfig.java
+++ b/src/test/java/org/candlepin/config/CandlepinCommonTestConfig.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/config/EncryptedConfigurationTest.java
+++ b/src/test/java/org/candlepin/config/EncryptedConfigurationTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/config/MapConfigurationTest.java
+++ b/src/test/java/org/candlepin/config/MapConfigurationTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/config/PropertiesFileConfigurationTest.java
+++ b/src/test/java/org/candlepin/config/PropertiesFileConfigurationTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/config/PropertyConverterTest.java
+++ b/src/test/java/org/candlepin/config/PropertyConverterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/ActiveMQStatusMonitorTest.java
+++ b/src/test/java/org/candlepin/controller/ActiveMQStatusMonitorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2016 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/CdnManagerTest.java
+++ b/src/test/java/org/candlepin/controller/CdnManagerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
+++ b/src/test/java/org/candlepin/controller/EntitlementCertificateGeneratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/EntitlerTest.java
+++ b/src/test/java/org/candlepin/controller/EntitlerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/ManifestManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ManifestManagerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/OwnerManagerTest.java
+++ b/src/test/java/org/candlepin/controller/OwnerManagerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerFunctionalTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -1577,4 +1577,3 @@ public class PoolManagerFunctionalTest extends DatabaseTestFixture {
         assertTrue(pool2.getEntitlements().size() == 1);
     }
 }
-

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/RefresherTest.java
+++ b/src/test/java/org/candlepin/controller/RefresherTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
+++ b/src/test/java/org/candlepin/controller/SuspendModeTransitionerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/mode/CandlepinModeManagerTest.java
+++ b/src/test/java/org/candlepin/controller/mode/CandlepinModeManagerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/RefreshResultTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/RefreshResultTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/RefreshWorkerVersioningTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/RefreshWorkerVersioningTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/builders/ContentNodeBuilderTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/builders/ContentNodeBuilderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/builders/NodeFactoryTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/builders/NodeFactoryTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/builders/ProductNodeBuilderTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/builders/ProductNodeBuilderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/mappers/ContentMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/ContentMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/mappers/NodeMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/NodeMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/mappers/PoolMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/PoolMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/mappers/ProductMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/ProductMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/nodes/AbstractNodeTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/nodes/AbstractNodeTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/nodes/ContentNodeTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/nodes/ContentNodeTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/nodes/ProductNodeTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/nodes/ProductNodeTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/visitors/Accessor.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/Accessor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitorTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/visitors/Mutator.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/Mutator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/visitors/NodeProcessorTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/NodeProcessorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitorTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/util/EntitlementContentPrefixTest.java
+++ b/src/test/java/org/candlepin/controller/util/EntitlementContentPrefixTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/controller/util/EntityVersioningRetryWrapperTest.java
+++ b/src/test/java/org/candlepin/controller/util/EntityVersioningRetryWrapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/controller/util/PromotedContentTest.java
+++ b/src/test/java/org/candlepin/controller/util/PromotedContentTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/controller/util/ScaContainerContentPrefixTest.java
+++ b/src/test/java/org/candlepin/controller/util/ScaContainerContentPrefixTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/controller/util/ScaContentPrefixTest.java
+++ b/src/test/java/org/candlepin/controller/util/ScaContentPrefixTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.controller.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/dto/AbstractDTOTest.java
+++ b/src/test/java/org/candlepin/dto/AbstractDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/AbstractTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/AbstractTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/SimpleModelTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/SimpleModelTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/TestDTO.java
+++ b/src/test/java/org/candlepin/dto/TestDTO.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ActivationKeyTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ActivationKeyTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/AsyncJobStatusTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/AsyncJobStatusTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/BrandingTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/BrandingTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/CapabilityTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/CapabilityTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/CdnTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/CdnTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/CertificateSerialTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/CertificateSerialTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/CertificateTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/CertificateTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ComplianceReasonTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ComplianceReasonTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ComplianceStatusTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ComplianceStatusTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ConsumerArrayElementTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ConsumerArrayElementTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ConsumerInstalledProductTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ConsumerInstalledProductTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ConsumerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ConsumerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ConsumerTypeTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ConsumerTypeTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ContentOverrideTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ContentOverrideTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ContentTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ContentTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/DeletedConsumerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/DeletedConsumerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/DistributorVersionTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/DistributorVersionTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/EntitlementTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/EntitlementTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/EnvironmentTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/EnvironmentTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/GuestIdArrayElementTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/GuestIdArrayElementTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/GuestIdTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/GuestIdTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/HypervisorConsumerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/HypervisorConsumerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/HypervisorIdTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/HypervisorIdTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ImportRecordTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ImportRecordTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ImportUpstreamConsumerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ImportUpstreamConsumerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/NestedOwnerDTOTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/NestedOwnerDTOTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.dto.api.v1;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/dto/api/v1/NestedOwnerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/NestedOwnerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/OwnerInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/OwnerInfoTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/OwnerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/OwnerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/PermissionBlueprintInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/PermissionBlueprintInfoTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/PermissionBlueprintTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/PermissionBlueprintTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/PoolQuantityTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/PoolQuantityTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/PoolToSubscriptionTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/PoolToSubscriptionTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/PoolTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/PoolTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ProductCertificateTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ProductCertificateTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ProductContentTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ProductContentTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/ProductTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ProductTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/RoleInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/RoleInfoTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/RoleTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/RoleTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/SystemPurposeComplianceStatusTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/UeberCertificateTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/UeberCertificateTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/UpstreamConsumerArrayElementTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/UpstreamConsumerArrayElementTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/UpstreamConsumerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/UpstreamConsumerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/UserInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/UserInfoTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/api/v1/UserTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/UserTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/BrandingDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/BrandingDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/BrandingTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/BrandingTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/CdnDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/CdnDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/CdnTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/CdnTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/CertificateDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/CertificateDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/CertificateSerialTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/CertificateTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/CertificateTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/ConsumerDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/ConsumerDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTypeDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTypeDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTypeTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/ConsumerTypeTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/ContentDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/ContentDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/DistributorVersionTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/EntitlementDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/EntitlementDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/EntitlementTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/EntitlementTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/OwnerDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/OwnerDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/OwnerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/OwnerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/PoolDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/PoolDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/PoolTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/PoolTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/ProductDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/ProductDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/ProductTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/ProductTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/SubscriptionDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/SubscriptionDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerDTOTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/UpstreamConsumerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/ActivationKeyDTOTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ActivationKeyDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/ActivationKeyTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ActivationKeyTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/ComplianceReasonDTOTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ComplianceReasonDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/ComplianceReasonTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ComplianceReasonTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/ComplianceStatusDTOTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ComplianceStatusDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/ComplianceStatusTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ComplianceStatusTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/ConsumerDTOTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ConsumerDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/ConsumerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ConsumerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/ConsumerTypeDTOTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ConsumerTypeDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/ConsumerTypeTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/ConsumerTypeTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/EntitlementDTOTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/EntitlementDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/EntitlementTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/EntitlementTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/GuestIdDTOTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/GuestIdDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/GuestIdTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/GuestIdTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/OwnerDTOTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/OwnerDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/OwnerTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/OwnerTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/PoolDTOTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/PoolDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/PoolTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/PoolTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/rules/v1/SuggestedQuantityDTOTest.java
+++ b/src/test/java/org/candlepin/dto/rules/v1/SuggestedQuantityDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/shim/BrandingInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/shim/BrandingInfoTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/shim/CertificateInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/shim/CertificateInfoTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/shim/CertificateSerialInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/shim/CertificateSerialInfoTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/shim/ContentInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/shim/ContentInfoTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/shim/ProductInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/shim/ProductInfoTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/dto/shim/SubscriptionInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/shim/SubscriptionInfoTranslatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/ApplicationExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/ApplicationExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/BadRequestExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/BadRequestExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/CandlepinExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/CandlepinExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/DefaultOptionsMethodExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/DefaultOptionsMethodExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/FailureExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/FailureExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/InternalServerErrorExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/InternalServerErrorExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/JAXBMarshalExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/JAXBMarshalExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/JAXBUnmarshalExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/JAXBUnmarshalExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/NoLogWebApplicationExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/NoLogWebApplicationExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/NotAcceptableExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/NotAcceptableExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/NotAllowedExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/NotAllowedExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/NotAuthorizedExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/NotAuthorizedExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/NotFoundExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/NotFoundExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/NotSupportedExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/NotSupportedExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/ReaderExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/ReaderExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/RuntimeExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/RuntimeExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/TestExceptionMapperBase.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/TestExceptionMapperBase.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/WebApplicationExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/WebApplicationExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/mappers/WriterExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/exceptions/mappers/WriterExceptionMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/util/JaxRsExceptionResponseBuilderTest.java
+++ b/src/test/java/org/candlepin/exceptions/util/JaxRsExceptionResponseBuilderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/exceptions/util/RegexMatcher.java
+++ b/src/test/java/org/candlepin/exceptions/util/RegexMatcher.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
+++ b/src/test/java/org/candlepin/guice/CandlepinContextListenerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/guice/CustomizableModulesTest.java
+++ b/src/test/java/org/candlepin/guice/CustomizableModulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/guice/DummyModuleForTesting.java
+++ b/src/test/java/org/candlepin/guice/DummyModuleForTesting.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/guice/HttpMethodMatcherTest.java
+++ b/src/test/java/org/candlepin/guice/HttpMethodMatcherTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/guice/I18nProviderTest.java
+++ b/src/test/java/org/candlepin/guice/I18nProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.guice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/guice/TestPrincipalProvider.java
+++ b/src/test/java/org/candlepin/guice/TestPrincipalProvider.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/guice/TestPrincipalProviderSetter.java
+++ b/src/test/java/org/candlepin/guice/TestPrincipalProviderSetter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/guice/TestingScope.java
+++ b/src/test/java/org/candlepin/guice/TestingScope.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/hibernate/EmptyStringInterceptorTest.java
+++ b/src/test/java/org/candlepin/hibernate/EmptyStringInterceptorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/hibernate/EmptyStringUserTypeTest.java
+++ b/src/test/java/org/candlepin/hibernate/EmptyStringUserTypeTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/hibernate/ResultDataUserTypeTest.java
+++ b/src/test/java/org/candlepin/hibernate/ResultDataUserTypeTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/jackson/AttributeDeserializerTest.java
+++ b/src/test/java/org/candlepin/jackson/AttributeDeserializerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.jackson;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/jackson/DynamicFilterDataTest.java
+++ b/src/test/java/org/candlepin/jackson/DynamicFilterDataTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/jackson/DynamicPropertyFilterTest.java
+++ b/src/test/java/org/candlepin/jackson/DynamicPropertyFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/jackson/OffsetDateTimeDeserializerTest.java
+++ b/src/test/java/org/candlepin/jackson/OffsetDateTimeDeserializerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/jackson/OffsetDateTimeSerializerTest.java
+++ b/src/test/java/org/candlepin/jackson/OffsetDateTimeSerializerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/jackson/StringTrimmingConverterTest.java
+++ b/src/test/java/org/candlepin/jackson/StringTrimmingConverterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/junit/LiquibaseExtension.java
+++ b/src/test/java/org/candlepin/junit/LiquibaseExtension.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/katello/KatelloUserServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/katello/KatelloUserServiceAdapterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/liquibase/SchemaCompatibilityTest.java
+++ b/src/test/java/org/candlepin/liquibase/SchemaCompatibilityTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/logging/LoggerAndMDCFilterTest.java
+++ b/src/test/java/org/candlepin/logging/LoggerAndMDCFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/logging/LoggingConfiguratorTest.java
+++ b/src/test/java/org/candlepin/logging/LoggingConfiguratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/AbstractHibernateCuratorTest.java
+++ b/src/test/java/org/candlepin/model/AbstractHibernateCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ActivationKeyContentOverrideCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ActivationKeyContentOverrideCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ActivationKeyCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ActivationKeyCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ActivationKeyTest.java
+++ b/src/test/java/org/candlepin/model/ActivationKeyTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/AsyncJobStatusCuratorTest.java
+++ b/src/test/java/org/candlepin/model/AsyncJobStatusCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/CPRestrictionsTest.java
+++ b/src/test/java/org/candlepin/model/CPRestrictionsTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/CertificateSerialCuratorTest.java
+++ b/src/test/java/org/candlepin/model/CertificateSerialCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/CertificateTest.java
+++ b/src/test/java/org/candlepin/model/CertificateTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/model/ColumnarResultIteratorTest.java
+++ b/src/test/java/org/candlepin/model/ColumnarResultIteratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ConsumerContentOverrideCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerContentOverrideCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ConsumerCuratorSearchTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerCuratorSearchTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ConsumerInstalledProductTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerInstalledProductTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ConsumerTypeCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerTypeCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ConsumerTypeTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerTypeTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ContentAccessCertificateCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentAccessCertificateCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ContentTest.java
+++ b/src/test/java/org/candlepin/model/ContentTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/CuratorPaginationTest.java
+++ b/src/test/java/org/candlepin/model/CuratorPaginationTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/DeletedConsumerTest.java
+++ b/src/test/java/org/candlepin/model/DeletedConsumerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/EntitlementCertificateCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EntitlementCertificateCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EntitlementCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/EnvironmentContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EnvironmentContentCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/EnvironmentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/EnvironmentCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ExporterMetadataCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ExporterMetadataCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/GuestIdCuratorTest.java
+++ b/src/test/java/org/candlepin/model/GuestIdCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/HibernateValidationAnnotationTest.java
+++ b/src/test/java/org/candlepin/model/HibernateValidationAnnotationTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/IdentityCertificateCuratorTest.java
+++ b/src/test/java/org/candlepin/model/IdentityCertificateCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/model/ManifestFileRecordCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ManifestFileRecordCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/MembershipTest.java
+++ b/src/test/java/org/candlepin/model/MembershipTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ModifierTestDataGenerator.java
+++ b/src/test/java/org/candlepin/model/ModifierTestDataGenerator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -247,4 +247,3 @@ public class ModifierTestDataGenerator {
     }
 
 }
-

--- a/src/test/java/org/candlepin/model/OwnerAccessControlTest.java
+++ b/src/test/java/org/candlepin/model/OwnerAccessControlTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerContentCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/OwnerInfoCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerInfoCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerProductCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/OwnerTest.java
+++ b/src/test/java/org/candlepin/model/OwnerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/PoolCuratorEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/model/PoolCuratorEntitlementRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
+++ b/src/test/java/org/candlepin/model/PoolCuratorFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/PoolCuratorTest.java
+++ b/src/test/java/org/candlepin/model/PoolCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/PoolTest.java
+++ b/src/test/java/org/candlepin/model/PoolTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ProductCertificateCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ProductCertificateCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ProductTest.java
+++ b/src/test/java/org/candlepin/model/ProductTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/ReleaseTest.java
+++ b/src/test/java/org/candlepin/model/ReleaseTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/RoleTest.java
+++ b/src/test/java/org/candlepin/model/RoleTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/RowResultIteratorTest.java
+++ b/src/test/java/org/candlepin/model/RowResultIteratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/RulesCuratorTest.java
+++ b/src/test/java/org/candlepin/model/RulesCuratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/UeberCertificateCuratorTests.java
+++ b/src/test/java/org/candlepin/model/UeberCertificateCuratorTests.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/UpstreamConsumerTest.java
+++ b/src/test/java/org/candlepin/model/UpstreamConsumerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/UserTest.java
+++ b/src/test/java/org/candlepin/model/UserTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/dto/CandlepinDTOTest.java
+++ b/src/test/java/org/candlepin/model/dto/CandlepinDTOTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/dto/ContentDataTest.java
+++ b/src/test/java/org/candlepin/model/dto/ContentDataTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/dto/ProductContentDataTest.java
+++ b/src/test/java/org/candlepin/model/dto/ProductContentDataTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/model/dto/ProductDataTest.java
+++ b/src/test/java/org/candlepin/model/dto/ProductDataTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/pki/CertificateReaderTest.java
+++ b/src/test/java/org/candlepin/pki/CertificateReaderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/pki/ProviderBasedPrivateKeyReaderTest.java
+++ b/src/test/java/org/candlepin/pki/ProviderBasedPrivateKeyReaderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/pki/SubjectKeyIdentifierWriterTest.java
+++ b/src/test/java/org/candlepin/pki/SubjectKeyIdentifierWriterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.pki;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;

--- a/src/test/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriterTest.java
+++ b/src/test/java/org/candlepin/pki/impl/DefaultSubjectKeyIdentifierWriterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/pki/impl/JSSPKIUtilityTest.java
+++ b/src/test/java/org/candlepin/pki/impl/JSSPKIUtilityTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/AutobindRulesTest.java
+++ b/src/test/java/org/candlepin/policy/AutobindRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
+++ b/src/test/java/org/candlepin/policy/CriteriaRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -205,5 +205,3 @@ public class CriteriaRulesTest extends DatabaseTestFixture {
         assertEquals(1, results.size());
     }
 }
-
-

--- a/src/test/java/org/candlepin/policy/EnforcerTest.java
+++ b/src/test/java/org/candlepin/policy/EnforcerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/ExportRulesTest.java
+++ b/src/test/java/org/candlepin/policy/ExportRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
+++ b/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -443,4 +443,3 @@ public class PoolRulesStackDerivedTest {
     }
 
 }
-

--- a/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/RulesVersionMatchingTest.java
+++ b/src/test/java/org/candlepin/policy/RulesVersionMatchingTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/SystemPurposeComplianceRulesTest.java
+++ b/src/test/java/org/candlepin/policy/SystemPurposeComplianceRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/ValidationResultTest.java
+++ b/src/test/java/org/candlepin/policy/ValidationResultTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/ValidationWarningTest.java
+++ b/src/test/java/org/candlepin/policy/ValidationWarningTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/activationkey/ActivationKeyRulesTest.java
+++ b/src/test/java/org/candlepin/policy/activationkey/ActivationKeyRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/js/JsRunnerProviderTest.java
+++ b/src/test/java/org/candlepin/policy/js/JsRunnerProviderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/ComplianceRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/StatusReasonMessageGeneratorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/hash/ComplianceStatusHasherTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.policy.js.compliance.hash;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/policy/js/compliance/hash/SystemPurposeStatusHasherTest.java
+++ b/src/test/java/org/candlepin/policy/js/compliance/hash/SystemPurposeStatusHasherTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.policy.js.compliance.hash;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/EntitlementRulesTestFixture.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/HostedVirtLimitEntitlementRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/js/entitlement/ManifestEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/ManifestEntitlementRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/js/entitlement/PostEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/PostEntitlementRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/js/entitlement/PreEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/entitlement/PreEntitlementRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
+++ b/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
+++ b/src/test/java/org/candlepin/policy/js/quantity/QuantityRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ActivationKeyContentOverrideResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ActivationKeyContentOverrideResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/AdminResourceTest.java
+++ b/src/test/java/org/candlepin/resource/AdminResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/CertificateSerialResourceTest.java
+++ b/src/test/java/org/candlepin/resource/CertificateSerialResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/CloudRegistrationResourceTest.java
+++ b/src/test/java/org/candlepin/resource/CloudRegistrationResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ConsumerContentOverrideResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerContentOverrideResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationLiberalNameRules.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationLiberalNameRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ConsumerResourceDisableStatusTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceDisableStatusTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ConsumerTypeResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerTypeResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ContentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ContentResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/CrlResourceTest.java
+++ b/src/test/java/org/candlepin/resource/CrlResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
+++ b/src/test/java/org/candlepin/resource/EntitlementResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.resource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/HypervisorCloudProfileTest.java
+++ b/src/test/java/org/candlepin/resource/HypervisorCloudProfileTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.resource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/resource/JobResourceTest.java
+++ b/src/test/java/org/candlepin/resource/JobResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.resource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceUeberCertOperationsTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
+++ b/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -72,4 +72,3 @@ public class PersonConsumerResourceCreationTest extends ConsumerResourceCreation
         // person consumer needs to by-pass this test.
     }
 }
-

--- a/src/test/java/org/candlepin/resource/PoolResourceTest.java
+++ b/src/test/java/org/candlepin/resource/PoolResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/RootResourceTest.java
+++ b/src/test/java/org/candlepin/resource/RootResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/RulesResourceTest.java
+++ b/src/test/java/org/candlepin/resource/RulesResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/StatusResourceTest.java
+++ b/src/test/java/org/candlepin/resource/StatusResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/UserResourceTest.java
+++ b/src/test/java/org/candlepin/resource/UserResourceTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/util/AttachedFileTest.java
+++ b/src/test/java/org/candlepin/resource/util/AttachedFileTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/util/CalculatedAttributesUtilTest.java
+++ b/src/test/java/org/candlepin/resource/util/CalculatedAttributesUtilTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/util/EntitlementEnvironmentFilterTest.java
+++ b/src/test/java/org/candlepin/resource/util/EntitlementEnvironmentFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2021 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
+++ b/src/test/java/org/candlepin/resource/util/InstalledProductStatusCalculatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/util/JobStateMapperTest.java
+++ b/src/test/java/org/candlepin/resource/util/JobStateMapperTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/util/KeyValueStringParserTest.java
+++ b/src/test/java/org/candlepin/resource/util/KeyValueStringParserTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2021 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resource/validation/DTOValidatorTest.java
+++ b/src/test/java/org/candlepin/resource/validation/DTOValidatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resteasy/JsonProviderTest.java
+++ b/src/test/java/org/candlepin/resteasy/JsonProviderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resteasy/ResourceLocatorMapTest.java
+++ b/src/test/java/org/candlepin/resteasy/ResourceLocatorMapTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.resteasy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/candlepin/resteasy/converter/OffsetDateTimeParamConverterProviderTest.java
+++ b/src/test/java/org/candlepin/resteasy/converter/OffsetDateTimeParamConverterProviderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resteasy/filter/AuthenticationFilterTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/AuthenticationFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resteasy/filter/AuthorizationFeatureTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/AuthorizationFeatureTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptorTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resteasy/filter/ConsumerCheckInFilterTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/ConsumerCheckInFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resteasy/filter/DynamicJsonFilterTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/DynamicJsonFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resteasy/filter/LinkHeaderResponseFilterTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/LinkHeaderResponseFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resteasy/filter/PageRequestFilterTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/PageRequestFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilterTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultIdentityCertServiceAdapterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/service/impl/DefaultProductServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultProductServiceAdapterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/service/impl/ProductCertCreationTest.java
+++ b/src/test/java/org/candlepin/service/impl/ProductCertCreationTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/service/impl/stub/StubEntitlementCertServiceAdapter.java
+++ b/src/test/java/org/candlepin/service/impl/stub/StubEntitlementCertServiceAdapter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/servlet/filter/CandlepinPersistFilterTest.java
+++ b/src/test/java/org/candlepin/servlet/filter/CandlepinPersistFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/servlet/filter/CandlepinScopeFilterTest.java
+++ b/src/test/java/org/candlepin/servlet/filter/CandlepinScopeFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/servlet/filter/logging/LoggingFilterTest.java
+++ b/src/test/java/org/candlepin/servlet/filter/logging/LoggingFilterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/servlet/filter/logging/TeeHttpServletRequestTest.java
+++ b/src/test/java/org/candlepin/servlet/filter/logging/TeeHttpServletRequestTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/servlet/filter/logging/TeeHttpServletResponseTest.java
+++ b/src/test/java/org/candlepin/servlet/filter/logging/TeeHttpServletResponseTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
+++ b/src/test/java/org/candlepin/sync/ConsumerExporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ConsumerImporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
+++ b/src/test/java/org/candlepin/sync/ConsumerTypeExporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/ConsumerTypeImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ConsumerTypeImporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
+++ b/src/test/java/org/candlepin/sync/EntitlementImporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2020 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/ImporterUtilsTest.java
+++ b/src/test/java/org/candlepin/sync/ImporterUtilsTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2018 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/MetaExporterTest.java
+++ b/src/test/java/org/candlepin/sync/MetaExporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/ProductExporterTest.java
+++ b/src/test/java/org/candlepin/sync/ProductExporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/ProductImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ProductImporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/RulesExporterTest.java
+++ b/src/test/java/org/candlepin/sync/RulesExporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/RulesImporterTest.java
+++ b/src/test/java/org/candlepin/sync/RulesImporterTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
+++ b/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/CacheTestFixture.java
+++ b/src/test/java/org/candlepin/test/CacheTestFixture.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/CertificateReaderForTesting.java
+++ b/src/test/java/org/candlepin/test/CertificateReaderForTesting.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/CollectionMatcher.java
+++ b/src/test/java/org/candlepin/test/CollectionMatcher.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/DateSourceForTesting.java
+++ b/src/test/java/org/candlepin/test/DateSourceForTesting.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/EnforcerForTesting.java
+++ b/src/test/java/org/candlepin/test/EnforcerForTesting.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/MatchesPattern.java
+++ b/src/test/java/org/candlepin/test/MatchesPattern.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/MockResultIterator.java
+++ b/src/test/java/org/candlepin/test/MockResultIterator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/SessionWrapper.java
+++ b/src/test/java/org/candlepin/test/SessionWrapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/test/VerifyAuthorizationFilterFactory.java
+++ b/src/test/java/org/candlepin/test/VerifyAuthorizationFilterFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/ArchTest.java
+++ b/src/test/java/org/candlepin/util/ArchTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/AttributeValidatorTest.java
+++ b/src/test/java/org/candlepin/util/AttributeValidatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/CollectionViewTest.java
+++ b/src/test/java/org/candlepin/util/CollectionViewTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/ContentOverrideValidatorTest.java
+++ b/src/test/java/org/candlepin/util/ContentOverrideValidatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/DateSourceImplTest.java
+++ b/src/test/java/org/candlepin/util/DateSourceImplTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/FactValidatorTest.java
+++ b/src/test/java/org/candlepin/util/FactValidatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/GuiceDebug.java
+++ b/src/test/java/org/candlepin/util/GuiceDebug.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/ListViewTest.java
+++ b/src/test/java/org/candlepin/util/ListViewTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/LongHashCodeBuilderTest.java
+++ b/src/test/java/org/candlepin/util/LongHashCodeBuilderTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2022 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/MapViewTest.java
+++ b/src/test/java/org/candlepin/util/MapViewTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/PropertyUtilTest.java
+++ b/src/test/java/org/candlepin/util/PropertyUtilTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/PropertyValidatorTest.java
+++ b/src/test/java/org/candlepin/util/PropertyValidatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/RpmVersionComparatorTest.java
+++ b/src/test/java/org/candlepin/util/RpmVersionComparatorTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/SetViewTest.java
+++ b/src/test/java/org/candlepin/util/SetViewTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2017 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/TransactionalTest.java
+++ b/src/test/java/org/candlepin/util/TransactionalTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2019 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/UtilTest.java
+++ b/src/test/java/org/candlepin/util/UtilTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/VersionUtilTest.java
+++ b/src/test/java/org/candlepin/util/VersionUtilTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/X509ExtensionUtilTest.java
+++ b/src/test/java/org/candlepin/util/X509ExtensionUtilTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
+++ b/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2009 - 2012 Red Hat, Inc.
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or


### PR DESCRIPTION
- Removed spaces from idea template
- Fixed template date so that it's automatically populated as current year
- Updated checkstyle to not expect copyright in javadoc format
- Applied updated copyright header