### PR TITLE
[M] CANDLEPIN-619: Re-run PR workflow when target branch gets pushed

### DIFF
--- a/.github/actions/rebase/action.yml
+++ b/.github/actions/rebase/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Rebase feature branch with base branch
       shell: bash
       run: |
-        git config --global --add safe.directory /__w/candlepin/candlepin
+        git config --global --add safe.directory $GITHUB_WORKSPACE
         git config --global user.email "ghaction@random.com"
         git config --global user.name "ghaction"
         

--- a/.github/workflows/rerun_workflow_on_push.yml
+++ b/.github/workflows/rerun_workflow_on_push.yml
@@ -1,0 +1,84 @@
+---
+name: Rerun affected workflows in long lived branches on push
+
+on:
+  push:
+    branches:
+      - main
+      - candlepin-*-HOTFIX
+
+jobs:
+  rerun-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mask secrets
+        shell: bash
+        run: |
+          echo "::add-mask::${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Get PR info
+        uses: 8BitJonny/gh-get-current-pr@fa2160116055f6fe10376375892b255f8b2ed8f6
+        id: PR
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Rerun workflows
+        if: ${{ !contains(steps.PR.outputs.pr_labels, 'skip CI') }}
+        shell: bash
+        run: |
+          base_branch="${GITHUB_REF#refs/heads/}"
+          
+          # List affected PRs exclude dependabots, weblate and draft PRs
+          pr_head_shas=$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          /repos/candlepin/candlepin/pulls | \
+          jq --arg base "$base_branch" -r '.[] | select(.base.ref == $base and .draft == false and .user.login != "weblate" and .user.login != "dependabot[bot]") | .head.sha')
+
+          # List runner ids from PRs(only for pr_verification.yml)
+          for head_sha in $pr_head_shas; do
+            runner_id=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/candlepin/candlepin/actions/workflows/pr_verification.yml/runs?head_sha=$head_sha | \
+            jq -r '.workflow_runs[] | .id')
+            runner_ids+=($runner_id)
+          done
+          
+          # Cancel running workflows
+          for id in "${runner_ids[@]}"; do
+            # Get status of running workflow
+            status=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/candlepin/candlepin/actions/runs/$id | \
+            jq -r '.status')
+          
+            # Cancel workflow if it in progress or in queue
+            if [ "$status" = "in_progress" ] || [ "$status" = "queued" ]; then
+              cancelled_ids+=($id)
+              gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              /repos/candlepin/candlepin/actions/runs/$id/cancel
+            fi
+          done
+          
+          # We need to wait here because canceling workflows take some time
+          for id in "${cancelled_ids[@]}"; do
+            while : ; do
+              sleep 2 # We sleep here so we don't overwhelm the GH API
+              status=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              /repos/candlepin/candlepin/actions/runs/$id | \
+              jq -r '.status')
+              [[ $status = "completed" ]] && break
+            done
+          done
+          
+          # Rerun workflows
+          for id in "${runner_ids[@]}"; do 
+            gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/candlepin/candlepin/actions/runs/$id/rerun
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Create a workflow that triggers when a PR is closed, and it will rerun all workflows associated with the affected branch
- Added feature when you mark PR with label `skip CI` it will not rerun affected workflows
- **We need to start again using merge commits, otherwise it doesn't work**