### PR TITLE
CANDLEPIN-569: Run liquibase update on startup

### DIFF
--- a/bin/deployment/deploy
+++ b/bin/deployment/deploy
@@ -26,7 +26,6 @@ gendb() {
 
     if [ "$GENDB" == "1" ]; then
         MESSAGE="Generating New Database"
-        CHANGELOG="changelog-update.xml"
         if [ "$USE_MYSQL" == "1" ]; then
             recreate_mysql $APP_DB_NAME $DBUSER
         else
@@ -38,32 +37,7 @@ gendb() {
         info_msg "Cleaning hornetq journal"
         $SUDO rm -rf /var/lib/candlepin/hornetq/*
         $SUDO rm -rf /var/lib/candlepin/activemq-artemis/*
-    else
-        MESSAGE="Updating Database"
-        CHANGELOG="changelog-update.xml"
     fi
-
-    info_msg "$MESSAGE"
-    LQCOMMAND="${PROJECT_DIR}/bin/deployment/liquibase.sh --driver=${JDBC_DRIVER} \
-      --classpath=build/classes/java/main/:${JDBC_JAR} --changelog-file=db/changelog/$CHANGELOG \
-      --url=${JDBC_URL} --username=candlepin --hub-mode=OFF "
-
-    if [ -n "$DBPASSWORD" ] ; then
-        LQCOMMAND="$LQCOMMAND --password=$DBPASSWORD "
-    fi
-
-    LQCOMMAND="$LQCOMMAND update -Dcommunity=True"
-
-    # At the time of writing, Liquibase does not respect any log-level parameter for reasons.
-    # So unless we're running with verbose mode set to on, we'll just pipe everything to the void.
-    if [ "$VERBOSE" == "1" ]; then
-        LQOUT=/dev/stdout
-    else
-        LQOUT=/dev/null
-    fi
-
-    (cd $PROJECT_DIR && $LQCOMMAND >$LQOUT 2>&1)
-    evalrc $? "Liquibase command failed"
 }
 
 deploy() {

--- a/config/candlepin/candlepin.conf.template
+++ b/config/candlepin/candlepin.conf.template
@@ -34,7 +34,7 @@ candlepin.pretty_print=true
 candlepin.async.scheduler.enabled=<%= candlepin.async_scheduler_enabled %>
 
 candlepin.hidden_resources=
-candlepin.db.halt_on_liquibase_desync=true
+candlepin.db.database_manage_on_startup=Manage
 
 <% if (candlepin.hidden_capabilities) { %>\
 candlepin.hidden_capabilities=<%= candlepin.hidden_capabilities %>

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -25,6 +25,7 @@ import org.candlepin.async.tasks.JobCleaner;
 import org.candlepin.async.tasks.ManifestCleanerJob;
 import org.candlepin.async.tasks.OrphanCleanupJob;
 import org.candlepin.async.tasks.UnmappedGuestEntitlementCleanerJob;
+import org.candlepin.guice.CandlepinContextListener;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -128,7 +129,7 @@ public class ConfigProperties {
     // Space separated list of resources to hide in GET /status
     public static final String HIDDEN_CAPABILITIES = "candlepin.hidden_capabilities";
 
-    public static final String HALT_ON_LIQUIBASE_DESYNC = "candlepin.db.halt_on_liquibase_desync";
+    public static final String DB_MANAGE_ON_START = "candlepin.db.database_manage_on_startup";
 
     // Authentication
     public static final String TRUSTED_AUTHENTICATION = "candlepin.auth.trusted.enable";
@@ -170,7 +171,11 @@ public class ConfigProperties {
     public static final String QUARTZ_CLUSTERED_MODE = "org.quartz.jobStore.isClustered";
 
     // Hibernate
+    public static final String DB_DRIVER_CLASS = JPA_CONFIG_PREFIX + "hibernate.connection.driver_class";
+    public static final String DB_URL = JPA_CONFIG_PREFIX + "hibernate.connection.url";
+    public static final String DB_USERNAME = JPA_CONFIG_PREFIX + "hibernate.connection.username";
     public static final String DB_PASSWORD = JPA_CONFIG_PREFIX + "hibernate.connection.password";
+
     // Cache
     public static final String CACHE_JMX_STATS = "cache.jmx.statistics";
     public static final String CACHE_CONFIG_FILE_URI = JPA_CONFIG_PREFIX + "hibernate.javax.cache.uri";
@@ -405,7 +410,7 @@ public class ConfigProperties {
             // submit one when registering.
             this.put(HIDDEN_RESOURCES, "environments");
             this.put(HIDDEN_CAPABILITIES, "");
-            this.put(HALT_ON_LIQUIBASE_DESYNC, "true");
+            this.put(DB_MANAGE_ON_START, CandlepinContextListener.DBManagementLevel.NONE.getName());
             this.put(SSL_VERIFY, "false");
 
             this.put(FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");


### PR DESCRIPTION
- Uses the existing lookup for unrun liquibase change sets to determine  the need for executing the update
- Has 4 levels of action
- Defaults to bypassing the process
- Update for liquibase package use to avoid deprecated methods