### PR TITLE
[F] CANDLEPIN-675: Update anon cloud consumers to store multiple SKUs

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
@@ -46,6 +46,7 @@ import org.candlepin.spec.bootstrap.data.util.StringUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.junit.jupiter.api.Test;
@@ -54,7 +55,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Base64;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -132,7 +135,7 @@ class CloudRegistrationSpecTest {
         String instanceId = StringUtil.random("cloud-instance-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, prod.getId());
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(prod.getId()));
         associateOwnerToCloudAccount(adminClient, accountId, owner.getKey());
 
         String metadata = buildMetadataJson(adminClient.MAPPER, accountId, instanceId, offerId);
@@ -161,7 +164,7 @@ class CloudRegistrationSpecTest {
         String instanceId = StringUtil.random("cloud-instance-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, prod.getId());
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(prod.getId()));
         associateOwnerToCloudAccount(adminClient, accountId, owner.getKey());
 
         String metadata = buildMetadataJson(adminClient.MAPPER, accountId, instanceId, offerId);
@@ -187,7 +190,7 @@ class CloudRegistrationSpecTest {
         String instanceId = StringUtil.random("cloud-instance-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, StringUtil.random("prod-"));
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(StringUtil.random("prod-")));
         associateOwnerToCloudAccount(adminClient, accountId, owner.getKey());
 
         String metadata = buildMetadataJson(adminClient.MAPPER, accountId, instanceId, offerId);
@@ -210,7 +213,7 @@ class CloudRegistrationSpecTest {
         String instanceId = StringUtil.random("cloud-instance-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, StringUtil.random("prod-"));
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(StringUtil.random("prod-")));
 
         String metadata = buildMetadataJson(adminClient.MAPPER, accountId, instanceId, offerId);
 
@@ -236,7 +239,7 @@ class CloudRegistrationSpecTest {
         String instanceId = StringUtil.random("cloud-instance-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, prod.getId());
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(prod.getId()));
         associateOwnerToCloudAccount(adminClient, accountId, owner.getKey());
 
         String metadata = buildMetadataJson(adminClient.MAPPER, accountId, instanceId, offerId);
@@ -261,11 +264,17 @@ class CloudRegistrationSpecTest {
         adminClient.hosted().createProduct(prod);
         adminClient.hosted().createSubscription(Subscriptions.random(owner, prod));
 
+        ProductDTO prodWithPool = adminClient.ownerProducts()
+            .createProductByOwner(owner.getKey(), Products.random());
+        adminClient.hosted().createProduct(prodWithPool);
+        adminClient.owners().createPool(owner.getKey(), Pools.random(prodWithPool));
+        adminClient.hosted().createSubscription(Subscriptions.random(owner, prodWithPool));
+
         String accountId = StringUtil.random("cloud-account-id-");
         String instanceId = StringUtil.random("cloud-instance-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, prod.getId());
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(prod.getId(), prodWithPool.getId()));
         associateOwnerToCloudAccount(adminClient, accountId, owner.getKey());
 
         String metadata = buildMetadataJson(adminClient.MAPPER, accountId, instanceId, offerId);
@@ -290,7 +299,7 @@ class CloudRegistrationSpecTest {
         String instanceId = StringUtil.random("cloud-instance-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, StringUtil.random("prod-"));
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(StringUtil.random("prod-")));
         associateOwnerToCloudAccount(adminClient, accountId, owner.getKey());
 
         String metadata = buildMetadataJson(adminClient.MAPPER, accountId, instanceId, offerId);
@@ -318,7 +327,7 @@ class CloudRegistrationSpecTest {
         String instanceId = StringUtil.random("cloud-instance-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, prod.getId());
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(prod.getId()));
 
         String metadata = buildMetadataJson(adminClient.MAPPER, null, instanceId, offerId);
 
@@ -335,7 +344,7 @@ class CloudRegistrationSpecTest {
         String cloudAccountId = StringUtil.random("cloud-account-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, prod.getId());
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(prod.getId()));
 
         String metadata = buildMetadataJson(adminClient.MAPPER, cloudAccountId, null, offerId);
 
@@ -391,7 +400,7 @@ class CloudRegistrationSpecTest {
         String instanceId = StringUtil.random("cloud-instance-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, StringUtil.random("prod-"));
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(StringUtil.random("prod-")));
         associateOwnerToCloudAccount(adminClient, accountId, owner.getKey());
 
         String metadata = buildMetadataJson(adminClient.MAPPER, accountId, instanceId, offerId);
@@ -426,7 +435,7 @@ class CloudRegistrationSpecTest {
         String instanceId = StringUtil.random("cloud-instance-id-");
         String offerId = StringUtil.random("cloud-offer-");
 
-        associateProductIdToCloudOffer(adminClient, offerId, StringUtil.random("prod-"));
+        associateProductIdToCloudOffer(adminClient, offerId, List.of(StringUtil.random("prod-")));
         associateOwnerToCloudAccount(adminClient, accountId, owner.getKey());
 
         String metadata = buildMetadataJson(adminClient.MAPPER, accountId, instanceId, offerId);
@@ -446,7 +455,7 @@ class CloudRegistrationSpecTest {
     }
 
     /**
-     * Associates a cloud offering ID to a product ID in the hosted test adapters.
+     * Associates a cloud offering ID to product IDs in the hosted test adapters.
      *
      * @param client
      *     client used to make the request to the hosted test endpoint
@@ -454,13 +463,17 @@ class CloudRegistrationSpecTest {
      * @param cloudOfferId
      *     the offering ID to associate to a product ID
      *
-     * @param productId
-     *     the product ID to associate to an offering ID
+     * @param productIds
+     *     the product IDs to associate to an offering ID
      */
-    private void associateProductIdToCloudOffer(ApiClient client, String cloudOfferId, String productId) {
+    private void associateProductIdToCloudOffer(ApiClient client, String cloudOfferId,
+        Collection<String> productIds) {
         ObjectNode objectNode = ApiClient.MAPPER.createObjectNode();
         objectNode.put("cloudOfferId", cloudOfferId);
-        objectNode.put("productId", productId);
+
+        ArrayNode productsNode = ApiClient.MAPPER.createArrayNode();
+        productIds.forEach(prod -> productsNode.add(prod));
+        objectNode.putPOJO("productIds", productsNode);
 
         Response response = Request.from(client)
             .setPath("/hostedtest/cloud/offers")

--- a/src/main/java/org/candlepin/hostedtest/HostedTestDataStore.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestDataStore.java
@@ -83,7 +83,7 @@ public class HostedTestDataStore {
     protected Map<String, Set<String>> productProductMap;
     protected Map<String, Set<String>> productSubscriptionMap;
 
-    protected Map<String, String> cloudOfferIdToProductId;
+    protected Map<String, Set<String>> cloudOfferIdToProductIds;
     protected Map<String, String> cloudAccountIdToOwnerKey;
 
     /**
@@ -102,7 +102,7 @@ public class HostedTestDataStore {
         this.productProductMap = new ConcurrentHashMap<>();
         this.productSubscriptionMap = new ConcurrentHashMap<>();
 
-        this.cloudOfferIdToProductId = new ConcurrentHashMap<>();
+        this.cloudOfferIdToProductIds = new ConcurrentHashMap<>();
         this.cloudAccountIdToOwnerKey = new ConcurrentHashMap<>();
     }
 
@@ -970,13 +970,14 @@ public class HostedTestDataStore {
         return null;
     }
 
-    protected void setProductIdForCloudOfferId(String cloudOfferId,
-        String productId) {
-        cloudOfferIdToProductId.put(cloudOfferId, productId);
+    protected void setProductIdsForCloudOfferId(String cloudOfferId,
+        Collection<String> productIds) {
+
+        cloudOfferIdToProductIds.put(cloudOfferId, new HashSet<String>(productIds));
     }
 
-    protected String getProductIdForOfferId(String cloudOfferId) {
-        return cloudOfferIdToProductId.get(cloudOfferId);
+    protected Set<String> getProductIdsForOfferId(String cloudOfferId) {
+        return cloudOfferIdToProductIds.get(cloudOfferId);
     }
 
     protected void setCloudAccountIdForOwnerKey(String cloudAccountId,
@@ -998,7 +999,7 @@ public class HostedTestDataStore {
         this.contentMap.clear();
         this.contentProductMap.clear();
         this.productSubscriptionMap.clear();
-        this.cloudOfferIdToProductId.clear();
+        this.cloudOfferIdToProductIds.clear();
         this.cloudAccountIdToOwnerKey.clear();
     }
 

--- a/src/main/java/org/candlepin/hostedtest/HostedTestResource.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestResource.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -757,12 +758,15 @@ public class HostedTestResource {
             throw new BadRequestException("cloud offer ID is null");
         }
 
-        String productId = root.get("productId").asText();
-        if (productId == null) {
-            throw new BadRequestException("product ID is null");
+        JsonNode productIdsNode = root.get("productIds");
+        if (productIdsNode == null) {
+            throw new BadRequestException("productIds is null");
         }
 
-        this.datastore.setProductIdForCloudOfferId(offerId, productId);
+        List<String> productIds = new ArrayList<>();
+        productIdsNode.elements().forEachRemaining(prod -> productIds.add(prod.asText()));
+
+        this.datastore.setProductIdsForCloudOfferId(offerId, productIds);
     }
 
     @POST

--- a/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
+++ b/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.Objects;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.MediaType;
@@ -204,8 +205,9 @@ public class CloudRegistrationResource implements CloudRegistrationApi {
         String anonymousConsumerUuid = null;
         if (!createAnonConsumer) {
             anonymousConsumerUuid = existingAnonConsumer == null ? null : existingAnonConsumer.getUuid();
-            boolean ownerAndPoolExists = poolCurator.hasPoolForProduct(ownerKey, authResult.getProductId());
-            if ((!ownerAndPoolExists && existingAnonConsumer == null)) {
+            boolean ownerAndPoolsExists = poolCurator
+                .hasPoolsForProducts(ownerKey, authResult.getProductIds());
+            if ((!ownerAndPoolsExists && existingAnonConsumer == null)) {
                 createAnonConsumer = true;
             }
         }
@@ -214,7 +216,7 @@ public class CloudRegistrationResource implements CloudRegistrationApi {
             AnonymousCloudConsumer createdAnonConsumer = new AnonymousCloudConsumer()
                 .setCloudAccountId(authResult.getCloudAccountId())
                 .setCloudInstanceId(authResult.getCloudInstanceId())
-                .setProductId(authResult.getProductId())
+                .setProductIds(authResult.getProductIds())
                 .setCloudProviderShortName(authResult.getCloudProvider().shortName());
 
             createdAnonConsumer = anonymousCloudConsumerCurator.create(createdAnonConsumer);
@@ -283,12 +285,13 @@ public class CloudRegistrationResource implements CloudRegistrationApi {
             throw new CloudRegistrationAuthorizationException(errmsg);
         }
 
-        String productId = result.getProductId();
-        if (productId == null || productId.isBlank()) {
-            String errmsg = this.i18n.tr("product ID could not be resolved");
+        Set<String> productIds = result.getProductIds();
+        if (productIds == null || productIds.isEmpty()) {
+            String errmsg = this.i18n.tr("product IDs could not be resolved");
 
             throw new CloudRegistrationAuthorizationException(errmsg);
         }
+
     }
 
 }

--- a/src/main/java/org/candlepin/service/model/CloudAuthenticationResult.java
+++ b/src/main/java/org/candlepin/service/model/CloudAuthenticationResult.java
@@ -16,6 +16,8 @@ package org.candlepin.service.model;
 
 import org.candlepin.service.CloudProvider;
 
+import java.util.Set;
+
 
 
 /**
@@ -51,10 +53,10 @@ public interface CloudAuthenticationResult {
     String getOfferId();
 
     /**
-     * @return the product ID that is associated to the cloud offering ID that is found in the
+     * @return the product IDs that are associated to the cloud offering ID that is found in the
      * {@link CloudRegistrationInfo} metadata
      */
-    String getProductId();
+    Set<String> getProductIds();
 
     /**
      * @return true if the owner is entitled to the product associated to the cloud offering ID found in

--- a/src/main/resources/db/changelog/20230803000000-create-anonymous-consumers.xml
+++ b/src/main/resources/db/changelog/20230803000000-create-anonymous-consumers.xml
@@ -25,7 +25,7 @@
             <column name="cloud_provider_short_name" type="varchar(15)">
                 <constraints nullable="false"/>
             </column>
-            <column name="product_id" type="varchar(32)">
+            <column name="product_ids" type="TEXT">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/src/test/java/org/candlepin/auth/AnonymousCloudConsumerPrincipalTest.java
+++ b/src/test/java/org/candlepin/auth/AnonymousCloudConsumerPrincipalTest.java
@@ -44,7 +44,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPrincipal principal = new AnonymousCloudConsumerPrincipal(consumer);
@@ -61,7 +61,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPrincipal principal = new AnonymousCloudConsumerPrincipal(consumer);
@@ -77,7 +77,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPrincipal principal = new AnonymousCloudConsumerPrincipal(consumer);
@@ -93,7 +93,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPrincipal principal = new AnonymousCloudConsumerPrincipal(consumer);
@@ -108,7 +108,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPrincipal principal = new AnonymousCloudConsumerPrincipal(consumer);
@@ -124,7 +124,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPrincipal principal = new AnonymousCloudConsumerPrincipal(consumer);
@@ -139,7 +139,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPrincipal principal = new AnonymousCloudConsumerPrincipal(consumer);
@@ -154,7 +154,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPrincipal principal = new AnonymousCloudConsumerPrincipal(consumer);
@@ -169,7 +169,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPrincipal principal = new AnonymousCloudConsumerPrincipal(consumer);
@@ -184,7 +184,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumer consumer2 = new AnonymousCloudConsumer()
@@ -192,7 +192,7 @@ public class AnonymousCloudConsumerPrincipalTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPrincipal principal1 = new AnonymousCloudConsumerPrincipal(consumer1);

--- a/src/test/java/org/candlepin/auth/AnonymousCloudRegistrationAuthTest.java
+++ b/src/test/java/org/candlepin/auth/AnonymousCloudRegistrationAuthTest.java
@@ -51,6 +51,7 @@ import org.mockito.quality.Strictness;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
 
 
@@ -304,7 +305,7 @@ public class AnonymousCloudRegistrationAuthTest {
             .setUuid(anonymousConsumerUuid)
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         doReturn(consumer).when(anonymousCloudConsumerCurator).getByUuid(anonymousConsumerUuid);

--- a/src/test/java/org/candlepin/auth/permissions/AnonymousCloudConsumerPermissionTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/AnonymousCloudConsumerPermissionTest.java
@@ -44,7 +44,7 @@ public class AnonymousCloudConsumerPermissionTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPermission permission = new AnonymousCloudConsumerPermission(consumer);
@@ -77,7 +77,7 @@ public class AnonymousCloudConsumerPermissionTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPermission permission = new AnonymousCloudConsumerPermission(consumer);
@@ -92,7 +92,7 @@ public class AnonymousCloudConsumerPermissionTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumer consumer2 = new AnonymousCloudConsumer()
@@ -100,7 +100,7 @@ public class AnonymousCloudConsumerPermissionTest {
             .setUuid("uuid2")
             .setCloudAccountId("cloudAccountId2")
             .setCloudInstanceId("instanceId2")
-            .setProductId("productId2")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPermission permission = new AnonymousCloudConsumerPermission(consumer1);
@@ -115,7 +115,7 @@ public class AnonymousCloudConsumerPermissionTest {
             .setUuid("uuid")
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         AnonymousCloudConsumerPermission permission = new AnonymousCloudConsumerPermission(consumer);

--- a/src/test/java/org/candlepin/model/AnonymousCloudConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/AnonymousCloudConsumerCuratorTest.java
@@ -14,7 +14,9 @@
  */
 package org.candlepin.model;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.collection;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.candlepin.test.DatabaseTestFixture;
@@ -38,10 +40,11 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testCreate() throws Exception {
+        String expectedProductId = "productId";
         AnonymousCloudConsumer expected = new AnonymousCloudConsumer()
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of(expectedProductId))
             .setCloudProviderShortName("shortName");
 
         this.anonymousCloudConsumerCurator.create(expected);
@@ -54,7 +57,8 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
             .returns(expected.getCloudAccountId(), AnonymousCloudConsumer::getCloudAccountId)
             .returns(expected.getCloudInstanceId(), AnonymousCloudConsumer::getCloudInstanceId)
             .returns(expected.getCloudProviderShortName(), AnonymousCloudConsumer::getCloudProviderShortName)
-            .returns(expected.getProductId(), AnonymousCloudConsumer::getProductId);
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProductId);
     }
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
@@ -64,7 +68,7 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
         AnonymousCloudConsumer expected = new AnonymousCloudConsumer()
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         this.anonymousCloudConsumerCurator.create(expected);
@@ -79,7 +83,7 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
         AnonymousCloudConsumer expected = new AnonymousCloudConsumer()
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
         this.anonymousCloudConsumerCurator.create(expected);
 
@@ -90,10 +94,11 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testGetByUuidWithExistingUuid() {
+        String expectedProductId = "productId";
         AnonymousCloudConsumer expected = new AnonymousCloudConsumer()
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of(expectedProductId))
             .setCloudProviderShortName("shortName");
         this.anonymousCloudConsumerCurator.create(expected);
 
@@ -106,7 +111,8 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
             .returns(expected.getCloudAccountId(), AnonymousCloudConsumer::getCloudAccountId)
             .returns(expected.getCloudInstanceId(), AnonymousCloudConsumer::getCloudInstanceId)
             .returns(expected.getCloudProviderShortName(), AnonymousCloudConsumer::getCloudProviderShortName)
-            .returns(expected.getProductId(), AnonymousCloudConsumer::getProductId);
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProductId);
     }
 
     @Test
@@ -129,17 +135,18 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testGetByUuidsWithExistingAnonymousCloudConsumer() {
+        String expectedProductId = "productId";
         AnonymousCloudConsumer expected = new AnonymousCloudConsumer()
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of(expectedProductId))
             .setCloudProviderShortName("shortName");
         expected = this.anonymousCloudConsumerCurator.create(expected);
 
         AnonymousCloudConsumer other = new AnonymousCloudConsumer()
             .setCloudAccountId("otherCloudAccountId")
             .setCloudInstanceId("otherInstanceId")
-            .setProductId("otherProductId")
+            .setProductIds(List.of("otherProductId"))
             .setCloudProviderShortName("shortName");
         other = this.anonymousCloudConsumerCurator.create(other);
 
@@ -153,7 +160,8 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
             .returns(expected.getCloudAccountId(), AnonymousCloudConsumer::getCloudAccountId)
             .returns(expected.getCloudInstanceId(), AnonymousCloudConsumer::getCloudInstanceId)
             .returns(expected.getCloudProviderShortName(), AnonymousCloudConsumer::getCloudProviderShortName)
-            .returns(expected.getProductId(), AnonymousCloudConsumer::getProductId);
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProductId);
     }
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
@@ -163,7 +171,7 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
         AnonymousCloudConsumer expected = new AnonymousCloudConsumer()
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
 
         this.anonymousCloudConsumerCurator.create(expected);
@@ -176,10 +184,11 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testGetByCloudInstanceIdWithExistingInstanceId() {
+        String expectedProductId = "productId";
         AnonymousCloudConsumer expected = new AnonymousCloudConsumer()
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of(expectedProductId))
             .setCloudProviderShortName("shortName");
         this.anonymousCloudConsumerCurator.create(expected);
 
@@ -193,7 +202,8 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
             .returns(expected.getCloudAccountId(), AnonymousCloudConsumer::getCloudAccountId)
             .returns(expected.getCloudInstanceId(), AnonymousCloudConsumer::getCloudInstanceId)
             .returns(expected.getCloudProviderShortName(), AnonymousCloudConsumer::getCloudProviderShortName)
-            .returns(expected.getProductId(), AnonymousCloudConsumer::getProductId);
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProductId);
     }
 
     @Test
@@ -201,7 +211,7 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
         AnonymousCloudConsumer expected = new AnonymousCloudConsumer()
             .setCloudAccountId("cloudAccountId")
             .setCloudInstanceId("instanceId")
-            .setProductId("productId")
+            .setProductIds(List.of("productId"))
             .setCloudProviderShortName("shortName");
         this.anonymousCloudConsumerCurator.create(expected);
 

--- a/src/test/java/org/candlepin/model/AnonymousCloudConsumerTest.java
+++ b/src/test/java/org/candlepin/model/AnonymousCloudConsumerTest.java
@@ -14,8 +14,9 @@
  */
 package org.candlepin.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.collection;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.candlepin.test.DatabaseTestFixture;
@@ -24,6 +25,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.validation.ConstraintViolationException;
 
@@ -40,23 +44,26 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
             .setCloudAccountId(expectedCloudAccountId)
             .setCloudInstanceId(expectedInstanceId)
-            .setProductId(expectedProductId)
+            .setProductIds(List.of(expectedProductId))
             .setCloudProviderShortName(expectedCloudProviderShortName);
 
         AnonymousCloudConsumer actual = anonymousCloudConsumerCurator.create(consumer);
 
-        assertNotNull(actual.getId());
-        assertNotNull(actual.getUuid());
-        assertEquals(expectedCloudAccountId, actual.getCloudAccountId());
-        assertEquals(expectedInstanceId, actual.getCloudInstanceId());
-        assertEquals(expectedProductId, actual.getProductId());
-        assertEquals(expectedCloudProviderShortName, actual.getCloudProviderShortName());
+        assertThat(actual)
+            .isNotNull()
+            .doesNotReturn(null, AnonymousCloudConsumer::getId)
+            .doesNotReturn(null, AnonymousCloudConsumer::getUuid)
+            .returns(expectedCloudAccountId, AnonymousCloudConsumer::getCloudAccountId)
+            .returns(expectedInstanceId, AnonymousCloudConsumer::getCloudInstanceId)
+            .returns(expectedCloudProviderShortName, AnonymousCloudConsumer::getCloudProviderShortName)
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProductId);
     }
 
     @Test
     public void testCloudAccountIdFieldRequired() throws Exception {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
-            .setProductId("product-id")
+            .setProductIds(List.of("product-id"))
             .setCloudInstanceId("instance-id")
             .setCloudProviderShortName("AWS");
 
@@ -68,7 +75,7 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
     public void testCloudInstanceIdFieldRequired() throws Exception {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
             .setCloudAccountId("cloud-account-id")
-            .setProductId("product-id")
+            .setProductIds(List.of("product-id"))
             .setCloudProviderShortName("AWS");
 
         assertThrows(ConstraintViolationException.class,
@@ -76,7 +83,7 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testProductIdFieldRequired() throws Exception {
+    public void testProductIdsFieldRequired() throws Exception {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
             .setCloudAccountId("cloud-account-id")
             .setCloudInstanceId("instance-id")
@@ -91,7 +98,7 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
             .setCloudAccountId("cloud-account-id")
             .setCloudInstanceId("instance-id")
-            .setProductId("product-id");
+            .setProductIds(List.of("product-id"));
 
         assertThrows(ConstraintViolationException.class,
             () -> anonymousCloudConsumerCurator.create(consumer));
@@ -140,7 +147,7 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
             .setCloudAccountId(expectedCloudAccountId)
             .setCloudInstanceId(expectedInstanceId)
-            .setProductId(expectedProductId)
+            .setProductIds(List.of(expectedProductId))
             .setCloudProviderShortName(expectedCloudProviderShortName);
 
         consumer = anonymousCloudConsumerCurator.create(consumer);
@@ -149,12 +156,15 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
 
         AnonymousCloudConsumer actual = anonymousCloudConsumerCurator.merge(consumer);
 
-        assertNotNull(actual.getId());
-        assertEquals(expectedUuid, actual.getUuid());
-        assertEquals(expectedCloudAccountId, actual.getCloudAccountId());
-        assertEquals(expectedInstanceId, actual.getCloudInstanceId());
-        assertEquals(expectedProductId, actual.getProductId());
-        assertEquals(expectedCloudProviderShortName, actual.getCloudProviderShortName());
+        assertThat(actual)
+            .isNotNull()
+            .doesNotReturn(null, AnonymousCloudConsumer::getId)
+            .returns(expectedUuid, AnonymousCloudConsumer::getUuid)
+            .returns(expectedCloudAccountId, AnonymousCloudConsumer::getCloudAccountId)
+            .returns(expectedInstanceId, AnonymousCloudConsumer::getCloudInstanceId)
+            .returns(expectedCloudProviderShortName, AnonymousCloudConsumer::getCloudProviderShortName)
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProductId);
     }
 
     @Test
@@ -180,7 +190,7 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
             .setCloudAccountId("initial-cloud-account-id")
             .setCloudInstanceId("instance-id")
-            .setProductId(expectedProductId)
+            .setProductIds(List.of(expectedProductId))
             .setCloudProviderShortName(expectedCloudProviderShortName);
 
         consumer = anonymousCloudConsumerCurator.create(consumer);
@@ -189,12 +199,15 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
 
         AnonymousCloudConsumer actual = anonymousCloudConsumerCurator.merge(consumer);
 
-        assertNotNull(actual.getId());
-        assertEquals(consumer.getUuid(), actual.getUuid());
-        assertEquals(expectedCloudAccountId, actual.getCloudAccountId());
-        assertEquals(expectedInstanceId, actual.getCloudInstanceId());
-        assertEquals(expectedProductId, actual.getProductId());
-        assertEquals(expectedCloudProviderShortName, actual.getCloudProviderShortName());
+        assertThat(actual)
+            .isNotNull()
+            .doesNotReturn(null, AnonymousCloudConsumer::getId)
+            .returns(consumer.getUuid(), AnonymousCloudConsumer::getUuid)
+            .returns(expectedCloudAccountId, AnonymousCloudConsumer::getCloudAccountId)
+            .returns(expectedInstanceId, AnonymousCloudConsumer::getCloudInstanceId)
+            .returns(expectedCloudProviderShortName, AnonymousCloudConsumer::getCloudProviderShortName)
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProductId);
     }
 
     @Test
@@ -220,7 +233,7 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
             .setCloudAccountId(expectedCloudAccountId)
             .setCloudInstanceId("init-instance-id")
-            .setProductId(expectedProductId)
+            .setProductIds(List.of(expectedProductId))
             .setCloudProviderShortName(expectedCloudProviderShortName);
 
         consumer = anonymousCloudConsumerCurator.create(consumer);
@@ -229,52 +242,80 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
 
         AnonymousCloudConsumer actual = anonymousCloudConsumerCurator.merge(consumer);
 
-        assertNotNull(actual.getId());
-        assertEquals(consumer.getUuid(), actual.getUuid());
-        assertEquals(expectedCloudAccountId, actual.getCloudAccountId());
-        assertEquals(expectedInstanceId, actual.getCloudInstanceId());
-        assertEquals(expectedProductId, actual.getProductId());
-        assertEquals(expectedCloudProviderShortName, actual.getCloudProviderShortName());
+        assertThat(actual)
+            .isNotNull()
+            .doesNotReturn(null, AnonymousCloudConsumer::getId)
+            .returns(consumer.getUuid(), AnonymousCloudConsumer::getUuid)
+            .returns(expectedCloudAccountId, AnonymousCloudConsumer::getCloudAccountId)
+            .returns(expectedInstanceId, AnonymousCloudConsumer::getCloudInstanceId)
+            .returns(expectedCloudProviderShortName, AnonymousCloudConsumer::getCloudProviderShortName)
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProductId);
     }
 
     @Test
-    public void testSetProductIdWithNull() {
+    public void testSetProductIdsWithNull() {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer();
 
-        assertThrows(IllegalArgumentException.class, () -> consumer.setProductId(null));
+        assertThrows(IllegalArgumentException.class, () -> consumer.setProductIds(null));
     }
 
     @Test
-    public void testSetProductIdWithGreaterThanMaxLength() {
-        String productId = generateString(AnonymousCloudConsumer.PRODUCT_ID_MAX_LENGTH + 1);
+    public void testSetProductIdsWithEmptyList() {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer();
 
-        assertThrows(IllegalArgumentException.class, () -> consumer.setProductId(productId));
+        assertThrows(IllegalArgumentException.class, () -> consumer.setProductIds(List.of()));
     }
 
     @Test
-    public void testUpdateToProductId() {
+    public void testSetProductIdsWithNullAndBlankValues() {
+        String expectedProdId = "prod-id";
+        List<String> productIds = new ArrayList<>();
+        productIds.add(expectedProdId);
+        productIds.add(null);
+        productIds.add("");
+        productIds.add("  ");
+
+        AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
+            .setCloudAccountId("account-id")
+            .setCloudInstanceId("instance-id")
+            .setProductIds(productIds)
+            .setCloudProviderShortName("short-name");
+
+        consumer = anonymousCloudConsumerCurator.create(consumer);
+
+        assertThat(consumer)
+            .isNotNull()
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProdId);
+    }
+
+    @Test
+    public void testUpdateToProductIds() {
         String expectedCloudAccountId = "cloud-account-id";
         String expectedInstanceId = "instance-id";
         String expectedCloudProviderShortName = "AWS";
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
             .setCloudAccountId(expectedCloudAccountId)
             .setCloudInstanceId("instance-id")
-            .setProductId("init-prod-id")
+            .setProductIds(List.of("init-prod-id"))
             .setCloudProviderShortName(expectedCloudProviderShortName);
 
         consumer = anonymousCloudConsumerCurator.create(consumer);
         String expectedProductId = "product-id";
-        consumer.setProductId(expectedProductId);
+        consumer.setProductIds(List.of(expectedProductId));
 
         AnonymousCloudConsumer actual = anonymousCloudConsumerCurator.merge(consumer);
 
-        assertNotNull(actual.getId());
-        assertEquals(consumer.getUuid(), actual.getUuid());
-        assertEquals(expectedCloudAccountId, actual.getCloudAccountId());
-        assertEquals(expectedInstanceId, actual.getCloudInstanceId());
-        assertEquals(expectedProductId, actual.getProductId());
-        assertEquals(expectedCloudProviderShortName, actual.getCloudProviderShortName());
+        assertThat(actual)
+            .isNotNull()
+            .doesNotReturn(null, AnonymousCloudConsumer::getId)
+            .returns(consumer.getUuid(), AnonymousCloudConsumer::getUuid)
+            .returns(expectedCloudAccountId, AnonymousCloudConsumer::getCloudAccountId)
+            .returns(expectedInstanceId, AnonymousCloudConsumer::getCloudInstanceId)
+            .returns(expectedCloudProviderShortName, AnonymousCloudConsumer::getCloudProviderShortName)
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProductId);
     }
 
     @Test
@@ -301,7 +342,7 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
             .setCloudAccountId(expectedCloudAccountId)
             .setCloudInstanceId(expectedInstanceId)
-            .setProductId(expectedProductId)
+            .setProductIds(List.of(expectedProductId))
             .setCloudProviderShortName("AWS");
 
         consumer = anonymousCloudConsumerCurator.create(consumer);
@@ -310,12 +351,15 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
 
         AnonymousCloudConsumer actual = anonymousCloudConsumerCurator.merge(consumer);
 
-        assertNotNull(actual.getId());
-        assertEquals(consumer.getUuid(), actual.getUuid());
-        assertEquals(expectedCloudAccountId, actual.getCloudAccountId());
-        assertEquals(expectedInstanceId, actual.getCloudInstanceId());
-        assertEquals(expectedProductId, actual.getProductId());
-        assertEquals(expectedCloudProviderShortName, actual.getCloudProviderShortName());
+        assertThat(actual)
+            .isNotNull()
+            .doesNotReturn(null, AnonymousCloudConsumer::getId)
+            .returns(consumer.getUuid(), AnonymousCloudConsumer::getUuid)
+            .returns(expectedCloudAccountId, AnonymousCloudConsumer::getCloudAccountId)
+            .returns(expectedInstanceId, AnonymousCloudConsumer::getCloudInstanceId)
+            .returns(expectedCloudProviderShortName, AnonymousCloudConsumer::getCloudProviderShortName)
+            .extracting(AnonymousCloudConsumer::getProductIds, as(collection(String.class)))
+            .containsExactly(expectedProductId);
     }
 
     private String generateString(int length) {

--- a/src/test/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilterTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/VerifyAuthorizationFilterTest.java
@@ -236,7 +236,7 @@ public class VerifyAuthorizationFilterTest extends DatabaseTestFixture {
             .setCloudAccountId("account-id")
             .setCloudInstanceId("instance-id")
             .setCloudProviderShortName("short-name")
-            .setProductId("product-id");
+            .setProductIds(List.of("product-id"));
         consumer = this.anonymousCloudConsumerCurator.create(consumer);
 
         String uri = "http://localhost/candlepin/fake/multiValueVerify/" + consumer.getUuid();
@@ -292,7 +292,7 @@ public class VerifyAuthorizationFilterTest extends DatabaseTestFixture {
             .setCloudAccountId("account-id")
             .setCloudInstanceId("instance-id")
             .setCloudProviderShortName("short-name")
-            .setProductId("product-id");
+            .setProductIds(List.of("product-id"));
         consumer = this.anonymousCloudConsumerCurator.create(consumer);
         mockPathParameters.addAll("uuid", List.of(consumer.getUuid(), Util.generateUUID()));
 


### PR DESCRIPTION
- updated cloud offering hosted test endpoint to use multiple products
- PoolCurator.hasPoolForProduct updated to check pools for multiple products