### PR TITLE
[4.3.7] CANDLEPIN-650: Reverted date/time serialization change

### DIFF
--- a/src/main/java/org/candlepin/jackson/OffsetDateTimeDeserializer.java
+++ b/src/main/java/org/candlepin/jackson/OffsetDateTimeDeserializer.java
@@ -25,6 +25,8 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 
+
+
 /**
  * A deserializer that turns ISO 8601 date strings into OffsetDateTime objects, with optional sections.
  * Specifically, it can handle parsing the following formats:
@@ -45,16 +47,17 @@ public class OffsetDateTimeDeserializer extends JsonDeserializer<OffsetDateTime>
 
     public OffsetDateTimeDeserializer() {
         this.formatter = new DateTimeFormatterBuilder()
-              .parseCaseInsensitive()
-              .append(DateTimeFormatter.ISO_LOCAL_DATE)
-              .optionalStart().appendLiteral('T').optionalEnd()
-              .optionalStart().appendLiteral(' ').optionalEnd()
-              .appendOptional(DateTimeFormatter.ISO_LOCAL_TIME)
-              .optionalStart().appendOffset("+HHMM", "+0000").optionalEnd()
-              .optionalStart().appendOffset("+HH:MM", "+00:00").optionalEnd()
-              .optionalStart().appendOffset("+HH", "+00").optionalEnd()
-              .optionalStart().appendZoneId().optionalEnd()
-              .toFormatter();
+            .parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .optionalStart().appendLiteral('T').optionalEnd()
+            .optionalStart().appendLiteral(' ').optionalEnd()
+            .appendOptional(DateTimeFormatter.ISO_LOCAL_TIME)
+            .optionalStart().appendOffset("+HHMM", "+0000").optionalEnd()
+            .optionalStart().appendOffset("+HH:MM", "+00:00").optionalEnd()
+            .optionalStart().appendOffset("+HH", "+00").optionalEnd()
+            .optionalStart().appendOffset("+Hmmss", "Z").optionalEnd()
+            .optionalStart().appendOffsetId().optionalEnd()
+            .toFormatter();
     }
 
     /**

--- a/src/main/java/org/candlepin/jackson/OffsetDateTimeSerializer.java
+++ b/src/main/java/org/candlepin/jackson/OffsetDateTimeSerializer.java
@@ -24,6 +24,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 
+
 /**
  * OffsetDateTimeSerializer
  * This serializer removes milliseconds from OffsetDateTime objects in order to be more
@@ -36,7 +37,7 @@ public class OffsetDateTimeSerializer extends JsonSerializer<OffsetDateTime> {
 
     public OffsetDateTimeSerializer() {
         // This DateTimeFormatter pattern is ISO 8601 without milliseconds
-        this.dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssxxx");
+        this.dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
     }
 
     @Override

--- a/src/test/java/org/candlepin/jackson/OffsetDateTimeDeserializerTest.java
+++ b/src/test/java/org/candlepin/jackson/OffsetDateTimeDeserializerTest.java
@@ -15,6 +15,7 @@
 package org.candlepin.jackson;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,6 +26,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+
 
 
 public class OffsetDateTimeDeserializerTest {
@@ -93,6 +96,12 @@ public class OffsetDateTimeDeserializerTest {
         when(parser.getText()).thenReturn("2021-01-24");
         OffsetDateTime dateTime = deserializer.deserialize(parser, null);
         assertEquals("2021-01-24T00:00Z", dateTime.toString());
+    }
+
+    @Test
+    public void testDateTimeWithMalformedOffset() throws IOException {
+        when(parser.getText()).thenReturn("2021-01-24T13:30:30.382Junk");
+        assertThrows(DateTimeParseException.class, () -> deserializer.deserialize(parser, null));
     }
 
 }

--- a/src/test/java/org/candlepin/jackson/OffsetDateTimeSerializerTest.java
+++ b/src/test/java/org/candlepin/jackson/OffsetDateTimeSerializerTest.java
@@ -26,6 +26,7 @@ import java.io.StringWriter;
 import java.time.OffsetDateTime;
 
 
+
 /**
  * Basic test for OffsetDateTimeSerializer
  */
@@ -40,6 +41,6 @@ public class OffsetDateTimeSerializerTest {
         OffsetDateTime dateTime = OffsetDateTime.parse("2021-01-24T13:30:30.382+01:00");
         serializer.serialize(dateTime, jsonGenerator, null);
         jsonGenerator.flush();
-        assertEquals("\"2021-01-24T13:30:30+01:00\"", stringWriter.toString());
+        assertEquals("\"2021-01-24T13:30:30+0100\"", stringWriter.toString());
     }
 }


### PR DESCRIPTION
- Reverted a change that modified the way date/time fields with timezone offset were serialized such that it no longer includes the optional colon in the timezone offset
- Updated the date/time deserializer to no longer accept arbitrary timezone IDs (such as "America/New York", or "UTC") in place of a proper timezone offset, or the zero-offset specifier ("Z")
- Added an additional test to check that an exception is thrown when a malformed timezone offset is received