### PR TITLE
Fix test coverage in Sonar scan

### DIFF
--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -87,14 +87,13 @@ jobs:
       - name: Run unit tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: test coverage
+          arguments: test
 
       - name: Archive reports
         uses: actions/upload-artifact@v3
         with:
           name: unit_test_reports
           path: |
-            **/build/test-results/**/*.xml
             **/build/jacoco/test.exec
 
   validate_translations:

--- a/.github/workflows/sonar_pr_analysis.yml
+++ b/.github/workflows/sonar_pr_analysis.yml
@@ -72,7 +72,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
-          arguments: sonar -x coverage
+          arguments: coverage sonar -x test
             -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
             -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
             -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}

--- a/build.gradle
+++ b/build.gradle
@@ -309,11 +309,13 @@ jacocoTestReport {
     dependsOn test
 
     reports {
+        csv.required = false
+        html.required = false
         xml.required = true
     }
 
     doLast {
-        println "Generated unit test coverage report at $buildDir/reports/jacoco/test/html/index.html"
+        println "Generated unit test coverage report at $buildDir/reports/jacoco/test/jacocoTestReport.xml"
     }
 }
 


### PR DESCRIPTION
- Disable unnecessary html and csv reports
- Upload only coverage info in unit tests
- Generate test report from coverage info during sonar scan