### PR TITLE
2213245: [4.2] Ensure pool lock order for activation keys

### DIFF
--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -316,6 +316,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: spec -Dspec.test.client.host=candlepin
+        env:
+          MYSQL_IN_USE: ${{ matrix.database == 'mariadb' }}
           
       - name: Collect docker logs on failure
         if: failure()

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,6 +34,7 @@ ext.plugins = [
 libraries["artemisServer"] = "org.apache.activemq:artemis-server:2.28.0"
 libraries["artemisStomp"] = "org.apache.activemq:artemis-stomp-protocol:2.28.0"
 libraries["assertj"] = 'org.assertj:assertj-core:3.24.2'
+libraries["awaitility"] = 'org.awaitility:awaitility:4.2.0'
 libraries["checkstyle"] = "com.puppycrawl.tools:checkstyle:10.7.0"
 libraries["checkstyleSevntu"] = "com.github.sevntu-checkstyle:sevntu-checks:1.44.1"
 libraries["commonsCodec"] = "commons-codec:commons-codec:1.15"

--- a/spec-tests/build.gradle
+++ b/spec-tests/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation libraries["oauth"]
 
     testImplementation libraries["jimfs"]
+    testImplementation libraries["awaitility"]
 
     testRuntimeOnly libraries["junitEngine"]
 

--- a/spec-tests/src/test/java/org/candlepin/spec/bootstrap/assertions/DatabaseEmployed.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/bootstrap/assertions/DatabaseEmployed.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2009 - 2022 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.bootstrap.assertions;
+
+/**
+ * Condition used to determine the mode in which Candlepin is running.
+ *
+ * Check is done only once and cached for the whole spec test run.
+ */
+@SuppressWarnings("unused")
+public final class DatabaseEmployed {
+
+    private DatabaseEmployed() {
+        throw new UnsupportedOperationException();
+    }
+
+    private static final boolean MYSQL;
+
+    static {
+        MYSQL = "true".equalsIgnoreCase(System.getenv("MYSQL_IN_USE"));
+    }
+
+    public static boolean notWithMySql() {
+        return !MYSQL;
+    }
+
+}

--- a/spec-tests/src/test/java/org/candlepin/spec/bootstrap/assertions/NotWithMySql.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/bootstrap/assertions/NotWithMySql.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2009 - 2022 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.bootstrap.assertions;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+
+/**
+ * This annotation marks a test or test suite to run only when not running against MariaDB/MySql.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@EnabledIf(value = "org.candlepin.spec.bootstrap.assertions.DatabaseEmployed#notWithMySql",
+    disabledReason = "Candlepin is running against MySQL")
+@Tag("notWithMySql")
+public @interface NotWithMySql {
+}

--- a/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -28,6 +28,7 @@ import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
+import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Release;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyContentOverride;
@@ -51,6 +52,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -67,18 +69,21 @@ public class ConsumerBindUtil {
     private OwnerCurator ownerCurator;
     private QuantityRules quantityRules;
     private ServiceLevelValidator serviceLevelValidator;
+    private PoolCurator poolCurator;
     private static Logger log = LoggerFactory.getLogger(ConsumerBindUtil.class);
 
     @Inject
     public ConsumerBindUtil(Entitler entitler, I18n i18n,
         ConsumerContentOverrideCurator consumerContentOverrideCurator,
-        OwnerCurator ownerCurator, QuantityRules quantityRules, ServiceLevelValidator serviceLevelValidator) {
+        OwnerCurator ownerCurator, QuantityRules quantityRules, ServiceLevelValidator serviceLevelValidator,
+        PoolCurator poolCurator) {
         this.entitler = entitler;
         this.i18n = i18n;
         this.consumerContentOverrideCurator = consumerContentOverrideCurator;
         this.ownerCurator = ownerCurator;
         this.quantityRules = quantityRules;
         this.serviceLevelValidator = serviceLevelValidator;
+        this.poolCurator = poolCurator;
     }
 
     public void handleActivationKeys(Consumer consumer, List<ActivationKey> keys,
@@ -88,6 +93,18 @@ public class ConsumerBindUtil {
         boolean listSuccess = false;
         boolean scaEnabledForAny = false;
         boolean isAutoheal = BooleanUtils.isTrue(consumer.isAutoheal());
+
+        // we need to lock all the pools in id order so that it won't deadlock if there are other
+        // processes in the same space at the same time. Current code sorts and locks
+        // per activation key which can lead to this deadlock when entitlement revocation is
+        // occurring on the same pools
+        Set<Pool> akPools = keys.stream()
+            .filter(Objects::nonNull)
+            .flatMap(key -> key.getPools().stream())
+            .map(ActivationKeyPool::getPool)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+        poolCurator.lock(akPools);
 
         for (ActivationKey key : keys) {
             boolean keySuccess = true;

--- a/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -35,6 +35,7 @@ import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
+import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.resource.dto.AutobindData;
@@ -66,6 +67,7 @@ public class ConsumerBindUtilTest {
     @Mock private OwnerCurator ownerCurator;
     @Mock private Entitler entitler;
     @Mock private ServiceLevelValidator serviceLevelValidator;
+    @Mock private PoolCurator poolCurator;
 
     private I18n i18n;
 
@@ -85,7 +87,7 @@ public class ConsumerBindUtilTest {
 
     private ConsumerBindUtil buildConsumerBindUtil() {
         return new ConsumerBindUtil(this.entitler, this.i18n, this.consumerContentOverrideCurator,
-            this.ownerCurator, null, this.serviceLevelValidator);
+            this.ownerCurator, null, this.serviceLevelValidator, this.poolCurator);
     }
 
     private List<ActivationKey> mockActivationKeys() {


### PR DESCRIPTION
This issue arises because the pool sorting and locking is happening in sub-sets based on key. The entitlement revoke sorts on all the pools that are attached. The difference in sort order while locking between the actions causes a deadlock when a force re-registration is done concurrently. Existing consumers that are all using the same combination (>1) of keys will have this issue if the earlier keys have "later" pool ids.

You can see the error if you comment out the new locking lines in ConsumerBindUtil.

Note that this does not solve an issue with the volume of concurrent force refresh operations that can successfully occur without lock wait timeouts.
