### PR TITLE
[M] CANDLEPIN-638: Relax auth restrictions for activation key management

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Permissions.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Permissions.java
@@ -17,31 +17,29 @@ package org.candlepin.spec.bootstrap.data.builder;
 import org.candlepin.dto.api.client.v1.OwnerDTO;
 import org.candlepin.dto.api.client.v1.PermissionBlueprintDTO;
 
+
+
 public enum Permissions {
 
-    OWNER("OWNER"),
-    OWNER_POOLS("OWNER_POOLS"),
-    USERNAME_CONSUMERS("USERNAME_CONSUMERS"),
-    USERNAME_CONSUMERS_ENTITLEMENTS("USERNAME_CONSUMERS_ENTITLEMENTS"),
-    ATTACH("ATTACH"),
-    OWNER_HYPERVISORS("OWNER_HYPERVISORS");
-
-    private final String permission;
-    Permissions(String permission) {
-        this.permission = permission;
-    }
+    OWNER,
+    OWNER_POOLS,
+    USERNAME_CONSUMERS,
+    USERNAME_CONSUMERS_ENTITLEMENTS,
+    ATTACH,
+    OWNER_HYPERVISORS,
+    MANAGE_ACTIVATION_KEYS;
 
     public PermissionBlueprintDTO all(OwnerDTO owner) {
         return new PermissionBlueprintDTO()
             .owner(Owners.toNested(owner))
-            .type(permission)
+            .type(this.name())
             .access("ALL");
     }
 
     public PermissionBlueprintDTO readOnly(OwnerDTO owner) {
         return new PermissionBlueprintDTO()
             .owner(Owners.toNested(owner))
-            .type(permission)
+            .type(this.name())
             .access("READ_ONLY");
     }
 }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Roles.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Roles.java
@@ -28,20 +28,18 @@ public final class Roles {
     }
 
     public static RoleDTO ownerAll(OwnerDTO owner) {
-        return createRole(Permissions.OWNER.all(owner));
+        return with(Permissions.OWNER.all(owner));
     }
 
     public static RoleDTO ownerReadOnly(OwnerDTO owner) {
-        return createRole(Permissions.OWNER.readOnly(owner));
+        return with(Permissions.OWNER.readOnly(owner));
     }
 
     public static RoleDTO with(PermissionBlueprintDTO... permissions) {
-        return createRole(permissions);
-    }
-
-    private static RoleDTO createRole(PermissionBlueprintDTO... permissions) {
         return new RoleDTO()
             .name(StringUtil.random("test-role"))
             .permissions(List.of(permissions));
     }
+
+
 }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/UserUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/UserUtil.java
@@ -20,11 +20,10 @@ import org.candlepin.dto.api.client.v1.RoleDTO;
 import org.candlepin.dto.api.client.v1.UserDTO;
 import org.candlepin.invoker.client.ApiException;
 import org.candlepin.resource.client.v1.RolesApi;
-import org.candlepin.resource.client.v1.UsersApi;
 import org.candlepin.spec.bootstrap.client.ApiClient;
 import org.candlepin.spec.bootstrap.data.builder.Roles;
 
-import org.jetbrains.annotations.NotNull;
+
 
 public final class UserUtil {
 
@@ -32,40 +31,37 @@ public final class UserUtil {
         throw new UnsupportedOperationException();
     }
 
-    public static UserDTO createAdminUser(ApiClient client, OwnerDTO owner)
+    private static UserDTO createUser(ApiClient client, boolean superAdmin, RoleDTO role)
         throws ApiException {
-        return createUsers(client, true, Roles.ownerAll(owner));
-    }
 
-    public static UserDTO createUser(ApiClient client, OwnerDTO owner)
-        throws ApiException {
-        return createUsers(client, false, Roles.ownerAll(owner));
-    }
-
-    public static UserDTO createReadOnlyUser(ApiClient client, OwnerDTO owner)
-        throws ApiException {
-        return createUsers(client, false, Roles.ownerReadOnly(owner));
-    }
-
-    public static UserDTO createWith(
-        ApiClient client, PermissionBlueprintDTO... type) throws ApiException {
-        return createUsers(client, false, Roles.with(type));
-    }
-
-    @NotNull
-    private static UserDTO createUsers(
-        ApiClient client, boolean superAdmin, RoleDTO role) throws ApiException {
         RolesApi roles = client.roles();
-        UsersApi usersClient = client.users();
         UserDTO user = new UserDTO()
             .username(StringUtil.random("test_user"))
             .password("password")
             .superAdmin(superAdmin);
-        usersClient.createUser(user);
+
+        client.users().createUser(user);
+
         RoleDTO userRole = roles.createRole(role);
         roles.addUserToRole(userRole.getName(), user.getUsername());
 
         return user;
+    }
+
+    public static UserDTO createAdminUser(ApiClient client, OwnerDTO owner) throws ApiException {
+        return createUser(client, true, Roles.ownerAll(owner));
+    }
+
+    public static UserDTO createUser(ApiClient client, OwnerDTO owner) throws ApiException {
+        return createUser(client, false, Roles.ownerAll(owner));
+    }
+
+    public static UserDTO createReadOnlyUser(ApiClient client, OwnerDTO owner) throws ApiException {
+        return createUser(client, false, Roles.ownerReadOnly(owner));
+    }
+
+    public static UserDTO createWith(ApiClient client, PermissionBlueprintDTO... type) throws ApiException {
+        return createUser(client, false, Roles.with(type));
     }
 
 }

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
@@ -77,6 +77,10 @@ public class OwnerResourceSpecTest {
         ownerProducts = admin.ownerProducts();
     }
 
+    private ProductDTO createProduct(OwnerDTO owner, AttributeDTO... attributes) throws ApiException {
+        return ownerProducts.createProductByOwner(owner.getKey(), Products.withAttributes(attributes));
+    }
+
     @Test
     public void shouldCreateOwner() {
         OwnerDTO ownerDTO = Owners.random();
@@ -149,9 +153,7 @@ public class OwnerResourceSpecTest {
         ConsumerDTO consumer = userClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
-        ProductDTO product = createProduct(owner,
-            ProductAttributes.SupportLevel.withValue("VIP")
-        );
+        ProductDTO product = createProduct(owner, ProductAttributes.SupportLevel.withValue("VIP"));
         owners.createPool(owner.getKey(), Pools.random(product));
 
         List<String> serviceLevels = consumerClient.owners()
@@ -775,10 +777,6 @@ public class OwnerResourceSpecTest {
         // return an error)
         SystemPurposeAttributesDTO attributes = userClient.owners().getSyspurpose(owner.getKey());
         assertEquals(owner.getKey(), attributes.getOwner().getKey());
-
     }
 
-    private ProductDTO createProduct(OwnerDTO owner, AttributeDTO... attributes) throws ApiException {
-        return ownerProducts.createProductByOwner(owner.getKey(), Products.withAttributes(attributes));
-    }
 }

--- a/src/main/java/org/candlepin/auth/SubResource.java
+++ b/src/main/java/org/candlepin/auth/SubResource.java
@@ -16,6 +16,7 @@ package org.candlepin.auth;
 
 /**
  * Enumeration of the sub-targets used in the Candlepin permission model.
+ *
  * See AuthInterceptor
  */
 public enum SubResource {
@@ -25,5 +26,8 @@ public enum SubResource {
     POOLS, // org pools
     SUBSCRIPTIONS, // org subscriptions
     SERVICE_LEVELS, // org service levels
-    HYPERVISOR;
+    HYPERVISOR,
+
+    /** Used for explicit permissions surrounding activation keys in an org */
+    ACTIVATION_KEYS;
 }

--- a/src/main/java/org/candlepin/auth/UserAuth.java
+++ b/src/main/java/org/candlepin/auth/UserAuth.java
@@ -59,7 +59,7 @@ public abstract class UserAuth implements AuthProvider {
         // without ever using them in the general case.
         return user.isSuperAdmin() != null && user.isSuperAdmin() ?
             (new UserPrincipal(username, null, true, user.getPrimaryOwner())) :
-            (new UserPrincipal(username, this.permissionFactory.createUserPermissions(user), false,
+            (new UserPrincipal(username, this.permissionFactory.createPermissions(user), false,
                 user.getPrimaryOwner()));
     }
 

--- a/src/main/java/org/candlepin/auth/UserPrincipal.java
+++ b/src/main/java/org/candlepin/auth/UserPrincipal.java
@@ -38,7 +38,7 @@ public class UserPrincipal extends Principal {
      *
      * @param username
      */
-    public UserPrincipal(String username, Collection<Permission> permissions, boolean admin) {
+    public UserPrincipal(String username, Collection<? extends Permission> permissions, boolean admin) {
         this(username, permissions, admin, null);
     }
 
@@ -47,8 +47,9 @@ public class UserPrincipal extends Principal {
      *
      * @param username
      */
-    public UserPrincipal(String username, Collection<Permission> permissions, boolean admin,
+    public UserPrincipal(String username, Collection<? extends Permission> permissions, boolean admin,
         OwnerInfo primaryOwner) {
+
         this.username = username;
         this.admin = admin;
         this.primaryOwner = primaryOwner;

--- a/src/main/java/org/candlepin/auth/permissions/ActivationKeyCreationPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ActivationKeyCreationPermission.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.auth.permissions;
+
+import org.candlepin.auth.Access;
+import org.candlepin.auth.SubResource;
+import org.candlepin.model.Owner;
+
+import org.hibernate.criterion.Criterion;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
+
+
+
+/**
+ * Grants permission to create activation keys under the specified org.
+ *
+ * Note: this permission's existence is a function of the way the API verifies on the org during
+ * key creation. The creation API is scoped by org, but the management APIs are not, which means
+ * creation must be verified as a subresource of Owner, where management is a verify on the keys
+ * directly.
+ */
+public class ActivationKeyCreationPermission extends TypedPermission<Owner> {
+
+    private final Owner owner;
+    private final String ownerId;
+
+    /**
+     * Creates a new activation key management permission providing write access to create or modify
+     * activation keys within the specified owner (organization).
+     *
+     * @param owner
+     *  the owner/org for which activation key creation permissions should be granted
+     *
+     * @throws IllegalArgumentException
+     *  if the provided owner is null or lacks an owner ID
+     */
+    public ActivationKeyCreationPermission(Owner owner) {
+        if (owner == null || owner.getId() == null) {
+            throw new IllegalArgumentException("owner is null or lacks an ID");
+        }
+
+        this.owner = owner;
+        this.ownerId = owner.getId();
+
+        // TODO: FIXME: this should be set by calling a constructor in our superclass rather than
+        // explicitly setting the field directly.
+        this.access = Access.CREATE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<Owner> getTargetType() {
+        return Owner.class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Owner getOwner() {
+        return this.owner;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canAccessTarget(Owner target, SubResource subresource, Access required) {
+        return target != null && this.ownerId.equals(target.getId()) &&
+            subresource == SubResource.ACTIVATION_KEYS &&
+            this.access.provides(required);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Criterion getCriteriaRestrictions(Class entityClass) {
+        // deprecated functionality; never return anything from this, as dynamically modifying
+        // arbitrary queries is error prone and a maintenance nightmare.
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
+        // deprecated functionality; never return anything from this, as dynamically modifying
+        // arbitrary queries is error prone and a maintenance nightmare.
+        return null;
+    }
+
+}

--- a/src/main/java/org/candlepin/auth/permissions/ActivationKeyManagementPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ActivationKeyManagementPermission.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.auth.permissions;
+
+import org.candlepin.auth.Access;
+import org.candlepin.auth.SubResource;
+import org.candlepin.model.Owner;
+import org.candlepin.model.activationkeys.ActivationKey;
+
+import org.hibernate.criterion.Criterion;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Predicate;
+
+
+
+/**
+ * Grants permissions to manage activation keys under a given organization.
+ */
+public class ActivationKeyManagementPermission extends TypedPermission<ActivationKey> {
+
+    private final Owner owner;
+    private final String ownerId;
+
+    /**
+     * Creates a new activation key management permission providing write access to create or modify
+     * activation keys within the specified owner (organization).
+     *
+     * @param owner
+     *  the owner/org for which activation key management permissions should be granted
+     *
+     * @throws IllegalArgumentException
+     *  if the provided owner is null or lacks an owner ID
+     */
+    public ActivationKeyManagementPermission(Owner owner) {
+        if (owner == null || owner.getId() == null) {
+            throw new IllegalArgumentException("owner is null or lacks an ID");
+        }
+
+        this.owner = owner;
+        this.ownerId = owner.getId();
+
+        // TODO: FIXME: this should be set by calling a constructor in our superclass rather than
+        // explicitly setting the field directly.
+        // If the permissions are ever made more granular, the access should become a constructor
+        // parameter rather than being hardcoded here.
+        this.access = Access.ALL;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<ActivationKey> getTargetType() {
+        return ActivationKey.class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Owner getOwner() {
+        return this.owner;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canAccessTarget(ActivationKey target, SubResource subresource, Access required) {
+        return target != null && this.ownerId.equals(target.getOwnerId()) &&
+            this.access.provides(required);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Criterion getCriteriaRestrictions(Class entityClass) {
+        // deprecated functionality; never return anything from this, as dynamically modifying
+        // arbitrary queries is error prone and a maintenance nightmare.
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Predicate getQueryRestriction(Class<T> entityClass, CriteriaBuilder builder, From<?, T> path) {
+        // deprecated functionality; never return anything from this, as dynamically modifying
+        // arbitrary queries is error prone and a maintenance nightmare.
+        return null;
+    }
+
+}

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -986,6 +986,7 @@ public class OwnerResource implements OwnerApi {
                 return result;
             }
         }
+
         // test is on the string "true" and is case insensitive.
         return poolManager.retrieveServiceLevelsForOwner(owner.getId(), Boolean.parseBoolean(exempt));
     }
@@ -1000,8 +1001,10 @@ public class OwnerResource implements OwnerApi {
     }
 
     @Override
-    public ActivationKeyDTO createActivationKey(@Verify(Owner.class) String ownerKey,
+    public ActivationKeyDTO createActivationKey(
+        @Verify(value = Owner.class, subResource = SubResource.ACTIVATION_KEYS) String ownerKey,
         ActivationKeyDTO dto) {
+
         validator.validateCollectionElementsNotNull(dto::getContentOverrides, dto::getPools,
             dto::getProducts);
 

--- a/src/main/java/org/candlepin/service/impl/DefaultUserServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultUserServiceAdapter.java
@@ -264,7 +264,7 @@ public class DefaultUserServiceAdapter implements UserServiceAdapter {
         }
         else {
             // We need to pair this down to just accessible owners...
-            Collection<Permission> permissions = this.permissionFactory.createUserPermissions(entity);
+            Collection<Permission> permissions = this.permissionFactory.createPermissions(entity);
             Set<OwnerInfo> owners = new HashSet<>();
 
             for (Permission permission : permissions) {

--- a/src/main/java/org/candlepin/service/model/PermissionBlueprintInfo.java
+++ b/src/main/java/org/candlepin/service/model/PermissionBlueprintInfo.java
@@ -25,14 +25,6 @@ package org.candlepin.service.model;
  */
 public interface PermissionBlueprintInfo extends ServiceAdapterModel {
 
-    // /**
-    //  * Fetches the ID of this role. If the ID has not yet been set, this method returns null.
-    //  *
-    //  * @return
-    //  *  The ID of this role, or null if the ID has not been set
-    //  */
-    // String getId();
-
     /**
      * Fetches the owner for which this permission applies. If the owner has not yet been set, this
      * method returns null.

--- a/src/test/java/org/candlepin/auth/permissions/ActivationKeyCreationPermissionTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/ActivationKeyCreationPermissionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.auth.permissions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.candlepin.auth.Access;
+import org.candlepin.auth.SubResource;
+import org.candlepin.model.Owner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+
+
+
+public class ActivationKeyCreationPermissionTest {
+
+    private Owner createOwner(String key) {
+        return new Owner()
+            .setId(key)
+            .setKey(key);
+    }
+
+    @Test
+    public void testRequiresOwnerInstance() {
+        assertThrows(IllegalArgumentException.class, () -> new ActivationKeyCreationPermission(null));
+    }
+
+    @Test
+    public void testRequiresOwnerWithID() {
+        Owner owner = new Owner()
+            .setKey("test_org");
+
+        assertThrows(IllegalArgumentException.class, () -> new ActivationKeyCreationPermission(owner));
+    }
+
+    @Test
+    public void testTargetType() {
+        Owner owner = this.createOwner("test_org");
+        ActivationKeyCreationPermission perm = new ActivationKeyCreationPermission(owner);
+
+        // This should always be an Owner class instance
+        assertEquals(Owner.class, perm.getTargetType());
+    }
+
+    @Test
+    public void testGetOwner() {
+        Owner owner = this.createOwner("test_org");
+        ActivationKeyCreationPermission perm = new ActivationKeyCreationPermission(owner);
+
+        // This should always be an Owner class instance
+        assertEquals(owner, perm.getOwner());
+    }
+
+    @Test
+    public void testCriteriaRestrictionsAreDisabled() {
+        Owner owner = this.createOwner("test_org");
+        ActivationKeyCreationPermission perm = new ActivationKeyCreationPermission(owner);
+
+        // These should always return null
+        assertNull(perm.getCriteriaRestrictions(Owner.class));
+        assertNull(perm.getQueryRestriction(Owner.class, mock(CriteriaBuilder.class), mock(From.class)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Access.class, names = {"ALL"}, mode = EnumSource.Mode.EXCLUDE)
+    public void testProvidesCreateLevelAccess(Access required) {
+        Owner owner = this.createOwner("test_org");
+        ActivationKeyCreationPermission perm = new ActivationKeyCreationPermission(owner);
+
+        boolean result = perm.canAccessTarget(owner, SubResource.ACTIVATION_KEYS, required);
+        assertTrue(result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Access.class, names = {"ALL"}, mode = EnumSource.Mode.INCLUDE)
+    public void testDoesNotProvideHigherThanCreateAccess(Access required) {
+        Owner owner = this.createOwner("test_org");
+        ActivationKeyCreationPermission perm = new ActivationKeyCreationPermission(owner);
+
+        boolean result = perm.canAccessTarget(owner, SubResource.ACTIVATION_KEYS, required);
+        assertFalse(result);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EnumSource(value = SubResource.class, names = {"ACTIVATION_KEYS"}, mode = EnumSource.Mode.EXCLUDE)
+    public void testRequiresActivationKeySubResource(SubResource subresource) {
+        Owner owner = this.createOwner("test_org");
+        ActivationKeyCreationPermission perm = new ActivationKeyCreationPermission(owner);
+
+        boolean result = perm.canAccessTarget(owner, subresource, Access.NONE);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testRequiresMatchingOwner() {
+        Owner owner1 = this.createOwner("test_org-1");
+        Owner owner2 = this.createOwner("test_org-2");
+
+        ActivationKeyCreationPermission perm = new ActivationKeyCreationPermission(owner1);
+
+        boolean result1 = perm.canAccessTarget(owner2, SubResource.ACTIVATION_KEYS, Access.NONE);
+        assertFalse(result1);
+
+        boolean result2 = perm.canAccessTarget(owner1, SubResource.ACTIVATION_KEYS, Access.NONE);
+        assertTrue(result2);
+    }
+
+}

--- a/src/test/java/org/candlepin/auth/permissions/ActivationKeyManagementPermissionTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/ActivationKeyManagementPermissionTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.auth.permissions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.candlepin.auth.Access;
+import org.candlepin.auth.SubResource;
+import org.candlepin.model.activationkeys.ActivationKey;
+import org.candlepin.model.Owner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.From;
+
+
+
+public class ActivationKeyManagementPermissionTest {
+
+    private Owner createOwner(String key) {
+        return new Owner()
+            .setId(key)
+            .setKey(key);
+    }
+
+    private ActivationKey createActivationKey(Owner owner) {
+        return new ActivationKey()
+            .setOwner(owner);
+    }
+
+    @Test
+    public void testRequiresOwnerInstance() {
+        assertThrows(IllegalArgumentException.class, () -> new ActivationKeyManagementPermission(null));
+    }
+
+    @Test
+    public void testRequiresOwnerWithID() {
+        Owner owner = new Owner()
+            .setKey("test_org");
+
+        assertThrows(IllegalArgumentException.class, () -> new ActivationKeyManagementPermission(owner));
+    }
+
+    @Test
+    public void testTargetType() {
+        Owner owner = this.createOwner("test_org");
+        ActivationKeyManagementPermission perm = new ActivationKeyManagementPermission(owner);
+
+        // This should always be an ActivationKey class instance
+        assertEquals(ActivationKey.class, perm.getTargetType());
+    }
+
+    @Test
+    public void testGetOwner() {
+        Owner owner = this.createOwner("test_org");
+        ActivationKeyManagementPermission perm = new ActivationKeyManagementPermission(owner);
+
+        // This should always be an Owner class instance
+        assertEquals(owner, perm.getOwner());
+    }
+
+    @Test
+    public void testCriteriaRestrictionsAreDisabled() {
+        Owner owner = this.createOwner("test_org");
+        ActivationKeyManagementPermission perm = new ActivationKeyManagementPermission(owner);
+
+        // These should always return null
+        assertNull(perm.getCriteriaRestrictions(ActivationKey.class));
+        assertNull(perm.getQueryRestriction(ActivationKey.class, mock(CriteriaBuilder.class), mock(From.class)));
+    }
+
+    // TODO: This should eventually change to *not* blanket permit all access, but at the time of
+    // writing, we don't have much more granularity with our permissions with respect to the
+    // operation requirements.
+    @ParameterizedTest
+    @EnumSource(value = Access.class)
+    public void testProvidesAllLevelAccess(Access required) {
+        Owner owner = this.createOwner("test_org");
+        ActivationKey key = this.createActivationKey(owner);
+
+        ActivationKeyManagementPermission perm = new ActivationKeyManagementPermission(owner);
+
+        boolean result = perm.canAccessTarget(key, SubResource.ACTIVATION_KEYS, required);
+        assertTrue(result);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EnumSource(value = SubResource.class)
+    public void testIgnoresSubResource(SubResource subresource) {
+        Owner owner = this.createOwner("test_org");
+        ActivationKey key = this.createActivationKey(owner);
+
+        ActivationKeyManagementPermission perm = new ActivationKeyManagementPermission(owner);
+
+        boolean result = perm.canAccessTarget(key, subresource, Access.NONE);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testRequiresMatchingOwner() {
+        Owner owner1 = this.createOwner("test_org-1");
+        Owner owner2 = this.createOwner("test_org-2");
+        ActivationKey key1 = this.createActivationKey(owner1);
+        ActivationKey key2 = this.createActivationKey(owner2);
+
+        ActivationKeyManagementPermission perm = new ActivationKeyManagementPermission(owner1);
+
+        boolean result1 = perm.canAccessTarget(key2, SubResource.ACTIVATION_KEYS, Access.NONE);
+        assertFalse(result1);
+
+        boolean result2 = perm.canAccessTarget(key1, SubResource.ACTIVATION_KEYS, Access.NONE);
+        assertTrue(result2);
+    }
+
+}


### PR DESCRIPTION
- Relaxed the authorization requirements for activation key management operations by adding a new permission specifically for providing authorization, instead of requiring only org admin or super admin priviledges
- Updated caching of org lookups during permission building
- Updated verification on several activation key endpoints to use the standard authorization logic
- Updated permission conversion to permit permission blueprints to result in the creation of more than one explicit permission