### PR TITLE
2213261: [M] Ensure pool lock order for activation keys

### DIFF
--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -386,6 +386,8 @@ jobs:
 
       - name: Run Spec tests
         uses: gradle/gradle-build-action@v2
+        env:
+          MYSQL_IN_USE: ${{ matrix.database == 'mariadb' }}
         with:
           arguments: spec -Dspec.test.client.host=candlepin
 

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/DatabaseEmployed.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/DatabaseEmployed.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.bootstrap.assertions;
+
+/**
+ * Condition used to determine the mode in which Candlepin is running.
+ *
+ * Check is done only once and cached for the whole spec test run.
+ */
+@SuppressWarnings("unused")
+public final class DatabaseEmployed {
+
+    private DatabaseEmployed() {
+        throw new UnsupportedOperationException();
+    }
+
+    private static final boolean MYSQL;
+
+    static {
+        MYSQL = "true".equalsIgnoreCase(System.getenv("MYSQL_IN_USE"));
+    }
+
+    public static boolean notWithMySql() {
+        return !MYSQL;
+    }
+
+}

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/NotWithMySql.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/NotWithMySql.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.bootstrap.assertions;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+
+/**
+ * This annotation marks a test or test suite to run only when not running against MariaDB/MySql.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@EnabledIf(value = "org.candlepin.spec.bootstrap.assertions.DatabaseEmployed#notWithMySql", disabledReason = "Candlepin is running against MySQL")
+@Tag("notWithMySql")
+public @interface NotWithMySql {
+}

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceActivationKeySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceActivationKeySpecTest.java
@@ -15,7 +15,9 @@
 package org.candlepin.spec.consumers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertBadRequest;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.candlepin.dto.api.client.v1.ActivationKeyDTO;
@@ -29,6 +31,7 @@ import org.candlepin.dto.api.client.v1.ProductDTO;
 import org.candlepin.dto.api.client.v1.ReleaseVerDTO;
 import org.candlepin.resource.client.v1.ActivationKeyApi;
 import org.candlepin.resource.client.v1.OwnerProductApi;
+import org.candlepin.spec.bootstrap.assertions.NotWithMySql;
 import org.candlepin.spec.bootstrap.client.ApiClient;
 import org.candlepin.spec.bootstrap.client.ApiClients;
 import org.candlepin.spec.bootstrap.client.SpecTest;
@@ -46,10 +49,20 @@ import org.candlepin.spec.bootstrap.data.util.StringUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
+
+
 
 @SpecTest
 public class ConsumerResourceActivationKeySpecTest {
@@ -59,7 +72,6 @@ public class ConsumerResourceActivationKeySpecTest {
     static ConsumerClient consumerClient;
     static OwnerProductApi ownerProductApi;
     static ActivationKeyApi activationKeyApi;
-
 
     @BeforeAll
     static void beforeAll() {
@@ -89,6 +101,146 @@ public class ConsumerResourceActivationKeySpecTest {
         assertThat(consumer.getUuid()).isNotNull();
         assertThat(client.pools().getPool(pool1.getId(), consumer.getUuid(), null))
             .returns(3L, PoolDTO::getConsumed);
+    }
+
+    /**
+     *  This test will only be run against Postgresql and not MySQL/MariaDB because
+     *   the initial deadlock comes occurs in a scenario (concurrent force reregistration)
+     *   that will only happen in Satellite where Postgresql is in use. The portal which employs
+     *   MariaDB has a request limiter that would not allow it to happen.
+     *  This test will create a lock contention in MySQL/MariaDB on the indexer (not the bug
+     *   to be fixed) so it will be skipped when MySQL/MariaDB is in use based on an environment
+     *   variable (MYSQL_IN_USE) on the system running the test.
+     * @throws Exception
+     */
+    @Test
+    @NotWithMySql
+    public void shouldAllowConsumerToRegisterThenUnregisterWithActKeysConcurrently()
+        throws Exception {
+        // The order of keys is important. The pool ids of the first key used should be
+        // sortable by id later than those in the second key in the combined list of pools
+        OwnerDTO owner = ownerClient.createOwner(Owners.random());
+
+        int consumerCount = 3;
+        int poolCount = 6;
+        List<ConsumerDTO> consumers = Collections.synchronizedList(new ArrayList<>());
+
+        // create 6 pools and 2 activation keys
+        ActivationKeyDTO key1 = ownerClient.createActivationKey(owner.getKey(),
+            ActivationKeys.random(owner));
+        ActivationKeyDTO key2 = ownerClient.createActivationKey(owner.getKey(),
+            ActivationKeys.random(owner));
+
+        createProductsAndPoolsForActivationKeys(owner, key1, key2, poolCount);
+        List<PoolDTO> pools = ownerClient.listOwnerPools(owner.getKey());
+        assertThat(pools).hasSize(poolCount);
+
+        // register new systems
+        List<Thread> threads = new ArrayList<>();
+        IntStream.range(0, consumerCount).forEach(entry -> {
+            threads.add(new Thread(() -> {
+                String uuid = StringUtil.random("uuid");
+                ConsumerDTO consumer = Consumers.random(owner)
+                    .facts(Map.of("system.certificate_version", "3.3", "dmi.system.uuid", uuid));
+                consumer = consumerClient.createConsumer(consumer, null, owner.getKey(),
+                    key2.getName() + "," + key1.getName(), true);
+                // this ensures completion of creation before proceeding
+                consumer = consumerClient.getConsumer(consumer.getUuid());
+                assertThat(consumer).isNotNull();
+                assertThat(consumer.getEntitlementCount()).isEqualTo(poolCount);
+                consumers.add(consumer);
+            }));
+        });
+        threads.forEach(assertDoesNotThrow(() -> Thread::start));
+        for (Thread thread : threads) {
+            while (thread.isAlive()) {
+                thread.join();
+            }
+        }
+        assertThat(consumers).hasSize(consumerCount);
+        pools.forEach(pool -> assertThat(client.pools().getPool(pool.getId(), null, null))
+            .isNotNull()
+            .returns(Long.valueOf(consumerCount), PoolDTO::getConsumed));
+
+        // force reregister
+        List<Callable<Result>> callables = consumers.stream()
+            .map(consumer -> (Callable<Result>) () -> {
+                try {
+                    ConsumerDTO originalConsumer = consumerClient.getConsumer(consumer.getUuid());
+                    consumerClient.deleteConsumer(consumer.getUuid());
+                    ConsumerDTO reregConsumer = Consumers.random(owner)
+                        .facts(Map.of("system.certificate_version", "3.3",
+                            "dmi.system.uuid", originalConsumer.getFacts().get("dmi.system.uuid")));
+                    reregConsumer = consumerClient.createConsumer(reregConsumer, null,
+                        owner.getKey(),
+                        key2.getName() + "," + key1.getName(), true);
+                    // this ensures completion of creation before proceeding
+                    reregConsumer = consumerClient.getConsumer(reregConsumer.getUuid());
+                    assertThat(reregConsumer).isNotNull();
+                    assertThat(reregConsumer.getEntitlementCount()).isEqualTo(poolCount);
+                    return new Result(reregConsumer, null);
+                }
+                catch (Exception e) {
+                    return new Result(null, e);
+                }
+            }).toList();
+
+        List<Future<Result>> results;
+        ExecutorService executor = null;
+        try {
+            executor = Executors.newFixedThreadPool(2);
+            results = executor.invokeAll(callables);
+        }
+        finally {
+            if (executor != null) {
+                executor.shutdown();
+            }
+        }
+
+        // Wait for the threads to finish
+        await().atMost(180, TimeUnit.SECONDS)
+            .until(() -> results.stream().allMatch(Future::isDone));
+
+        List<ConsumerDTO> reregConsumers = results.stream()
+            .map(future -> {
+                try {
+                    return future.get();
+                }
+                catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .map(Result::consumer)
+            .toList();
+
+        assertThat(reregConsumers).hasSize(consumerCount);
+        pools.forEach(pool -> assertThat(client.pools().getPool(pool.getId(), null, null))
+            .isNotNull()
+            .returns(Long.valueOf(consumerCount), PoolDTO::getConsumed));
+
+        reregConsumers.forEach(consumer -> consumerClient.deleteConsumer(consumer.getUuid()));
+        pools.forEach(pool -> assertThat(client.pools().getPool(pool.getId(), null, null))
+            .isNotNull()
+            .returns(0L, PoolDTO::getConsumed));
+    }
+
+    record Result(ConsumerDTO consumer, Exception exception) {
+    }
+
+    private void createProductsAndPoolsForActivationKeys(OwnerDTO owner,
+        ActivationKeyDTO key1, ActivationKeyDTO key2, int poolCount) {
+        IntStream.range(0, poolCount).forEach(entry -> {
+            ProductDTO prod = Products.random()
+                .addAttributesItem(ProductAttributes.MultiEntitlement.withValue("yes"));
+            prod = ownerProductApi.createProductByOwner(owner.getKey(), prod);
+            PoolDTO pool = ownerClient.createPool(owner.getKey(), Pools.random(prod).quantity(100L));
+            if (entry < poolCount / 2) {
+                activationKeyApi.addPoolToKey(key1.getId(), pool.getId(), 1L);
+            }
+            else {
+                activationKeyApi.addPoolToKey(key2.getId(), pool.getId(), 1L);
+            }
+        });
     }
 
     @Test
@@ -391,7 +543,7 @@ public class ConsumerResourceActivationKeySpecTest {
         ActivationKeyDTO key2 = ActivationKeys.random(owner).contentOverrides(Set.of(override2));
         key2 = ownerClient.createActivationKey(owner.getKey(), key2);
 
-        ConsumerDTO consumer1 =  consumerClient.createConsumer(Consumers.random(owner), null,
+        ConsumerDTO consumer1 = consumerClient.createConsumer(Consumers.random(owner), null,
             owner.getKey(), key1.getName() + "," + key2.getName(), true);
         assertThat(consumerClient.listConsumerContentOverrides(consumer1.getUuid()))
             .singleElement()

--- a/src/main/java/org/candlepin/bind/PoolOpProcessor.java
+++ b/src/main/java/org/candlepin/bind/PoolOpProcessor.java
@@ -12,7 +12,6 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.bind;
 
 import org.candlepin.audit.EventSink;
@@ -29,8 +28,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+
 
 
 /**
@@ -80,7 +81,6 @@ public class PoolOpProcessor {
         }
     }
 
-
     /**
      * Set the count of pools. The caller sets the absolute quantity.
      *   Current use is setting unlimited bonus pool to -1 or 0.
@@ -90,7 +90,9 @@ public class PoolOpProcessor {
             return;
         }
 
-        poolCurator.lock(poolQuantities.keySet());
+        poolCurator.lock(poolQuantities.keySet().stream()
+            .filter(x -> !x.isLocked())
+            .collect(Collectors.toSet()));
         for (Map.Entry<Pool, Long> entry : poolQuantities.entrySet()) {
             entry.getKey().setQuantity(entry.getValue());
         }

--- a/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -35,6 +35,7 @@ import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
+import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.resource.dto.AutobindData;
@@ -61,10 +62,16 @@ import java.util.Set;
 @ExtendWith(MockitoExtension.class)
 public class ConsumerBindUtilTest {
 
-    @Mock private ConsumerContentOverrideCurator consumerContentOverrideCurator;
-    @Mock private OwnerCurator ownerCurator;
-    @Mock private Entitler entitler;
-    @Mock private ServiceLevelValidator serviceLevelValidator;
+    @Mock
+    private ConsumerContentOverrideCurator consumerContentOverrideCurator;
+    @Mock
+    private OwnerCurator ownerCurator;
+    @Mock
+    private Entitler entitler;
+    @Mock
+    private ServiceLevelValidator serviceLevelValidator;
+    @Mock
+    private PoolCurator poolCurator;
 
     private I18n i18n;
 
@@ -84,7 +91,7 @@ public class ConsumerBindUtilTest {
 
     private ConsumerBindUtil buildConsumerBindUtil() {
         return new ConsumerBindUtil(this.entitler, this.i18n, this.consumerContentOverrideCurator,
-            this.ownerCurator, null, this.serviceLevelValidator);
+            this.ownerCurator, null, this.serviceLevelValidator, this.poolCurator);
     }
 
     private List<ActivationKey> mockActivationKeys() {


### PR DESCRIPTION
This issue arises because the pool sorting and locking is happening in sub-sets based on key. The entitlement revoke sorts on all the pools that are attached. The difference in sort order while locking between the actions causes a deadlock when a force re-registration is done concurrently. Existing consumers that are all using the same combination (>1) of keys will have this issue if the earlier keys have "later" pool ids.

You can see the error if you comment out the new locking lines in ConsumerBindUtil.

Note that this does not solve an issue with the volume of concurrent force refresh operations that can successfully occur without lock wait timeouts.