### PR TITLE
Fix random unit test failures

### DIFF
--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -59,9 +59,6 @@ import org.candlepin.util.Util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.commons.io.FileUtils;
-
-import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -803,22 +800,6 @@ public class TestUtil {
         char[] charArray = new char[size];
         Arrays.fill(charArray, 'x');
         return new String(charArray);
-    }
-
-    public static void cleanupDir(String dir, String basename) {
-        File tempDir = new File(dir);
-
-        for (File f : tempDir.listFiles()) {
-            if (f.getName().startsWith(basename)) {
-                try {
-                    FileUtils.deleteDirectory(f);
-                }
-                catch (IOException e) {
-                    throw new RuntimeException(
-                        "Failed to cleanup directory: " + dir, e);
-                }
-            }
-        }
     }
 
     public static Map<String, Product> stubChangedProducts(Product ... products) {


### PR DESCRIPTION
Sometimes tests in ConsumerResourceIntegrationtest fail when run on a jenkins node where spec tests were previously run and left some temp files behind.