### PR TITLE
[M] During i18n job, only check for diffs on the .pot file

### DIFF
--- a/.github/scripts/i18n.sh
+++ b/.github/scripts/i18n.sh
@@ -11,19 +11,18 @@ evalrc() {
 ./gradlew gettext
 evalrc $? "Gettext was not successful for branch $GIT_BRANCH."
 
-files=$(git diff | egrep -v -e '^( |\+#|\-#|@@|\+\+\+|\-\-\-|diff|index)' -e 'X-Generator' -e 'POT-Creation-Date')
+files=$(git diff po/keys.pot | egrep -v -e '^( |\+#|\-#|@@|\+\+\+|\-\-\-|diff|index)' -e 'X-Generator' \
+  -e 'POT-Creation-Date')
 
 if [ ! -z "$files" ]; then
+  #Code to commit the updated template file
+  git add po/keys.pot
+  evalrc $? "Git add file was not successful for branch $GIT_BRANCH."
 
-#Code to commit the updated template file
-git add po/keys.pot
-evalrc $? "Git add file was not successful for branch $GIT_BRANCH."
+  echo "Committing and pushing the template file."
+  git -c "user.name=$GIT_AUTHOR_NAME" -c "user.email=$GIT_AUTHOR_EMAIL" commit -m "updated po/keys.pot template"
+  evalrc $? "Git commit was not successful for branch $GIT_BRANCH."
 
-echo "Committing and pushing the template file."
-git -c "user.name=$GIT_AUTHOR_NAME" -c "user.email=$GIT_AUTHOR_EMAIL" commit -m "updated po/keys.pot template"
-evalrc $? "Git commit was not successful for branch $GIT_BRANCH."
-
-git push https://${GITHUB_TOKEN}@github.com/candlepin/candlepin $GIT_BRANCH
-evalrc $? "Git push was not successful for branch $GIT_BRANCH."
-
+  git push https://${GITHUB_TOKEN}@github.com/candlepin/candlepin $GIT_BRANCH
+  evalrc $? "Git push was not successful for branch $GIT_BRANCH."
 fi


### PR DESCRIPTION
- When the i18n job runs in GH Actions, some non-staged files end up with their file mode changed, which causes the 'git diff' to flag them as actual changes, and ends up pushing redundant commits such as the POT-Creation-Date update. This change only runs the diff on the keys.pot file to avoid issues like that.