### PR TITLE
[M] Increase gradle memory for sonar analysis reports

### DIFF
--- a/.github/workflows/sonar_branch_analysis.yml
+++ b/.github/workflows/sonar_branch_analysis.yml
@@ -50,3 +50,4 @@ jobs:
         with:
           arguments: test coverage sonar
             -Dsonar.branch.name=${{ github.ref_name }}
+            -Dorg.gradle.jvmargs='-Xmx1g -XX:MaxMetaspaceSize=512m'


### PR DESCRIPTION
- Avoid errors in the long-lived branch sonar analysis around JVM heap space running out.