### PR TITLE
[M] CANDLEPIN-504: Migrated spec tests to GH Actions

### DIFF
--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -1,0 +1,83 @@
+FROM quay.io/centos/centos:stream9 as builder
+
+USER root
+
+# Update and install dependencies
+RUN dnf -y --setopt install_weak_deps=False update && \
+    dnf -y --setopt install_weak_deps=False install java-17-openjdk-devel jss gettext && \
+    dnf clean all
+
+ENV JAVA_HOME=/usr/lib/jvm/jre-17-openjdk
+ENV JRE_HOME=/usr/lib/jvm/jre-17-openjdk
+
+# Copy source code
+COPY . ./candlepin
+WORKDIR /candlepin
+
+# Build the Candlpepin WAR file.
+# Note: we need to includes -Phostedtest=true so that we can run spec tests
+# using our hosted test endpoints.
+RUN ./gradlew war -Phostedtest=true && \
+    mkdir -p /app/build && \
+    cp $(find ./build/libs -name 'candlepin*.war' | head -n 1) /app/build
+
+WORKDIR /app/build
+RUN jar xf $(find . -name 'candlepin*.war' | head -n 1); \
+    sed -i 's/jss4.jar/jss.jar/g' ./META-INF/context.xml
+
+FROM quay.io/centos/centos:stream9
+LABEL author="Josh Albrecht <jalbrech@redhat.com>"
+
+RUN dnf install -y glibc-langpack-en
+ENV LANG en_US.UTF-8
+
+USER root
+
+# Update and install dependencies
+RUN dnf -y --setopt install_weak_deps=False update && \
+    dnf update ca-certificates && \
+    dnf -y --setopt install_weak_deps=False install epel-release java-17-openjdk openssl tomcatjss initscripts wget tar && \
+    dnf clean all
+
+ENV JAVA_HOME=/usr/lib/jvm/jre-17-openjdk
+ENV JRE_HOME=/usr/lib/jvm/jre-17-openjdk
+ENV CATALINA_OPTS=-Djavax.net.ssl.trustStore=$JAVA_HOME/lib/security/cacerts
+
+# Tomcat Setup
+RUN wget https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.76/bin/apache-tomcat-9.0.76.tar.gz; \
+    tar xzf apache-tomcat-9.0.76.tar.gz; \
+    mkdir /opt/tomcat; \
+    mv apache-tomcat-9.0.76/* /opt/tomcat/; \
+    rm apache-tomcat-9.0.76.tar.gz; \
+    rm -R apache-tomcat-9.0.76; \
+    mkdir -p /etc/candlepin/certs; \
+    mkdir -p /var/cache/candlepin/sync; \
+    usermod -u 10001 tomcat; \
+    groupmod -g 10000 tomcat; \
+    chown -R tomcat.tomcat /opt/tomcat; \
+    chown -R tomcat.tomcat /var/log/; \
+    chown -R tomcat.tomcat /var/lib/; \
+    chown -R tomcat.tomcat /etc/candlepin/; \
+    chown -R tomcat:tomcat /var/cache/; \
+    chmod -R 775 /opt/tomcat/webapps; \
+    chmod -R 775 /var/log/;
+
+# Candlepin install
+COPY --from=builder /app/build /opt/tomcat/webapps/candlepin
+
+# Setup certificate and key
+WORKDIR /etc/candlepin/certs
+COPY ./bin/deployment/gen_certs.sh .
+RUN ./gen_certs.sh --trust --cert_out ./candlepin-ca.crt --key_out ./candlepin-ca.key --hostname candlepin; \
+    rm gen_certs.sh;
+
+COPY ./.github/containers/server.xml /opt/tomcat/conf
+
+WORKDIR /opt/tomcat/bin
+
+USER tomcat
+
+# Expose ports for tomcat, candlepin, postgres and mariadb
+EXPOSE 8080 8443 5432 3306
+
+CMD ["/opt/tomcat/bin/catalina.sh", "run"]

--- a/.github/containers/mariadb.docker-compose.yml
+++ b/.github/containers/mariadb.docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3.8'
+
+services:
+  mariadb:
+    image: mariadb:10.6.14
+    command: --transaction-isolation=READ-COMMITTED
+    container_name: mariadb
+    environment:
+      MARIADB_USER: candlepin
+      MARIADB_PASSWORD: candlepin
+      MARIADB_DATABASE: candlepin
+      MARIADB_ROOT_PASSWORD: candlepin
+    networks:
+      - gh_network
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  candlepin:
+    image: ${CANDLEPIN_IMAGE}
+    container_name: candlepin
+    environment:
+      JPA_CONFIG_HIBERNATE_DIALECT: org.hibernate.dialect.MySQL5InnoDBDialect
+      JPA_CONFIG_HIBERNATE_CONNECTION_DRIVER_CLASS: org.mariadb.jdbc.Driver
+      JPA_CONFIG_HIBERNATE_CONNECTION_URL: jdbc:mariadb://mariadb/candlepin
+      JPA_CONFIG_HIBERNATE_CONNECTION_USERNAME: candlepin
+      JPA_CONFIG_HIBERNATE_CONNECTION_PASSWORD: candlepin
+      CANDLEPIN_AUTH_TRUSTED_ENABLE: "true"
+      CANDLEPIN_AUTH_OAUTH_ENABLE: "true"
+      CANDLEPIN_AUTH_OAUTH_CONSUMER_RSPEC_SECRET: rspec-oauth-secret
+      CANDLEPIN_DB_DATABASE_MANAGE_ON_STARTUP: Manage
+      CANDLEPIN_REFRESH_ORPHAN_ENTITY_GRACE_PERIOD: 0
+      CANDLEPIN_STANDALONE: ${CANDLEPIN_STANDALONE}
+      MODULE_CONFIG_HOSTED_CONFIGURATION_MODULE: ${MODULE_CONFIG_HOSTED_CONFIGURATION_MODULE}
+    networks:
+      - gh_network
+    ports:
+      - "8443:8443"
+    healthcheck:
+      test: wget --tries=1 --spider https://localhost:8443/candlepin/status || exit 1
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+networks:
+  gh_network:
+    name: ${NETWORK}
+    external: true
+

--- a/.github/containers/postgres.docker-compose.yml
+++ b/.github/containers/postgres.docker-compose.yml
@@ -1,0 +1,55 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:latest
+    container_name: postgres
+    environment:
+      POSTGRES_USER: candlepin
+      POSTGRES_PASSWORD: candlepin
+      POSTGRES_DB: candlepin
+      POSTGRES_HOST_AUTH_METHOD: trust
+    networks:
+      - gh_network
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  candlepin:
+    image: ${CANDLEPIN_IMAGE}
+    container_name: candlepin
+    environment:
+      JPA_CONFIG_HIBERNATE_DIALECT: org.hibernate.dialect.PostgreSQL92Dialect
+      JPA_CONFIG_HIBERNATE_CONNECTION_DRIVER_CLASS: org.postgresql.Driver
+      JPA_CONFIG_HIBERNATE_CONNECTION_URL: jdbc:postgresql://postgres/candlepin
+      JPA_CONFIG_HIBERNATE_CONNECTION_USERNAME: candlepin
+      JPA_CONFIG_HIBERNATE_CONNECTION_PASSWORD: candlepin
+      CANDLEPIN_AUTH_TRUSTED_ENABLE: "true"
+      CANDLEPIN_AUTH_OAUTH_ENABLE: "true"
+      CANDLEPIN_AUTH_OAUTH_CONSUMER_RSPEC_SECRET: rspec-oauth-secret
+      CANDLEPIN_DB_DATABASE_MANAGE_ON_STARTUP: Manage
+      CANDLEPIN_REFRESH_ORPHAN_ENTITY_GRACE_PERIOD: 0
+      CANDLEPIN_STANDALONE: ${CANDLEPIN_STANDALONE}
+      MODULE_CONFIG_HOSTED_CONFIGURATION_MODULE: ${MODULE_CONFIG_HOSTED_CONFIGURATION_MODULE}
+    networks:
+      - gh_network
+    ports:
+      - "8443:8443"
+    healthcheck:
+      test: wget --tries=1 --spider https://localhost:8443/candlepin/status || exit 1
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+networks:
+  gh_network:
+    name: ${NETWORK}
+    external: true
+

--- a/.github/containers/server.xml
+++ b/.github/containers/server.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <GlobalNamingResources>
+    <Resource name="UserDatabase" auth="Container" type="org.apache.catalina.UserDatabase"
+      description="User database that can be updated and saved"
+      factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+      pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <Service name="Catalina">
+
+    <Connector
+      port="8443"
+      protocol="HTTP/1.1"
+      scheme="https"
+      secure="true"
+      SSLEnabled="true"
+      maxThreads="150">
+
+      <SSLHostConfig
+        certificateVerification="optional"
+        protocols="+TLSv1,+TLSv1.1,+TLSv1.2"
+        sslProtocol="TLS">
+        <Certificate
+          certificateFile="/etc/candlepin/certs/candlepin-ca.crt"
+          certificateKeyFile="/etc/candlepin/certs/candlepin-ca.key"
+          type="RSA" />
+      </SSLHostConfig>
+    </Connector>
+
+    <Connector port="8080" protocol="HTTP/1.1" connectionTimeout="20000" redirectPort="8443" />
+    <Engine name="Catalina" defaultHost="localhost">
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm" resourceName="UserDatabase" />
+      </Realm>
+
+      <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="true">
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/var/log/candlepin/"
+          prefix="access" rotatable="false" checkExists="true" suffix=".log"
+          pattern="%h %l %u %t &quot;%r&quot; %s %b &quot;&quot; &quot;%{user-agent}i sm/%{x-subscription-manager-version}i&quot; &quot;req_time=%T,req=%{requestUuid}r&quot;"
+          resolveHosts="false" />
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -101,6 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: fedora:38
+      options: --privileged
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -132,3 +133,119 @@ jobs:
         with:
           # Cause the check to fail on any broke rules
           fail-on-error: true
+
+  build_image:
+    name: build Candlepin image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install \
+            git-core \
+            buildah
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Candlepin image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ghcr.io/candlepin/gha_build
+          tags: pr-${{ github.event.pull_request.number }}
+          containerfiles: ./.github/containers/Dockerfile
+
+      - name: Push to registry
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ghcr.io/candlepin/gha_build
+          tags: pr-${{ github.event.pull_request.number }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+  spec_tests:
+    name: spec tests
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:38
+      options: --privileged
+    permissions:
+      contents: read
+      packages: write
+    needs: build_image
+    strategy:
+      fail-fast: false
+      matrix:
+        database: [postgres, mariadb]
+        mode: [standalone, hosted]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          dnf -y --setopt install_weak_deps=False update
+          dnf --setopt install_weak_deps=False install -y gettext jss docker
+
+      - name: Install docker compose
+        shell: bash
+        run: |
+          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+          mkdir -p $DOCKER_CONFIG/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.18.1/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+          sudo chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+
+      - name: Log in to the registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: matrix.mode == 'standalone'
+        name: Add standalone env variable
+        working-directory: ./.github/containers
+        shell: bash
+        run: echo "CANDLEPIN_STANDALONE=true" > .env
+
+      - if: matrix.mode == 'hosted'
+        name: Add hosted env variables
+        working-directory: ./.github/containers
+        shell: bash
+        run: |
+          echo "CANDLEPIN_STANDALONE=false" > .env
+          echo "MODULE_CONFIG_HOSTED_CONFIGURATION_MODULE=org.candlepin.hostedtest.AdapterOverrideModule" >> .env
+
+      - name: Create Candlepin and database containers
+        shell: bash
+        run: |
+          echo "CANDLEPIN_IMAGE=ghcr.io/candlepin/gha_build:pr-${{ github.event.pull_request.number }}" >> ./.github/containers/.env
+          echo "SOURCE_LOCATION=${{ github.workspace }}" >> ./.github/containers/.env
+          BRIDGE_NETWORK=$(docker network ls --filter=name=github_network_ --format="{{ .Name }}")
+          echo "NETWORK=$BRIDGE_NETWORK" >> ./.github/containers/.env
+          docker image pull ghcr.io/candlepin/gha_build:pr-${{ github.event.pull_request.number }}
+          docker compose -f ./.github/containers/${{ matrix.database }}.docker-compose.yml --env-file ./.github/containers/.env up -d --wait
+
+      - name: run spec tests
+        shell: bash
+        run: ./gradlew spec -Dspec.test.client.host=candlepin
+
+      - if: always()
+        name: stop containers
+        shell: bash
+        run: docker compose -f ./.github/containers/${{ matrix.database }}.docker-compose.yml down

--- a/src/main/java/org/candlepin/guice/CustomizableModules.java
+++ b/src/main/java/org/candlepin/guice/CustomizableModules.java
@@ -51,6 +51,10 @@ public class CustomizableModules {
             Set<Module> toReturn = new HashSet<>();
 
             for (Map.Entry<String, String> entry : moduleConfig.entrySet()) {
+                if (entry.getValue() == null || entry.getValue().isEmpty()) {
+                    continue;
+                }
+
                 log.info("Found custom module {}", entry.getKey());
                 Class<? extends Module> c = (Class<? extends Module>)
                     Class.forName(entry.getValue());


### PR DESCRIPTION
# Migration of spec tests to Github Actions

I wanted to add some additional information on some the choices that were made for migrating the spec tests to Github Actions.

## Spec test jobs

For the spec tests jobs, I used a matrix for the two databases (postgres and mariadb) and the two modes (standalone and hosted) to create 4 jobs after the Candlepin image build job has completed. To run the database and Candlepin container, I choose to use docker-compose instead of the Github service containers for a couple of reasons.

- I don't believe you can conditionally start the database containers running as service containers based on the job's matrix database value. So, you would have to create both a mariadb and postgres as service containers and only use one of them for the spec test that is running.
- We can add database specific environment variables for the two different compose files (mariadb.docker-compose.yml and postgres.docker-compose.yml)