### PR TITLE
[M] CANDLEPIN-589: Added support for forced-update owner refresh

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -6438,6 +6438,14 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: force
+          in: query
+          description: |
+            Specifies whether or not to perform a forced-update refresh, which will update all
+            refreshed entities, even in cases where an explicit change in data is not detected.
+          schema:
+            type: boolean
+            default: false
       responses:
         200:
           description: A successful operation

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/OwnerClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/OwnerClient.java
@@ -274,4 +274,46 @@ public class OwnerClient extends OwnerApi {
         return super.listEnvironments(owner.getKey(), name);
     }
 
+    /**
+     * Invokes the refresh pools operation, optionally creating the owner if it doesn't already
+     * exist.
+     *
+     * @param ownerKey
+     *  the key of the owner for which to refresh pools
+     *
+     * @param autoCreateOwner
+     *  whether or not to automatically create the owner if it doesn't already exist
+     *
+     * @return
+     *  the status of the refresh pools job started as a result of this call
+     */
+    public AsyncJobStatusDTO refreshPools(String ownerKey, boolean autoCreateOwner) {
+        return this.refreshPools(ownerKey, autoCreateOwner, false);
+    }
+
+    /**
+     * Invokes the refresh pools operation for the given owner using the default settings.
+     *
+     * @param ownerKey
+     *  the key of the owner for which to refresh pools
+     *
+     * @return
+     *  the status of the refresh pools job started as a result of this call
+     */
+    public AsyncJobStatusDTO refreshPools(String ownerKey) {
+        return this.refreshPools(ownerKey, false, false);
+    }
+
+    /**
+     * Invokes the refresh pools operation for the given owner using the default settings.
+     *
+     * @param owner
+     *  the owner for which to refresh pools
+     *
+     * @return
+     *  the status of the refresh pools job started as a result of this call
+     */
+    public AsyncJobStatusDTO refreshPools(OwnerDTO owner) {
+        return this.refreshPools(owner != null ? owner.getKey() : null);
+    }
 }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Contents.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Contents.java
@@ -15,6 +15,7 @@
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.ContentDTO;
+import org.candlepin.dto.api.client.v1.ProductContentDTO;
 import org.candlepin.spec.bootstrap.data.util.StringUtil;
 
 import java.util.Collection;
@@ -108,5 +109,28 @@ public final class Contents {
         }
 
         return content.stream().collect(Collectors.toMap(ContentDTO::getId, Function.identity()));
+    }
+
+    /**
+     * Utility method to convert a content DTO to a ProductContentDTO instance for attaching to a
+     * product DTO. If the given content is null, this method returns null.
+     *
+     * @param content
+     *  the content instance to convert
+     *
+     * @param enabled
+     *  whether or not the enabled flag should be set on the generated product-content join object
+     *
+     * @return
+     *  a new ProductContentDTO containing the given content instance and enabled flag
+     */
+    public static ProductContentDTO toProductContent(ContentDTO content, boolean enabled) {
+        if (content == null) {
+            return null;
+        }
+
+        return new ProductContentDTO()
+            .content(content)
+            .enabled(enabled);
     }
 }

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/RefreshPoolsSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/RefreshPoolsSpecTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.from;
 import static org.assertj.core.api.InstanceOfAssertFactories.collection;
+import static org.candlepin.spec.bootstrap.assertions.JobStatusAssert.assertThatJob;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertNotFound;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -37,6 +38,7 @@ import org.candlepin.dto.api.client.v1.PoolDTO;
 import org.candlepin.dto.api.client.v1.ProductDTO;
 import org.candlepin.dto.api.client.v1.ProvidedProductDTO;
 import org.candlepin.dto.api.client.v1.SubscriptionDTO;
+import org.candlepin.resource.HostedTestApi;
 import org.candlepin.spec.bootstrap.assertions.CandlepinMode;
 import org.candlepin.spec.bootstrap.assertions.OnlyInHosted;
 import org.candlepin.spec.bootstrap.client.ApiClient;
@@ -55,6 +57,7 @@ import org.candlepin.spec.bootstrap.data.util.StringUtil;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -65,6 +68,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @SpecTest
@@ -1711,17 +1715,140 @@ public class RefreshPoolsSpecTest {
             .containsExactlyInAnyOrder(provProd1.getUuid(), provProd2.getUuid(), provProd3.getUuid());
     }
 
-    private AsyncJobStatusDTO refreshPools(ApiClient client, String ownerKey) {
-        AsyncJobStatusDTO job = adminClient.owners().refreshPools(ownerKey, true);
+    @Test
+    @OnlyInHosted
+    public void shouldUpdateUnchangedDataWhenForced() {
+        HostedTestApi hostedApi = this.adminClient.hosted();
+
+        OwnerDTO owner = adminClient.owners().createOwner(Owners.random());
+
+        // create a bunch of data for upstream
+        ContentDTO content1 = hostedApi.createContent(Contents.random());
+        ContentDTO content2 = hostedApi.createContent(Contents.random());
+        ContentDTO content3 = hostedApi.createContent(Contents.random());
+        ContentDTO content4 = hostedApi.createContent(Contents.random());
+        ContentDTO content5 = hostedApi.createContent(Contents.random());
+
+        ProductDTO provProduct1 = Products.random()
+            .addProductContentItem(Contents.toProductContent(content1, true));
+        ProductDTO provProduct2 = Products.random()
+            .addProductContentItem(Contents.toProductContent(content2, true));
+        ProductDTO provProduct3 = Products.random()
+            .addProductContentItem(Contents.toProductContent(content3, true));
+        ProductDTO provProduct4 = Products.random()
+            .addProductContentItem(Contents.toProductContent(content4, true));
+        ProductDTO provProduct5 = Products.random()
+            .addProductContentItem(Contents.toProductContent(content5, true));
+
+        ProductDTO derivedProduct = Products.random()
+            .addProvidedProductsItem(provProduct1);
+
+        ProductDTO product1 = Products.random()
+            .addProvidedProductsItem(provProduct2)
+            .addProvidedProductsItem(provProduct3);
+
+        ProductDTO product2 = Products.random()
+            .derivedProduct(derivedProduct)
+            .addProvidedProductsItem(provProduct4)
+            .addProvidedProductsItem(provProduct5);
+
+        // register all the data upstream
+        hostedApi.createProduct(provProduct1);
+        hostedApi.createProduct(provProduct2);
+        hostedApi.createProduct(provProduct3);
+        hostedApi.createProduct(provProduct4);
+        hostedApi.createProduct(provProduct5);
+        hostedApi.createProduct(derivedProduct);
+        hostedApi.createProduct(product1);
+        hostedApi.createProduct(product2);
+        hostedApi.createSubscription(Subscriptions.random(owner, product1));
+        hostedApi.createSubscription(Subscriptions.random(owner, product2));
+
+        // Perform a refresh, and then fetch the initial refreshed state
+        this.refreshPools(this.adminClient, owner.getKey(), false);
+
+        // Fetch our list of products, content, and pools, and store them in maps for later comparison.
+        Map<String, ContentDTO> contentMap = this.adminClient.ownerContent()
+            .listOwnerContent(owner.getKey())
+            .stream()
+            .collect(Collectors.toMap(ContentDTO::getId, Function.identity()));
+
+        Map<String, ProductDTO> productMap = this.adminClient.ownerProducts()
+            .getProductsByOwner(owner.getKey(), List.of())
+            .stream()
+            .collect(Collectors.toMap(ProductDTO::getId, Function.identity()));
+
+        Map<String, PoolDTO> poolMap = this.adminClient.owners()
+            .listOwnerPools(owner.getKey())
+            .stream()
+            .collect(Collectors.toMap(PoolDTO::getId, Function.identity()));
+
+        // Refresh again, but with a forced update. We should end up with the same set of entities,
+        // but with new UUIDs and a newer updated timestamp, indicating they've been re-rolled even
+        // though nothing changed.
+        this.refreshPools(this.adminClient, owner.getKey(), true);
+
+        List<ContentDTO> contentList = this.adminClient.ownerContent().listOwnerContent(owner.getKey());
+        assertThat(contentList)
+            .isNotNull()
+            .hasSize(contentMap.size())
+            .allSatisfy(entity -> {
+                assertThat(contentMap)
+                    .containsKey(entity.getId())
+                    .extractingByKey(entity.getId())
+                    .doesNotReturn(entity.getUuid(), ContentDTO::getUuid)
+                    .extracting(ContentDTO::getUpdated, as(InstanceOfAssertFactories.OFFSET_DATE_TIME))
+                    .isBefore(entity.getUpdated());
+            });
+
+        List<ProductDTO> productList = this.adminClient.ownerProducts()
+            .getProductsByOwner(owner.getKey(), List.of());
+        assertThat(productList)
+            .isNotNull()
+            .hasSize(productMap.size())
+            .allSatisfy(entity -> {
+                assertThat(productMap)
+                    .containsKey(entity.getId())
+                    .extractingByKey(entity.getId())
+                    .doesNotReturn(entity.getUuid(), ProductDTO::getUuid)
+                    .extracting(ProductDTO::getUpdated, as(InstanceOfAssertFactories.OFFSET_DATE_TIME))
+                    .isBefore(entity.getUpdated());
+            });
+
+        List<PoolDTO> poolList = this.adminClient.owners().listOwnerPools(owner.getKey());
+        assertThat(poolList)
+            .isNotNull()
+            .hasSize(poolList.size())
+            .allSatisfy(entity -> {
+                assertThat(poolMap)
+                    .containsKey(entity.getId())
+                    .extractingByKey(entity.getId())
+                    .extracting(PoolDTO::getUpdated, as(InstanceOfAssertFactories.OFFSET_DATE_TIME))
+                    .isBefore(entity.getUpdated());
+            });
+    }
+
+    private AsyncJobStatusDTO refreshPools(ApiClient client, String ownerKey, boolean force) {
+        AsyncJobStatusDTO job = adminClient.owners().refreshPools(ownerKey, true, force);
+
+        // When running in standalone mode, the refresh pools op will still create the org when
+        // the "autoCreateOwner" flag is set, but it will not create the job to actually refresh.
+        // As a consequence of this design, this method will always send up the request and then
+        // perform the hosted-mode check afterward.
         if (!CandlepinMode.isHosted()) {
             return null;
         }
 
         assertNotNull(job);
+
         job = adminClient.jobs().waitForJob(job);
-        assertEquals("FINISHED", job.getState());
+        assertThatJob(job).isFinished();
 
         return job;
+    }
+
+    private AsyncJobStatusDTO refreshPools(ApiClient client, String ownerKey) {
+        return this.refreshPools(client, ownerKey, false);
     }
 
     private ProductDTO createProductWithContent() {

--- a/src/main/java/org/candlepin/async/tasks/RefreshPoolsForProductJob.java
+++ b/src/main/java/org/candlepin/async/tasks/RefreshPoolsForProductJob.java
@@ -74,7 +74,8 @@ public class RefreshPoolsForProductJob implements AsyncJob {
         final Product product = this.productCurator.get(productUuid);
 
         if (product != null) {
-            poolManager.getRefresher(this.subAdapter, this.prodAdapter, lazy)
+            poolManager.getRefresher(this.subAdapter, this.prodAdapter)
+                .setLazyCertificateRegeneration(true)
                 .add(product)
                 .run();
 

--- a/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
+++ b/src/main/java/org/candlepin/async/tasks/RefreshPoolsJob.java
@@ -43,6 +43,7 @@ public class RefreshPoolsJob implements AsyncJob {
 
     protected static final String OWNER_KEY = "org";
     protected static final String LAZY_REGEN = "lazy_regen";
+    protected static final String FORCE_UPDATE = "force_update";
 
     protected OwnerCurator ownerCurator;
     protected PoolManager poolManager;
@@ -99,6 +100,22 @@ public class RefreshPoolsJob implements AsyncJob {
             return this;
         }
 
+        /**
+         * Sets the flag for performing a forced-update refresh, causing all entities to be updated
+         * even if no explicit change in data is detected.
+         *
+         * @param force
+         *  whether or not to perform a forced-update refresh
+         *
+         * @return
+         *  a reference to this job config
+         */
+        public RefreshPoolsJobConfig setForceUpdate(boolean force) {
+            this.setJobArgument(FORCE_UPDATE, force);
+
+            return this;
+        }
+
         @Override
         public void validate() throws JobConfigValidationException {
             super.validate();
@@ -147,6 +164,8 @@ public class RefreshPoolsJob implements AsyncJob {
         JobArguments args = context.getJobArguments();
         String ownerKey = args.getAsString(OWNER_KEY);
         boolean lazy = args.getAsBoolean(LAZY_REGEN);
+        boolean force = args.getAsBoolean(FORCE_UPDATE, false);
+
         Owner owner = ownerCurator.getByKey(ownerKey);
 
         if (owner == null) {
@@ -155,7 +174,9 @@ public class RefreshPoolsJob implements AsyncJob {
 
         try {
             // Assume that we verified the request in the resource layer:
-            poolManager.getRefresher(this.subAdapter, this.prodAdapter, lazy)
+            poolManager.getRefresher(this.subAdapter, this.prodAdapter)
+                .setLazyCertificateRegeneration(lazy)
+                .setForceUpdate(force)
                 .add(owner)
                 .run();
         }

--- a/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/src/main/java/org/candlepin/controller/PoolManager.java
@@ -131,8 +131,6 @@ public interface PoolManager {
     List<Pool> getBySubscriptionIds(String ownerId, Collection<String> id);
 
     Refresher getRefresher(SubscriptionServiceAdapter subAdapter, ProductServiceAdapter prodAdapter);
-    Refresher getRefresher(SubscriptionServiceAdapter subAdapter, ProductServiceAdapter prodAdapter,
-        boolean lazy);
 
     void regenerateCertificatesOf(Entitlement e, boolean lazy);
 
@@ -219,12 +217,16 @@ public interface PoolManager {
 
     /**
      * Updates the pool based on the entitlements in the specified stack.
+     *
      * @param pool
      * @param changedProducts
+     * @param force
+     *  whether or not to apply the update even in cases where an explicit data change is not
+     *  detected
      *
      * @return pool update specifics
      */
-    PoolUpdate updatePoolFromStack(Pool pool, Map<String, Product> changedProducts);
+    PoolUpdate updatePoolFromStack(Pool pool, Map<String, Product> changedProducts, boolean force);
 
     /**
      * Updates the pools based on the entitlements in the specified stack.

--- a/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
+++ b/src/main/java/org/candlepin/controller/refresher/RefreshWorker.java
@@ -90,6 +90,7 @@ public class RefreshWorker {
     private ContentMapper contentMapper;
 
     private int orphanedEntityGracePeriod;
+    private boolean forceUpdate;
 
 
     /**
@@ -111,6 +112,7 @@ public class RefreshWorker {
         this.contentMapper = new ContentMapper();
 
         this.orphanedEntityGracePeriod = ORPHANED_ENTITY_DEFAULT_GRACE_PERIOD;
+        this.forceUpdate = false;
     }
 
     /**
@@ -148,6 +150,21 @@ public class RefreshWorker {
      */
     public RefreshWorker setOrphanedEntityGracePeriod(int period) {
         this.orphanedEntityGracePeriod = period;
+        return this;
+    }
+
+    /**
+     * Sets the flag for performing a forced-update refresh, causing all entities to be updated
+     * even if no explicit change in data is detected.
+     *
+     * @param force
+     *  whether or not to perform a forced-update refresh
+     *
+     * @return
+     *  a reference to this refresh worker
+     */
+    public RefreshWorker setForceUpdate(boolean force) {
+        this.forceUpdate = force;
         return this;
     }
 
@@ -387,7 +404,7 @@ public class RefreshWorker {
             return;
         }
 
-        this.poolMapper.addExistingEntities(pools);
+        this.poolMapper.addExistingEntities(pools, this.forceUpdate);
 
         Set<String> productUuids = pools.stream()
             .map(Pool::getProductUuid)
@@ -412,7 +429,7 @@ public class RefreshWorker {
             return;
         }
 
-        this.productMapper.addExistingEntities(products);
+        this.productMapper.addExistingEntities(products, this.forceUpdate);
 
         Set<String> productUuids = products.stream()
             .map(Product::getUuid)
@@ -442,7 +459,7 @@ public class RefreshWorker {
             return;
         }
 
-        this.contentMapper.addExistingEntities(content);
+        this.contentMapper.addExistingEntities(content, this.forceUpdate);
     }
 
     /**

--- a/src/main/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapper.java
@@ -179,14 +179,29 @@ public abstract class AbstractEntityMapper<E extends AbstractHibernateObject, I 
      */
     @Override
     public EntityMapper<E, I> addExistingEntity(E entity) {
+        return this.addExistingEntity(entity, false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntityMapper<E, I> addExistingEntity(E entity, boolean dirty) {
         if (entity != null) {
             String eid = this.getEntityId(entity);
 
             this.existingEntities.compute(eid, (id, existing) -> {
+                // Necessary workaround since we're operating in a lambda
+                boolean flag = dirty;
+
                 if (existing != null && !this.entitiesMatch(existing, entity)) {
                     log.warn("Remapping existing entity with a different entity version; " +
                         "discarding previous... {} -> {} != {}", id, existing, entity);
 
+                    flag = true;
+                }
+
+                if (flag) {
                     this.dirtyEntityRefs.add(id);
                 }
 
@@ -202,8 +217,16 @@ public abstract class AbstractEntityMapper<E extends AbstractHibernateObject, I 
      */
     @Override
     public EntityMapper<E, I> addExistingEntities(Collection<? extends E> entities) {
+        return this.addExistingEntities(entities, false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntityMapper<E, I> addExistingEntities(Collection<? extends E> entities, boolean dirty) {
         if (entities != null) {
-            entities.forEach(this::addExistingEntity);
+            entities.forEach(entity -> this.addExistingEntity(entity, dirty));
         }
 
         return this;

--- a/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/EntityMapper.java
@@ -117,8 +117,8 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
     Map<String, I> getImportedEntities();
 
     /**
-     * Adds an existing entity to this mapper. Null values will be silently ignored, but the entity
-     * must have a valid, mappable ID.
+     * Adds an existing entity to this mapper. Null values will be silently ignored, but non-null
+     * entities must have a valid, mappable ID.
      *
      * @param entity
      *  the existing entity to add to this mapper
@@ -130,6 +130,25 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
      *  a reference to this entity mapper
      */
     EntityMapper<E, I> addExistingEntity(E entity);
+
+    /**
+     * Adds an existing entity to this mapper as a dirty entity, indicating it has a mapping or
+     * data error. Null values will be silently ignored, but non-null entities must have a valid,
+     * mappable ID.
+     *
+     * @param entity
+     *  the existing entity to add to this mapper
+     *
+     * @param dirty
+     *  whether or not the entity should be mapped as a dirty entity
+     *
+     * @throws IllegalArgumentException
+     *  if the provided entity does not have a valid entity ID
+     *
+     * @return
+     *  a reference to this entity mapper
+     */
+    EntityMapper<E, I> addExistingEntity(E entity, boolean dirty);
 
     /**
      * Adds the collection of existing entities to this mapper. Null values will be silently
@@ -146,6 +165,23 @@ public interface EntityMapper<E extends AbstractHibernateObject, I extends Servi
      *  a reference to this entity mapper
      */
     EntityMapper<E, I> addExistingEntities(Collection<? extends E> entities);
+
+    /**
+     * Adds the collection of existing entities to this mapper as dirty entities, indicating they
+     * have mapping or data errors. Null values will be silently ignored, but all non-null entities
+     * must have a valid, mappable ID.
+     *
+     * @param entities
+     *  a collection of existing entities to add to this mapper
+     *
+     * @throws IllegalArgumentException
+     *  if the collection contains one or more entities which are null or do not have valid entity
+     *  IDs
+     *
+     * @return
+     *  a reference to this entity mapper
+     */
+    EntityMapper<E, I> addExistingEntities(Collection<? extends E> entities, boolean dirty);
 
     /**
      * Adds an imported entity to this mapper. Null values will be silently ignored, but the entity

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1274,7 +1274,7 @@ public class OwnerResource implements OwnerApi {
     }
 
     @Override
-    public AsyncJobStatusDTO refreshPools(String ownerKey, Boolean autoCreateOwner) {
+    public AsyncJobStatusDTO refreshPools(String ownerKey, Boolean autoCreateOwner, Boolean forceUpdate) {
         Owner owner = ownerCurator.getByKey(ownerKey);
         if (owner == null) {
             if (autoCreateOwner && ownerService.isOwnerKeyValidForCreation(ownerKey)) {
@@ -1292,7 +1292,8 @@ public class OwnerResource implements OwnerApi {
 
         JobConfig config = RefreshPoolsJob.createJobConfig()
             .setOwner(owner)
-            .setLazyRegeneration(true);
+            .setLazyRegeneration(true)
+            .setForceUpdate(forceUpdate != null && forceUpdate);
 
         try {
             AsyncJobStatus job = this.jobManager.queueJob(config);

--- a/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
@@ -78,8 +78,10 @@ public class RefreshPoolsForProductJobTest {
         doReturn(product).when(productCurator).get(eq(VALID_ID));
 
         Refresher mockRefresher = mock(Refresher.class);
-        doReturn(mockRefresher).when(poolManager).getRefresher(any(), any(), anyBoolean());
+        doReturn(mockRefresher).when(poolManager).getRefresher(any(), any());
         doReturn(mockRefresher).when(mockRefresher).add(any(Product.class));
+        doReturn(mockRefresher).when(mockRefresher).setLazyCertificateRegeneration(anyBoolean());
+        doReturn(mockRefresher).when(mockRefresher).setForceUpdate(anyBoolean());
 
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
 

--- a/src/test/java/org/candlepin/async/tasks/RefreshPoolsJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/RefreshPoolsJobTest.java
@@ -17,6 +17,7 @@ package org.candlepin.async.tasks;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -135,8 +136,10 @@ public class RefreshPoolsJobTest {
         doReturn(jobConfig.getJobArguments()).when(status).getJobArguments();
 
         doReturn(owner).when(ownerCurator).getByKey(eq("my-test-owner"));
-        doReturn(refresher).when(poolManager).getRefresher(eq(subAdapter), eq(prodAdapter), eq(true));
+        doReturn(refresher).when(poolManager).getRefresher(eq(subAdapter), eq(prodAdapter));
         doReturn(refresher).when(refresher).add(eq(owner));
+        doReturn(refresher).when(refresher).setLazyCertificateRegeneration(anyBoolean());
+        doReturn(refresher).when(refresher).setForceUpdate(anyBoolean());
 
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
 
@@ -163,8 +166,10 @@ public class RefreshPoolsJobTest {
         doReturn(jobConfig.getJobArguments()).when(status).getJobArguments();
 
         doReturn(owner).when(ownerCurator).getByKey(eq("my-test-owner"));
-        doReturn(refresher).when(poolManager).getRefresher(eq(subAdapter), eq(prodAdapter), eq(false));
+        doReturn(refresher).when(poolManager).getRefresher(eq(subAdapter), eq(prodAdapter));
         doReturn(refresher).when(refresher).add(eq(owner));
+        doReturn(refresher).when(refresher).setLazyCertificateRegeneration(anyBoolean());
+        doReturn(refresher).when(refresher).setForceUpdate(anyBoolean());
         doThrow(new RuntimeException("something went wrong with refresh")).when(refresher).run();
 
         Exception e = assertThrows(JobExecutionException.class, () -> job.execute(context));

--- a/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -92,7 +91,7 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         this.i18n = I18nFactory.getI18n(this.getClass(), Locale.US, I18nFactory.FALLBACK);
 
         // Setup common behavior
-        when(this.poolManager.getRefresher(eq(this.subAdapter), eq(this.prodAdapter), anyBoolean()))
+        when(this.poolManager.getRefresher(eq(this.subAdapter), eq(this.prodAdapter)))
             .thenReturn(this.refresher);
 
         when(this.refresher.add(any(Owner.class))).thenReturn(this.refresher);

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -466,7 +466,7 @@ public class PoolManagerTest {
 
         // Make sure that only the floating pool was regenerated
         expectedFloating.add(floating);
-        verify(this.manager).updateFloatingPools(eq(expectedFloating), eq(true), anyMap());
+        verify(this.manager).updateFloatingPools(eq(expectedFloating), anyMap(), eq(true), eq(false));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -504,10 +504,10 @@ public class PoolManagerTest {
 
         // Make sure that only the floating pool was regenerated
         expectedModified.add(p);
-        verify(this.manager).updateFloatingPools(eq(new LinkedList()), eq(true), anyMap());
+        verify(this.manager).updateFloatingPools(eq(new LinkedList()), anyMap(), eq(true), eq(false));
         ArgumentCaptor<Pool> argPool = ArgumentCaptor.forClass(Pool.class);
         verify(this.manager).updatePoolsForPrimaryPool(eq(expectedModified), argPool.capture(),
-            eq(sub.getQuantity()), eq(false), anyMap());
+            eq(sub.getQuantity()), eq(false), anyMap(), eq(false));
         assertPoolsAreEqual(TestUtil.copyFromSub(sub), argPool.getValue());
     }
 
@@ -913,7 +913,7 @@ public class PoolManagerTest {
 
         this.manager.getRefresher(mockSubAdapter, mockProdAdapter).add(owner).run();
         ArgumentCaptor<List> poolCaptor = ArgumentCaptor.forClass(List.class);
-        verify(this.poolRulesMock).updatePools(poolCaptor.capture(), anyMap());
+        verify(this.poolRulesMock).updateFloatingPools(poolCaptor.capture(), anyMap(), anyBoolean());
         assertEquals(1, poolCaptor.getValue().size());
         assertEquals(p, poolCaptor.getValue().get(0));
     }
@@ -989,8 +989,8 @@ public class PoolManagerTest {
         u.setOrderChanged(true);
         updates.add(u);
         ArgumentCaptor<Pool> argPool = ArgumentCaptor.forClass(Pool.class);
-        when(poolRulesMock.updatePools(argPool.capture(), eq(pools), eq(s.getQuantity()), anyMap()))
-            .thenReturn(updates);
+        when(poolRulesMock.updatePools(argPool.capture(), eq(pools), eq(s.getQuantity()), anyMap(),
+            anyBoolean())).thenReturn(updates);
 
         when(mockOwnerCurator.getByKey(owner.getKey())).thenReturn(owner);
         this.mockProducts(owner, product);

--- a/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
@@ -32,6 +33,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.candlepin.controller.refresher.RefreshResult.EntityState;
 import org.candlepin.controller.util.EntityVersioningRetryWrapper;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Content;
@@ -1140,8 +1142,7 @@ public class RefreshWorkerTest {
         doReturn(Collections.emptyList()).when(this.mockOwnerProductCurator).getProductsByOwner(eq(owner));
         doReturn(Collections.emptyList()).when(this.mockOwnerContentCurator).getContentByOwner(eq(owner));
 
-        // Throw the constraint violation exception on the first invocation, triggering
-        // a retry
+        // Throw the constraint violation exception on the first invocation, triggering a retry
         Exception exception = this.buildVersioningConstraintViolationException();
 
         doThrow(exception).doAnswer(returnsFirstArg())
@@ -1175,8 +1176,7 @@ public class RefreshWorkerTest {
         doReturn(Collections.emptyList()).when(this.mockOwnerProductCurator).getProductsByOwner(eq(owner));
         doReturn(Collections.emptyList()).when(this.mockOwnerContentCurator).getContentByOwner(eq(owner));
 
-        // Throw the constraint violation exception on the first invocation, triggering
-        // a retry
+        // Throw the constraint violation exception on the first invocation, triggering a retry
         Exception exception = this.buildVersioningConstraintViolationException();
 
         doThrow(exception).doAnswer(returnsFirstArg())
@@ -1274,4 +1274,97 @@ public class RefreshWorkerTest {
             .rebuildOwnerContentMapping(eq(owner), Mockito.any(Map.class));
     }
 
+    @Test
+    public void testUnchangedEntitiesUpdatedWhenForced() {
+        Owner owner = new Owner();
+        Product prod1 = new Product()
+            .setId("pid-1")
+            .setUuid("product1");
+        Content content1 = new Content()
+            .setId("cid-1")
+            .setUuid("content1")
+            .setName("content-1");
+
+        prod1.addContent(content1, true);
+
+        this.mockChildrenContentLookup(List.of(prod1));
+        doReturn(List.of(prod1)).when(this.mockOwnerProductCurator)
+            .getProductsByOwner(eq(owner));
+        doReturn(List.of(content1)).when(this.mockOwnerContentCurator)
+            .getContentByOwner(eq(owner));
+
+        RefreshWorker worker = this.buildRefreshWorker()
+            .setForceUpdate(true);
+
+        RefreshResult result = worker.execute(owner);
+
+        assertNotNull(result);
+
+        Map<String, Content> unchangedContent = result.getEntities(Content.class, EntityState.UNCHANGED);
+        assertNotNull(unchangedContent);
+        assertTrue(unchangedContent.isEmpty());
+
+        Map<String, Content> updatedContent = result.getEntities(Content.class, EntityState.UPDATED);
+        assertNotNull(updatedContent);
+        assertEquals(1, updatedContent.size());
+        assertTrue(updatedContent.containsKey(content1.getId()));
+        assertEquals(content1, updatedContent.get(content1.getId()));
+
+        Map<String, Product> unchangedProducts = result.getEntities(Product.class, EntityState.UNCHANGED);
+        assertNotNull(unchangedProducts);
+        assertTrue(unchangedProducts.isEmpty());
+
+        Map<String, Product> updatedProducts = result.getEntities(Product.class, EntityState.UPDATED);
+        assertNotNull(updatedProducts);
+        assertEquals(1, updatedProducts.size());
+        assertTrue(updatedProducts.containsKey(prod1.getId()));
+        assertEquals(prod1, updatedProducts.get(prod1.getId()));
+    }
+
+    @Test
+    public void testUnchangedEntitiesIgnoredWhenNotForced() {
+        Owner owner = new Owner();
+        Product prod1 = new Product()
+            .setId("pid-1")
+            .setUuid("product1");
+        Content content1 = new Content()
+            .setId("cid-1")
+            .setUuid("content1")
+            .setName("content-1");
+
+        prod1.addContent(content1, true);
+
+        this.mockChildrenContentLookup(List.of(prod1));
+        doReturn(List.of(prod1)).when(this.mockOwnerProductCurator)
+            .getProductsByOwner(eq(owner));
+        doReturn(List.of(content1)).when(this.mockOwnerContentCurator)
+            .getContentByOwner(eq(owner));
+
+        RefreshWorker worker = this.buildRefreshWorker()
+            .setForceUpdate(false);
+
+        RefreshResult result = worker.execute(owner);
+
+        assertNotNull(result);
+
+        Map<String, Content> unchangedContent = result.getEntities(Content.class, EntityState.UNCHANGED);
+        assertNotNull(unchangedContent);
+        assertEquals(1, unchangedContent.size());
+        assertTrue(unchangedContent.containsKey(content1.getId()));
+        assertEquals(content1, unchangedContent.get(content1.getId()));
+
+        Map<String, Content> updatedContent = result.getEntities(Content.class, EntityState.UPDATED);
+        assertNotNull(updatedContent);
+        assertTrue(updatedContent.isEmpty());
+
+        Map<String, Product> unchangedProducts = result.getEntities(Product.class, EntityState.UNCHANGED);
+        assertNotNull(unchangedProducts);
+        assertEquals(1, unchangedProducts.size());
+        assertTrue(unchangedProducts.containsKey(prod1.getId()));
+        assertEquals(prod1, unchangedProducts.get(prod1.getId()));
+
+        Map<String, Product> updatedProducts = result.getEntities(Product.class, EntityState.UPDATED);
+        assertNotNull(updatedProducts);
+        assertTrue(updatedProducts.isEmpty());
+    }
 }

--- a/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
+++ b/src/test/java/org/candlepin/policy/PoolRulesInstanceTest.java
@@ -129,7 +129,7 @@ public class PoolRulesInstanceTest {
         List<Pool> existingPools = new LinkedList<>();
         existingPools.add(pool);
         List<PoolUpdate> updates = poolRules.updatePools(p, existingPools, p.getQuantity(),
-            TestUtil.stubChangedProducts(p.getProduct()));
+            TestUtil.stubChangedProducts(p.getProduct()), false);
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -154,7 +154,7 @@ public class PoolRulesInstanceTest {
         List<Pool> existingPools = new LinkedList<>();
         existingPools.add(pool);
         List<PoolUpdate> updates = poolRules.updatePools(primaryPool, existingPools, s.getQuantity(),
-            TestUtil.stubChangedProducts(primaryPool.getProduct()));
+            TestUtil.stubChangedProducts(primaryPool.getProduct()), false);
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);
@@ -180,7 +180,7 @@ public class PoolRulesInstanceTest {
         List<Pool> existingPools = new LinkedList<>();
         existingPools.add(pool);
         List<PoolUpdate> updates = poolRules.updatePools(primaryPool, existingPools,
-            primaryPool.getQuantity(), TestUtil.stubChangedProducts(primaryPool.getProduct()));
+            primaryPool.getQuantity(), TestUtil.stubChangedProducts(primaryPool.getProduct()), false);
 
         assertEquals(1, updates.size());
         PoolUpdate update = updates.get(0);

--- a/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
+++ b/src/test/java/org/candlepin/policy/PoolRulesStackDerivedTest.java
@@ -296,7 +296,7 @@ public class PoolRulesStackDerivedTest {
     @Test
     public void addEarlierStartDate() {
         stackedEnts.add(createEntFromPool(pool1));
-        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null);
+        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null, false);
         assertTrue(update.changed());
         assertTrue(update.getDatesChanged());
         assertEquals(pool1.getStartDate(), stackDerivedPool.getStartDate());
@@ -307,7 +307,7 @@ public class PoolRulesStackDerivedTest {
     public void addLaterEndDate() {
         stackedEnts.add(createEntFromPool(pool1));
         stackedEnts.add(createEntFromPool(pool3));
-        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null);
+        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null, false);
         assertTrue(update.changed());
         assertTrue(update.getDatesChanged());
         assertEquals(pool1.getStartDate(), stackDerivedPool.getStartDate());
@@ -321,7 +321,7 @@ public class PoolRulesStackDerivedTest {
 
         stackedEnts.add(ent1);
         stackedEnts.add(createEntFromPool(pool3));
-        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null);
+        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null, false);
         assertTrue(update.changed());
 
         assertTrue(update.getProductAttributesChanged());
@@ -332,11 +332,11 @@ public class PoolRulesStackDerivedTest {
     public void removeEldestEntitlement() {
         stackedEnts.add(createEntFromPool(pool1));
         stackedEnts.add(createEntFromPool(pool3));
-        poolRules.updatePoolFromStack(stackDerivedPool, null);
+        poolRules.updatePoolFromStack(stackDerivedPool, null, false);
 
         // Should change a variety of settings on the pool.
         stackedEnts.remove(0);
-        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null);
+        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null, false);
         assertTrue(update.changed());
         assertFalse(update.getDatesChanged());
 
@@ -353,11 +353,11 @@ public class PoolRulesStackDerivedTest {
     public void removeEarliestStartingEntitlement() {
         stackedEnts.add(createEntFromPool(pool1));
         stackedEnts.add(createEntFromPool(pool3));
-        poolRules.updatePoolFromStack(stackDerivedPool, null);
+        poolRules.updatePoolFromStack(stackDerivedPool, null, false);
 
         // Should change a variety of settings on the pool.
         stackedEnts.remove(1);
-        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null);
+        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null, false);
         assertTrue(update.changed());
         assertTrue(update.getDatesChanged());
 
@@ -371,7 +371,7 @@ public class PoolRulesStackDerivedTest {
         stackedEnts.add(createEntFromPool(pool1));
         stackedEnts.add(createEntFromPool(pool3));
 
-        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null);
+        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null, false);
         assertTrue(update.changed());
         assertTrue(update.getQuantityChanged());
         assertEquals((Long) 2L, stackDerivedPool.getQuantity());
@@ -410,11 +410,11 @@ public class PoolRulesStackDerivedTest {
         stackedEnts.clear();
         stackedEnts.add(createEntFromPool(pool1));
         stackedEnts.add(createEntFromPool(pool2));
-        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null);
+        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null, false);
         assertEquals((Long) 2L, stackDerivedPool.getQuantity());
 
         stackedEnts.remove(0);
-        update = poolRules.updatePoolFromStack(stackDerivedPool, null);
+        update = poolRules.updatePoolFromStack(stackDerivedPool, null, false);
         assertTrue(update.changed());
         assertTrue(update.getQuantityChanged());
         assertEquals(-1L, stackDerivedPool.getQuantity());
@@ -433,11 +433,11 @@ public class PoolRulesStackDerivedTest {
         stackedEnts.add(createEntFromPool(pool1));
         stackedEnts.add(createEntFromPool(pool2));
 
-        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null);
+        PoolUpdate update = poolRules.updatePoolFromStack(stackDerivedPool, null, false);
         assertEquals(-1L, stackDerivedPool.getQuantity());
 
         stackedEnts.remove(0);
-        update = poolRules.updatePoolFromStack(stackDerivedPool, null);
+        update = poolRules.updatePoolFromStack(stackDerivedPool, null, false);
         assertTrue(update.changed());
         assertTrue(update.getDatesChanged());
         assertFalse(update.getQuantityChanged());


### PR DESCRIPTION
- Added support for performing forced-update refresh operations, which will cause refreshed entities to be updated even in cases where an explicit change in data is not detected
- Added the "force" query parameter to the refresh pools API endpoint (PUT /owners/{owner_key}/subscriptions), which will put the refresh operation into forced-update mode
- Removed the trace-level logging of upstream subscriptions and product data from the refresh operation