### PR TITLE
[M] CANDLEPIN-557: Added support for entitlement cleanup in SCA mode

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -3179,7 +3179,13 @@ paths:
 
   /environments/{env_id}/content:
     post:
-      description: Promotes a Content into an Environment. This call accepts multiple content sets to promote at once, after which all affected certificates for consumers in the environment will be regenerated. Consumers registered to this environment will now receive this content in their entitlement certificates. Because the certificate regeneraiton can be quite time consuming, this is done as an asynchronous job. The content will be promoted and immediately available for new entitlements, but existing entitlements could take some time to be regenerated and sent down to clients as they check in.
+      description: |
+        Promotes a Content into an Environment. This call accepts multiple content sets to promote at once,
+        after which all affected certificates for consumers in the environment will be regenerated. Consumers
+        registered to this environment will now receive this content in their entitlement certificates.
+        Because the certificate regeneraiton can be quite time consuming, this is done as an asynchronous job.
+        The content will be promoted and immediately available for new entitlements, but existing entitlements
+        could take some time to be regenerated and sent down to clients as they check in.
       operationId: promoteContent
       tags:
         - environment

--- a/spec-tests/src/test/java/org/candlepin/spec/ExportSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ExportSpecTest.java
@@ -263,8 +263,7 @@ class ExportSpecTest {
         @Test
         void shouldExportConsumers() throws Exception {
             String path = EXPORT_PATH + "consumer.json";
-            ConsumerDTO actual = ExportUtil
-                .deserializeJsonFile(export, path, ConsumerDTO.class);
+            ConsumerDTO actual = ExportUtil.deserializeJsonFile(export, path, ConsumerDTO.class);
             assertNotNull(actual);
             assertEquals(consumer.getUuid(), actual.getUuid());
             assertEquals(consumer.getName(), actual.getName());

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -296,6 +296,10 @@ public class ConfigProperties {
     // manifest import. Default: 30 days
     public static final String ORPHANED_ENTITY_GRACE_PERIOD = "candlepin.refresh.orphan_entity_grace_period";
 
+    // Whether or not to automatically revoke consumer entitlements during a regeneration request
+    // when operating in SCA mode.
+    public static final String SCA_ENTITLEMENT_CLEANUP = "candlepin.sca_entitlement_cleanup";
+
     /**
      * Fetches a string representing the prefix for all per-job configuration for the specified job.
      * The job key or class name may be used, but the usage must be consistent.
@@ -377,13 +381,7 @@ public class ConfigProperties {
 
             this.put(ENTITLER_BULK_SIZE, "1000");
 
-            /**
-            * These default DO_NOT_FILTER events are those events needed by
-            * other Satellite components. See sources:
-            *
-            * https://gitlab.sat.lab.tlv.redhat.com/satellite6/katello/blob/
-            * SATELLITE-6.1.0/app/lib/actions/candlepin/reindex_pool_subscription_handler.rb#L43
-            */
+            // These default DO_NOT_FILTER events are those events needed by other Satellite components.
             this.put(AUDIT_FILTER_DO_NOT_FILTER,
                 "CREATED-ENTITLEMENT," +
                 "DELETED-ENTITLEMENT," +
@@ -501,6 +499,8 @@ public class ConfigProperties {
             this.put(ASYNC_JOBS_TRIGGERABLE_JOBS, String.join(", ", ASYNC_JOBS_TRIGGERABLE_JOBS_LIST));
 
             this.put(ORPHANED_ENTITY_GRACE_PERIOD, "30");
+
+            this.put(SCA_ENTITLEMENT_CLEANUP, "true");
         }
     };
 }

--- a/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -67,6 +67,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import javax.inject.Inject;
 import javax.naming.ldap.Rdn;
@@ -85,7 +86,10 @@ public class ContentAccessManager {
      * utility methods for resolving, matching, and converting to database-compatible values.
      */
     public enum ContentAccessMode {
+        /** traditional entitlement mode requiring clients to consume pools to access content */
         ENTITLEMENT,
+
+        /** simple content access (SCA) mode; clients have access to all org content by default */
         ORG_ENVIRONMENT;
 
         /**
@@ -189,6 +193,43 @@ public class ContentAccessManager {
             ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
     }
 
+    /**
+     * Resolves the content access mode for the given consumer, translating the mode name assigned
+     * to a ContentAccessMode enum value. If no explicit value is defined for the consumer or its
+     * owner, this function returns the default content access mode.
+     *
+     * @param consumer
+     *  the consumer for which to fetch the content access mode
+     *
+     * @throws IllegalArgumentException
+     *  if the provided consumer is null
+     *
+     * @throws IllegalStateException
+     *  if the resolved content access mode for the consumer is invalid or otherwise cannot be
+     *  mapped to a ContentAccessMode value
+     *
+     * @return
+     *  a ContentAccessMode enum value for the given consumer
+     */
+    public static ContentAccessMode resolveContentAccessMode(Consumer consumer) {
+        if (consumer == null) {
+            throw new IllegalArgumentException("consumer is null");
+        }
+
+        Predicate<String> predicate = (str) -> str != null && !str.isEmpty();
+
+        String caMode = Util.firstOf(predicate,
+            consumer.getContentAccessMode(),
+            consumer.getOwner().getContentAccessMode());
+
+        try {
+            return ContentAccessMode.resolveModeName(caMode, true);
+        }
+        catch (IllegalArgumentException e) {
+            throw new IllegalStateException("consumer is using an invalid content access mode: " + caMode, e);
+        }
+    }
+
     private final Configuration config;
     private final PKIUtility pki;
     private final CertificateSerialCurator serialCurator;
@@ -201,6 +242,7 @@ public class ContentAccessManager {
     private final EnvironmentCurator environmentCurator;
     private final ContentAccessCertificateCurator contentAccessCertCurator;
     private final EventSink eventSink;
+
     private final boolean standalone;
 
     @Inject
@@ -599,7 +641,6 @@ public class ContentAccessManager {
         }
     }
 
-
     /**
      * Updates the content access mode state for the given owner using the updated content access mode
      * list and content access mode provided.
@@ -691,10 +732,13 @@ public class ContentAccessManager {
             owner = this.ownerCurator.merge(owner);
             ownerCurator.flush();
 
-            this.syncOwnerLastContentUpdate(owner);
-            if (isTurningOffSca(updatedMode, currentMode)) {
+            // Delete the SCA cert if we're leaving SCA mode
+            if (this.isTransitioningFrom(currentMode, updatedMode, ContentAccessMode.ORG_ENVIRONMENT)) {
                 this.contentAccessCertCurator.deleteForOwner(owner);
             }
+
+            // Update sync times & report
+            this.syncOwnerLastContentUpdate(owner);
             this.eventSink.emitOwnerContentAccessModeChanged(owner);
 
             log.info("Content access mode changed from {} to {} for owner {}", currentMode,
@@ -715,9 +759,52 @@ public class ContentAccessManager {
         return owner;
     }
 
-    private boolean isTurningOffSca(String updatedMode, String currentMode) {
-        return ContentAccessMode.ORG_ENVIRONMENT.matches(currentMode) &&
-            ContentAccessMode.ENTITLEMENT.matches(updatedMode);
+    /**
+     * Checks if the content access mode is transitioning and, if so, if it is transitioning to the
+     * target mode. That is, the current mode and updated modes are not equal, and the updated mode
+     * is equal to the target mode.
+     *
+     * @param current
+     *  the current content access mode name
+     *
+     * @param updated
+     *  the updated content access mode name
+     *
+     * @param target
+     *  the targeted content access mode to check
+     *
+     * @return
+     *  true if the content access mode is transitioning to the target mode; false otherwise
+     */
+    private boolean isTransitioningTo(String current, String updated, ContentAccessMode target) {
+        ContentAccessMode currentMode = ContentAccessMode.resolveModeName(current, true);
+        ContentAccessMode updatedMode = ContentAccessMode.resolveModeName(updated, true);
+
+        return currentMode != updatedMode && updatedMode == target;
+    }
+
+    /**
+     * Checks if the content access mode is transitioning and, if so, if it is transitioning away
+     * the target mode. That is, the current mode and updated modes are not equal, and the current
+     * mode is equal to the target mode.
+     *
+     * @param current
+     *  the current content access mode name
+     *
+     * @param updated
+     *  the updated content access mode name
+     *
+     * @param target
+     *  the targeted content access mode to check
+     *
+     * @return
+     *  true if the content access mode is transitioning away the target mode; false otherwise
+     */
+    private boolean isTransitioningFrom(String current, String updated, ContentAccessMode target) {
+        ContentAccessMode currentMode = ContentAccessMode.resolveModeName(current, true);
+        ContentAccessMode updatedMode = ContentAccessMode.resolveModeName(updated, true);
+
+        return currentMode != updatedMode && currentMode == target;
     }
 
     /**

--- a/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -314,10 +314,8 @@ public class EntitlementCertificateGenerator {
      */
     @Transactional
     public void regenerateCertificatesOf(Consumer consumer, boolean lazy) {
-        log.info(
-            "Regenerating #{}, entitlement certificates for consumer: {}",
-            consumer.getEntitlements().size(), consumer
-        );
+        log.info("Regenerating {} entitlement certificate(s) for consumer: {}",
+            consumer.getEntitlements().size(), consumer);
 
         // we need to clear the content access cert on regenerate
         Owner owner = ownerCurator.findOwnerById(consumer.getOwnerId());

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -81,6 +81,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -96,6 +100,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 
@@ -328,6 +333,81 @@ public class ContentAccessManagerTest {
         cert.setKey("test-key");
         cert.setConsumer(consumer);
         return cert;
+    }
+
+    public static Stream<Arguments> contentAccessModeConfigProvider() {
+        String entMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
+        String scaMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
+
+        return Stream.of(
+            Arguments.of(null, null, ContentAccessMode.getDefault()),
+            Arguments.of(null, entMode, ContentAccessMode.ENTITLEMENT),
+            Arguments.of(null, scaMode, ContentAccessMode.ORG_ENVIRONMENT),
+
+            Arguments.of(entMode, null, ContentAccessMode.ENTITLEMENT),
+            Arguments.of(entMode, entMode, ContentAccessMode.ENTITLEMENT),
+            Arguments.of(entMode, scaMode, ContentAccessMode.ORG_ENVIRONMENT),
+
+            Arguments.of(scaMode, null, ContentAccessMode.ORG_ENVIRONMENT),
+            Arguments.of(scaMode, entMode, ContentAccessMode.ENTITLEMENT),
+            Arguments.of(scaMode, scaMode, ContentAccessMode.ORG_ENVIRONMENT)
+        );
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}, {1} => {2}")
+    @MethodSource("contentAccessModeConfigProvider")
+    public void testResolveContentAccessMode(String orgCAMode, String consumerCAMode,
+        ContentAccessMode expected) {
+
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+
+        // Set up org and consumer content access modes
+        owner.setContentAccessModeList(String.join(",", orgCAMode, consumerCAMode));
+        owner.setContentAccessMode(orgCAMode);
+        consumer.setContentAccessMode(consumerCAMode);
+
+        ContentAccessMode output = ContentAccessManager.resolveContentAccessMode(consumer);
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testResolveContentAccessModeRequiresValidInput() {
+        assertThrows(IllegalArgumentException.class, () ->
+            ContentAccessManager.resolveContentAccessMode(null));
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @EnumSource
+    public void testResolveContentAccessModeThrowsExceptionOnInvalidConsumerCAMode(
+        ContentAccessMode orgCAMode) {
+
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+
+        String consumerCAMode = "invalid_mode";
+
+        owner.setContentAccessModeList(String.join(",", orgCAMode.toDatabaseValue(), consumerCAMode));
+        owner.setContentAccessMode(orgCAMode.toDatabaseValue());
+        consumer.setContentAccessMode(consumerCAMode);
+
+        assertThrows(IllegalStateException.class, () ->
+            ContentAccessManager.resolveContentAccessMode(consumer));
+    }
+
+    @Test
+    public void testResolveContentAccessModeThrowsExceptionOnInvalidOrgCAMode() {
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+
+        String orgCAMode = "invalid_mode";
+
+        owner.setContentAccessModeList(orgCAMode);
+        owner.setContentAccessMode(orgCAMode);
+        consumer.setContentAccessMode(null);
+
+        assertThrows(IllegalStateException.class, () ->
+            ContentAccessManager.resolveContentAccessMode(consumer));
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationLiberalNameRules.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationLiberalNameRules.java
@@ -16,17 +16,15 @@ package org.candlepin.resource;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
-import org.candlepin.config.MapConfiguration;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
-import java.util.HashMap;
 
 
 
@@ -37,20 +35,13 @@ import java.util.HashMap;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class ConsumerResourceCreationLiberalNameRules extends ConsumerResourceCreationTest {
 
-    private static class ConfigForTesting extends MapConfiguration {
-        @SuppressWarnings("serial")
-        ConfigForTesting() {
-            super(new HashMap<String, String>() {
-                {
-                    this.put(ConfigProperties.CONSUMER_SYSTEM_NAME_PATTERN, ".+");
-                    this.put(ConfigProperties.CONSUMER_PERSON_NAME_PATTERN, ".+");
-                }
-            });
-        }
-    }
     public Configuration initConfig() {
-        Configuration config = new ConfigForTesting();
+        Configuration config = new CandlepinCommonTestConfig();
+
+        config.setProperty(ConfigProperties.CONSUMER_SYSTEM_NAME_PATTERN, ".+");
+        config.setProperty(ConfigProperties.CONSUMER_PERSON_NAME_PATTERN, ".+");
         config.setProperty(ConfigProperties.USE_SYSTEM_UUID_FOR_MATCHING, "true");
+
         return config;
     }
 

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -38,9 +38,9 @@ import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.permissions.OwnerPermission;
 import org.candlepin.auth.permissions.Permission;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
-import org.candlepin.config.MapConfiguration;
 import org.candlepin.controller.ContentAccessManager;
 import org.candlepin.controller.EntitlementCertificateGenerator;
 import org.candlepin.controller.Entitler;
@@ -114,7 +114,6 @@ import org.xnap.commons.i18n.I18nFactory;
 
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -306,8 +305,14 @@ public class ConsumerResourceCreationTest {
     }
 
     public Configuration initConfig() {
-        Configuration config = new ConfigForTesting();
+        Configuration config = new CandlepinCommonTestConfig();
+
+        config.setProperty(ConfigProperties.CONSUMER_SYSTEM_NAME_PATTERN,
+            "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
+        config.setProperty(ConfigProperties.CONSUMER_PERSON_NAME_PATTERN,
+            "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
         config.setProperty(ConfigProperties.USE_SYSTEM_UUID_FOR_MATCHING, "true");
+
         return config;
     }
 
@@ -343,22 +348,6 @@ public class ConsumerResourceCreationTest {
 
         return ctype;
     }
-
-    private static class ConfigForTesting extends MapConfiguration {
-        @SuppressWarnings("serial")
-        public ConfigForTesting() {
-            super(new HashMap<String, String>() {
-                {
-                    this.put(ConfigProperties.CONSUMER_SYSTEM_NAME_PATTERN,
-                        "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
-                    this.put(ConfigProperties.CONSUMER_PERSON_NAME_PATTERN,
-                        "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
-                }
-            });
-        }
-
-    }
-
 
     protected ConsumerDTO createConsumer(String consumerName) {
         Collection<Permission> perms = new HashSet<>();

--- a/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -154,10 +154,23 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         standardSystemTypeDTO = modelTranslator.translate(standardSystemType, ConsumerTypeDTO.class);
         personType = consumerTypeCurator.create(new ConsumerType(ConsumerTypeEnum.PERSON));
         personTypeDTO = modelTranslator.translate(personType, ConsumerTypeDTO.class);
-        owner = ownerCurator.create(new Owner("test-owner"));
-        ownerDTO = modelTranslator.translate(owner, OwnerDTO.class);
-        owner.setDefaultServiceLevel(DEFAULT_SERVICE_LEVEL);
-        ownerCurator.create(owner);
+
+        this.owner = new Owner()
+            .setKey("test-owner")
+            .setDisplayName("test-owner")
+            .setDefaultServiceLevel(DEFAULT_SERVICE_LEVEL);
+
+        // Many of these tests were written before the conception of SCA mode, so explicitly set the
+        // shared owners's CA mode to entitlement. In the future, the tests should be updated to
+        // (a) not use shared data like this, and (b) be explicit about the operating mode necessary
+        // for testing a given unit.
+        this.owner.setContentAccessModeList(ContentAccessMode.ENTITLEMENT.toDatabaseValue())
+            .setContentAccessMode(ContentAccessMode.ENTITLEMENT.toDatabaseValue());
+
+        this.owner = this.ownerCurator.create(owner);
+
+        this.ownerDTO = modelTranslator.translate(owner, OwnerDTO.class);
+
         this.principalProvider = mock(PrincipalProvider.class);
         someuser = userCurator.create(new User(USER_NAME, "dontcare"));
 

--- a/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
+++ b/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
@@ -48,8 +48,7 @@ public class PersonConsumerResourceCreationLiberalNameRules extends
         // create an owner, an ownerperm, and roles for the user we provide
         // as coming from userService
         owner = new Owner("test_owner");
-        PermissionBlueprint p = new PermissionBlueprint(PermissionType.OWNER, owner,
-            Access.ALL);
+        PermissionBlueprint p = new PermissionBlueprint(PermissionType.OWNER, owner, Access.ALL);
         User user = new User("anyuser", "");
         role = new Role();
         role.addPermission(p);


### PR DESCRIPTION
- Added an option to enable revoking consumer entitlements during an
  entitlement certificate regeneration operation when the consumer is
  running in SCA mode. This feature is enabled by default, but can be
  disabled by setting the configuration
  "candlepin.sca_entitlement.cleanup" to "false".
- Miscellaneous comment, logging, and documentation cleanup