### PR TITLE
[M] Collecting logs from spec tests runners in GH action

### DIFF
--- a/.github/workflows/pr_verification.yml
+++ b/.github/workflows/pr_verification.yml
@@ -395,6 +395,38 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: spec -Dspec.test.client.host=candlepin
+          
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@4599896f4f5414b2444c1512096809da191c9e81
+        with:
+          dest: './logs-${{ matrix.database }}-${{ matrix.mode }}'
+
+      - name: Collect candlepin and Tomcat logs on failure
+        if: failure()
+        shell: bash
+        run: | 
+          docker cp candlepin:/var/log/candlepin/ ./logs-${{ matrix.database }}-${{ matrix.mode }}/candlepin/
+          docker cp candlepin:/opt/tomcat/logs/ ./logs-${{ matrix.database }}-${{ matrix.mode }}/tomcat/
+          
+      - name: Collect postgress logs on failure
+        if: failure() && matrix.database == 'postgres'
+        run:  docker cp postgres:/var/log/postgresql/ ./logs-${{ matrix.database }}-${{ matrix.mode }}/postgresql/
+      
+      - name: Collect mariadb logs on failure
+        if: failure() && matrix.database == 'mariadb'
+        run:  docker cp mariadb:/var/log/mysql/ ./logs-${{ matrix.database }}-${{ matrix.mode }}/mysql/
+
+      - name: Tar logs
+        if: failure()
+        run: sudo tar cvzf ./logs-${{ matrix.database }}-${{ matrix.mode }}.tgz ./logs-${{ matrix.database }}-${{ matrix.mode }}
+
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs-${{ matrix.database }}-${{ matrix.mode }}.tgz
+          path: ./logs-${{ matrix.database }}-${{ matrix.mode }}.tgz
 
       - if: always()
         name: Stop containers


### PR DESCRIPTION
During backporting GH action I need to get logs from runners with spec test. So I write this to get logs and upload them as artifacts. I think it could be useful also in main, if not just close it. Or if you want more logs to collect just write me. Now its collecting docker log, candlepin logs and tomcat logs. It collects them only when spec test fail, so we save time on successful run.