### PR TITLE
Gradle Wrapper auto-update workflow

### DIFF
--- a/.github/workflows/gradle_wrapper_update.yml
+++ b/.github/workflows/gradle_wrapper_update.yml
@@ -1,0 +1,18 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Every midnight UTC
+  workflow_dispatch:
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1
+        with:
+          repo-token: ${{ secrets.AUTOASSIGNREVIEWERSECRET }}

--- a/build.gradle
+++ b/build.gradle
@@ -332,7 +332,7 @@ sonar {
 }
 
 wrapper {
-    distributionType = Wrapper.DistributionType.ALL
+    distributionType = Wrapper.DistributionType.BIN
 }
 
 clean.doFirst {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 networkTimeout=60000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Add a workflow that periodically checks for Gradle Wrapper updates and opens a PR if update is available.
- Switch to wrapper distribution to bin for faster setup. It can be switched to full locally.