### PR TITLE
[M] Cancel outdated GH Actions workflows on new commits

### DIFF
--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -9,6 +9,11 @@ env:
   JAVA_DISTRIBUTION: 'temurin'
   JAVA_VERSION: '17'
 
+# Cancel in-progress PR verification workflows. We only care about verifying the latest commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   bugzilla_check:
     name: bugzilla reference check

--- a/.github/workflows/sonar_branch_analysis.yml
+++ b/.github/workflows/sonar_branch_analysis.yml
@@ -11,6 +11,11 @@ env:
   JAVA_DISTRIBUTION: 'temurin'
   JAVA_VERSION: '17'
 
+# Cancel in-progress sonar branch analysis workflows. We only care about analyzing the latest commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   branch_sonar_analysis:
     name: long-lived branch sonar analysis


### PR DESCRIPTION
- When pushing a new commit on a PR or branch, we only care about the workflow on the latest change, so cancel workflows that on outdated commits that are in progress.