### PR TITLE
CANDLEPIN-505: Add Sonarcloud long-lived branch analysis GH Action

### DIFF
--- a/.github/workflows/sonar_branch_analysis.yml
+++ b/.github/workflows/sonar_branch_analysis.yml
@@ -1,0 +1,47 @@
+---
+name: Sonar analysis for long-lived branches
+
+on:
+  push:
+    branches:
+      - main
+      - candlepin-*-HOTFIX
+
+env:
+  JAVA_DISTRIBUTION: 'temurin'
+  JAVA_VERSION: '17'
+
+jobs:
+  branch_sonar_analysis:
+    name: long-lived branch sonar analysis
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:38
+    steps:
+      - name: Mask secrets
+        shell: bash
+        run: |
+          echo "::add-mask::${{ secrets.GITHUB_TOKEN }}"
+          echo "::add-mask::${{ secrets.SONAR_TOKEN }}"
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        shell: bash
+        run: dnf --setopt install_weak_deps=False install -y gettext jss
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Run unit tests & Analyze
+        uses: gradle/gradle-build-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          arguments: test coverage sonar
+            -Dsonar.branch.name=${{ github.ref_name }}

--- a/build.gradle
+++ b/build.gradle
@@ -322,6 +322,9 @@ sonarqube {
     properties {
         property "sonar.sourceEncoding", "Utf-8"
         property "sonar.exclusions", "**/*generated*"
+        property "sonar.projectKey", "candlepin_candlepin"
+        property "sonar.organization", "candlepin"
+        property "sonar.host.url", "https://sonarcloud.io"
     }
 }
 


### PR DESCRIPTION
- We need this for when sonarcloud compares each PR code's analysis with the analysis of its target branch. If it's not there, then the PR analysis will show sonar issues that aren't actually in the PR code itself, but only exist in the target branch's commits that weren't analysed yet.