### PR TITLE
[M] CANDLEPIN-557: Fixed content access mode resolution for consumers

### DIFF
--- a/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -67,7 +67,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Predicate;
 
 import javax.inject.Inject;
 import javax.naming.ldap.Rdn;
@@ -193,42 +192,6 @@ public class ContentAccessManager {
             ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
     }
 
-    /**
-     * Resolves the content access mode for the given consumer, translating the mode name assigned
-     * to a ContentAccessMode enum value. If no explicit value is defined for the consumer or its
-     * owner, this function returns the default content access mode.
-     *
-     * @param consumer
-     *  the consumer for which to fetch the content access mode
-     *
-     * @throws IllegalArgumentException
-     *  if the provided consumer is null
-     *
-     * @throws IllegalStateException
-     *  if the resolved content access mode for the consumer is invalid or otherwise cannot be
-     *  mapped to a ContentAccessMode value
-     *
-     * @return
-     *  a ContentAccessMode enum value for the given consumer
-     */
-    public static ContentAccessMode resolveContentAccessMode(Consumer consumer) {
-        if (consumer == null) {
-            throw new IllegalArgumentException("consumer is null");
-        }
-
-        Predicate<String> predicate = (str) -> str != null && !str.isEmpty();
-
-        String caMode = Util.firstOf(predicate,
-            consumer.getContentAccessMode(),
-            consumer.getOwner().getContentAccessMode());
-
-        try {
-            return ContentAccessMode.resolveModeName(caMode, true);
-        }
-        catch (IllegalArgumentException e) {
-            throw new IllegalStateException("consumer is using an invalid content access mode: " + caMode, e);
-        }
-    }
 
     private final Configuration config;
     private final PKIUtility pki;

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2626,19 +2626,7 @@ public class ConsumerResource implements ConsumerApi {
 
         // If consumer is in an org running in SCA mode and the client has requested entitlement cleanup,
         // revoke all entitlements. They won't be needing them anymore, apparently.
-        try {
-            ContentAccessMode caMode = ContentAccessManager.resolveContentAccessMode(consumer);
-            if (caMode != ContentAccessMode.ORG_ENVIRONMENT) {
-                cleanupEntitlements = false;
-            }
-        }
-        catch (IllegalStateException e) {
-            // Consumer or org have an invald mode set. Assume it's not SCA.
-            log.error("Invalid content access mode set for consumer; skipping entitlement cleanup", e);
-            cleanupEntitlements = false;
-        }
-
-        if (cleanupEntitlements) {
+        if (cleanupEntitlements && consumer.getOwner().isUsingSimpleContentAccess()) {
             // At the time of writing, we should only be doing this cleanup in SCA mode, which
             // omits consumer status calculation anyway. As a result, we can save some time by
             // skipping the recalculation during revocation.

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -81,10 +81,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
@@ -100,7 +96,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 
@@ -333,81 +328,6 @@ public class ContentAccessManagerTest {
         cert.setKey("test-key");
         cert.setConsumer(consumer);
         return cert;
-    }
-
-    public static Stream<Arguments> contentAccessModeConfigProvider() {
-        String entMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
-        String scaMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
-
-        return Stream.of(
-            Arguments.of(null, null, ContentAccessMode.getDefault()),
-            Arguments.of(null, entMode, ContentAccessMode.ENTITLEMENT),
-            Arguments.of(null, scaMode, ContentAccessMode.ORG_ENVIRONMENT),
-
-            Arguments.of(entMode, null, ContentAccessMode.ENTITLEMENT),
-            Arguments.of(entMode, entMode, ContentAccessMode.ENTITLEMENT),
-            Arguments.of(entMode, scaMode, ContentAccessMode.ORG_ENVIRONMENT),
-
-            Arguments.of(scaMode, null, ContentAccessMode.ORG_ENVIRONMENT),
-            Arguments.of(scaMode, entMode, ContentAccessMode.ENTITLEMENT),
-            Arguments.of(scaMode, scaMode, ContentAccessMode.ORG_ENVIRONMENT)
-        );
-    }
-
-    @ParameterizedTest(name = "{displayName} {index}: {0}, {1} => {2}")
-    @MethodSource("contentAccessModeConfigProvider")
-    public void testResolveContentAccessMode(String orgCAMode, String consumerCAMode,
-        ContentAccessMode expected) {
-
-        Owner owner = this.mockOwner();
-        Consumer consumer = this.mockConsumer(owner);
-
-        // Set up org and consumer content access modes
-        owner.setContentAccessModeList(String.join(",", orgCAMode, consumerCAMode));
-        owner.setContentAccessMode(orgCAMode);
-        consumer.setContentAccessMode(consumerCAMode);
-
-        ContentAccessMode output = ContentAccessManager.resolveContentAccessMode(consumer);
-        assertEquals(expected, output);
-    }
-
-    @Test
-    public void testResolveContentAccessModeRequiresValidInput() {
-        assertThrows(IllegalArgumentException.class, () ->
-            ContentAccessManager.resolveContentAccessMode(null));
-    }
-
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @EnumSource
-    public void testResolveContentAccessModeThrowsExceptionOnInvalidConsumerCAMode(
-        ContentAccessMode orgCAMode) {
-
-        Owner owner = this.mockOwner();
-        Consumer consumer = this.mockConsumer(owner);
-
-        String consumerCAMode = "invalid_mode";
-
-        owner.setContentAccessModeList(String.join(",", orgCAMode.toDatabaseValue(), consumerCAMode));
-        owner.setContentAccessMode(orgCAMode.toDatabaseValue());
-        consumer.setContentAccessMode(consumerCAMode);
-
-        assertThrows(IllegalStateException.class, () ->
-            ContentAccessManager.resolveContentAccessMode(consumer));
-    }
-
-    @Test
-    public void testResolveContentAccessModeThrowsExceptionOnInvalidOrgCAMode() {
-        Owner owner = this.mockOwner();
-        Consumer consumer = this.mockConsumer(owner);
-
-        String orgCAMode = "invalid_mode";
-
-        owner.setContentAccessModeList(orgCAMode);
-        owner.setContentAccessMode(orgCAMode);
-        consumer.setContentAccessMode(null);
-
-        assertThrows(IllegalStateException.class, () ->
-            ContentAccessManager.resolveContentAccessMode(consumer));
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -523,8 +523,8 @@ public class ConsumerResourceTest {
         entitlement     unset               true                    retain
         sca             unset               true                    > revoke
         entitlement     entitlement         true                    retain
-        sca             entitlement         true                    retain
-        entitlement     sca                 true                    > revoke
+        sca             entitlement         true                    > revoke
+        entitlement     sca                 true                    retain
         sca             sca                 true                    > revoke
         *               *                   false                   retain
         *               *                   null                    retain
@@ -546,9 +546,9 @@ public class ConsumerResourceTest {
             Arguments.of(scaMode, null, false),
             Arguments.of(scaMode, null, true),
             Arguments.of(scaMode, null, null),
-            Arguments.of(entitlementMode, scaMode, false),
-            Arguments.of(entitlementMode, scaMode, true),
-            Arguments.of(entitlementMode, scaMode, null),
+            Arguments.of(scaMode, entitlementMode, false),
+            Arguments.of(scaMode, entitlementMode, true),
+            Arguments.of(scaMode, entitlementMode, null),
             Arguments.of(scaMode, scaMode, false),
             Arguments.of(scaMode, scaMode, true),
             Arguments.of(scaMode, scaMode, null));
@@ -584,9 +584,9 @@ public class ConsumerResourceTest {
             Arguments.of(entitlementMode, null, true),
             Arguments.of(entitlementMode, null, false),
             Arguments.of(entitlementMode, null, null),
-            Arguments.of(scaMode, entitlementMode, true),
-            Arguments.of(scaMode, entitlementMode, false),
-            Arguments.of(scaMode, entitlementMode, null),
+            Arguments.of(entitlementMode, scaMode, false),
+            Arguments.of(entitlementMode, scaMode, true),
+            Arguments.of(entitlementMode, scaMode, null),
             Arguments.of(entitlementMode, entitlementMode, true),
             Arguments.of(entitlementMode, entitlementMode, false),
             Arguments.of(entitlementMode, entitlementMode, null));


### PR DESCRIPTION
- Fixed the resolution of a consumer's content access mode to no longer consider the mode a consumer may use for manifest import or export purposes