### PR TITLE
Update healt check for GH action compose file

### DIFF
--- a/.github/containers/mariadb.docker-compose.yml
+++ b/.github/containers/mariadb.docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping"]
+      test: ["CMD-SHELL", "mysqladmin ping -ucandlepin -pcandlepin"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
- Add parameters for mysql command to ping as candlepin user not as root user. It was generating warnings to logs.