### PR TITLE
[M] CANDLEPIN-610: GH actions spec tests can't push images from forks

### DIFF
--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -25,19 +25,16 @@ WORKDIR /app/build
 RUN jar xf $(find . -name 'candlepin*.war' | head -n 1); \
     sed -i 's/jss4.jar/jss.jar/g' ./META-INF/context.xml
 
-FROM quay.io/centos/centos:stream9
+FROM registry.access.redhat.com/ubi9-minimal:9.2-691
 LABEL author="Josh Albrecht <jalbrech@redhat.com>"
-
-RUN dnf install -y glibc-langpack-en
-ENV LANG en_US.UTF-8
 
 USER root
 
 # Update and install dependencies
-RUN dnf -y --setopt install_weak_deps=False update && \
-    dnf update ca-certificates && \
-    dnf -y --setopt install_weak_deps=False install epel-release java-17-openjdk openssl tomcatjss initscripts wget tar && \
-    dnf clean all
+RUN microdnf -y update && \
+    microdnf -y update ca-certificates && \
+    microdnf install -y java-17-openjdk-headless openssl jss initscripts wget tar && \
+    microdnf clean all
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-17-openjdk
 ENV JRE_HOME=/usr/lib/jvm/jre-17-openjdk
@@ -52,8 +49,8 @@ RUN wget https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.76/bin/apache-tomc
     rm -R apache-tomcat-9.0.76; \
     mkdir -p /etc/candlepin/certs; \
     mkdir -p /var/cache/candlepin/sync; \
-    usermod -u 10001 tomcat; \
-    groupmod -g 10000 tomcat; \
+    groupadd -g 10000 tomcat; \
+    useradd -g tomcat -u 10001 tomcat; \
     chown -R tomcat.tomcat /opt/tomcat; \
     chown -R tomcat.tomcat /var/log/; \
     chown -R tomcat.tomcat /var/lib/; \

--- a/.github/containers/postgres.docker-compose.yml
+++ b/.github/containers/postgres.docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U candlepin -d candlepin"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -187,6 +187,7 @@ jobs:
 
     steps:
       - name: Install packages
+        if: ${{ github.event.pull_request.head.repo.full_name == 'candlepin/candlepin' }}
         run: |
           sudo apt-get update
           sudo apt-get -y install \
@@ -197,6 +198,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to the registry
+        if: ${{ github.event.pull_request.head.repo.full_name == 'candlepin/candlepin' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -204,6 +206,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Candlepin image
+        if: ${{ github.event.pull_request.head.repo.full_name == 'candlepin/candlepin' }}
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
@@ -212,6 +215,7 @@ jobs:
           containerfiles: ./.github/containers/Dockerfile
 
       - name: Push to registry
+        if: ${{ github.event.pull_request.head.repo.full_name == 'candlepin/candlepin' }}
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ghcr.io/candlepin/gha_build
@@ -219,6 +223,25 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: ${{ github.event.pull_request.head.repo.full_name != 'candlepin/candlepin' }}
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and export
+        if: ${{ github.event.pull_request.head.repo.full_name != 'candlepin/candlepin' }}
+        uses: docker/build-push-action@v4
+        with:
+          file: ./.github/containers/Dockerfile
+          tags: ghcr.io/candlepin/gha_build:pr-${{ github.event.pull_request.number }}
+          outputs: type=docker,dest=/tmp/gha_build.tar
+
+      - name: Upload artifact
+        if: ${{ github.event.pull_request.head.repo.full_name != 'candlepin/candlepin' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: gha_build
+          path: /tmp/gha_build.tar
 
   spec_tests:
     name: spec tests
@@ -255,11 +278,32 @@ jobs:
           sudo chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
 
       - name: Log in to the registry
+        if: ${{ github.event.pull_request.head.repo.full_name == 'candlepin/candlepin' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull candlepin image
+        if: ${{ github.event.pull_request.head.repo.full_name == 'candlepin/candlepin' }}
+        shell: bash
+        run: docker image pull ghcr.io/candlepin/gha_build:pr-${{ github.event.pull_request.number }}
+
+      - name: Set up Docker Buildx
+        if: ${{ github.event.pull_request.head.repo.full_name != 'candlepin/candlepin' }}
+        uses: docker/setup-buildx-action@v2
+
+      - name: Download artifact
+        if: ${{ github.event.pull_request.head.repo.full_name != 'candlepin/candlepin' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: gha_build
+          path: /tmp
+
+      - name: Load image
+        if: ${{ github.event.pull_request.head.repo.full_name != 'candlepin/candlepin' }}
+        run: docker load --input /tmp/gha_build.tar
 
       - if: matrix.mode == 'standalone'
         name: Add standalone env variable
@@ -282,7 +326,6 @@ jobs:
           echo "SOURCE_LOCATION=${{ github.workspace }}" >> ./.github/containers/.env
           BRIDGE_NETWORK=$(docker network ls --filter=name=github_network_ --format="{{ .Name }}")
           echo "NETWORK=$BRIDGE_NETWORK" >> ./.github/containers/.env
-          docker image pull ghcr.io/candlepin/gha_build:pr-${{ github.event.pull_request.number }}
           docker compose -f ./.github/containers/${{ matrix.database }}.docker-compose.yml --env-file ./.github/containers/.env up -d --wait
 
       - name: Set up Java
@@ -297,6 +340,6 @@ jobs:
           arguments: spec -Dspec.test.client.host=candlepin
 
       - if: always()
-        name: stop containers
+        name: Stop containers
         shell: bash
         run: docker compose -f ./.github/containers/${{ matrix.database }}.docker-compose.yml down


### PR DESCRIPTION
- updated postgres docker-compose health check
- updated spec test Dockerfile to use UBI 9 base image

I created a PR from a forked repository to validate that the spec tests properly run:
https://github.com/candlepin/candlepin/actions/runs/5338261121/jobs/9675387427