### PR TITLE
[4.2] CANDLEPIN-531: Update RHEL dependency from pki-servlet-engine to tomcat

### DIFF
--- a/ansible/roles/candlepin/tasks/el9/el9_base_deps.yml
+++ b/ansible/roles/candlepin/tasks/el9/el9_base_deps.yml
@@ -31,7 +31,7 @@
       - jss
       - make
       - openssl
-      - pki-servlet-engine
+      - tomcat
       - platform-python
       - python3
       - python3-libxml2

--- a/candlepin.spec.tmpl
+++ b/candlepin.spec.tmpl
@@ -51,9 +51,8 @@ BuildRequires: /usr/bin/pathfix.py
 
 Requires: java-11 >= 1:11.0.0
 Requires: wget
-## tomcatjss itself depends on jss and tomcat/pki-servlet-container/pki-servlet-engine
-## without having to worry about about the renaming of those packages.
-Requires: tomcatjss >= 7.2.1-7.1
+Requires: tomcat < 10
+Requires: jss
 Requires: javapackages-tools
 
 %description


### PR DESCRIPTION
- Change package from pki-servelet-engine to tomcat in candlepin.spec.tmpl and for cs9 images