### PR TITLE
[M] CANDLEPIN-557: Added support for entitlement cleanup in SCA mode

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -1090,6 +1090,14 @@ paths:
           schema:
             type: boolean
             default: true
+        - name: cleanup_entitlements
+          in: query
+          description: |
+            Whether or not to remove unnecessary or unused entitlements for the consumer before regenerating
+            certificates
+          schema:
+            type: boolean
+            default: false
       responses:
         204:
           description: Successful operation
@@ -3179,7 +3187,13 @@ paths:
 
   /environments/{env_id}/content:
     post:
-      description: Promotes a Content into an Environment. This call accepts multiple content sets to promote at once, after which all affected certificates for consumers in the environment will be regenerated. Consumers registered to this environment will now receive this content in their entitlement certificates. Because the certificate regeneraiton can be quite time consuming, this is done as an asynchronous job. The content will be promoted and immediately available for new entitlements, but existing entitlements could take some time to be regenerated and sent down to clients as they check in.
+      description: |
+        Promotes a Content into an Environment. This call accepts multiple content sets to promote at once,
+        after which all affected certificates for consumers in the environment will be regenerated. Consumers
+        registered to this environment will now receive this content in their entitlement certificates.
+        Because the certificate regeneraiton can be quite time consuming, this is done as an asynchronous job.
+        The content will be promoted and immediately available for new entitlements, but existing entitlements
+        could take some time to be regenerated and sent down to clients as they check in.
       operationId: promoteContent
       tags:
         - environment

--- a/spec-tests/src/test/java/org/candlepin/spec/EntitlementCertificateSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/EntitlementCertificateSpecTest.java
@@ -108,7 +108,7 @@ public class EntitlementCertificateSpecTest {
     @Test
     public void shouldBeManuallyRegeneratedForAConsumer() throws Exception {
         List<CertificateDTO> oldCerts = consumerApi.fetchCertificates(system.getUuid());
-        consumerApi.regenerateEntitlementCertificates(system.getUuid(), null, false);
+        consumerApi.regenerateEntitlementCertificates(system.getUuid(), null, false, false);
         List<CertificateDTO> newCerts = consumerApi.fetchCertificates(system.getUuid());
         assertThat(newCerts).hasSize(1);
         assertNotEquals(oldCerts.get(0).getSerial().getId(), newCerts.get(0).getSerial().getId());
@@ -118,7 +118,7 @@ public class EntitlementCertificateSpecTest {
     public void shouldRegenerateACertByEntId() throws Exception {
         List<CertificateDTO> oldCerts = consumerApi.fetchCertificates(system.getUuid());
         List<EntitlementDTO> ents = consumerApi.listEntitlements(system.getUuid());
-        consumerApi.regenerateEntitlementCertificates(system.getUuid(), ents.get(0).getId(), false);
+        consumerApi.regenerateEntitlementCertificates(system.getUuid(), ents.get(0).getId(), false, false);
         List<CertificateDTO> newCerts = consumerApi.fetchCertificates(system.getUuid());
         assertThat(newCerts).hasSize(1);
         assertNotEquals(oldCerts.get(0).getSerial().getId(), newCerts.get(0).getSerial().getId());
@@ -130,9 +130,8 @@ public class EntitlementCertificateSpecTest {
         ConsumerDTO system2 = client.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(system2);
         ConsumerClient consumerApi2 = consumerClient.consumers();
-        assertNotFound(
-            () -> consumerApi2.regenerateEntitlementCertificates(
-            system.getUuid(), ents.get(0).getId(), false));
+        assertNotFound(() -> consumerApi2.regenerateEntitlementCertificates(
+            system.getUuid(), ents.get(0).getId(), false, false));
     }
 
     @Test
@@ -140,8 +139,8 @@ public class EntitlementCertificateSpecTest {
         ConsumerDTO system2 = client.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(system2);
         ConsumerClient consumerApi2 = consumerClient.consumers();
-        assertNotFound(
-            () -> consumerApi2.regenerateEntitlementCertificates(system.getUuid(), null, false));
+        assertNotFound(() -> consumerApi2.regenerateEntitlementCertificates(
+            system.getUuid(), null, false, false));
     }
 
     @Test

--- a/spec-tests/src/test/java/org/candlepin/spec/ExportSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ExportSpecTest.java
@@ -263,8 +263,7 @@ class ExportSpecTest {
         @Test
         void shouldExportConsumers() throws Exception {
             String path = EXPORT_PATH + "consumer.json";
-            ConsumerDTO actual = ExportUtil
-                .deserializeJsonFile(export, path, ConsumerDTO.class);
+            ConsumerDTO actual = ExportUtil.deserializeJsonFile(export, path, ConsumerDTO.class);
             assertNotNull(actual);
             assertEquals(consumer.getUuid(), actual.getUuid());
             assertEquals(consumer.getName(), actual.getName());
@@ -391,7 +390,7 @@ class ExportSpecTest {
 
             // Regenerate some entitlement certificates, and generate a new manifest:
             String consumerUuid = consumer.getUuid();
-            consumerApi.regenerateEntitlementCertificates(consumerUuid, null, true);
+            consumerApi.regenerateEntitlementCertificates(consumerUuid, null, true, false);
             File newManifest = createExport(client, consumerUuid, cdn);
             ZipFile newExport = ExportUtil.getExportArchive(newManifest);
             long newEntitlementsSize = newExport.stream()

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerCheckinSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerCheckinSpecTest.java
@@ -66,7 +66,7 @@ public class ConsumerCheckinSpecTest {
         ApiClient consumerClient = ApiClients.ssl(consumer);
         OffsetDateTime initialCheckin = consumer.getLastCheckin();
 
-        consumerClient.consumers().regenerateEntitlementCertificates(consumer.getUuid(), null, true);
+        consumerClient.consumers().regenerateEntitlementCertificates(consumer.getUuid(), null, true, false);
 
         consumer = consumerClient.consumers().getConsumer(consumer.getUuid());
         assertThat(consumer)

--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
@@ -537,7 +537,7 @@ public class ContentAccessSpecTest {
         assertThatCert(X509Cert.from(payloadCerts.get(0)))
             .hasEntitlementType("OrgLevel");
 
-        consumerClient.consumers().regenerateEntitlementCertificates(consumer.getUuid(), null, true);
+        consumerClient.consumers().regenerateEntitlementCertificates(consumer.getUuid(), null, true, true);
 
         export = consumerApi.exportCertificates(consumer.getUuid(), null);
         List<JsonNode> updatedCerts = CertificateUtil

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportUpdateSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportUpdateSpecTest.java
@@ -259,7 +259,7 @@ public class ImportUpdateSpecTest {
         ownerProductApi.addContent(ownerKey, product2.getId(), archContent.getId(), true);
 
         EntitlementDTO ent1 = consumerApi.listEntitlements(consumer.getUuid()).get(0);
-        consumerApi.regenerateEntitlementCertificates(consumer.getUuid(), ent1.getId(), false);
+        consumerApi.regenerateEntitlementCertificates(consumer.getUuid(), ent1.getId(), false, false);
         consumerApi.listEntitlements(consumer.getUuid());
 
         PoolDTO pool1 = Pools.random().productId(product1.getId())

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -377,13 +377,7 @@ public class ConfigProperties {
 
             this.put(ENTITLER_BULK_SIZE, "1000");
 
-            /**
-            * These default DO_NOT_FILTER events are those events needed by
-            * other Satellite components. See sources:
-            *
-            * https://gitlab.sat.lab.tlv.redhat.com/satellite6/katello/blob/
-            * SATELLITE-6.1.0/app/lib/actions/candlepin/reindex_pool_subscription_handler.rb#L43
-            */
+            // These default DO_NOT_FILTER events are those events needed by other Satellite components.
             this.put(AUDIT_FILTER_DO_NOT_FILTER,
                 "CREATED-ENTITLEMENT," +
                 "DELETED-ENTITLEMENT," +

--- a/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
+++ b/src/main/java/org/candlepin/controller/EntitlementCertificateGenerator.java
@@ -314,10 +314,8 @@ public class EntitlementCertificateGenerator {
      */
     @Transactional
     public void regenerateCertificatesOf(Consumer consumer, boolean lazy) {
-        log.info(
-            "Regenerating #{}, entitlement certificates for consumer: {}",
-            consumer.getEntitlements().size(), consumer
-        );
+        log.info("Regenerating {} entitlement certificate(s) for consumer: {}",
+            consumer.getEntitlements().size(), consumer);
 
         // we need to clear the content access cert on regenerate
         Owner owner = ownerCurator.findOwnerById(consumer.getOwnerId());

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -81,6 +81,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -96,6 +100,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 
@@ -328,6 +333,81 @@ public class ContentAccessManagerTest {
         cert.setKey("test-key");
         cert.setConsumer(consumer);
         return cert;
+    }
+
+    public static Stream<Arguments> contentAccessModeConfigProvider() {
+        String entMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
+        String scaMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
+
+        return Stream.of(
+            Arguments.of(null, null, ContentAccessMode.getDefault()),
+            Arguments.of(null, entMode, ContentAccessMode.ENTITLEMENT),
+            Arguments.of(null, scaMode, ContentAccessMode.ORG_ENVIRONMENT),
+
+            Arguments.of(entMode, null, ContentAccessMode.ENTITLEMENT),
+            Arguments.of(entMode, entMode, ContentAccessMode.ENTITLEMENT),
+            Arguments.of(entMode, scaMode, ContentAccessMode.ORG_ENVIRONMENT),
+
+            Arguments.of(scaMode, null, ContentAccessMode.ORG_ENVIRONMENT),
+            Arguments.of(scaMode, entMode, ContentAccessMode.ENTITLEMENT),
+            Arguments.of(scaMode, scaMode, ContentAccessMode.ORG_ENVIRONMENT)
+        );
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}, {1} => {2}")
+    @MethodSource("contentAccessModeConfigProvider")
+    public void testResolveContentAccessMode(String orgCAMode, String consumerCAMode,
+        ContentAccessMode expected) {
+
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+
+        // Set up org and consumer content access modes
+        owner.setContentAccessModeList(String.join(",", orgCAMode, consumerCAMode));
+        owner.setContentAccessMode(orgCAMode);
+        consumer.setContentAccessMode(consumerCAMode);
+
+        ContentAccessMode output = ContentAccessManager.resolveContentAccessMode(consumer);
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testResolveContentAccessModeRequiresValidInput() {
+        assertThrows(IllegalArgumentException.class, () ->
+            ContentAccessManager.resolveContentAccessMode(null));
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @EnumSource
+    public void testResolveContentAccessModeThrowsExceptionOnInvalidConsumerCAMode(
+        ContentAccessMode orgCAMode) {
+
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+
+        String consumerCAMode = "invalid_mode";
+
+        owner.setContentAccessModeList(String.join(",", orgCAMode.toDatabaseValue(), consumerCAMode));
+        owner.setContentAccessMode(orgCAMode.toDatabaseValue());
+        consumer.setContentAccessMode(consumerCAMode);
+
+        assertThrows(IllegalStateException.class, () ->
+            ContentAccessManager.resolveContentAccessMode(consumer));
+    }
+
+    @Test
+    public void testResolveContentAccessModeThrowsExceptionOnInvalidOrgCAMode() {
+        Owner owner = this.mockOwner();
+        Consumer consumer = this.mockConsumer(owner);
+
+        String orgCAMode = "invalid_mode";
+
+        owner.setContentAccessModeList(orgCAMode);
+        owner.setContentAccessMode(orgCAMode);
+        consumer.setContentAccessMode(null);
+
+        assertThrows(IllegalStateException.class, () ->
+            ContentAccessManager.resolveContentAccessMode(consumer));
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationLiberalNameRules.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationLiberalNameRules.java
@@ -16,17 +16,15 @@ package org.candlepin.resource;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
-import org.candlepin.config.MapConfiguration;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
-import java.util.HashMap;
 
 
 
@@ -37,20 +35,13 @@ import java.util.HashMap;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class ConsumerResourceCreationLiberalNameRules extends ConsumerResourceCreationTest {
 
-    private static class ConfigForTesting extends MapConfiguration {
-        @SuppressWarnings("serial")
-        ConfigForTesting() {
-            super(new HashMap<String, String>() {
-                {
-                    this.put(ConfigProperties.CONSUMER_SYSTEM_NAME_PATTERN, ".+");
-                    this.put(ConfigProperties.CONSUMER_PERSON_NAME_PATTERN, ".+");
-                }
-            });
-        }
-    }
     public Configuration initConfig() {
-        Configuration config = new ConfigForTesting();
+        Configuration config = new CandlepinCommonTestConfig();
+
+        config.setProperty(ConfigProperties.CONSUMER_SYSTEM_NAME_PATTERN, ".+");
+        config.setProperty(ConfigProperties.CONSUMER_PERSON_NAME_PATTERN, ".+");
         config.setProperty(ConfigProperties.USE_SYSTEM_UUID_FOR_MATCHING, "true");
+
         return config;
     }
 

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -38,9 +38,9 @@ import org.candlepin.auth.UserPrincipal;
 import org.candlepin.auth.permissions.OwnerPermission;
 import org.candlepin.auth.permissions.Permission;
 import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
+import org.candlepin.config.CandlepinCommonTestConfig;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
-import org.candlepin.config.MapConfiguration;
 import org.candlepin.controller.ContentAccessManager;
 import org.candlepin.controller.EntitlementCertificateGenerator;
 import org.candlepin.controller.Entitler;
@@ -114,7 +114,6 @@ import org.xnap.commons.i18n.I18nFactory;
 
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -306,8 +305,14 @@ public class ConsumerResourceCreationTest {
     }
 
     public Configuration initConfig() {
-        Configuration config = new ConfigForTesting();
+        Configuration config = new CandlepinCommonTestConfig();
+
+        config.setProperty(ConfigProperties.CONSUMER_SYSTEM_NAME_PATTERN,
+            "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
+        config.setProperty(ConfigProperties.CONSUMER_PERSON_NAME_PATTERN,
+            "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
         config.setProperty(ConfigProperties.USE_SYSTEM_UUID_FOR_MATCHING, "true");
+
         return config;
     }
 
@@ -343,22 +348,6 @@ public class ConsumerResourceCreationTest {
 
         return ctype;
     }
-
-    private static class ConfigForTesting extends MapConfiguration {
-        @SuppressWarnings("serial")
-        public ConfigForTesting() {
-            super(new HashMap<String, String>() {
-                {
-                    this.put(ConfigProperties.CONSUMER_SYSTEM_NAME_PATTERN,
-                        "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
-                    this.put(ConfigProperties.CONSUMER_PERSON_NAME_PATTERN,
-                        "[\\#\\?\\'\\`\\!@{}()\\[\\]\\?&\\w-\\.]+");
-                }
-            });
-        }
-
-    }
-
 
     protected ConsumerDTO createConsumer(String consumerName) {
         Collection<Permission> perms = new HashSet<>();

--- a/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceIntegrationTest.java
@@ -154,10 +154,23 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         standardSystemTypeDTO = modelTranslator.translate(standardSystemType, ConsumerTypeDTO.class);
         personType = consumerTypeCurator.create(new ConsumerType(ConsumerTypeEnum.PERSON));
         personTypeDTO = modelTranslator.translate(personType, ConsumerTypeDTO.class);
-        owner = ownerCurator.create(new Owner("test-owner"));
-        ownerDTO = modelTranslator.translate(owner, OwnerDTO.class);
-        owner.setDefaultServiceLevel(DEFAULT_SERVICE_LEVEL);
-        ownerCurator.create(owner);
+
+        this.owner = new Owner()
+            .setKey("test-owner")
+            .setDisplayName("test-owner")
+            .setDefaultServiceLevel(DEFAULT_SERVICE_LEVEL);
+
+        // Many of these tests were written before the conception of SCA mode, so explicitly set the
+        // shared owners's CA mode to entitlement. In the future, the tests should be updated to
+        // (a) not use shared data like this, and (b) be explicit about the operating mode necessary
+        // for testing a given unit.
+        this.owner.setContentAccessModeList(ContentAccessMode.ENTITLEMENT.toDatabaseValue())
+            .setContentAccessMode(ContentAccessMode.ENTITLEMENT.toDatabaseValue());
+
+        this.owner = this.ownerCurator.create(owner);
+
+        this.ownerDTO = modelTranslator.translate(owner, OwnerDTO.class);
+
         this.principalProvider = mock(PrincipalProvider.class);
         someuser = userCurator.create(new User(USER_NAME, "dontcare"));
 
@@ -695,7 +708,8 @@ public class ConsumerResourceIntegrationTest extends DatabaseTestFixture {
         assertEquals(1, ent.getCertificates().size());
         CertificateDTO entCertBefore = ent.getCertificates().iterator().next();
 
-        consumerResource.regenerateEntitlementCertificates(this.consumer.getUuid(), ent.getId(), false);
+        consumerResource.regenerateEntitlementCertificates(this.consumer.getUuid(), ent.getId(), false,
+            false);
 
         Entitlement entWithRefreshedCerts = entitlementCurator.get(ent.getId());
         ent = this.modelTranslator.translate(entWithRefreshedCerts, EntitlementDTO.class);

--- a/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
+++ b/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
@@ -48,8 +48,7 @@ public class PersonConsumerResourceCreationLiberalNameRules extends
         // create an owner, an ownerperm, and roles for the user we provide
         // as coming from userService
         owner = new Owner("test_owner");
-        PermissionBlueprint p = new PermissionBlueprint(PermissionType.OWNER, owner,
-            Access.ALL);
+        PermissionBlueprint p = new PermissionBlueprint(PermissionType.OWNER, owner, Access.ALL);
         User user = new User("anyuser", "");
         role = new Role();
         role.addPermission(p);


### PR DESCRIPTION
- Added a new query parameter, cleanup_entitlements, to the consumer entitlement certificate regeneration endpoint. When set, if the consumer is operating in SCA mode, unused entitlements will be removed before certificate regeneration occurs
- Miscellaneous comment, logging, and documentation cleanup