### PR TITLE
Enable Gradle Build Scan on GH Actions

### DIFF
--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 env:
+  CI: 'true'
   JAVA_DISTRIBUTION: 'temurin'
   JAVA_VERSION: '17'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,19 @@
+plugins {
+    id "com.gradle.enterprise" version "3.13.3"
+}
+
+def runsOnCI = System.getenv("CI") == 'true'
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+
+        publishAlwaysIf(runsOnCI)
+    }
+}
+
 rootProject.name = "candlepin"
+
 include 'client'
 include 'spec-tests'


### PR DESCRIPTION
This is the gradle scan I mentioned some time ago. It will enable scan only on GH Actions and will let us check if there are ways we could optimize our build.