### PR TITLE
Minor spec test optimization

### DIFF
--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -241,9 +241,16 @@ jobs:
           docker image pull ghcr.io/candlepin/gha_build:pr-${{ github.event.pull_request.number }}
           docker compose -f ./.github/containers/${{ matrix.database }}.docker-compose.yml --env-file ./.github/containers/.env up -d --wait
 
-      - name: run spec tests
-        shell: bash
-        run: ./gradlew spec -Dspec.test.client.host=candlepin
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Run Spec tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: spec -Dspec.test.client.host=candlepin
 
       - if: always()
         name: stop containers

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,6 +34,7 @@ ext.plugins = [
 libraries["artemisServer"] = "org.apache.activemq:artemis-server:2.28.0"
 libraries["artemisStomp"] = "org.apache.activemq:artemis-stomp-protocol:2.28.0"
 libraries["assertj"] = 'org.assertj:assertj-core:3.24.2'
+libraries["awaitility"] = 'org.awaitility:awaitility:4.2.0'
 libraries["checkstyle"] = "com.puppycrawl.tools:checkstyle:10.12.0"
 libraries["checkstyleSevntu"] = "com.github.sevntu-checkstyle:sevntu-checks:1.44.1"
 libraries["commonsCodec"] = "commons-codec:commons-codec:1.15"

--- a/spec-tests/build.gradle
+++ b/spec-tests/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation libraries["oauth"]
 
     testImplementation libraries["jimfs"]
+    testImplementation libraries["awaitility"]
 
     testRuntimeOnly libraries["junitEngine"]
 
@@ -45,11 +46,11 @@ test {
     enabled = false
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
 }
 
-task spec(type: Test) {
+tasks.register('spec', Test) {
     description = 'Run Java based spec tests'
     group = 'Verification'
     outputs.upToDateWhen { false }
@@ -59,6 +60,9 @@ task spec(type: Test) {
     }
 
     useJUnitPlatform()
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    reports.html.required = false
+    reports.junitXml.required = false
 
     // We have to propagate the -D params if we want them available in tests
     System.properties.keys().each { key ->


### PR DESCRIPTION
- Add concurrency limit to spec tests
- Disable Gradle spec test reports
- Use lazy config in spec tests
- Fixed content versioning spec. Occasionally it failed with concurrent modification exception in test code.