### PR TITLE
[M] CANDLEPIN-580: Fixed various remapping issues during refresh

### DIFF
--- a/src/main/java/org/candlepin/controller/refresher/builders/ContentNodeBuilder.java
+++ b/src/main/java/org/candlepin/controller/refresher/builders/ContentNodeBuilder.java
@@ -59,7 +59,8 @@ public class ContentNodeBuilder implements NodeBuilder<Content, ContentInfo> {
 
         EntityNode<Content, ContentInfo> node = new ContentNode(owner, id)
             .setExistingEntity(existingEntity)
-            .setImportedEntity(importedEntity);
+            .setImportedEntity(importedEntity)
+            .setDirty(mapper.isDirty(id));
 
         return node;
     }

--- a/src/main/java/org/candlepin/controller/refresher/builders/ProductNodeBuilder.java
+++ b/src/main/java/org/candlepin/controller/refresher/builders/ProductNodeBuilder.java
@@ -61,6 +61,7 @@ public class ProductNodeBuilder implements NodeBuilder<Product, ProductInfo> {
 
         Product existingEntity = mapper.getExistingEntity(id);
         ProductInfo importedEntity = mapper.getImportedEntity(id);
+        boolean dirty = mapper.isDirty(id);
 
         EntityNode<Product, ProductInfo> node = new ProductNode(owner, id)
             .setExistingEntity(existingEntity)
@@ -85,6 +86,7 @@ public class ProductNodeBuilder implements NodeBuilder<Product, ProductInfo> {
                     <Product, ProductInfo>buildNode(owner, Product.class, provided.getId());
 
                 node.addChildNode(child);
+                dirty = dirty || child.isDirty();
             }
         }
 
@@ -93,6 +95,7 @@ public class ProductNodeBuilder implements NodeBuilder<Product, ProductInfo> {
         if (derived != null) {
             EntityNode<Product, ProductInfo> child = factory.buildNode(owner, Product.class, derived.getId());
             node.addChildNode(child);
+            dirty = dirty || child.isDirty();
         }
 
         // Add content nodes
@@ -126,8 +129,12 @@ public class ProductNodeBuilder implements NodeBuilder<Product, ProductInfo> {
                     <Content, ContentInfo>buildNode(owner, Content.class, content.getId());
 
                 node.addChildNode(child);
+                dirty = dirty || child.isDirty();
             }
         }
+
+        // If the node or any of its children were dirty, set the dirty flag
+        node.setDirty(dirty);
 
         return node;
     }

--- a/src/main/java/org/candlepin/controller/refresher/mappers/ContentMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/ContentMapper.java
@@ -72,4 +72,52 @@ public class ContentMapper extends AbstractEntityMapper<Content, ContentInfo> {
         return this.getEntityId((ContentInfo) entity);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean entitiesMatch(Content current, Content inbound) {
+        if (current == null) {
+            throw new IllegalArgumentException("current is null");
+        }
+
+        if (inbound == null) {
+            throw new IllegalArgumentException("inbound is null");
+        }
+
+        // Impl note:
+        // This test is contingent on some internal knowledge of the model and how Content.equals
+        // works. Since content entities are expected to be immutable, a matching UUID *should* also
+        // guarantee entity equality. Content.equals also leverages this knowledge to avoid a bunch
+        // of additional field checks if the UUID is present and equal on both entities, which is
+        // why we don't bother calling into it unless one of them lacks a UUID (which itself isn't
+        // something that should happen).
+        // Even in the weird case where the UUIDs equal but the product instances themselves are
+        // not, we'll still be defaulting to taking the last one seen (which should be the locally
+        // mapped instance from the DB), so we should maintain consistency even in the worst case.
+
+        String currentUuid = current.getUuid();
+        String inboundUuid = inbound.getUuid();
+
+        return currentUuid == null || inboundUuid == null ?
+            current.equals(inbound) :
+            currentUuid.equals(inboundUuid);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean entitiesMatch(ContentInfo current, ContentInfo inbound) {
+        if (current == null) {
+            throw new IllegalArgumentException("current is null");
+        }
+
+        if (inbound == null) {
+            throw new IllegalArgumentException("inbound is null");
+        }
+
+        return current.equals(inbound);
+    }
+
 }

--- a/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
@@ -203,9 +203,10 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
     boolean isDirty(String id);
 
     /**
-     * Checks that this mapper only contains only existing entity mappings for entities with the
-     * given IDs. If the given collection is null or empty, this method will return true if, and
-     * only if, the mapper contains no existing entity mappings.
+     * Checks if this mapper contains one or more "unmapped" existing entities, defined as an
+     * existing entity mapping which is not represented in the specified collection of IDs. If the
+     * given collection is null or empty, this method will return true if the mapper contains one or
+     * more mapped existing entities.
      * <p></p>
      * <strong>Note:</strong> This method has no effect on the state of the dirty flag for any
      * mapped existing entity.
@@ -214,15 +215,16 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
      *  a collection of entity IDs representing the superset of expected mapped existing entities
      *
      * @return
-     *  true if this mapper contains only existing entities with IDs that are not present in the
-     *  provided collection of IDs; false otherwise
+     *  true if this mapper contains one or more existing entities with IDs that are not present in
+     *  the provided collection of IDs; false otherwise
      */
-    boolean containsOnlyExistingEntityIds(Collection<String> ids);
+    boolean containsUnmappedExistingEntityIds(Collection<String> ids);
 
     /**
-     * Checks that this mapper only contains only existing entity mappings for entities contained in
-     * the given collection of entities. If the given collection is null or empty, this method will
-     * return true if, and only if, the mapper contains no existing entity mappings.
+     * Checks if this mapper contains one or more "unmapped" existing entities, defined as an
+     * existing entity mapping which is not represented in the specified collection of IDs. If the
+     * given collection is null or empty, this method will return true if the mapper contains one or
+     * more mapped existing entities.
      * <p></p>
      * <strong>Note:</strong> This method has no effect on the state of the dirty flag for any
      * mapped existing entity.
@@ -231,10 +233,10 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
      *  a collection of entities representing the superset of expected mapped existing entities
      *
      * @return
-     *  true if this mapper contains only existing entities that are not present in the
-     *  provided entity collection; false otherwise
+     *  true if this mapper contains one or more existing entities that are not present in the
+     *  provided collection of IDs; false otherwise
      */
-    boolean containsOnlyExistingEntities(Collection<? extends E> entities);
+    boolean containsUnmappedExistingEntities(Collection<? extends E> entities);
 
     /**
      * Clears this entity mapper, removing all known existing and imported entities

--- a/src/main/java/org/candlepin/controller/refresher/mappers/PoolMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/PoolMapper.java
@@ -87,4 +87,20 @@ public class PoolMapper extends AbstractEntityMapper<Pool, SubscriptionInfo> {
         return id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean entitiesMatch(Pool existing, Pool inbound) {
+        return existing.equals(inbound);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean entitiesMatch(SubscriptionInfo existing, SubscriptionInfo inbound) {
+        return existing.equals(inbound);
+    }
+
 }

--- a/src/main/java/org/candlepin/controller/refresher/mappers/ProductMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/ProductMapper.java
@@ -72,4 +72,52 @@ public class ProductMapper extends AbstractEntityMapper<Product, ProductInfo> {
         return this.getEntityId((ProductInfo) entity);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean entitiesMatch(Product current, Product inbound) {
+        if (current == null) {
+            throw new IllegalArgumentException("current is null");
+        }
+
+        if (inbound == null) {
+            throw new IllegalArgumentException("inbound is null");
+        }
+
+        // Impl note:
+        // This test is contingent on some internal knowledge of the model and how Product.equals
+        // works. Since product entities are expected to be immutable, a matching UUID *should* also
+        // guarantee entity equality. Product.equals also leverages this knowledge to avoid a bunch
+        // of additional field checks if the UUID is present and equal on both entities, which is
+        // why we don't bother calling into it unless one of them lacks a UUID (which itself isn't
+        // something that should happen).
+        // Even in the weird case where the UUIDs equal but the product instances themselves are
+        // not, we'll still be defaulting to taking the last one seen (which should be the locally
+        // mapped instance from the DB), so we should maintain consistency even in the worst case.
+
+        String currentUuid = current.getUuid();
+        String inboundUuid = inbound.getUuid();
+
+        return currentUuid == null || inboundUuid == null ?
+            current.equals(inbound) :
+            currentUuid.equals(inboundUuid);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected boolean entitiesMatch(ProductInfo current, ProductInfo inbound) {
+        if (current == null) {
+            throw new IllegalArgumentException("current is null");
+        }
+
+        if (inbound == null) {
+            throw new IllegalArgumentException("inbound is null");
+        }
+
+        return current.equals(inbound);
+    }
+
 }

--- a/src/main/java/org/candlepin/controller/refresher/nodes/AbstractNode.java
+++ b/src/main/java/org/candlepin/controller/refresher/nodes/AbstractNode.java
@@ -44,6 +44,7 @@ public abstract class AbstractNode<E extends AbstractHibernateObject, I extends 
     private Map<Class<?>, Map<String, EntityNode<?, ?>>> parents;
     private Map<Class<?>, Map<String, EntityNode<?, ?>>> children;
     private NodeState state;
+    private boolean dirty;
 
     private E existingEntity;
     private I importedEntity;
@@ -75,6 +76,7 @@ public abstract class AbstractNode<E extends AbstractHibernateObject, I extends 
 
         this.parents = new HashMap<>();
         this.children = new HashMap<>();
+        this.dirty = false;
     }
 
     /**
@@ -210,6 +212,23 @@ public abstract class AbstractNode<E extends AbstractHibernateObject, I extends 
      * {@inheritDoc}
      */
     @Override
+    public boolean isDirty() {
+        return this.dirty;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntityNode<E, I> setDirty(boolean dirty) {
+        this.dirty = dirty;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public NodeState getNodeState() {
         return this.state;
     }
@@ -279,7 +298,7 @@ public abstract class AbstractNode<E extends AbstractHibernateObject, I extends 
      */
     @Override
     public String toString() {
-        return String.format("EntityNode [class: %s, entity id: %s, state: %s]",
-            this.getEntityClass(), this.getEntityId(), this.getNodeState());
+        return String.format("EntityNode [class: %s, entity id: %s, state: %s, dirty: %s]",
+            this.getEntityClass(), this.getEntityId(), this.getNodeState(), this.isDirty());
     }
 }

--- a/src/main/java/org/candlepin/controller/refresher/nodes/EntityNode.java
+++ b/src/main/java/org/candlepin/controller/refresher/nodes/EntityNode.java
@@ -199,6 +199,27 @@ public interface EntityNode<E extends AbstractHibernateObject, I extends Service
     boolean changed();
 
     /**
+     * Checks if this node represents an existing entity that is dirty, or needs to be forcefully
+     * updated, even in cases where it otherwise may not be.
+     *
+     * @return
+     *  true if this node represents a "dirty" existing entity which needs updating; false otherwise
+     */
+    boolean isDirty();
+
+    /**
+     * Sets whether or not this node represents a dirty existing entity which needs to be forcefully
+     * updated, even in cases where it otherwise may not be.
+     *
+     * @param dirty
+     *  whether or not this node should be considered dirty
+     *
+     * @return
+     *  a reference to this entity node
+     */
+    EntityNode<E, I> setDirty(boolean dirty);
+
+    /**
      * Fetches the operation to be performed on this node
      *
      * @return
@@ -283,4 +304,5 @@ public interface EntityNode<E extends AbstractHibernateObject, I extends Service
      *  change
      */
     E getMergedEntity();
+
 }

--- a/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/src/main/java/org/candlepin/model/ContentCurator.java
@@ -158,18 +158,18 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
     }
 
     /**
-     * Fetches a set consisting of the content of the  products specified by the given UUIDs. If the
-     * given products do not have any content or no products exist with the provided UUIDs, this
-     * method returns an empty set.
+     * Fetches a collection consisting of the content of the products specified by the given UUIDs.
+     * If the given products do not have any content or no products exist with the provided UUIDs,
+     * this method returns an empty collection.
      *
      * @param productUuids
      *  a collection of UUIDs of products for which to fetch children content
      *
      * @return
-     *  a set consisting of the content of the products specified by the given UUIDs
+     *  a collection consisting of the content of the products specified by the given UUIDs
      */
-    public Set<Content> getChildrenContentOfProductsByUuids(Collection<String> productUuids) {
-        Set<Content> output = new HashSet<>();
+    public Collection<Content> getChildrenContentOfProductsByUuids(Collection<String> productUuids) {
+        Map<String, Content> contentMap = new HashMap<>();
 
         if (productUuids != null && !productUuids.isEmpty()) {
             String jpql = "SELECT pc.content FROM Product p JOIN p.productContent pc " +
@@ -179,10 +179,12 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
                 .createQuery(jpql, Content.class);
 
             for (List<String> block : this.partition(productUuids)) {
-                output.addAll(query.setParameter("product_uuids", block).getResultList());
+                query.setParameter("product_uuids", block)
+                    .getResultList()
+                    .forEach(entity -> contentMap.put(entity.getUuid(), entity));
             }
         }
 
-        return output;
+        return contentMap.values();
     }
 }

--- a/src/main/java/org/candlepin/model/OwnerProductCurator.java
+++ b/src/main/java/org/candlepin/model/OwnerProductCurator.java
@@ -1171,4 +1171,5 @@ public class OwnerProductCurator extends AbstractHibernateCurator<OwnerProduct> 
             this.clearProductEntityVersion(entity.getUuid());
         }
     }
+
 }

--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -1287,10 +1287,9 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder(7, 17)
-            .append(this.id);
-
-        return builder.toHashCode();
+        return new HashCodeBuilder(7, 17)
+            .append(this.getId())
+            .toHashCode();
     }
 
     /**

--- a/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
@@ -52,6 +52,7 @@ import org.candlepin.service.model.ProductInfo;
 import org.candlepin.service.model.SubscriptionInfo;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.TransactionExecutionException;
+import org.candlepin.util.Util;
 
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
@@ -108,17 +109,21 @@ public class RefreshWorkerTest {
             this.mockProductCurator, this.mockOwnerProductCurator, this.mockContentCurator,
             this.mockOwnerContentCurator);
 
-        doAnswer(returnsFirstArg())
-            .when(this.mockProductCurator)
-            .create(Mockito.any(Product.class), anyBoolean());
+        // TODO: This is a pretty clear sign that we're using mocks incorrectly. Replace this with
+        // an actual database mock or test database
+        doAnswer(iom -> {
+            Product entity = iom.getArgument(0);
+            return entity.setUuid(Util.generateDbUUID());
+        }).when(this.mockProductCurator).create(Mockito.any(Product.class), anyBoolean());
 
         doAnswer(returnsFirstArg())
             .when(this.mockOwnerProductCurator)
             .create(Mockito.any(OwnerProduct.class), anyBoolean());
 
-        doAnswer(returnsFirstArg())
-            .when(this.mockContentCurator)
-            .create(Mockito.any(Content.class), anyBoolean());
+        doAnswer(iom -> {
+            Content entity = iom.getArgument(0);
+            return entity.setUuid(Util.generateDbUUID());
+        }).when(this.mockContentCurator).create(Mockito.any(Content.class), anyBoolean());
 
         doAnswer(returnsFirstArg())
             .when(this.mockOwnerContentCurator)
@@ -1034,19 +1039,34 @@ public class RefreshWorkerTest {
         ProductInfo pinfo1 = this.mockProductInfo("pid-1", "product-1");
         ProductInfo pinfo2 = this.mockProductInfo("pid-2", "product-2");
         ProductInfo pinfo3 = this.mockProductInfo("pid-3a", "imported_product");
-        Product product1 = new Product("pid-1", "product-1");
-        Product product2 = new Product("pid-2", "product-2");
-        Product product3 = new Product("pid-3b", "existing_product");
+        Product product1 = new Product()
+            .setUuid("product_uuid-1")
+            .setId("pid-1")
+            .setName("product-1");
+        Product product2 = new Product()
+            .setUuid("product_uuid-2")
+            .setId("pid-2")
+            .setName("product-2");
+        Product product3 = new Product()
+            .setUuid("product_uuid-3")
+            .setId("pid-3b")
+            .setName("existing_product");
 
         ContentInfo cinfo1 = this.mockContentInfo("cid-1", "content-1");
         ContentInfo cinfo2 = this.mockContentInfo("cid-2", "content-2");
         ContentInfo cinfo3 = this.mockContentInfo("cid-3a", "imported_content");
-        Content content1 = new Content("cid-1");
-        content1.setName("content-1");
-        Content content2 = new Content("cid-2");
-        content2.setName("content-2");
-        Content content3 = new Content("cid-3b");
-        content3.setName("existing_content");
+        Content content1 = new Content()
+            .setUuid("content_uuid-1")
+            .setId("cid-1")
+            .setName("content-1");
+        Content content2 = new Content()
+            .setUuid("content_uuid-2")
+            .setId("cid-2")
+            .setName("content-2");
+        Content content3 = new Content()
+            .setUuid("content_uuid-3")
+            .setId("cid-3b")
+            .setName("existing_content");
 
         doReturn(Arrays.asList(product1, product2, product3)).when(this.mockOwnerProductCurator)
             .getProductsByOwner(eq(owner));
@@ -1181,45 +1201,6 @@ public class RefreshWorkerTest {
     // resultant state instead of probing for specific code paths.
 
     @Test
-    public void testRemapperInvokedOnDuplicateExistingProductReference() {
-        Owner owner = new Owner();
-
-        Product prod1 = new Product()
-            .setId("pid-1")
-            .setUuid("product1");
-        Product prod2 = new Product()
-            .setId("pid-2")
-            .setUuid("product2");
-
-        Product child1a = new Product()
-            .setId("child-1")
-            .setName("provided product v1")
-            .setUuid("child_product-v1");
-        Product child1b = new Product()
-            .setId("child-1")
-            .setName("provided product v2")
-            .setUuid("child_product-v2");
-
-        // Set these up as different versions of a provided product so we can trigger
-        // detection of two different versions of the same product ID
-        prod1.addProvidedProduct(child1a);
-        prod2.addProvidedProduct(child1b);
-
-        this.mockChildrenProductLookup(List.of(prod1, prod2));
-
-        doReturn(Arrays.asList(prod1, prod2, child1a, child1b)).when(this.mockOwnerProductCurator)
-            .getProductsByOwner(eq(owner));
-        doReturn(Collections.emptyList()).when(this.mockOwnerContentCurator)
-            .getContentByOwner(eq(owner));
-
-        RefreshWorker worker = this.buildRefreshWorker();
-        worker.execute(owner);
-
-        verify(mockOwnerProductCurator, times(1))
-            .rebuildOwnerProductMapping(eq(owner), Mockito.any(Map.class));
-    }
-
-    @Test
     public void testRemapperInvokedOnExtraneousExistingProductReference() {
         Owner owner = new Owner();
 
@@ -1253,45 +1234,6 @@ public class RefreshWorkerTest {
 
         verify(mockOwnerProductCurator, times(1))
             .rebuildOwnerProductMapping(eq(owner), Mockito.any(Map.class));
-    }
-
-    @Test
-    public void testRemapperInvokedOnDuplicateExistingContentReference() {
-        Owner owner = new Owner();
-
-        Product prod1 = new Product()
-            .setId("pid-1")
-            .setUuid("product1");
-        Product prod2 = new Product()
-            .setId("pid-2")
-            .setUuid("product2");
-
-        Content child1a = new Content()
-            .setId("cid-1")
-            .setUuid("content1v1")
-            .setName("content-1 v1");
-        Content child1b = new Content()
-            .setId("cid-1")
-            .setUuid("content1v2")
-            .setName("content-1 v2");
-
-        // Set these up as different versions of a provided product so we can trigger
-        // detection of two different versions of the same product ID
-        prod1.addContent(child1a, true);
-        prod2.addContent(child1b, true);
-
-        this.mockChildrenContentLookup(List.of(prod1, prod2));
-
-        doReturn(Arrays.asList(prod1, prod2)).when(this.mockOwnerProductCurator)
-            .getProductsByOwner(eq(owner));
-        doReturn(Arrays.asList(child1a, child1b)).when(this.mockOwnerContentCurator)
-            .getContentByOwner(eq(owner));
-
-        RefreshWorker worker = this.buildRefreshWorker();
-        worker.execute(owner);
-
-        verify(mockOwnerContentCurator, times(1))
-            .rebuildOwnerContentMapping(eq(owner), Mockito.any(Map.class));
     }
 
     @Test

--- a/src/test/java/org/candlepin/controller/refresher/builders/ContentNodeBuilderTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/builders/ContentNodeBuilderTest.java
@@ -15,11 +15,15 @@
 package org.candlepin.controller.refresher.builders;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 import org.candlepin.controller.refresher.mappers.ContentMapper;
 import org.candlepin.controller.refresher.nodes.EntityNode;
@@ -105,6 +109,9 @@ public class ContentNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
     }
 
     @Test
@@ -146,6 +153,9 @@ public class ContentNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
     }
 
     @Test
@@ -186,6 +196,73 @@ public class ContentNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyExistingEntityUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Content existing = TestUtil.createContent(id, "existing");
+        ContentInfo imported = TestUtil.createContent(id, "imported");
+
+        ContentMapper mapper = spy(new ContentMapper());
+
+        mapper.addExistingEntity(existing);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ContentNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Content, ContentInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyImportedEntityUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Content existing = TestUtil.createContent(id, "existing");
+        ContentInfo imported = TestUtil.createContent(id, "imported");
+
+        ContentMapper mapper = spy(new ContentMapper());
+
+        mapper.addImportedEntity(imported);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ContentNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Content, ContentInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyExistingAndImportedEntitiesUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Content existing = TestUtil.createContent(id, "existing");
+        ContentInfo imported = TestUtil.createContent(id, "imported");
+
+        ContentMapper mapper = spy(new ContentMapper());
+
+        mapper.addExistingEntity(existing);
+        mapper.addImportedEntity(imported);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ContentNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Content, ContentInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
     }
 
     @Test

--- a/src/test/java/org/candlepin/controller/refresher/builders/ProductNodeBuilderTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/builders/ProductNodeBuilderTest.java
@@ -17,6 +17,7 @@ package org.candlepin.controller.refresher.builders;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -30,11 +31,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.candlepin.controller.refresher.mappers.ProductMapper;
+import org.candlepin.controller.refresher.nodes.ContentNode;
 import org.candlepin.controller.refresher.nodes.EntityNode;
+import org.candlepin.controller.refresher.nodes.ProductNode;
 import org.candlepin.model.AbstractHibernateObject;
 import org.candlepin.model.Content;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Product;
+import org.candlepin.service.model.ContentInfo;
 import org.candlepin.service.model.ProductInfo;
 import org.candlepin.service.model.ServiceAdapterModel;
 import org.candlepin.test.TestUtil;
@@ -136,6 +140,9 @@ public class ProductNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
     }
 
     @Test
@@ -180,6 +187,9 @@ public class ProductNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
     }
 
     @Test
@@ -223,6 +233,73 @@ public class ProductNodeBuilderTest {
         // Its pseudo-state getters should match our expectations
         assertTrue(output.isRootNode());
         assertTrue(output.isLeafNode());
+
+        // The node should not be flagged dirty
+        assertFalse(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyExistingEntityUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Product existing = TestUtil.createProduct(id, "existing");
+        ProductInfo imported = TestUtil.createProduct(id, "imported");
+
+        ProductMapper mapper = spy(new ProductMapper());
+
+        mapper.addExistingEntity(existing);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ProductNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Product, ProductInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyImportedEntityUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Product existing = TestUtil.createProduct(id, "existing");
+        ProductInfo imported = TestUtil.createProduct(id, "imported");
+
+        ProductMapper mapper = spy(new ProductMapper());
+
+        mapper.addImportedEntity(imported);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ProductNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Product, ProductInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeWithOnlyExistingAndImportedEntitiesUsingDirtyMappingCreatesDirtyNode() {
+        String id = "test_id";
+
+        Owner owner = TestUtil.createOwner();
+        Product existing = TestUtil.createProduct(id, "existing");
+        ProductInfo imported = TestUtil.createProduct(id, "imported");
+
+        ProductMapper mapper = spy(new ProductMapper());
+
+        mapper.addExistingEntity(existing);
+        mapper.addImportedEntity(imported);
+        doReturn(true).when(mapper).isDirty(eq(id));
+
+        ProductNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Product, ProductInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner, id);
+
+        assertNotNull(output);
+        assertEquals(id, output.getEntityId());
+        assertTrue(output.isDirty());
     }
 
     @Test
@@ -782,6 +859,99 @@ public class ProductNodeBuilderTest {
         // Ensure that the children were created using the node factory and not an internal method
         verify(this.mockNodeFactory, times(2)).buildNode(eq(owner), eq(Product.class), anyString());
         verify(this.mockNodeFactory, times(2)).buildNode(eq(owner), eq(Content.class), anyString());
+    }
+
+    @Test
+    public void testBuildNodeCreatesDirtyNodeWhenAChildContentIsDirty() {
+        Owner owner = TestUtil.createOwner();
+        Product product = TestUtil.createProduct("p1", "product");
+        Content content = TestUtil.createContent("content");
+
+        product.addContent(content, true);
+
+        EntityNode<Content, ContentInfo> childNode = new ContentNode(owner, content.getId())
+            .setExistingEntity(content)
+            .setDirty(true);
+
+        doReturn(childNode).when(this.mockNodeFactory)
+            .buildNode(eq(owner), eq(childNode.getEntityClass()), eq(childNode.getEntityId()));
+
+        ProductMapper mapper = new ProductMapper();
+        mapper.addExistingEntity(product);
+
+        ProductNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Product, ProductInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner,
+            product.getId());
+
+        assertNotNull(output);
+
+        // Verify the mapping itself is not dirty
+        assertFalse(mapper.isDirty(product.getId()));
+
+        // ...but the node is
+        assertTrue(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeCreatesDirtyNodeWhenAProvidedProductIsDirty() {
+        Owner owner = TestUtil.createOwner();
+        Product product = TestUtil.createProduct("p1", "product");
+        Product provided = TestUtil.createProduct("pp1", "provided_product");
+
+        product.addProvidedProduct(provided);
+
+        EntityNode<Product, ProductInfo> childNode = new ProductNode(owner, provided.getId())
+            .setExistingEntity(provided)
+            .setDirty(true);
+
+        doReturn(childNode).when(this.mockNodeFactory)
+            .buildNode(eq(owner), eq(childNode.getEntityClass()), eq(childNode.getEntityId()));
+
+        ProductMapper mapper = new ProductMapper();
+        mapper.addExistingEntity(product);
+
+        ProductNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Product, ProductInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner,
+            product.getId());
+
+        assertNotNull(output);
+
+        // Verify the mapping itself is not dirty
+        assertFalse(mapper.isDirty(product.getId()));
+
+        // ...but the node is
+        assertTrue(output.isDirty());
+    }
+
+    @Test
+    public void testBuildNodeCreatesDirtyNodeWhenTheDerivedProductIsDirty() {
+        Owner owner = TestUtil.createOwner();
+        Product product = TestUtil.createProduct("p1", "product");
+        Product derived = TestUtil.createProduct("dp1", "derived_product");
+
+        product.setDerivedProduct(derived);
+
+        EntityNode<Product, ProductInfo> childNode = new ProductNode(owner, derived.getId())
+            .setExistingEntity(derived)
+            .setDirty(true);
+
+        doReturn(childNode).when(this.mockNodeFactory)
+            .buildNode(eq(owner), eq(childNode.getEntityClass()), eq(childNode.getEntityId()));
+
+        ProductMapper mapper = new ProductMapper();
+        mapper.addExistingEntity(product);
+
+        ProductNodeBuilder builder = this.buildNodeBuilder();
+        EntityNode<Product, ProductInfo> output = builder.buildNode(this.mockNodeFactory, mapper, owner,
+            product.getId());
+
+        assertNotNull(output);
+
+        // Verify the mapping itself is not dirty
+        assertFalse(mapper.isDirty(product.getId()));
+
+        // ...but the node is
+        assertTrue(output.isDirty());
     }
 
     @Test

--- a/src/test/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapperTest.java
@@ -322,9 +322,6 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
         }
     }
 
-
-
-
     @Test
     public void testAddImportedEntity() {
         Owner owner = TestUtil.createOwner();
@@ -884,7 +881,7 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
     }
 
     @Test
-    public void testContainsOnlyExistingEntityIds() {
+    public void testContainsUnmappedExistingEntityIds() {
         Owner owner = TestUtil.createOwner();
 
         E entity1 = this.buildLocalEntity(owner, "test_entity-1");
@@ -898,21 +895,21 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
             .collect(Collectors.toList());
 
         // An empty mapper is still a subset of the expected list
-        assertTrue(mapper.containsOnlyExistingEntityIds(entityIds));
+        assertFalse(mapper.containsUnmappedExistingEntityIds(entityIds));
 
         for (E entity : List.of(entity1, entity2, entity3)) {
             mapper.addExistingEntity(entity);
-            assertTrue(mapper.containsOnlyExistingEntityIds(entityIds));
+            assertFalse(mapper.containsUnmappedExistingEntityIds(entityIds));
         }
 
         // Add a new entity and verify the original entityId list is no longer a superset
         mapper.addExistingEntity(this.buildLocalEntity(owner, "test_entity-4"));
-        assertFalse(mapper.containsOnlyExistingEntityIds(entityIds));
+        assertTrue(mapper.containsUnmappedExistingEntityIds(entityIds));
     }
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
     @NullAndEmptySource
-    public void testContainsOnlyExistingEntityIdsPermitsEmptyCollections(List<String> input) {
+    public void testContainsUnmappedExistingEntityIdsPermitsEmptyCollections(List<String> input) {
         Owner owner = TestUtil.createOwner();
 
         E entity1 = this.buildLocalEntity(owner, "test_entity-1");
@@ -922,20 +919,20 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
         EntityMapper<E, I> mapper = this.buildEntityMapper();
 
         // Empty is a subset of empty. Null/empty values should match until the mapper has data
-        assertTrue(mapper.containsOnlyExistingEntityIds(input));
+        assertFalse(mapper.containsUnmappedExistingEntityIds(input));
 
         for (E entity : List.of(entity1, entity2, entity3)) {
             mapper.addExistingEntity(entity);
-            assertFalse(mapper.containsOnlyExistingEntityIds(input));
+            assertTrue(mapper.containsUnmappedExistingEntityIds(input));
         }
 
         // Clearing the mapper should bring this back to its original state and return as expected
         mapper.clear();
-        assertTrue(mapper.containsOnlyExistingEntityIds(input));
+        assertFalse(mapper.containsUnmappedExistingEntityIds(input));
     }
 
     @Test
-    public void testContainsOnlyExistingEntities() {
+    public void testContainsUnmappedExistingEntities() {
         Owner owner = TestUtil.createOwner();
 
         E entity1 = this.buildLocalEntity(owner, "test_entity-1");
@@ -947,21 +944,21 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
         List<E> entities = List.of(entity1, entity2, entity3);
 
         // An empty mapper is still a subset of the expected list
-        assertTrue(mapper.containsOnlyExistingEntities(entities));
+        assertFalse(mapper.containsUnmappedExistingEntities(entities));
 
         for (E entity : List.of(entity1, entity2, entity3)) {
             mapper.addExistingEntity(entity);
-            assertTrue(mapper.containsOnlyExistingEntities(entities));
+            assertFalse(mapper.containsUnmappedExistingEntities(entities));
         }
 
         // Add a new entity and verify the original entityId list is no longer a superset
         mapper.addExistingEntity(this.buildLocalEntity(owner, "test_entity-4"));
-        assertFalse(mapper.containsOnlyExistingEntities(entities));
+        assertTrue(mapper.containsUnmappedExistingEntities(entities));
     }
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
     @NullAndEmptySource
-    public void testContainsOnlyExistingEntitiesPermitsEmptyCollections(List<E> input) {
+    public void testContainsUnmappedExistingEntitiesPermitsEmptyCollections(List<E> input) {
         Owner owner = TestUtil.createOwner();
 
         E entity1 = this.buildLocalEntity(owner, "test_entity-1");
@@ -971,15 +968,15 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
         EntityMapper<E, I> mapper = this.buildEntityMapper();
 
         // Empty is a subset of empty. Null/empty values should match until the mapper has data
-        assertTrue(mapper.containsOnlyExistingEntities(input));
+        assertFalse(mapper.containsUnmappedExistingEntities(input));
 
         for (E entity : List.of(entity1, entity2, entity3)) {
             mapper.addExistingEntity(entity);
-            assertFalse(mapper.containsOnlyExistingEntities(input));
+            assertTrue(mapper.containsUnmappedExistingEntities(input));
         }
 
         // Clearing the mapper should bring this back to its original state and return as expected
         mapper.clear();
-        assertTrue(mapper.containsOnlyExistingEntities(input));
+        assertFalse(mapper.containsUnmappedExistingEntities(input));
     }
 }

--- a/src/test/java/org/candlepin/controller/refresher/mappers/ContentMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/ContentMapperTest.java
@@ -14,14 +14,26 @@
  */
 package org.candlepin.controller.refresher.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.Content;
 import org.candlepin.model.Owner;
 import org.candlepin.service.model.ContentInfo;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import java.util.stream.Stream;
 
 
 
@@ -46,7 +58,7 @@ public class ContentMapperTest extends AbstractEntityMapperTest<Content, Content
     }
 
     @Override
-    protected EntityMapper<Content, ContentInfo> buildEntityMapper() {
+    protected ContentMapper buildEntityMapper() {
         return new ContentMapper();
     }
 
@@ -62,6 +74,183 @@ public class ContentMapperTest extends AbstractEntityMapperTest<Content, Content
         return new Content()
             .setId(entityId)
             .setName(String.format("%s-%d", entityId, ++generatedEntityCount));
+    }
+
+    @Test
+    public void testLocalEntitiesMatchMatchesEntitiesWithSameIDAndUUID() {
+        Content current = new Content()
+            .setId("content1")
+            .setUuid("content_uuid")
+            .setName("content name");
+
+        Content inbound = new Content()
+            .setId(current.getId())
+            .setUuid(current.getUuid())
+            .setName(current.getName());
+
+        ContentMapper mapper = this.buildEntityMapper();
+
+        // uuids equal => should match
+        assertEquals(current, inbound);
+        assertTrue(mapper.entitiesMatch(current, inbound));
+
+        // uuids equal + objects differ => still match
+        inbound.setName(current.getName() + " modified");
+        assertNotEquals(current.getName(), inbound.getName());
+        assertTrue(mapper.entitiesMatch(current, inbound));
+    }
+
+    @Test
+    public void testLocalEntitiesMatchRejectsEntitiesWithSameIDAndDifferentUUIDs() {
+        Content current = new Content()
+            .setId("content1")
+            .setUuid("content_uuid")
+            .setName("content name");
+
+        Content inbound = new Content()
+            .setId(current.getId())
+            .setUuid(current.getUuid() + " modified")
+            .setName(current.getName());
+
+        ContentMapper mapper = this.buildEntityMapper();
+
+        // uuids differ => no match, even when the objects are otherwise equal
+        assertEquals(current, inbound);
+        assertFalse(mapper.entitiesMatch(current, inbound));
+
+        // uuids differ + data differs => no match
+        inbound.setName(current.getName() + " modified");
+        assertNotEquals(current, inbound);
+        assertFalse(mapper.entitiesMatch(current, inbound));
+    }
+
+    private static Stream<Arguments> mixedNullUUIDProvider() {
+        return Stream.of(
+            Arguments.of("content_uuid", null),
+            Arguments.of(null, "content_uuid"),
+            Arguments.of(null, null));
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}, {1}")
+    @MethodSource("mixedNullUUIDProvider")
+    public void testLocalEntitiesMatchDefaultsToEqualityChecksWithoutUUID(
+        String currentUuid, String inboundUuid) {
+
+        Content current = new Content()
+            .setId("content1")
+            .setUuid(currentUuid)
+            .setName("content name");
+
+        Content inbound = new Content()
+            .setId(current.getId())
+            .setUuid(inboundUuid)
+            .setName(current.getName());
+
+        ContentMapper mapper = this.buildEntityMapper();
+
+        // no uuid + entities equal => match
+        assertEquals(current, inbound);
+        assertTrue(mapper.entitiesMatch(current, inbound));
+
+        // no uuid + entities differ => no match
+        inbound.setName(current.getName() + " modified");
+        assertNotEquals(current, inbound);
+        assertFalse(mapper.entitiesMatch(current, inbound));
+    }
+
+    @Test
+    public void testLocalEntitiesMatchErrorsOnNullCurrentEntity() {
+        Content entity = this.buildLocalEntity(new Owner(), "content_id");
+        ContentMapper mapper = this.buildEntityMapper();
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.entitiesMatch(null, entity));
+    }
+
+    @Test
+    public void testLocalEntitiesMatchErrorsOnNullInboundEntity() {
+        Content entity = this.buildLocalEntity(new Owner(), "content_id");
+        ContentMapper mapper = this.buildEntityMapper();
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.entitiesMatch(entity, null));
+    }
+
+    @Test
+    public void testUpstreamEntitiesMatchMatchesOnEquality() {
+        // Impl note: Content is a ContentInfo
+        Content current = new Content()
+            .setId("content1")
+            .setName("content name");
+
+        Content inbound = new Content()
+            .setId(current.getId())
+            .setName(current.getName());
+
+        ContentMapper mapper = this.buildEntityMapper();
+
+        // no uuid + entities equal => match
+        assertEquals(current, inbound);
+        assertTrue(mapper.entitiesMatch((ContentInfo) current, (ContentInfo) inbound));
+
+        // no uuid + entities differ => no match
+        inbound.setName(current.getName() + " modified");
+        assertNotEquals(current, inbound);
+        assertFalse(mapper.entitiesMatch((ContentInfo) current, (ContentInfo) inbound));
+    }
+
+    @Test
+    public void testUpstreamEntitiesMatchErrorsOnNullCurrentEntity() {
+        ContentInfo entity = this.buildImportedEntity(new Owner(), "content_id");
+        ContentMapper mapper = this.buildEntityMapper();
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.entitiesMatch(null, entity));
+    }
+
+    @Test
+    public void testUpstreamEntitiesMatchErrorsOnNullInboundEntity() {
+        ContentInfo entity = this.buildImportedEntity(new Owner(), "content_id");
+        ContentMapper mapper = this.buildEntityMapper();
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.entitiesMatch(entity, null));
+    }
+
+    /**
+     * This oddly named test captures the case where we have two content instances that are equal
+     * but have different UUIDs, usually stemming from a case where the entity versions were either
+     * manually cleared or cleared during a previous mapping resolution run that didn't fully clean
+     * up the mapping issues.
+     *
+     * In such a case where two local content instances only differ by UUID, we expect the mapper to
+     * use the most recently mapped entity, but flag the mapping as dirty.
+     */
+    @Test
+    public void testAddExistingEntityCorrectlyFlagsMappingErrorsOnEqualContent() {
+        String id = "content_id";
+
+        Content current = new Content()
+            .setId(id)
+            .setUuid("content_uuid-1")
+            .setName("content name");
+
+        Content inbound = new Content()
+            .setId(id)
+            .setUuid("content_uuid-2")
+            .setName(current.getName());
+
+        ContentMapper mapper = this.buildEntityMapper();
+
+        // Adding the first entity should be normal
+        mapper.addExistingEntity(current);
+        assertFalse(mapper.isDirty(id));
+
+        // Re-adding itself should also be fine
+        mapper.addExistingEntity(current);
+        assertFalse(mapper.isDirty(id));
+
+        // Adding the new inbound entity which is equal but has a different UUID should flip the
+        // dirty flag
+        assertEquals(current, inbound);
+        mapper.addExistingEntity(inbound);
+        assertTrue(mapper.isDirty(id));
     }
 
 }

--- a/src/test/java/org/candlepin/controller/refresher/mappers/ProductMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/ProductMapperTest.java
@@ -14,14 +14,26 @@
  */
 package org.candlepin.controller.refresher.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.Owner;
 import org.candlepin.model.Product;
 import org.candlepin.service.model.ProductInfo;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import java.util.stream.Stream;
 
 
 
@@ -46,7 +58,7 @@ public class ProductMapperTest extends AbstractEntityMapperTest<Product, Product
     }
 
     @Override
-    protected EntityMapper<Product, ProductInfo> buildEntityMapper() {
+    protected ProductMapper buildEntityMapper() {
         return new ProductMapper();
     }
 
@@ -64,4 +76,180 @@ public class ProductMapperTest extends AbstractEntityMapperTest<Product, Product
             .setName(String.format("%s-%d", entityId, ++generatedEntityCount));
     }
 
+    @Test
+    public void testLocalEntitiesMatchMatchesEntitiesWithSameIDAndUUID() {
+        Product current = new Product()
+            .setId("product1")
+            .setUuid("product_uuid")
+            .setName("product name");
+
+        Product inbound = new Product()
+            .setId(current.getId())
+            .setUuid(current.getUuid())
+            .setName(current.getName());
+
+        ProductMapper mapper = this.buildEntityMapper();
+
+        // uuids equal => should match
+        assertEquals(current, inbound);
+        assertTrue(mapper.entitiesMatch(current, inbound));
+
+        // uuids equal + objects differ => still match
+        inbound.setName(current.getName() + " modified");
+        assertNotEquals(current.getName(), inbound.getName());
+        assertTrue(mapper.entitiesMatch(current, inbound));
+    }
+
+    @Test
+    public void testLocalEntitiesMatchRejectsEntitiesWithSameIDAndDifferentUUIDs() {
+        Product current = new Product()
+            .setId("product1")
+            .setUuid("product_uuid")
+            .setName("product name");
+
+        Product inbound = new Product()
+            .setId(current.getId())
+            .setUuid(current.getUuid() + " modified")
+            .setName(current.getName());
+
+        ProductMapper mapper = this.buildEntityMapper();
+
+        // uuids differ => no match, even when the objects are otherwise equal
+        assertEquals(current, inbound);
+        assertFalse(mapper.entitiesMatch(current, inbound));
+
+        // uuids differ + data differs => no match
+        inbound.setName(current.getName() + " modified");
+        assertNotEquals(current, inbound);
+        assertFalse(mapper.entitiesMatch(current, inbound));
+    }
+
+    private static Stream<Arguments> mixedNullUUIDProvider() {
+        return Stream.of(
+            Arguments.of("product_uuid", null),
+            Arguments.of(null, "product_uuid"),
+            Arguments.of(null, null));
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}, {1}")
+    @MethodSource("mixedNullUUIDProvider")
+    public void testLocalEntitiesMatchDefaultsToEqualityChecksWithoutUUID(
+        String currentUuid, String inboundUuid) {
+
+        Product current = new Product()
+            .setId("product1")
+            .setUuid(currentUuid)
+            .setName("product name");
+
+        Product inbound = new Product()
+            .setId(current.getId())
+            .setUuid(inboundUuid)
+            .setName(current.getName());
+
+        ProductMapper mapper = this.buildEntityMapper();
+
+        // no uuid + entities equal => match
+        assertEquals(current, inbound);
+        assertTrue(mapper.entitiesMatch(current, inbound));
+
+        // no uuid + entities differ => no match
+        inbound.setName(current.getName() + " modified");
+        assertNotEquals(current, inbound);
+        assertFalse(mapper.entitiesMatch(current, inbound));
+    }
+
+    @Test
+    public void testLocalEntitiesMatchErrorsOnNullCurrentEntity() {
+        Product entity = this.buildLocalEntity(new Owner(), "product_id");
+        ProductMapper mapper = this.buildEntityMapper();
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.entitiesMatch(null, entity));
+    }
+
+    @Test
+    public void testLocalEntitiesMatchErrorsOnNullInboundEntity() {
+        Product entity = this.buildLocalEntity(new Owner(), "product_id");
+        ProductMapper mapper = this.buildEntityMapper();
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.entitiesMatch(entity, null));
+    }
+
+    @Test
+    public void testUpstreamEntitiesMatchMatchesOnEquality() {
+        // Impl note: Product is a ProductInfo
+        Product current = new Product()
+            .setId("product1")
+            .setName("product name");
+
+        Product inbound = new Product()
+            .setId(current.getId())
+            .setName(current.getName());
+
+        ProductMapper mapper = this.buildEntityMapper();
+
+        // no uuid + entities equal => match
+        assertEquals(current, inbound);
+        assertTrue(mapper.entitiesMatch((ProductInfo) current, (ProductInfo) inbound));
+
+        // no uuid + entities differ => no match
+        inbound.setName(current.getName() + " modified");
+        assertNotEquals(current, inbound);
+        assertFalse(mapper.entitiesMatch((ProductInfo) current, (ProductInfo) inbound));
+    }
+
+    @Test
+    public void testUpstreamEntitiesMatchErrorsOnNullCurrentEntity() {
+        ProductInfo entity = this.buildImportedEntity(new Owner(), "product_id");
+        ProductMapper mapper = this.buildEntityMapper();
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.entitiesMatch(null, entity));
+    }
+
+    @Test
+    public void testUpstreamEntitiesMatchErrorsOnNullInboundEntity() {
+        ProductInfo entity = this.buildImportedEntity(new Owner(), "product_id");
+        ProductMapper mapper = this.buildEntityMapper();
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.entitiesMatch(entity, null));
+    }
+
+    /**
+     * This oddly named test captures the case where we have two product instances that are equal
+     * but have different UUIDs, usually stemming from a case where the entity versions were either
+     * manually cleared or cleared during a previous mapping resolution run that didn't fully clean
+     * up the mapping issues.
+     *
+     * In such a case where two local product instances only differ by UUID, we expect the mapper to
+     * use the most recently mapped entity, but flag the mapping as dirty.
+     */
+    @Test
+    public void testAddExistingEntityCorrectlyFlagsMappingErrorsOnEqualProduct() {
+        String id = "product_id";
+
+        Product current = new Product()
+            .setId(id)
+            .setUuid("product_uuid-1")
+            .setName("product name");
+
+        Product inbound = new Product()
+            .setId(id)
+            .setUuid("product_uuid-2")
+            .setName(current.getName());
+
+        ProductMapper mapper = this.buildEntityMapper();
+
+        // Adding the first entity should be normal
+        mapper.addExistingEntity(current);
+        assertFalse(mapper.isDirty(id));
+
+        // Re-adding itself should also be fine
+        mapper.addExistingEntity(current);
+        assertFalse(mapper.isDirty(id));
+
+        // Adding the new inbound entity which is equal but has a different UUID should flip the
+        // dirty flag
+        assertEquals(current, inbound);
+        mapper.addExistingEntity(inbound);
+        assertTrue(mapper.isDirty(id));
+    }
 }

--- a/src/test/java/org/candlepin/controller/refresher/nodes/AbstractNodeTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/nodes/AbstractNodeTest.java
@@ -410,4 +410,34 @@ public abstract class AbstractNodeTest<E extends AbstractHibernateObject, I exte
         // Verify the entity was cleared
         assertNull(node.getMergedEntity());
     }
+
+    @Test
+    public void testDirtyFlag() {
+        Owner owner = TestUtil.createOwner();
+        EntityNode<E, I> node = this.buildEntityNode(owner, "test_id");
+        EntityNode<E, I> output = null;
+
+        // Initial state should always be false
+        assertFalse(node.isDirty());
+
+        // no change call, false => false
+        output = node.setDirty(false);
+        assertFalse(node.isDirty());
+        assertSame(node, output);
+
+        // false => true should result in the obvious change
+        output = node.setDirty(true);
+        assertTrue(node.isDirty());
+        assertSame(node, output);
+
+        // no change call, true => true
+        output = node.setDirty(true);
+        assertTrue(node.isDirty());
+        assertSame(node, output);
+
+        // true => false should also result with the obvious expectation
+        output = node.setDirty(false);
+        assertFalse(node.isDirty());
+        assertSame(node, output);
+    }
 }

--- a/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -23,12 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
+import org.candlepin.util.Util;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -359,7 +361,7 @@ public class ContentCuratorTest extends DatabaseTestFixture {
 
         List<Product> products = List.of(product1, product2, product3, product4);
 
-        Set<Content> expected = products.stream()
+        Collection<Content> expected = products.stream()
             .flatMap(product -> product.getProductContent().stream())
             .map(ProductContent::getContent)
             .collect(Collectors.toSet());
@@ -368,9 +370,10 @@ public class ContentCuratorTest extends DatabaseTestFixture {
             .map(Product::getUuid)
             .collect(Collectors.toList());
 
-        Set<Content> output = this.contentCurator.getChildrenContentOfProductsByUuids(input);
+        Collection<Content> output = this.contentCurator.getChildrenContentOfProductsByUuids(input);
         assertNotNull(output);
-        assertEquals(expected, output);
+        assertTrue(Util.collectionsAreEqual(expected, output),
+            String.format("Collections are not equal.\n  Expected: %s\n  Actual: %s", expected, output));
     }
 
     @Test
@@ -385,16 +388,17 @@ public class ContentCuratorTest extends DatabaseTestFixture {
 
         List<Product> products = List.of(product2, product3);
 
-        Set<Content> expected = products.stream()
+        Collection<Content> expected = products.stream()
             .flatMap(product -> product.getProductContent().stream())
             .map(ProductContent::getContent)
             .collect(Collectors.toSet());
 
         List<String> input = Arrays.asList(product2.getUuid(), "invalid", product3.getUuid(), null);
 
-        Set<Content> output = this.contentCurator.getChildrenContentOfProductsByUuids(input);
+        Collection<Content> output = this.contentCurator.getChildrenContentOfProductsByUuids(input);
         assertNotNull(output);
-        assertEquals(expected, output);
+        assertTrue(Util.collectionsAreEqual(expected, output),
+            String.format("Collections are not equal.\n  Expected: %s\n  Actual: %s", expected, output));
     }
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
@@ -409,7 +413,7 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         Product product3 = this.createProductWithContent("p3", 3, owner2);
         Product product4 = this.createProductWithContent("p4", 4, owner1, owner2);
 
-        Set<Content> output = this.contentCurator.getChildrenContentOfProductsByUuids(input);
+        Collection<Content> output = this.contentCurator.getChildrenContentOfProductsByUuids(input);
         assertNotNull(output);
         assertTrue(output.isEmpty());
     }

--- a/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -29,6 +29,7 @@ import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.AttributeValidator;
 import org.candlepin.util.PropertyValidationException;
+import org.candlepin.util.Util;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -830,7 +832,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
         List<Product> products = List.of(product1, product2, product3, product4);
 
-        Set<Product> expected = products.stream()
+        Collection<Product> expected = products.stream()
             .flatMap(product -> product.getProvidedProducts().stream())
             .collect(Collectors.toSet());
 
@@ -838,9 +840,10 @@ public class ProductCuratorTest extends DatabaseTestFixture {
             .map(Product::getUuid)
             .collect(Collectors.toList());
 
-        Set<Product> output = this.productCurator.getChildrenProductsOfProductsByUuids(input);
+        Collection<Product> output = this.productCurator.getChildrenProductsOfProductsByUuids(input);
         assertNotNull(output);
-        assertEquals(expected, output);
+        assertTrue(Util.collectionsAreEqual(expected, output),
+            String.format("Collections are not equal.\n  Expected: %s\n  Actual: %s", expected, output));
     }
 
     @Test
@@ -855,7 +858,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
         List<Product> products = List.of(product1, product2, product3, product4);
 
-        Set<Product> expected = products.stream()
+        Collection<Product> expected = products.stream()
             .map(Product::getDerivedProduct)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
@@ -864,9 +867,10 @@ public class ProductCuratorTest extends DatabaseTestFixture {
             .map(Product::getUuid)
             .collect(Collectors.toList());
 
-        Set<Product> output = this.productCurator.getChildrenProductsOfProductsByUuids(input);
+        Collection<Product> output = this.productCurator.getChildrenProductsOfProductsByUuids(input);
         assertNotNull(output);
-        assertEquals(expected, output);
+        assertTrue(Util.collectionsAreEqual(expected, output),
+            String.format("Collections are not equal.\n  Expected: %s\n  Actual: %s", expected, output));
     }
 
     @Test
@@ -881,7 +885,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
         List<Product> products = List.of(product2, product3);
 
-        Set<Product> expected = new HashSet<>();
+        Collection<Product> expected = new HashSet<>();
 
         products.stream()
             .flatMap(product -> product.getProvidedProducts().stream())
@@ -894,9 +898,10 @@ public class ProductCuratorTest extends DatabaseTestFixture {
 
         List<String> input = Arrays.asList(product2.getUuid(), "invalid", product3.getUuid(), null);
 
-        Set<Product> output = this.productCurator.getChildrenProductsOfProductsByUuids(input);
+        Collection<Product> output = this.productCurator.getChildrenProductsOfProductsByUuids(input);
         assertNotNull(output);
-        assertEquals(expected, output);
+        assertTrue(Util.collectionsAreEqual(expected, output),
+            String.format("Collections are not equal.\n  Expected: %s\n  Actual: %s", expected, output));
     }
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
@@ -910,7 +915,7 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         Product product3 = this.createProduct("p3", "product_3", owner2);
         Product product4 = this.createProduct("p4", "product_4", owner2);
 
-        Set<Product> output = this.productCurator.getChildrenProductsOfProductsByUuids(input);
+        Collection<Product> output = this.productCurator.getChildrenProductsOfProductsByUuids(input);
         assertNotNull(output);
         assertTrue(output.isEmpty());
     }

--- a/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -227,12 +227,14 @@ public class PoolRulesStackDerivedTest {
      * @return
      */
     private Pool copyFromSub(Subscription sub) {
-        Pool pool = TestUtil.copyFromSub(sub);
-        pool.setId("" + lastPoolId++);
+        Pool pool = TestUtil.copyFromSub(sub)
+            .setId(String.valueOf(lastPoolId++));
+
         when(productCurator.getPoolProvidedProductsCached(pool))
-            .thenReturn((Set<Product>) pool.getProduct().getProvidedProducts());
+            .thenReturn(new ArrayList<>(pool.getProduct().getProvidedProducts()));
         when(productCurator.getPoolDerivedProvidedProductsCached(pool))
-            .thenReturn((Set<Product>) pool.getProduct().getProvidedProducts());
+            .thenReturn(new ArrayList<>(pool.getProduct().getProvidedProducts()));
+
         return pool;
     }
 

--- a/src/test/java/org/candlepin/policy/PoolRulesTest.java
+++ b/src/test/java/org/candlepin/policy/PoolRulesTest.java
@@ -595,9 +595,10 @@ public class PoolRulesTest {
         derivedProd.addProvidedProduct(derivedProvidedProd2);
 
         when(productCurator.getPoolProvidedProductsCached(p))
-            .thenReturn((Set<Product>) p.getProduct().getProvidedProducts());
+            .thenReturn(new ArrayList<>(p.getProduct().getProvidedProducts()));
         when(productCurator.getPoolDerivedProvidedProductsCached(p))
-            .thenReturn((Set<Product>) p.getDerivedProduct().getProvidedProducts());
+            .thenReturn(new ArrayList<>(p.getDerivedProduct().getProvidedProducts()));
+
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<>());
 
         // Should be virt_only pool for unmapped guests:
@@ -629,13 +630,16 @@ public class PoolRulesTest {
     @Test
     public void standaloneVirtLimitSubCreateDerived() {
         when(config.getBoolean(ConfigProperties.STANDALONE)).thenReturn(true);
-        Subscription s = createVirtLimitSubWithDerivedProducts("virtLimitProduct",
-            "derivedProd", 10, 10);
-        Pool p = TestUtil.copyFromSub(s);
+
+        Subscription s = createVirtLimitSubWithDerivedProducts("virtLimitProduct", "derivedProd", 10, 10);
+
+        Pool p = TestUtil.copyFromSub(s)
+            .setId("mockVirtLimitSubCreateDerived");
+
         when(poolManager.isManaged(eq(p))).thenReturn(true);
-        p.setId("mockVirtLimitSubCreateDerived");
         when(productCurator.getPoolDerivedProvidedProductsCached(p))
-            .thenReturn((Set<Product>) p.getDerivedProduct().getProvidedProducts());
+            .thenReturn(new ArrayList<>(p.getDerivedProduct().getProvidedProducts()));
+
         List<Pool> pools = poolRules.createAndEnrichPools(p, new LinkedList<>());
 
         // Should be virt_only pool for unmapped guests:


### PR DESCRIPTION
- Fixed an issue where a "dirty" local reference to one or more
  existing entities would trigger a global org-entity remapping,
  but would not fix the mapping error in the entity model
- Reduced the conditions in which the global org-entity remapping
  logic would be invoked to only cases where an org has one or
  more missing org-entity mappings
- Entity trees which contain one or more dirty nodes will now be
  entirely rebuilt, clearing the versioning of any dirty node and
  all nodes above any dirty nodes in the tree
- Versioning lookup will now be skipped for dirty nodes to avoid a
  case where the rebuild process will resolve to an existing
  entity, undoing the work of the rebuild step
- Extremely rare cases where entity version resolution would
  result in an entity mapping back to itself will now be skipped
  from the mapping operation, and a warning will be issued instead
- Certain UUID-based entity lookups which used sets have been
  converted to use lists or generic collections to avoid a case
  where two entities with different UUIDs but are otherwise equal
  would cause one of them to be overwritten