### PR TITLE
[M] CANDLEPIN-648: Fixed NPE when activating subscriptions in standalone

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/StatusCodeAssertions.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/StatusCodeAssertions.java
@@ -25,10 +25,18 @@ import org.assertj.core.api.ThrowableAssert;
 
 import java.util.function.Supplier;
 
+
+
 public final class StatusCodeAssertions {
 
     private StatusCodeAssertions() {
         throw new UnsupportedOperationException();
+    }
+
+    public static AbstractThrowableAssert<?, ? extends Throwable> assertNotModified(
+        ThrowableAssert.ThrowingCallable callable) {
+        ApiException exception = catchApiException(callable);
+        return assertReturnCode(304, exception);
     }
 
     public static AbstractThrowableAssert<?, ? extends Throwable> assertBadRequest(
@@ -67,10 +75,10 @@ public final class StatusCodeAssertions {
         return assertReturnCode(410, exception);
     }
 
-    public static AbstractThrowableAssert<?, ? extends Throwable> assertNotModified(
+    public static AbstractThrowableAssert<?, ? extends Throwable> assertUnavailable(
         ThrowableAssert.ThrowingCallable callable) {
         ApiException exception = catchApiException(callable);
-        return assertReturnCode(304, exception);
+        return assertReturnCode(503, exception);
     }
 
     public static CandlepinStatusAssert assertThatStatus(

--- a/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/ImportSubscriptionServiceAdapter.java
@@ -16,20 +16,16 @@ package org.candlepin.service.impl;
 
 import org.candlepin.dto.manifest.v1.ProductDTO;
 import org.candlepin.dto.manifest.v1.SubscriptionDTO;
-import org.candlepin.exceptions.ServiceUnavailableException;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.model.ConsumerInfo;
-
-import org.xnap.commons.i18n.I18n;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import javax.inject.Inject;
+
 
 /**
  * @author mstead
@@ -38,18 +34,16 @@ public class ImportSubscriptionServiceAdapter implements SubscriptionServiceAdap
 
     private List<SubscriptionDTO> subscriptions;
     private Map<String, SubscriptionDTO> subsBySubId = new HashMap<>();
-    private I18n i18n;
-
-    @Inject
-    public ImportSubscriptionServiceAdapter(I18n i18n) {
-        this(new LinkedList<>());
-    }
 
     public ImportSubscriptionServiceAdapter(List<SubscriptionDTO> subs) {
         this.subscriptions = subs;
         for (SubscriptionDTO sub : this.subscriptions) {
             subsBySubId.put(sub.getId(), sub);
         }
+    }
+
+    public ImportSubscriptionServiceAdapter() {
+        this(new ArrayList<>());
     }
 
     @Override
@@ -74,7 +68,7 @@ public class ImportSubscriptionServiceAdapter implements SubscriptionServiceAdap
 
     @Override
     public Collection<? extends SubscriptionDTO> getSubscriptionsByProductId(String productId) {
-        List<SubscriptionDTO> subs = new LinkedList<>();
+        List<SubscriptionDTO> subs = new ArrayList<>();
 
         if (productId != null) {
             for (SubscriptionDTO sub : this.subscriptions) {
@@ -105,8 +99,7 @@ public class ImportSubscriptionServiceAdapter implements SubscriptionServiceAdap
 
     @Override
     public void activateSubscription(ConsumerInfo consumer, String email, String emailLocale) {
-        throw new ServiceUnavailableException(
-            i18n.tr("Standalone candlepin does not support redeeming a subscription."));
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
- Fixed a NullPointerException (NPE) that occurred when attempting to activate a subscription in standalone mode
- Moved user-facing error message generation for subscription activation out of the adapter domain
- Added a unit and spec test for verifying the correct behavior in standalone mode