### PR TITLE
CANDLEPIN-619: Re-run PR workflow when target branch gets pushed

### DIFF
--- a/.github/workflows/closed_pr_workflow.yml
+++ b/.github/workflows/closed_pr_workflow.yml
@@ -1,0 +1,51 @@
+name: Workflow run on closed PR
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  rerun-workflows:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mask secrets
+        shell: bash
+        run: |
+          echo "::add-mask::${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Trigger workflow runs
+        run: |
+          token="${{ secrets.GITHUB_TOKEN }}"
+          base="${{ github.base_ref }}"
+          
+          pr_head_shas=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $token"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/candlepin/candlepin/pulls |\
+            jq -r '.[] | select(.base.ref == $base) | .head.sha')
+          
+          for head_sha in $pr_head_shas; do
+            runner_id=$(curl -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $token"\
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/candlepin/candlepin/actions/workflows/pr_verification.yml/runs?head_sha=$head_sha |\
+              jq -r '.workflow_runs[] | .id')
+            runner_ids+=($runner_id)
+          done
+          
+          for id in "${runner_ids[@]}"
+          do
+            curl -L \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $token"\
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/candlepin/candlepin/actions/runs/$id/rerun
+          done


### PR DESCRIPTION
- Create a workflow that triggers when a PR is closed, and it will rerun all workflows associated with the affected branch