### PR TITLE
CP-561: POC to use small-rye configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,10 @@ dependencies {
     implementation libraries["hibernateJpamodelgen"]
     annotationProcessor libraries["hibernateJpamodelgen"]
 
+    //Small Rye Config
+    implementation libraries["smallrye"]
+    implementation libraries["annotations"]
+
     // Use wildcard because this could be called jss4.jar or jss.jar
     // (depending on if we are before Fedora35/RHEL9 or after)
     providedCompile fileTree(dir: '/usr/lib64/jss', include: '*.jar')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -31,6 +31,7 @@ ext.plugins = [
     "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.0.0.2929",
 ]
 
+libraries["annotations"] = "org.apache.tomcat:tomcat-annotations-api:10.0.0"
 libraries["artemisServer"] = "org.apache.activemq:artemis-server:2.28.0"
 libraries["artemisStomp"] = "org.apache.activemq:artemis-stomp-protocol:2.28.0"
 libraries["assertj"] = 'org.assertj:assertj-core:3.24.2'
@@ -100,5 +101,6 @@ libraries["resteasyMultipart"] = "org.jboss.resteasy:resteasy-multipart-provider
 libraries["resteasyValidator"] = "org.jboss.resteasy:resteasy-validator-provider:4.7.9.Final"
 libraries["rhino"] = "org.mozilla:rhino:1.7.14"
 libraries["slf4j"] = "org.slf4j:slf4j-api:2.0.7"
+libraries["smallrye"] = "io.smallrye.config:smallrye-config:3.2.1"
 libraries["spotbugs"] = "com.github.spotbugs:spotbugs-annotations:4.7.3"
 libraries["swagger"] = "io.swagger:swagger-annotations:1.6.10"

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -26,6 +26,8 @@ import org.candlepin.async.tasks.ManifestCleanerJob;
 import org.candlepin.async.tasks.OrphanCleanupJob;
 import org.candlepin.async.tasks.UnmappedGuestEntitlementCleanerJob;
 
+import org.hibernate.dialect.PostgreSQL92Dialect;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -174,6 +176,8 @@ public class ConfigProperties {
     // Cache
     public static final String CACHE_JMX_STATS = "cache.jmx.statistics";
     public static final String CACHE_CONFIG_FILE_URI = JPA_CONFIG_PREFIX + "hibernate.javax.cache.uri";
+    public static final String HIBERNATE_DIALECT = JPA_CONFIG_PREFIX + "hibernate.dialect";
+
 
     public static final String[] ENCRYPTED_PROPERTIES = new String[] {
         DB_PASSWORD,
@@ -412,6 +416,7 @@ public class ConfigProperties {
 
             this.put(CACHE_JMX_STATS, "false");
             this.put(CACHE_CONFIG_FILE_URI, "ehcache.xml");
+            this.put(HIBERNATE_DIALECT, PostgreSQL92Dialect.class.getName());
 
             this.put(SUSPEND_MODE_ENABLED, "true");
 

--- a/src/main/java/org/candlepin/config/LegacyEncryptedInterceptor.java
+++ b/src/main/java/org/candlepin/config/LegacyEncryptedInterceptor.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.config;
+
+import static io.smallrye.config.SecretKeys.doLocked;
+
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.Priorities;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import jakarta.annotation.Priority;
+
+
+@Priority(Priorities.LIBRARY + 1000)
+public class LegacyEncryptedInterceptor implements ConfigSourceInterceptor {
+    private static final Logger log = LoggerFactory.getLogger(LegacyEncryptedInterceptor.class);
+    String[] encryptedProperties;
+    String passphrase;
+    public static final String PASSPHRASE_SECRET_FILE = "candlepin.passphrase.path";
+
+    public LegacyEncryptedInterceptor(String[] encryptedProperties) {
+        this.encryptedProperties = encryptedProperties;
+    }
+
+    public ConfigValue getValue(final ConfigSourceInterceptorContext context, final String property) {
+        ConfigValue configValue = doLocked(() -> context.proceed(property));
+        if (configValue == null ||
+            Arrays.stream(encryptedProperties).noneMatch(v -> v.equals(configValue.getName()))) {
+            return configValue;
+        }
+        if (passphrase == null) {
+            passphrase = readPassphrase(context);
+        }
+        if (StringUtils.isEmpty(passphrase)) {
+            log.debug("Passphrase is empty. Skipping decrypt.");
+            return configValue;
+        }
+        if (configValue == null) {
+            log.debug("Can't decrypt missing property: {}", property);
+            return configValue;
+        }
+
+        String toDecrypt = configValue.getValue();
+        if (!toDecrypt.startsWith("$1$")) {
+            // this is not an encrypted password, just return it
+            log.debug("Value for {} is not an encrypted string", property);
+            return configValue;
+        }
+
+        // remove the magic string
+        toDecrypt = toDecrypt.substring(3);
+
+        try {
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+
+            // NOTE: we are creating a 64byte digest here,
+            // but only the first 16 bytes are used as the iv
+            String ivString = passphrase + passphrase;
+            String iv = DigestUtils.sha256Hex(ivString);
+            String passphraseDigest = DigestUtils.sha256Hex(passphrase);
+
+            // FIXME: katello-password creates a 64 byte key, but somewhere
+            // it gets truncated to 32 bytes, so we have to do that here.
+            SecretKeySpec spec = new SecretKeySpec(
+                Arrays.copyOfRange(passphraseDigest.getBytes(), 0, 32), "AES");
+
+            cipher.init(Cipher.DECRYPT_MODE, spec, new IvParameterSpec(iv.getBytes(), 0, 16));
+
+            // NOTE: the encrypted password is stored hex base64
+            byte[] b64bytes = Base64.decodeBase64(toDecrypt);
+            String decrypted = new String(cipher.doFinal(b64bytes));
+            return configValue.withValue(decrypted);
+        }
+        catch (Exception e) {
+            log.error("Failure trying to decrypt value of {}", property, e);
+        }
+        return configValue;
+    }
+
+    protected String readPassphrase(final ConfigSourceInterceptorContext context) {
+        ConfigValue configValue = doLocked(() -> context.proceed(PASSPHRASE_SECRET_FILE));
+        String passFilePath = configValue.getValue();
+        if (StringUtils.isEmpty(passFilePath)) {
+            log.info("No secret file provided.");
+            return null;
+        }
+        Path path = Paths.get(passFilePath);
+        if (!Files.exists(path)) {
+            log.warn("{} is present in the configuration but the file does not exist",
+                PASSPHRASE_SECRET_FILE);
+            return null;
+        }
+
+        log.debug("reading secret file: {}", passFilePath);
+        try (InputStream bs = new FileInputStream(passFilePath)) {
+            /* XXX Maybe it'd be better to use the charset the caller specifies during
+             * construction?  But just because the config is in that charset doesn't mean
+             * the password file is.  Stick with system default for now. */
+            return IOUtils.toString(bs, Charset.defaultCharset().name()).trim();
+        }
+        catch (Exception e) {
+            String msg = String.format("Could not read: %s", passFilePath);
+            log.error(msg);
+            throw new RuntimeException(msg, e);
+        }
+    }
+}

--- a/src/main/java/org/candlepin/config/RyeConfig.java
+++ b/src/main/java/org/candlepin/config/RyeConfig.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.config;
+
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RyeConfig implements Configuration {
+    SmallRyeConfig config;
+
+    public Configuration setConfig(SmallRyeConfig config) {
+        this.config = config;
+        return this;
+    }
+
+    @Override
+    public Configuration subset(String prefix) {
+        Map<String, String> subMap = new HashMap<>();
+        config.getPropertyNames().forEach(x -> {
+            if (x.startsWith(prefix)) {
+                subMap.put(x, config.getRawValue(x));
+            }
+        });
+        return (Configuration) new RyeConfig()
+            .setConfig(new SmallRyeConfigBuilder()
+            .withSources(new PropertiesConfigSource(subMap, prefix, 100))
+            .build());
+    }
+
+    @Override
+    public Configuration strippedSubset(String prefix) {
+        Map<String, String> subMap = new HashMap<>();
+        String thePrefix = prefix.endsWith(".") ? prefix : (prefix + ".");
+        config.getPropertyNames().forEach(x -> {
+            if (x.startsWith(thePrefix)) {
+                subMap.put(x.substring(thePrefix.length()), config.getRawValue(x));
+            }
+        });
+        return new RyeConfig()
+            .setConfig(new SmallRyeConfigBuilder()
+            .withSources(new PropertiesConfigSource(subMap, prefix, 100))
+            .build());
+    }
+
+    @Override
+    public Properties toProperties() {
+        Properties result = new Properties();
+        config.getPropertyNames().forEach(x -> result.put(x, config.getRawValue(x)));
+        return  result;
+    }
+
+    @Override
+    public Properties toProperties(Map<String, String> defaults) {
+        Properties result = new Properties();
+        defaults.keySet().forEach(x -> result.put(x, defaults.get(x)));
+        config.getPropertyNames().forEach(x -> result.put(x, config.getRawValue(x)));
+        return  result;
+    }
+
+    @Override
+    public Properties toProperties(Properties defaults) {
+        Properties result = new Properties();
+        defaults.keySet().forEach(x -> result.put(x, defaults.get(x)));
+        config.getPropertyNames().forEach(x -> result.put(x, config.getRawValue(x)));
+        return  result;
+    }
+
+    @Override
+    public Map<String, String> toMap() {
+        Map result = new HashMap();
+        config.getPropertyNames().forEach(x -> result.put(x, config.getRawValue(x)));
+        return  result;
+    }
+
+    @Override
+    public Map<String, String> toMap(Map<String, String> defaults) {
+        Map result = new HashMap();
+        defaults.keySet().forEach(x -> result.put(x, defaults.get(x)));
+        config.getPropertyNames().forEach(x -> result.put(x, config.getRawValue(x)));
+        return  result;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return !config.getPropertyNames().iterator().hasNext();
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return config.isPropertyPresent(key);
+    }
+
+    @Override
+    public void setProperty(String key, String value) {
+        ConfigValue configValue = config.getConfigValue(key);
+        if (configValue != null) {
+            configValue.withValue(value);
+        }
+        else {
+            throw new RuntimeException("Cannot set value for unknown configuration property");
+        }
+    }
+
+    @Override
+    public void clear() {
+        config.getPropertyNames().forEach(x -> clearProperty(x));
+    }
+
+    @Override
+    public void clearProperty(String key) {
+        ConfigValue configValue = config.getConfigValue(key);
+        if (configValue != null) {
+            configValue.withValue(null);
+        }
+    }
+
+    @Override
+    public Iterable<String> getKeys() {
+        return config.getPropertyNames();
+    }
+
+    @Override
+    public String getProperty(String key) {
+        return config.getRawValue(key);
+    }
+
+    @Override
+    public String getProperty(String key, String defaultValue) {
+        ConfigValue configValue = config.getConfigValue(key);
+        if (configValue == null || configValue.getValue() == null) {
+            return defaultValue;
+        }
+        return getProperty(key);
+    }
+
+    @Override
+    public boolean getBoolean(String key) {
+        return config.getValue(key, Boolean.class);
+    }
+
+    @Override
+    public boolean getBoolean(String key, boolean defaultValue) {
+        ConfigValue configValue = config.getConfigValue(key);
+        if (configValue == null || configValue.getValue() == null) {
+            return defaultValue;
+        }
+        return getBoolean(key);
+    }
+
+    @Override
+    public int getInt(String key) {
+        return config.getValue(key, Integer.class);
+    }
+
+    @Override
+    public int getInt(String key, int defaultValue) {
+        ConfigValue configValue = config.getConfigValue(key);
+        if (configValue == null || configValue.getValue() == null) {
+            return defaultValue;
+        }
+        return getInt(key);
+    }
+
+    @Override
+    public long getLong(String key) {
+        return config.getValue(key, Long.class);
+    }
+
+    @Override
+    public long getLong(String key, long defaultValue) {
+        ConfigValue configValue = config.getConfigValue(key);
+        if (configValue == null || configValue.getValue() == null) {
+            return defaultValue;
+        }
+        return getLong(key);
+    }
+
+    @Override
+    public String getString(String key) {
+        return config.getRawValue(key);
+    }
+
+    @Override
+    public String getString(String key, String defaultValue) {
+        ConfigValue configValue = config.getConfigValue(key);
+        if (configValue == null || configValue.getValue() == null) {
+            return defaultValue;
+        }
+        return getString(key);
+    }
+
+    @Override
+    public String getString(String key, String defaultValue, TrimMode trimMode) {
+        ConfigValue configValue = config.getConfigValue(key);
+        if (configValue == null || configValue.getValue() == null) {
+            return defaultValue;
+        }
+        return TrimMode.TRIM.equals(trimMode) ? getString(key).trim() : getString(key);
+    }
+
+    @Override
+    public List<String> getList(String key) {
+        if (config.getConfigValue(key) == null ||
+            StringUtils.isEmpty(config.getRawValue(key))) {
+            return new ArrayList<>();
+        }
+        return config.getValues(key, String.class);
+    }
+
+    @Override
+    public List<String> getList(String key, List<String> defaultValue) {
+        ConfigValue configValue = config.getConfigValue(key);
+        if (configValue == null || configValue.getValue() == null) {
+            return defaultValue;
+        }
+        return getList(key);
+    }
+
+    @Override
+    public Set<String> getSet(String key) {
+        return getList(key).stream().collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<String> getSet(String key, Set<String> defaultValue) {
+        ConfigValue configValue = config.getConfigValue(key);
+        if (configValue == null || configValue.getValue() == null) {
+            return defaultValue;
+        }
+        return getSet(key);
+    }
+}


### PR DESCRIPTION
I did not remove all of the old configuration classes.
It should be running completely with the small-rye config.
Unit tests will need to be added on implementation.
Moved the default database dialect setting to regular defaults.

The only real constraint I saw that could not be overcome in the wrapper I wrote:
You cannot create a parameter name/value with a new name after the config is built. You must put in a default value to "reserve" a spot. 