### PR TITLE
Fixed i18n puzzles in few error messages

### DIFF
--- a/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
+++ b/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
@@ -88,11 +88,15 @@ public class HealEntireOrgJob implements AsyncJob {
                     i18n.tr("Healing attempted against non-existent org key \"{}\"", ownerKey), true);
             }
 
-            if (owner.isAutobindDisabled() || owner.isUsingSimpleContentAccess()) {
-                String caMessage = owner.isUsingSimpleContentAccess() ?
-                    " because of the content access mode setting" : "";
+            if (owner.isUsingSimpleContentAccess()) {
                 throw new JobExecutionException(
-                    i18n.tr("Auto-attach is disabled for owner {0}{1}.", owner.getKey(), caMessage), true);
+                    i18n.tr("Auto-attach is disabled for owner \"{0}\" because of the content access " +
+                    "mode setting.", owner.getKey()), true);
+            }
+
+            if (owner.isAutobindDisabled()) {
+                throw new JobExecutionException(
+                    i18n.tr("Auto-attach is disabled for owner \"{0}\".", owner.getKey()), true);
             }
 
             Date entitleDate = arguments.getAs(ENTITLE_DATE_KEY, Date.class);

--- a/src/main/java/org/candlepin/controller/Entitler.java
+++ b/src/main/java/org/candlepin/controller/Entitler.java
@@ -234,9 +234,11 @@ public class Entitler {
                 consumer.getUuid(), owner.getKey(), caMessage, hypMessage);
 
             if (autobindHypervisorDisabled) {
-                throw new AutobindHypervisorDisabledException(i18n.tr(
-                    "Auto-attach is disabled for owner \"{0}\"{1}.",
-                    owner.getKey(), hypMessage));
+                String message = owner.isAutobindHypervisorDisabled() ?
+                    i18n.tr("Auto-attach is disabled for owner \"{0}\" because of the hypervisor " +
+                    "autobind setting.", owner.getKey()) :
+                    i18n.tr("Auto-attach is disabled for owner \"{0}\".", owner.getKey());
+                throw new AutobindHypervisorDisabledException(message);
             }
             else if (owner.isAutobindDisabled()) {
                 throw new AutobindDisabledForOwnerException(i18n.tr(

--- a/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
+++ b/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
@@ -52,9 +52,10 @@ public class CalculatedAttributesUtil {
 
         // TODO: Check that this doesn't break our translation stuff. We may need to have the
         // description strings translated instead.
-        attrMap.put("compliance_type",
-            i18n.tr("{0}{1}", type.getDescription(), (pool.isUnmappedGuestPool() ? " (Temporary)" : ""))
-        );
+        String message = pool.isUnmappedGuestPool() ?
+            i18n.tr("{0} (Temporary)", type.getDescription()) :
+            type.getDescription();
+        attrMap.put("compliance_type", message);
 
         return attrMap;
     }


### PR DESCRIPTION
Joining two parts of a message to make a single translatable message is
a bad idea:
- the message will be harder to translate
- in some cases, parts were even not marked as translatable (so the
  resulting message always resulted in "half-English" text)
             
Hence, to avoid this:
- some code blocks were simplified to avoid checking things multiple
  times
- error messages were rolled out as single messages, making them
  properly translatable
- one description text was used as-is, without wrapping it in a 
  redundant string
- a couple of messages got quotes around the placeholders in them, so 
  they now are either the same or similar to existing versions of the
  same messages