### PR TITLE
CANDLEPIN-120: Add setup for PNC build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,15 @@
 import groovy.text.GStringTemplateEngine
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 import org.yaml.snakeyaml.Yaml
 
 plugins {
     id "nebula.lint"
-    /*
-    The Versions plugin is used to provide the dependencyUpdates task which is used
-    to look for libraries that have newer versions available.
-     */
     id "com.github.ben-manes.versions"
-    // Openapi version is set in the buildscript block for use in the pom generation as well
     id "org.openapi.generator"
     id "java"
-    id "maven-publish"
     id "war"
+    id "distribution"
+    id "maven-publish"
     id "org.owasp.dependencycheck"
     id "jacoco"
     id "org.sonarqube"
@@ -47,7 +44,7 @@ ext {
     }
 
     if (!project.findProperty("db_host") ||
-        (project.findProperty("db_host") && "".equals(project.findProperty("db_host")))) {
+            (project.findProperty("db_host") && "".equals(project.findProperty("db_host")))) {
 
         db_host = "localhost"
     }
@@ -72,17 +69,7 @@ ext {
     external_broker = "true".equals(project.findProperty("external_broker"))
     hostedtest = "true".equals(project.findProperty("hostedtest"))
     async_scheduler_enabled = !project.findProperty("async_scheduler_enabled") ||
-        "true".equals(project.findProperty("async_scheduler_enabled"))
-
-    generatedMetamodels = "${buildDir}/generated/api/src/gen/java"
-}
-
-ext {
-    // Denotes BOM versions
-    resteasy_version = "4.4.3.Final"
-    jackson_version = "2.13.2"
-    guice_version = "5.1.0"
-    junit_version = "5.8.2"
+            "true".equals(project.findProperty("async_scheduler_enabled"))
 }
 
 dependencies {
@@ -210,7 +197,7 @@ compileJava.dependsOn(processResources)
 
 // Add the openapi generated classes to the main java source sets to compile in the generated interfaces
 sourceSets {
-    main.java.srcDir generatedMetamodels
+    main.java.srcDir "${buildDir}/generated/api/src/gen/java"
 }
 
 java {
@@ -226,7 +213,7 @@ gradleLint {
     // criticalRules = ["unused-dependency"]
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
     // options.compilerArgs << "-Xlint:deprecation"
     // options.compilerArgs.addAll(['--release', '8'])
@@ -250,9 +237,9 @@ openApiGenerate {
     outputDir = "$buildDir/generated/api"
     configOptions = [
             interfaceOnly: 'true',
-            generatePom: 'false',
-            dateLibrary: "java8",
-            useTags: "true"
+            generatePom  : 'false',
+            dateLibrary  : "java8",
+            useTags      : "true"
     ]
     templateDir = "$rootDir/buildSrc/src/main/resources/templates"
 }
@@ -261,7 +248,7 @@ openApiValidate {
     inputSpec = api_spec_path
 }
 
-task generateApiDocs(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+tasks.register('generateApiDocs', GenerateTask) {
     generatorName = "html"
     inputSpec = api_spec_path
     outputDir = "$buildDir/docs"
@@ -272,7 +259,7 @@ task generateApiDocs(type: org.openapitools.generator.gradle.plugin.tasks.Genera
     withXml = false
 }
 
-task generateOpenApiJson(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+tasks.register('generateOpenApiJson', GenerateTask) {
     generatorName = "openapi"
     inputSpec = api_spec_path
     outputDir = "$buildDir/generated/json"
@@ -331,10 +318,10 @@ tasks.register("coverage") {
 }
 
 project.tasks["sonar"].dependsOn "coverage"
-sonarqube{
-    properties{
-        property "sonar.sourceEncoding","Utf-8"
-        property "sonar.exclusions","**/*generated*"
+sonarqube {
+    properties {
+        property "sonar.sourceEncoding", "Utf-8"
+        property "sonar.exclusions", "**/*generated*"
     }
 }
 
@@ -359,7 +346,7 @@ processResources {
 }
 
 // A task to generate the the candlepin config file for use in etc or other locations.
-task generateConfig() {
+tasks.register('generateConfig') {
     dependsOn ":processResources"
     def template = file("$projectDir/config/candlepin/candlepin.conf.template")
     def targetFile = file("$buildDir/candlepin.conf")
@@ -392,7 +379,7 @@ assemble.dependsOn(generateConfig)
 
 // task to generate candlepin-api jar that Hosted adapters build against
 // invoked as `./gradlew apiJar`
-task apiJar(type: Jar) {
+tasks.register('apiJar', Jar) {
     archiveBaseName = 'candlepin-api'
     from sourceSets.main.output
     includes = [
@@ -440,51 +427,61 @@ war {
     }
 }
 
-task pom {
+tasks.register('pom') {
     dependsOn "generatePomFileForLocalPublication"
 }
 
 publishing {
-  publications {
-    local(MavenPublication) {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId 'org.candlepin'
+            artifactId 'candlepin'
 
-        generatePomFileForLocalPublication {
-           destination = file("./pom.xml")
+            from components.web
+            pom {
+                name = 'Candlepin'
+                description = 'Candlepin WAR'
+            }
         }
+        local(MavenPublication) {
 
-        pom {
-            description = 'The Candlepin Entitlement Engine'
-            packaging = 'war'
-            licenses {
-                license {
-                    name = 'GNU Public License (GPL) version 2.0'
-                    url = 'http://www.gnu.org/licenses/gpl-2.0.html'
-                    distribution = 'repo'
+            generatePomFileForLocalPublication {
+                destination = file("./pom.xml")
+            }
+
+            pom {
+                description = 'The Candlepin Entitlement Engine'
+                packaging = 'war'
+                licenses {
+                    license {
+                        name = 'GNU Public License (GPL) version 2.0'
+                        url = 'http://www.gnu.org/licenses/gpl-2.0.html'
+                        distribution = 'repo'
+                    }
                 }
-            }
 
-            scm {
-                connection = 'scm:git:git://github.com/candlepin/candlepin.git'
-                developerConnection = 'scm:git:git@github.com:candlepin/candlepin.git'
-            }
+                scm {
+                    connection = 'scm:git:git://github.com/candlepin/candlepin.git'
+                    developerConnection = 'scm:git:git@github.com:candlepin/candlepin.git'
+                }
 
-            pom.withXml {
-                PomToolkit.generatePomDependencies(
-                    asNode(),
-                    configurations.compileOnly.dependencies,
-                    configurations.implementation.dependencies,
-                    configurations.providedCompile.dependencies,
-                    configurations.runtimeOnly.dependencies,
-                    configurations.testImplementation.dependencies,
-                    configurations.testRuntimeOnly.dependencies
-                )
+                pom.withXml {
+                    PomToolkit.generatePomDependencies(
+                            asNode(),
+                            configurations.compileOnly.dependencies,
+                            configurations.implementation.dependencies,
+                            configurations.providedCompile.dependencies,
+                            configurations.runtimeOnly.dependencies,
+                            configurations.testImplementation.dependencies,
+                            configurations.testRuntimeOnly.dependencies
+                    )
 
-                PomToolkit.generateRepositories(asNode())
-                PomToolkit.generateBuild(asNode(), configurations.annotationProcessor.dependencies)
-                PomToolkit.generateProfiles(asNode())
-                PomToolkit.generateDependencyManagement(asNode())
+                    PomToolkit.generateRepositories(asNode())
+                    PomToolkit.generateBuild(asNode(), configurations.annotationProcessor.dependencies)
+                    PomToolkit.generateProfiles(asNode())
+                    PomToolkit.generateDependencyManagement(asNode())
+                }
             }
         }
     }
-  }
 }

--- a/candlepin.spec.tmpl
+++ b/candlepin.spec.tmpl
@@ -6,6 +6,15 @@
 %global selinux_variants mls minimum targeted
 %global modulename candlepin
 
+#if $artifacts
+%global tar_gz_filename $artifacts['.gz'][0]
+%global war_filename $artifacts['.war'][0]
+
+## Remove the '-project-sources.tar.gz' suffix from the tar.gz filename, to get the source dir name
+## e.g. candlepin-x.y.z.redhat-00000 from a file called candlepin-x.y.z.redhat-00000-project-sources.tar.gz
+%global source_top_directory_name %(echo %{tar_gz_filename} | sed s/"-project-sources.tar.gz"// )
+#end if
+
 ## If you follow the Java packaging guidelines, you
 ## only need to run brp-java-repack-jars on packages that include
 ## arch-independent JAR files under /usr/share and that also include
@@ -23,8 +32,8 @@ Summary: Candlepin is an open source entitlement management system
 Group: System Environment/Daemons
 URL: http://www.candlepinproject.org
 License: GPLv2
-Source0: %{name}-%{version}-complete.tar.gz
-Source1: %{name}-%{version}.war
+Source0: %{tar_gz_filename}
+Source1: %{war_filename}
 
 Suggests: %{name}-selinux = %{version}-%{release}
 
@@ -88,7 +97,7 @@ Requires(postun): /usr/sbin/semanage
 SELinux policy module supporting candlepin
 
 %prep
-%setup -q %{SOURCE0}
+%setup -n %{source_top_directory_name}
 
 %build
 cd selinux

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.14.2</version>
+      <version>2.15.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -292,7 +292,7 @@
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-servlet-filter-adapter</artifactId>
-      <version>21.0.2</version>
+      <version>21.1.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -322,13 +322,13 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.9.2</version>
+      <version>5.9.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>5.9.2</version>
+      <version>5.9.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -364,7 +364,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.9.2</version>
+      <version>5.9.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
- Setup maven publish for candlepin artifacts
- Update spec template to support PNC build

Example usage

```bash
# Clone build config
bacon pnc build-config clone 10925 --buildConfigName=test2 --scmRevision=ojanus/pnc4

# Start build
bacon pnc build start 10925

# Push to brew
bacon pnc brew-push build AYLIGMPK3RQAA --tag-prefix=candlepin-1-pnc
bacon pnc brew-push status AYLIGMPK3RQAA

# Run wrapper RPM build
brew wrapper-rpm --create-build candlepin-1-rhel-9-candidate org.candlepin-candlepin-4.3.2.redhat_00005-1 "git://git.app.eng.bos.redhat.com/candlepin/candlepin.git?#4.3.2.redhat-00005" --scratch
```