### PR TITLE
Run Sonar scan as a separate workflow

### DIFF
--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Archive reports
         uses: actions/upload-artifact@v3
         with:
-          name: jacocoReports
+          name: unit_test_reports
           path: |
             **/build/test-results/**/*.xml
             **/build/jacoco/test.exec
@@ -132,47 +132,3 @@ jobs:
         with:
           # Cause the check to fail on any broke rules
           fail-on-error: true
-
-  sonarqube:
-    needs: unit_tests
-    name: sonarqube
-    runs-on: ubuntu-latest
-    container:
-      image: fedora:38
-    steps:
-      - name: Mask secrets
-        shell: bash
-        run: |
-          echo "::add-mask::${{ secrets.GITHUB_TOKEN }}"
-          echo "::add-mask::${{ secrets.SONAR_TOKEN }}"
-
-      - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: Install dependencies
-        shell: bash
-        run: dnf --setopt install_weak_deps=False install -y gettext jss
-
-      - name: Set up Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
-
-      - name: Download reports
-        uses: actions/download-artifact@v3
-        with:
-          name: jacocoReports
-          path: build
-
-      - name: Analyze
-        uses: gradle/gradle-build-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          arguments: sonar
-            -x coverage
-            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
-            -Dsonar.pullrequest.base=${{ github.base_ref }}
-            -Dsonar.pullrequest.branch=${{ github.head_ref }}

--- a/.github/workflows/sonar_pr_analysis.yml
+++ b/.github/workflows/sonar_pr_analysis.yml
@@ -1,0 +1,79 @@
+---
+name: Sonar analysis for pull requests
+
+on:
+  workflow_run:
+    workflows:
+      - Pull request verification
+    types:
+      - completed
+env:
+  JAVA_DISTRIBUTION: 'temurin'
+  JAVA_VERSION: '17'
+
+# Cancel in-progress sonar branch analysis workflows. We only care about analyzing the latest commit.
+concurrency:
+  group: ${{ github.event.workflow.name }}-${{ github.event.workflow_run.pull_requests[0].number }}
+  cancel-in-progress: true
+
+jobs:
+  pr_sonar_analysis:
+    name: PR sonar analysis
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:38
+    steps:
+      - name: Mask secrets
+        shell: bash
+        run: |
+          echo "::add-mask::${{ secrets.GITHUB_TOKEN }}"
+          echo "::add-mask::${{ secrets.SONAR_TOKEN }}"
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Download test reports
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "unit_test_reports"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/unit_test_reports.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip unit_test_reports.zip
+
+      - name: Install dependencies
+        shell: bash
+        run: dnf --setopt install_weak_deps=False install -y gettext jss
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Run sonar
+        uses: gradle/gradle-build-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          arguments: sonar -x coverage
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
+            -Dorg.gradle.jvmargs=-Xmx1g


### PR DESCRIPTION
Workflows triggered by PRs from forks do not have access to secrets, so jobs like sonar cannot run. Moving sonar job to a separate workflow triggered by workflow_run lets it access secrets.