### PR TITLE
[M] Removed string concatenation from translated messages

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/AutobindDisabledForOwnerSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/AutobindDisabledForOwnerSpecTest.java
@@ -169,8 +169,8 @@ public class AutobindDisabledForOwnerSpecTest {
         AsyncJobStatusDTO job = adminClient.owners().healEntire(owner.getKey());
         job = adminClient.jobs().waitForJob(job);
 
-        assertThatJob(job).isFailed();
         assertThatJob(job)
+            .isFailed()
             .contains("org.candlepin.async.JobExecutionException: Auto-attach is disabled for owner");
     }
 
@@ -183,10 +183,10 @@ public class AutobindDisabledForOwnerSpecTest {
         AsyncJobStatusDTO job = adminClient.owners().healEntire(owner.getKey());
         job = adminClient.jobs().waitForJob(job);
 
-        assertThatJob(job).isFailed();
         assertThatJob(job)
-            .contains("org.candlepin.async.JobExecutionException: Auto-attach is disabled for owner");
-        assertThatJob(job).contains("because of the content access mode setting.");
+            .isFailed()
+            .contains("org.candlepin.async.JobExecutionException: Auto-attach is disabled for owner")
+            .contains("simple content access");
     }
 
     @Test

--- a/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
+++ b/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
@@ -88,11 +88,15 @@ public class HealEntireOrgJob implements AsyncJob {
                     i18n.tr("Healing attempted against non-existent org key \"{}\"", ownerKey), true);
             }
 
-            if (owner.isAutobindDisabled() || owner.isUsingSimpleContentAccess()) {
-                String caMessage = owner.isUsingSimpleContentAccess() ?
-                    " because of the content access mode setting" : "";
-                throw new JobExecutionException(
-                    i18n.tr("Auto-attach is disabled for owner {0}{1}.", owner.getKey(), caMessage), true);
+            if (owner.isAutobindDisabled()) {
+                String errmsg = this.i18n.tr("Auto-attach is disabled for owner {0}", owner.getKey());
+                throw new JobExecutionException(errmsg, true);
+            }
+
+            if (owner.isUsingSimpleContentAccess()) {
+                String errmsg = this.i18n.tr("Auto-attach is disabled for owner {0} while using simple " +
+                    "content access", owner.getKey());
+                throw new JobExecutionException(errmsg, true);
             }
 
             Date entitleDate = arguments.getAs(ENTITLE_DATE_KEY, Date.class);

--- a/src/main/java/org/candlepin/model/ConsumerType.java
+++ b/src/main/java/org/candlepin/model/ConsumerType.java
@@ -65,6 +65,10 @@ public class ConsumerType extends AbstractHibernateObject<ConsumerType> {
             return this.manifest;
         }
 
+        public boolean matches(ConsumerType type) {
+            return type != null && type.getLabel().equals(this.getLabel());
+        }
+
         @Override
         public String toString() {
             return getLabel();

--- a/src/main/java/org/candlepin/model/Pool.java
+++ b/src/main/java/org/candlepin/model/Pool.java
@@ -28,6 +28,7 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.annotations.Type;
+import org.xnap.commons.i18n.I18n;
 
 import java.util.Collections;
 import java.util.Date;
@@ -165,12 +166,12 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
      * Indicates how a pool can be used
      */
     public enum PoolComplianceType {
-        UNKNOWN("Other"),
-        STANDARD("Standard"),
-        INSTANCE_BASED("Instance Based"),
-        STACKABLE("Stackable"),
-        UNIQUE_STACKABLE("Stackable only with other subscriptions"),
-        MULTI_ENTITLEMENT("Multi-Entitleable");
+        UNKNOWN(I18n.marktr("Other")),
+        STANDARD(I18n.marktr("Standard")),
+        INSTANCE_BASED(I18n.marktr("Instance Based")),
+        STACKABLE(I18n.marktr("Stackable")),
+        UNIQUE_STACKABLE(I18n.marktr("Stackable only with other subscriptions")),
+        MULTI_ENTITLEMENT(I18n.marktr("Multi-Entitleable"));
 
         private final String description;
 

--- a/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
+++ b/src/main/java/org/candlepin/resource/util/CalculatedAttributesUtil.java
@@ -50,11 +50,12 @@ public class CalculatedAttributesUtil {
         Map<String, String> attrMap = new HashMap<>();
         PoolComplianceType type = pool.getComplianceType();
 
-        // TODO: Check that this doesn't break our translation stuff. We may need to have the
-        // description strings translated instead.
-        attrMap.put("compliance_type",
-            i18n.tr("{0}{1}", type.getDescription(), (pool.isUnmappedGuestPool() ? " (Temporary)" : ""))
-        );
+        String complianceType = this.i18n.tr(type.getDescription());
+        if (pool.isUnmappedGuestPool()) {
+            complianceType = this.i18n.tr("{0} (Temporary)", complianceType);
+        }
+
+        attrMap.put("compliance_type", complianceType);
 
         return attrMap;
     }


### PR DESCRIPTION
- Removed a few instances of string concatenation on messages intended to be translated for clients
- Updated grammar on some affected messages and, where applicable, updated verbiage to match other, similar messages
- Added missing translation flagging on pool compliance types