### PR TITLE
[M] CANDLEPIN-580: Fixed various remapping issues during refresh

### DIFF
--- a/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
+++ b/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
@@ -540,18 +540,24 @@ public class RefreshWorker {
             // state necessary to finalize everything
             RefreshResult result = nodeProcessor.processNodes();
 
-            // If we had any dirty mappings, rebuild the org's mappings to ensure no leftover shenanigans
-            if (this.productMapper.isDirty() ||
-                !this.productMapper.containsOnlyExistingEntities(ownerProducts)) {
-
-                log.warn("Found one or more dirty product mappings for org {}; remapping products", owner);
+            // Check if we have any unmapped existing entities, indicating the org's entity map is
+            // busted.
+            //
+            // Impl note:
+            // this is an entirely inefficient way of going about this process, but our hands are
+            // somewhat tied by Hibernate lacking a proper way of doing an INSERT IGNORE, and not
+            // having all of the data necessary at the curator level. This code path shouldn't be
+            // hit anyway, so we're erroring on the side of clean + never used vs. complex + part of
+            // the primary code path.
+            if (this.productMapper.containsUnmappedExistingEntities(ownerProducts)) {
+                log.warn("Found one or more unmapped existing products for org {}; remapping products",
+                    owner);
                 this.rebuildOwnerProductMapping(owner, result);
             }
 
-            if (this.contentMapper.isDirty() ||
-                !this.contentMapper.containsOnlyExistingEntities(ownerContent)) {
-
-                log.warn("Found one or more dirty content mappings for org {}; remapping content", owner);
+            if (this.contentMapper.containsUnmappedExistingEntities(ownerContent)) {
+                log.warn("Found one or more unmapped existing content for org {}; remapping content",
+                    owner);
                 this.rebuildOwnerContentMapping(owner, result);
             }
 

--- a/src/main/java/org/candlepin/controller/refresher/builders/ContentNodeBuilder.java
+++ b/src/main/java/org/candlepin/controller/refresher/builders/ContentNodeBuilder.java
@@ -59,7 +59,8 @@ public class ContentNodeBuilder implements NodeBuilder<Content, ContentInfo> {
 
         EntityNode<Content, ContentInfo> node = new ContentNode(owner, id)
             .setExistingEntity(existingEntity)
-            .setImportedEntity(importedEntity);
+            .setImportedEntity(importedEntity)
+            .setDirty(mapper.isDirty(id));
 
         return node;
     }

--- a/src/main/java/org/candlepin/controller/refresher/builders/ProductNodeBuilder.java
+++ b/src/main/java/org/candlepin/controller/refresher/builders/ProductNodeBuilder.java
@@ -64,7 +64,8 @@ public class ProductNodeBuilder implements NodeBuilder<Product, ProductInfo> {
 
         EntityNode<Product, ProductInfo> node = new ProductNode(owner, id)
             .setExistingEntity(existingEntity)
-            .setImportedEntity(importedEntity);
+            .setImportedEntity(importedEntity)
+            .setDirty(mapper.isDirty(id));
 
         // Figure out our source entity from which we'll derive children nodes
         ProductInfo sourceEntity = importedEntity != null ? importedEntity : existingEntity;

--- a/src/main/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapper.java
@@ -221,26 +221,26 @@ public abstract class AbstractEntityMapper<E extends AbstractHibernateObject, I 
      * {@inheritDoc}
      */
     @Override
-    public boolean containsOnlyExistingEntityIds(Collection<String> ids) {
+    public boolean containsUnmappedExistingEntityIds(Collection<String> ids) {
         return ids != null ?
-            ids.containsAll(this.existingEntities.keySet()) :
-            this.existingEntities.isEmpty();
+            !ids.containsAll(this.existingEntities.keySet()) :
+            !this.existingEntities.isEmpty();
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public boolean containsOnlyExistingEntities(Collection<? extends E> entities) {
-        if (entities != null && !entities.isEmpty()) {
-            Collection<String> ids = entities.stream()
-                .map(this::getEntityId)
-                .collect(Collectors.toSet());
-
-            return this.containsOnlyExistingEntityIds(ids);
+    public boolean containsUnmappedExistingEntities(Collection<? extends E> entities) {
+        if (entities == null || entities.isEmpty()) {
+            return !this.existingEntities.isEmpty();
         }
 
-        return this.existingEntities.isEmpty();
+        Collection<String> ids = entities.stream()
+            .map(this::getEntityId)
+            .collect(Collectors.toSet());
+
+        return this.containsUnmappedExistingEntityIds(ids);
     }
 
     /**

--- a/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
@@ -203,9 +203,10 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
     boolean isDirty(String id);
 
     /**
-     * Checks that this mapper only contains only existing entity mappings for entities with the
-     * given IDs. If the given collection is null or empty, this method will return true if, and
-     * only if, the mapper contains no existing entity mappings.
+     * Checks if this mapper contains one or more "unmapped" existing entities, defined as an
+     * existing entity mapping which is not represented in the specified collection of IDs. If the
+     * given collection is null or empty, this method will return true if the mapper contains one or
+     * more mapped existing entities.
      * <p></p>
      * <strong>Note:</strong> This method has no effect on the state of the dirty flag for any
      * mapped existing entity.
@@ -214,15 +215,16 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
      *  a collection of entity IDs representing the superset of expected mapped existing entities
      *
      * @return
-     *  true if this mapper contains only existing entities with IDs that are not present in the
-     *  provided collection of IDs; false otherwise
+     *  true if this mapper contains one or more existing entities with IDs that are not present in
+     *  the provided collection of IDs; false otherwise
      */
-    boolean containsOnlyExistingEntityIds(Collection<String> ids);
+    boolean containsUnmappedExistingEntityIds(Collection<String> ids);
 
     /**
-     * Checks that this mapper only contains only existing entity mappings for entities contained in
-     * the given collection of entities. If the given collection is null or empty, this method will
-     * return true if, and only if, the mapper contains no existing entity mappings.
+     * Checks if this mapper contains one or more "unmapped" existing entities, defined as an
+     * existing entity mapping which is not represented in the specified collection of IDs. If the
+     * given collection is null or empty, this method will return true if the mapper contains one or
+     * more mapped existing entities.
      * <p></p>
      * <strong>Note:</strong> This method has no effect on the state of the dirty flag for any
      * mapped existing entity.
@@ -231,10 +233,10 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
      *  a collection of entities representing the superset of expected mapped existing entities
      *
      * @return
-     *  true if this mapper contains only existing entities that are not present in the
-     *  provided entity collection; false otherwise
+     *  true if this mapper contains one or more existing entities that are not present in the
+     *  provided collection of IDs; false otherwise
      */
-    boolean containsOnlyExistingEntities(Collection<? extends E> entities);
+    boolean containsUnmappedExistingEntities(Collection<? extends E> entities);
 
     /**
      * Clears this entity mapper, removing all known existing and imported entities

--- a/src/main/java/org/candlepin/controller/refresher/nodes/AbstractNode.java
+++ b/src/main/java/org/candlepin/controller/refresher/nodes/AbstractNode.java
@@ -44,6 +44,7 @@ public abstract class AbstractNode<E extends AbstractHibernateObject, I extends 
     private Map<Class<?>, Map<String, EntityNode<?, ?>>> parents;
     private Map<Class<?>, Map<String, EntityNode<?, ?>>> children;
     private NodeState state;
+    private boolean dirty;
 
     private E existingEntity;
     private I importedEntity;
@@ -75,6 +76,7 @@ public abstract class AbstractNode<E extends AbstractHibernateObject, I extends 
 
         this.parents = new HashMap<>();
         this.children = new HashMap<>();
+        this.dirty = false;
     }
 
     /**
@@ -204,6 +206,23 @@ public abstract class AbstractNode<E extends AbstractHibernateObject, I extends 
     public boolean changed() {
         NodeState state = this.getNodeState();
         return state == NodeState.CREATED || state == NodeState.UPDATED;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isDirty() {
+        return this.dirty;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntityNode<E, I> setDirty(boolean dirty) {
+        this.dirty = dirty;
+        return this;
     }
 
     /**

--- a/src/main/java/org/candlepin/controller/refresher/nodes/EntityNode.java
+++ b/src/main/java/org/candlepin/controller/refresher/nodes/EntityNode.java
@@ -199,6 +199,27 @@ public interface EntityNode<E extends AbstractHibernateObject, I extends Service
     boolean changed();
 
     /**
+     * Checks if this node represents an existing entity that is dirty, or needs to be forcefully
+     * updated, even in cases where it otherwise may not be.
+     *
+     * @return
+     *  true if this node represents a "dirty" existing entity which needs updating; false otherwise
+     */
+    boolean isDirty();
+
+    /**
+     * Sets whether or not this node represents a dirty existing entity which needs to be forcefully
+     * updated, even in cases where it otherwise may not be.
+     *
+     * @param dirty
+     *  whether or not this node should be considered dirty
+     *
+     * @return
+     *  a reference to this entity node
+     */
+    EntityNode<E, I> setDirty(boolean dirty);
+
+    /**
      * Fetches the operation to be performed on this node
      *
      * @return
@@ -283,4 +304,5 @@ public interface EntityNode<E extends AbstractHibernateObject, I extends Service
      *  change
      */
     E getMergedEntity();
+
 }

--- a/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
@@ -114,13 +114,18 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
         node.setNodeState(NodeState.UNCHANGED);
 
         if (existingEntity != null) {
-            if (importedEntity != null) {
-                if (ContentManager.isChangedBy(existingEntity, importedEntity)) {
-                    Content mergedEntity = this.createEntity(node);
-                    node.setMergedEntity(mergedEntity);
+            // Check if the node is dirty or has changed any...
+            boolean nodeChanged = node.isDirty();
 
-                    node.setNodeState(NodeState.UPDATED);
-                }
+            // Check if the node has changed upstream...
+            nodeChanged = nodeChanged || (importedEntity != null &&
+                ContentManager.isChangedBy(existingEntity, importedEntity));
+
+            if (nodeChanged) {
+                Content mergedEntity = this.createEntity(node);
+                node.setMergedEntity(mergedEntity);
+
+                node.setNodeState(NodeState.UPDATED);
             }
         }
         else if (importedEntity != null) {

--- a/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
@@ -52,6 +52,7 @@ import org.candlepin.service.model.ProductInfo;
 import org.candlepin.service.model.SubscriptionInfo;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.TransactionExecutionException;
+import org.candlepin.util.Util;
 
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
@@ -108,17 +109,21 @@ public class RefreshWorkerTest {
             this.mockProductCurator, this.mockOwnerProductCurator, this.mockContentCurator,
             this.mockOwnerContentCurator);
 
-        doAnswer(returnsFirstArg())
-            .when(this.mockProductCurator)
-            .create(Mockito.any(Product.class), anyBoolean());
+        // TODO: This is a pretty clear sign that we're using mocks incorrectly. Replace this with
+        // an actual database mock or test database
+        doAnswer(iom -> {
+            Product entity = iom.getArgument(0);
+            return entity.setUuid(Util.generateDbUUID());
+        }).when(this.mockProductCurator).create(Mockito.any(Product.class), anyBoolean());
 
         doAnswer(returnsFirstArg())
             .when(this.mockOwnerProductCurator)
             .create(Mockito.any(OwnerProduct.class), anyBoolean());
 
-        doAnswer(returnsFirstArg())
-            .when(this.mockContentCurator)
-            .create(Mockito.any(Content.class), anyBoolean());
+        doAnswer(iom -> {
+            Content entity = iom.getArgument(0);
+            return entity.setUuid(Util.generateDbUUID());
+        }).when(this.mockContentCurator).create(Mockito.any(Content.class), anyBoolean());
 
         doAnswer(returnsFirstArg())
             .when(this.mockOwnerContentCurator)
@@ -1181,45 +1186,6 @@ public class RefreshWorkerTest {
     // resultant state instead of probing for specific code paths.
 
     @Test
-    public void testRemapperInvokedOnDuplicateExistingProductReference() {
-        Owner owner = new Owner();
-
-        Product prod1 = new Product()
-            .setId("pid-1")
-            .setUuid("product1");
-        Product prod2 = new Product()
-            .setId("pid-2")
-            .setUuid("product2");
-
-        Product child1a = new Product()
-            .setId("child-1")
-            .setName("provided product v1")
-            .setUuid("child_product-v1");
-        Product child1b = new Product()
-            .setId("child-1")
-            .setName("provided product v2")
-            .setUuid("child_product-v2");
-
-        // Set these up as different versions of a provided product so we can trigger
-        // detection of two different versions of the same product ID
-        prod1.addProvidedProduct(child1a);
-        prod2.addProvidedProduct(child1b);
-
-        this.mockChildrenProductLookup(List.of(prod1, prod2));
-
-        doReturn(Arrays.asList(prod1, prod2, child1a, child1b)).when(this.mockOwnerProductCurator)
-            .getProductsByOwner(eq(owner));
-        doReturn(Collections.emptyList()).when(this.mockOwnerContentCurator)
-            .getContentByOwner(eq(owner));
-
-        RefreshWorker worker = this.buildRefreshWorker();
-        worker.execute(owner);
-
-        verify(mockOwnerProductCurator, times(1))
-            .rebuildOwnerProductMapping(eq(owner), Mockito.any(Map.class));
-    }
-
-    @Test
     public void testRemapperInvokedOnExtraneousExistingProductReference() {
         Owner owner = new Owner();
 
@@ -1253,45 +1219,6 @@ public class RefreshWorkerTest {
 
         verify(mockOwnerProductCurator, times(1))
             .rebuildOwnerProductMapping(eq(owner), Mockito.any(Map.class));
-    }
-
-    @Test
-    public void testRemapperInvokedOnDuplicateExistingContentReference() {
-        Owner owner = new Owner();
-
-        Product prod1 = new Product()
-            .setId("pid-1")
-            .setUuid("product1");
-        Product prod2 = new Product()
-            .setId("pid-2")
-            .setUuid("product2");
-
-        Content child1a = new Content()
-            .setId("cid-1")
-            .setUuid("content1v1")
-            .setName("content-1 v1");
-        Content child1b = new Content()
-            .setId("cid-1")
-            .setUuid("content1v2")
-            .setName("content-1 v2");
-
-        // Set these up as different versions of a provided product so we can trigger
-        // detection of two different versions of the same product ID
-        prod1.addContent(child1a, true);
-        prod2.addContent(child1b, true);
-
-        this.mockChildrenContentLookup(List.of(prod1, prod2));
-
-        doReturn(Arrays.asList(prod1, prod2)).when(this.mockOwnerProductCurator)
-            .getProductsByOwner(eq(owner));
-        doReturn(Arrays.asList(child1a, child1b)).when(this.mockOwnerContentCurator)
-            .getContentByOwner(eq(owner));
-
-        RefreshWorker worker = this.buildRefreshWorker();
-        worker.execute(owner);
-
-        verify(mockOwnerContentCurator, times(1))
-            .rebuildOwnerContentMapping(eq(owner), Mockito.any(Map.class));
     }
 
     @Test

--- a/src/test/java/org/candlepin/controller/refresher/builders/ContentNodeBuilderTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/builders/ContentNodeBuilderTest.java
@@ -15,11 +15,15 @@
 package org.candlepin.controller.refresher.builders;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 import org.candlepin.controller.refresher.mappers.ContentMapper;
 import org.candlepin.controller.refresher.nodes.EntityNode;
@@ -105,6 +109,9 @@ public class ContentNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
     }
 
     @Test
@@ -146,6 +153,9 @@ public class ContentNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
     }
 
     @Test
@@ -186,6 +196,73 @@ public class ContentNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyExistingEntityUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Content existing = TestUtil.createContent(id, "existing");
+        ContentInfo imported = TestUtil.createContent(id, "imported");
+
+        ContentMapper mapper = spy(new ContentMapper());
+
+        mapper.addExistingEntity(existing);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ContentNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Content, ContentInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyImportedEntityUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Content existing = TestUtil.createContent(id, "existing");
+        ContentInfo imported = TestUtil.createContent(id, "imported");
+
+        ContentMapper mapper = spy(new ContentMapper());
+
+        mapper.addImportedEntity(imported);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ContentNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Content, ContentInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyExistingAndImportedEntitiesUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Content existing = TestUtil.createContent(id, "existing");
+        ContentInfo imported = TestUtil.createContent(id, "imported");
+
+        ContentMapper mapper = spy(new ContentMapper());
+
+        mapper.addExistingEntity(existing);
+        mapper.addImportedEntity(imported);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ContentNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Content, ContentInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
     }
 
     @Test

--- a/src/test/java/org/candlepin/controller/refresher/builders/ProductNodeBuilderTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/builders/ProductNodeBuilderTest.java
@@ -17,6 +17,7 @@ package org.candlepin.controller.refresher.builders;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -136,6 +137,9 @@ public class ProductNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
     }
 
     @Test
@@ -180,6 +184,9 @@ public class ProductNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
     }
 
     @Test
@@ -223,6 +230,73 @@ public class ProductNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyExistingEntityUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Product existing = TestUtil.createProduct(id, "existing");
+        ProductInfo imported = TestUtil.createProduct(id, "imported");
+
+        ProductMapper mapper = spy(new ProductMapper());
+
+        mapper.addExistingEntity(existing);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ProductNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Product, ProductInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyImportedEntityUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Product existing = TestUtil.createProduct(id, "existing");
+        ProductInfo imported = TestUtil.createProduct(id, "imported");
+
+        ProductMapper mapper = spy(new ProductMapper());
+
+        mapper.addImportedEntity(imported);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ProductNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Product, ProductInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyExistingAndImportedEntitiesUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Product existing = TestUtil.createProduct(id, "existing");
+        ProductInfo imported = TestUtil.createProduct(id, "imported");
+
+        ProductMapper mapper = spy(new ProductMapper());
+
+        mapper.addExistingEntity(existing);
+        mapper.addImportedEntity(imported);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ProductNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Product, ProductInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
     }
 
     @Test

--- a/src/test/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapperTest.java
@@ -884,7 +884,7 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
     }
 
     @Test
-    public void testContainsOnlyExistingEntityIds() {
+    public void testContainsUnmappedExistingEntityIds() {
         Owner owner = TestUtil.createOwner();
 
         E entity1 = this.buildLocalEntity(owner, "test_entity-1");
@@ -898,21 +898,21 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
             .collect(Collectors.toList());
 
         // An empty mapper is still a subset of the expected list
-        assertTrue(mapper.containsOnlyExistingEntityIds(entityIds));
+        assertFalse(mapper.containsUnmappedExistingEntityIds(entityIds));
 
         for (E entity : List.of(entity1, entity2, entity3)) {
             mapper.addExistingEntity(entity);
-            assertTrue(mapper.containsOnlyExistingEntityIds(entityIds));
+            assertFalse(mapper.containsUnmappedExistingEntityIds(entityIds));
         }
 
         // Add a new entity and verify the original entityId list is no longer a superset
         mapper.addExistingEntity(this.buildLocalEntity(owner, "test_entity-4"));
-        assertFalse(mapper.containsOnlyExistingEntityIds(entityIds));
+        assertTrue(mapper.containsUnmappedExistingEntityIds(entityIds));
     }
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
     @NullAndEmptySource
-    public void testContainsOnlyExistingEntityIdsPermitsEmptyCollections(List<String> input) {
+    public void testContainsUnmappedExistingEntityIdsPermitsEmptyCollections(List<String> input) {
         Owner owner = TestUtil.createOwner();
 
         E entity1 = this.buildLocalEntity(owner, "test_entity-1");
@@ -922,20 +922,20 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
         EntityMapper<E, I> mapper = this.buildEntityMapper();
 
         // Empty is a subset of empty. Null/empty values should match until the mapper has data
-        assertTrue(mapper.containsOnlyExistingEntityIds(input));
+        assertFalse(mapper.containsUnmappedExistingEntityIds(input));
 
         for (E entity : List.of(entity1, entity2, entity3)) {
             mapper.addExistingEntity(entity);
-            assertFalse(mapper.containsOnlyExistingEntityIds(input));
+            assertTrue(mapper.containsUnmappedExistingEntityIds(input));
         }
 
         // Clearing the mapper should bring this back to its original state and return as expected
         mapper.clear();
-        assertTrue(mapper.containsOnlyExistingEntityIds(input));
+        assertFalse(mapper.containsUnmappedExistingEntityIds(input));
     }
 
     @Test
-    public void testContainsOnlyExistingEntities() {
+    public void testContainsUnmappedExistingEntities() {
         Owner owner = TestUtil.createOwner();
 
         E entity1 = this.buildLocalEntity(owner, "test_entity-1");
@@ -947,21 +947,21 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
         List<E> entities = List.of(entity1, entity2, entity3);
 
         // An empty mapper is still a subset of the expected list
-        assertTrue(mapper.containsOnlyExistingEntities(entities));
+        assertFalse(mapper.containsUnmappedExistingEntities(entities));
 
         for (E entity : List.of(entity1, entity2, entity3)) {
             mapper.addExistingEntity(entity);
-            assertTrue(mapper.containsOnlyExistingEntities(entities));
+            assertFalse(mapper.containsUnmappedExistingEntities(entities));
         }
 
         // Add a new entity and verify the original entityId list is no longer a superset
         mapper.addExistingEntity(this.buildLocalEntity(owner, "test_entity-4"));
-        assertFalse(mapper.containsOnlyExistingEntities(entities));
+        assertTrue(mapper.containsUnmappedExistingEntities(entities));
     }
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
     @NullAndEmptySource
-    public void testContainsOnlyExistingEntitiesPermitsEmptyCollections(List<E> input) {
+    public void testContainsUnmappedExistingEntitiesPermitsEmptyCollections(List<E> input) {
         Owner owner = TestUtil.createOwner();
 
         E entity1 = this.buildLocalEntity(owner, "test_entity-1");
@@ -971,15 +971,15 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
         EntityMapper<E, I> mapper = this.buildEntityMapper();
 
         // Empty is a subset of empty. Null/empty values should match until the mapper has data
-        assertTrue(mapper.containsOnlyExistingEntities(input));
+        assertFalse(mapper.containsUnmappedExistingEntities(input));
 
         for (E entity : List.of(entity1, entity2, entity3)) {
             mapper.addExistingEntity(entity);
-            assertFalse(mapper.containsOnlyExistingEntities(input));
+            assertTrue(mapper.containsUnmappedExistingEntities(input));
         }
 
         // Clearing the mapper should bring this back to its original state and return as expected
         mapper.clear();
-        assertTrue(mapper.containsOnlyExistingEntities(input));
+        assertFalse(mapper.containsUnmappedExistingEntities(input));
     }
 }

--- a/src/test/java/org/candlepin/controller/refresher/nodes/AbstractNodeTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/nodes/AbstractNodeTest.java
@@ -410,4 +410,34 @@ public abstract class AbstractNodeTest<E extends AbstractHibernateObject, I exte
         // Verify the entity was cleared
         assertNull(node.getMergedEntity());
     }
+
+    @Test
+    public void testDirtyFlag() {
+        Owner owner = TestUtil.createOwner();
+        EntityNode<E, I> node = this.buildEntityNode(owner, "test_id");
+        EntityNode<E, I> output = null;
+
+        // Initial state should always be false
+        assertFalse(node.isDirty());
+
+        // no change call, false => false
+        output = node.setDirty(false);
+        assertFalse(node.isDirty());
+        assertSame(node, output);
+
+        // false => true should result in the obvious change
+        output = node.setDirty(true);
+        assertTrue(node.isDirty());
+        assertSame(node, output);
+
+        // no change call, true => true
+        output = node.setDirty(true);
+        assertTrue(node.isDirty());
+        assertSame(node, output);
+
+        // true => false should also result with the obvious expectation
+        output = node.setDirty(false);
+        assertFalse(node.isDirty());
+        assertSame(node, output);
+    }
 }

--- a/src/test/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitorTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitorTest.java
@@ -249,6 +249,46 @@ public class ContentNodeVisitorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testProcessNodeFlagsUnchangedNodesCorrectlyWhenNotDirty() {
+        Owner owner = this.createOwner();
+
+        Content existing = this.createContent("test_content", "test content", owner);
+        Content imported = existing.clone();
+
+        EntityNode<Content, ContentInfo> pnode = new ContentNode(owner, existing.getId())
+            .setExistingEntity(existing)
+            .setImportedEntity(imported)
+            .setDirty(false);
+
+        assertNull(pnode.getNodeState());
+
+        ContentNodeVisitor visitor = this.buildNodeVisitor();
+        visitor.processNode(pnode);
+
+        assertEquals(NodeState.UNCHANGED, pnode.getNodeState());
+    }
+
+    @Test
+    public void testProcessNodeFlagsAlwaysUpdatesDirtyNodes() {
+        Owner owner = this.createOwner();
+
+        // The content should be identical to ensure that we still update dirty nodes even when we
+        // have no reason to do so otherwise
+        Content existing = this.createContent("test_content", "test content", owner);
+        Content imported = existing.clone();
+
+        EntityNode<Content, ContentInfo> pnode = new ContentNode(owner, existing.getId())
+            .setExistingEntity(existing)
+            .setImportedEntity(imported)
+            .setDirty(true);
+
+        ContentNodeVisitor visitor = this.buildNodeVisitor();
+        visitor.processNode(pnode);
+
+        assertEquals(NodeState.UPDATED, pnode.getNodeState());
+    }
+
+    @Test
     public void testProcessNodeFlagsCreatedNodeCorrectly() {
         Owner owner = this.createOwner();
         ContentInfo importedEntity = this.createContent("test_content-1", "Test Content", owner);

--- a/src/test/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitorTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitorTest.java
@@ -103,6 +103,46 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testProcessNodeFlagsUnchangedNodesCorrectlyWhenNotDirty() {
+        Owner owner = this.createOwner();
+
+        Product existing = this.createProduct("test_product", "test product", owner);
+        Product imported = existing.clone();
+
+        EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existing.getId())
+            .setExistingEntity(existing)
+            .setImportedEntity(imported)
+            .setDirty(false);
+
+        assertNull(pnode.getNodeState());
+
+        ProductNodeVisitor visitor = this.buildNodeVisitor();
+        visitor.processNode(pnode);
+
+        assertEquals(NodeState.UNCHANGED, pnode.getNodeState());
+    }
+
+    @Test
+    public void testProcessNodeFlagsAlwaysUpdatesDirtyNodes() {
+        Owner owner = this.createOwner();
+
+        // The products should be identical to ensure that we still update dirty nodes even when we
+        // have no reason to do so otherwise
+        Product existing = this.createProduct("test_product", "test product", owner);
+        Product imported = existing.clone();
+
+        EntityNode<Product, ProductInfo> pnode = new ProductNode(owner, existing.getId())
+            .setExistingEntity(existing)
+            .setImportedEntity(imported)
+            .setDirty(true);
+
+        ProductNodeVisitor visitor = this.buildNodeVisitor();
+        visitor.processNode(pnode);
+
+        assertEquals(NodeState.UPDATED, pnode.getNodeState());
+    }
+
+    @Test
     public void testProcessNodeFlagsUnchangedNodeAsUpdatedWithUpdatedChildren() {
         Owner owner = this.createOwner();
         Product existingEntity = this.createProduct("test_prod-1", "Test Product", owner);


### PR DESCRIPTION
- Fixed an issue where a "dirty" local reference to one or more existing entities would trigger a global org-entity remapping, but would not fix the mapping error in the entity model
- Reduced the conditions in which the global org-entity remapping logic would be invoked to only cases where an org has one or more missing org-entity mappings