### PR TITLE
2231503: CertificateCleanupJob execution takes a very long time; CANDLEPIN-643

### DIFF
--- a/src/main/resources/db/changelog/20230811183400-add-indexes-certificate-cleanup.xml
+++ b/src/main/resources/db/changelog/20230811183400-add-indexes-certificate-cleanup.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+    <!-- For making the CertificateCleanupJob queries faster -->
+    <changeSet id="20230811183400-1" author="wpoteat" dbms="postgresql,hsqldb">
+        <createIndex tableName="cp_cont_access_cert" indexName="cp_cont_access_cert_serial_id_idx">
+            <column name="serial_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="20230811183400-2" author="wpoteat" dbms="postgresql,hsqldb">
+        <createIndex tableName="cp_ueber_cert" indexName="cp_ueber_cert_serial_id_idx">
+            <column name="serial_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="20230811183400-3" author="wpoteat" dbms="postgresql,hsqldb">
+        <createIndex tableName="cp_consumer" indexName="cp_consumer_cont_acc_cert_id_idx">
+            <column name="cont_acc_cert_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -186,4 +186,5 @@
     <include file="db/changelog/20230220150433-drop-act-key-env-tables.xml"/>
     <include file="db/changelog/20230322103117-reduce-consumer-name.xml"/>
     <include file="db/changelog/20230725171517-add-anonymous-claimed_column.xml"/>
+    <include file="db/changelog/20230811183400-add-indexes-certificate-cleanup.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- When there was a lot of old data in the Content Access Certificate table, it to hours for the cleanup to process
- Indexes added to tables that have a serial id column that were not indexed like other similar tables
- Index added to consumer table for content access cert id column