### PR TITLE
2211434: Ensure pool lock order for activation keys

### DIFF
--- a/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -29,6 +29,7 @@ import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
+import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.resource.dto.AutobindData;
@@ -68,6 +69,8 @@ public class ConsumerBindUtilTest {
     @Mock private Entitler entitler;
     @Mock private ServiceLevelValidator serviceLevelValidator;
 
+    @Mock private PoolCurator poolCurator;
+
     private I18n i18n;
 
     private ConsumerType systemConsumerType;
@@ -85,7 +88,7 @@ public class ConsumerBindUtilTest {
 
     private ConsumerBindUtil buildConsumerBindUtil() {
         return new ConsumerBindUtil(this.entitler, this.i18n, this.consumerContentOverrideCurator,
-            this.ownerCurator, null, this.serviceLevelValidator);
+            this.ownerCurator, null, this.serviceLevelValidator, this.poolCurator);
     }
 
     private List<ActivationKey> mockActivationKeys() {


### PR DESCRIPTION
This issue arises because the pool sorting and locking is happening in sub-sets based on key. The entitlement revoke sorts on all the pools that are attached. The difference in sort order while locking between the actions causes a deadlock when a force re-registration is done concurrently. Existing consumers that are all using the same combination (>1) of keys will have this issue if the earlier keys have "later" pool ids. 

You can see the error if you comment out the new locking lines in ConsumerBindUtil.