### PR TITLE
CANDLEPIN-603: Update Java version in build images

### DIFF
--- a/containers/candlepin-base/setup-devel-env.sh
+++ b/containers/candlepin-base/setup-devel-env.sh
@@ -7,7 +7,7 @@ set -ve
 
 source /root/containerlib.sh
 
-export JAVA_VERSION=1.8.0
+export JAVA_VERSION=11
 export JAVA_HOME=/usr/lib/jvm/java-$JAVA_VERSION
 
 # Install & configure dev environment


### PR DESCRIPTION
Java 11 is the minimum for sonarcube