### PR TITLE
CANDLEPIN-639: Add secret for I18n push

### DIFF
--- a/.github/scripts/i18n.sh
+++ b/.github/scripts/i18n.sh
@@ -17,12 +17,12 @@ files=$(git diff po/keys.pot | egrep -v -e '^( |\+#|\-#|@@|\+\+\+|\-\-\-|diff|in
 if [ ! -z "$files" ]; then
   #Code to commit the updated template file
   git add po/keys.pot
-  evalrc $? "Git add file was not successful for branch $GIT_BRANCH."
+  evalrc $? " <== System return for git add file for branch $GIT_BRANCH."
 
   echo "Committing and pushing the template file."
   git -c "user.name=$GIT_AUTHOR_NAME" -c "user.email=$GIT_AUTHOR_EMAIL" commit -m "updated po/keys.pot template"
-  evalrc $? "Git commit was not successful for branch $GIT_BRANCH."
+  evalrc $? " <== System return for git commit for branch $GIT_BRANCH."
 
-  git push https://${GITHUB_TOKEN}@github.com/candlepin/candlepin $GIT_BRANCH
-  evalrc $? "Git push was not successful for branch $GIT_BRANCH."
+  git push https://candlepin:${I18N_TOKEN}@github.com/candlepin/candlepin $GIT_BRANCH
+  evalrc $? " <== System return for git push for branch $GIT_BRANCH."
 fi

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Mask secrets
         shell: bash
         run: |
-          echo "::add-mask::${{ secrets.GITHUB_TOKEN }}"
+          echo "::add-mask::${{ secrets.I18N_TOKEN }}"
 
       - name: Install dependencies
         shell: bash
@@ -61,4 +61,5 @@ jobs:
           GIT_AUTHOR_NAME: 'candlepin-bot'
           GIT_BRANCH: ${{ matrix.branch }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          I18N_TOKEN: ${{ secrets.I18N_TOKEN }}
 


### PR DESCRIPTION
How to test:
1. Check out the branch locally.
2. Clone the branch.
3. In the i18n.yml file matrix section: add the cloned branch to the branch list and the include list for Java versions.
4. Push the change to the cloned branch.
5. Protect the cloned branch to https://github.com/candlepin/candlepin/settings/branches. Do not check merge queue or status checks.
6. Run the i18n action on the cloned branch.
7. Note that the cloned branch will have a new version of the keys.pot file committed.

Note that the main branch will not succeed until this is merged. Both the merge queue and status check requirement will need to be taken off main for this to work.
 