### PR TITLE
[4.3.7] Disallow creating consumers in org without permission

### DIFF
--- a/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
@@ -69,7 +69,7 @@ public class UsernameConsumersPermission implements Permission, Serializable {
         // Implied create access to the owner's consumers collection, which includes
         // read as well:
         if (target.getClass().equals(Owner.class) && subResource.equals(SubResource.CONSUMERS) &&
-            Access.CREATE.provides(required)) {
+            Access.CREATE.provides(required) && ((Owner) target).getId().equals(owner.getId())) {
             return true;
         }
 


### PR DESCRIPTION
- This issue allowed a user that has no 'create consumer' permission in a certain org, to create consumers in it, if they could guess the organization key.