### PR TITLE
CANDLEPIN-323: Update exception handling for adapters [4.3.9]

### DIFF
--- a/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
+++ b/src/main/java/org/candlepin/async/tasks/HealEntireOrgJob.java
@@ -32,6 +32,7 @@ import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.resource.dto.AutobindData;
+import org.candlepin.service.exception.product.ProductUnknownRetrievalException;
 import org.candlepin.util.Transactional;
 
 import org.slf4j.Logger;
@@ -147,7 +148,8 @@ public class HealEntireOrgJob implements AsyncJob {
      * Each consumer heal should be a separate transaction
      */
     public String healSingleConsumer(Object... args)
-        throws AutobindDisabledForOwnerException, AutobindHypervisorDisabledException {
+        throws AutobindDisabledForOwnerException, AutobindHypervisorDisabledException,
+        ProductUnknownRetrievalException {
 
         Consumer consumer = (Consumer) args[0];
         Owner owner = (Owner) args[1];

--- a/src/main/java/org/candlepin/auth/BasicAuth.java
+++ b/src/main/java/org/candlepin/auth/BasicAuth.java
@@ -20,6 +20,8 @@ import org.candlepin.exceptions.NotAuthorizedException;
 import org.candlepin.exceptions.ServiceUnavailableException;
 import org.candlepin.resteasy.filter.AuthUtil;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.exception.user.UserServiceException;
+import org.candlepin.service.exception.user.UserServiceExceptionMapper;
 
 import org.apache.commons.codec.binary.Base64;
 import org.jboss.resteasy.spi.HttpRequest;
@@ -29,6 +31,8 @@ import org.xnap.commons.i18n.I18n;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+
+
 
 /**
  * BasicAuth
@@ -46,6 +50,7 @@ public class BasicAuth extends UserAuth {
 
     @Override
     public Principal getPrincipal(HttpRequest httpRequest) {
+        String username = "";
         try {
             String auth = AuthUtil.getHeader(httpRequest, "Authorization");
 
@@ -53,7 +58,7 @@ public class BasicAuth extends UserAuth {
                 String userpassEncoded = auth.substring(6);
                 String[] userpass = new String(Base64
                     .decodeBase64(userpassEncoded)).split(":", 2);
-                String username = userpass[0];
+                username = userpass[0];
                 String password = null;
                 if (userpass.length > 1) {
                     password = userpass[1];
@@ -74,6 +79,9 @@ public class BasicAuth extends UserAuth {
                 }
             }
         }
+        catch (UserServiceException e) {
+            UserServiceExceptionMapper.map(e, username, i18nProvider.get());
+        }
         catch (CandlepinException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error getting principal " + e);
@@ -88,5 +96,4 @@ public class BasicAuth extends UserAuth {
         }
         return null;
     }
-
 }

--- a/src/main/java/org/candlepin/auth/CloudRegistrationAuth.java
+++ b/src/main/java/org/candlepin/auth/CloudRegistrationAuth.java
@@ -24,8 +24,9 @@ import org.candlepin.model.OwnerCurator;
 import org.candlepin.pki.CertificateReader;
 import org.candlepin.resteasy.filter.AuthUtil;
 import org.candlepin.service.CloudRegistrationAdapter;
-import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
-import org.candlepin.service.exception.MalformedCloudRegistrationException;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationAuthorizationException;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationBadMetadataException;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationServiceException;
 import org.candlepin.service.model.CloudRegistrationInfo;
 import org.candlepin.util.Util;
 
@@ -236,15 +237,13 @@ public class CloudRegistrationAuth implements AuthProvider {
      *  if cloud registration is not permitted for the cloud provider or account holder specified by
      *  the cloud registration details
      *
-     * @throws MalformedCloudRegistrationException
-     *  if the cloud registration details are null, incomplete, or malformed
      *
      * @return
      *  a registration token to be used for completing registration for the client identified by the
      *  specified cloud registration details
      */
     public String generateRegistrationToken(Principal principal, CloudRegistrationInfo cloudRegistrationInfo)
-        throws CloudRegistrationAuthorizationException, MalformedCloudRegistrationException {
+            throws CloudRegistrationServiceException {
 
         if (!this.enabled) {
             throw new UnsupportedOperationException(
@@ -264,7 +263,7 @@ public class CloudRegistrationAuth implements AuthProvider {
             String errmsg = this.i18nProvider.get()
                 .tr("cloud provider or account details could not be resolved to an organization");
 
-            throw new CloudRegistrationAuthorizationException(errmsg);
+            throw new CloudRegistrationBadMetadataException(errmsg);
         }
 
         return this.buildRegistrationToken(principal, ownerKey);

--- a/src/main/java/org/candlepin/auth/UserAuth.java
+++ b/src/main/java/org/candlepin/auth/UserAuth.java
@@ -17,6 +17,8 @@ package org.candlepin.auth;
 import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.exception.user.UserServiceException;
+import org.candlepin.service.exception.user.UserServiceExceptionMapper;
 import org.candlepin.service.model.UserInfo;
 
 import org.xnap.commons.i18n.I18n;
@@ -48,8 +50,13 @@ public abstract class UserAuth implements AuthProvider {
      * Creates a user principal for a given username
      */
     protected Principal createPrincipal(String username) {
-        UserInfo user = this.userServiceAdapter.findByLogin(username);
-
+        UserInfo user = null;
+        try {
+            user = this.userServiceAdapter.findByLogin(username);
+        }
+        catch (UserServiceException e) {
+            UserServiceExceptionMapper.map(e, username, i18nProvider.get());
+        }
         if (user == null) {
             throw new BadRequestException(this.i18nProvider.get().tr("User not found: {0}", username));
         }

--- a/src/main/java/org/candlepin/hostedtest/HostedTestCloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestCloudRegistrationAdapter.java
@@ -15,8 +15,8 @@
 package org.candlepin.hostedtest;
 
 import org.candlepin.service.CloudRegistrationAdapter;
-import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
-import org.candlepin.service.exception.MalformedCloudRegistrationException;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationBadMetadataException;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationMissingInfoException;
 import org.candlepin.service.model.CloudRegistrationInfo;
 import org.candlepin.service.model.OwnerInfo;
 
@@ -48,15 +48,15 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
      */
     @Override
     public String resolveCloudRegistrationData(CloudRegistrationInfo cloudRegInfo)
-        throws CloudRegistrationAuthorizationException, MalformedCloudRegistrationException {
+            throws CloudRegistrationMissingInfoException, CloudRegistrationBadMetadataException {
 
         if (cloudRegInfo == null) {
-            throw new MalformedCloudRegistrationException("No cloud registration information provided");
+            throw new CloudRegistrationMissingInfoException("No cloud registration information provided");
         }
 
         if (cloudRegInfo.getMetadata() == null) {
-            throw new MalformedCloudRegistrationException(
-                "No metadata provided with the cloud registration info");
+            throw new CloudRegistrationBadMetadataException(
+                    "No metadata provided with the cloud registration info");
 
         }
 
@@ -65,5 +65,4 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
         OwnerInfo owner = this.datastore.getOwner(cloudRegInfo.getMetadata());
         return owner != null ? owner.getKey() : null;
     }
-
 }

--- a/src/main/java/org/candlepin/katello/KatelloUserServiceAdapter.java
+++ b/src/main/java/org/candlepin/katello/KatelloUserServiceAdapter.java
@@ -35,7 +35,7 @@ import java.util.Collection;
 public class KatelloUserServiceAdapter implements UserServiceAdapter {
 
     @Override
-    public boolean validateUser(String username, String password) throws Exception {
+    public boolean validateUser(String username, String password) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
+++ b/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
@@ -20,12 +20,11 @@ import org.candlepin.auth.Principal;
 import org.candlepin.auth.SecurityHole;
 import org.candlepin.dto.api.server.v1.CloudRegistrationDTO;
 import org.candlepin.exceptions.BadRequestException;
-import org.candlepin.exceptions.NotAuthorizedException;
 import org.candlepin.exceptions.NotImplementedException;
 import org.candlepin.resource.server.v1.CloudRegistrationApi;
 import org.candlepin.resource.validation.DTOValidator;
-import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
-import org.candlepin.service.exception.MalformedCloudRegistrationException;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationServiceException;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationServiceExceptionMapper;
 
 import org.jboss.resteasy.core.ResteasyContext;
 import org.xnap.commons.i18n.I18n;
@@ -68,12 +67,10 @@ public class CloudRegistrationResource implements CloudRegistrationApi {
             String errmsg = this.i18n.tr("Cloud registration is not supported by this Candlepin instance");
             throw new NotImplementedException(errmsg, e);
         }
-        catch (CloudRegistrationAuthorizationException e) {
-            throw new NotAuthorizedException(e.getMessage());
+        catch (CloudRegistrationServiceException e) {
+            CloudRegistrationServiceExceptionMapper.map(e, registrationData.getType(), i18n);
         }
-        catch (MalformedCloudRegistrationException e) {
-            throw new BadRequestException(e.getMessage(), e);
-        }
+        return null;
     }
 
     private CloudRegistrationData getCloudRegistrationData(CloudRegistrationDTO cloudRegistrationDTO) {

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -66,6 +66,7 @@ import org.candlepin.dto.api.server.v1.SystemPurposeComplianceStatusDTO;
 import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.CandlepinException;
 import org.candlepin.exceptions.ConflictException;
+import org.candlepin.exceptions.ExceptionMessage;
 import org.candlepin.exceptions.ForbiddenException;
 import org.candlepin.exceptions.GoneException;
 import org.candlepin.exceptions.IseException;
@@ -132,6 +133,10 @@ import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.exception.product.ProductUnknownRetrievalException;
+import org.candlepin.service.exception.subscription.SubscriptionUnknownTermsException;
+import org.candlepin.service.exception.user.UserServiceException;
+import org.candlepin.service.exception.user.UserServiceExceptionMapper;
 import org.candlepin.service.model.OwnerInfo;
 import org.candlepin.service.model.UserInfo;
 import org.candlepin.sync.ExportCreationException;
@@ -181,6 +186,7 @@ import javax.persistence.OptimisticLockException;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
 
 
 /**
@@ -236,7 +242,7 @@ public class ConsumerResource implements ConsumerApi {
     private final Pattern consumerPersonNamePattern;
 
     @Inject
-    @SuppressWarnings({"checkstyle:parameternumber"})
+    @SuppressWarnings({ "checkstyle:parameternumber" })
     public ConsumerResource(ConsumerCurator consumerCurator,
         ConsumerTypeCurator consumerTypeCurator,
         SubscriptionServiceAdapter subAdapter,
@@ -698,13 +704,11 @@ public class ConsumerResource implements ConsumerApi {
         String caMode = Util.firstOf(predicate,
             consumer.getContentAccessMode(),
             consumer.getOwner().getContentAccessMode(),
-            ContentAccessManager.ContentAccessMode.getDefault().toDatabaseValue()
-        );
+            ContentAccessManager.ContentAccessMode.getDefault().toDatabaseValue());
 
         String caList = Util.firstOf(predicate,
             consumer.getOwner().getContentAccessModeList(),
-            ContentAccessManager.getListDefaultDatabaseValue()
-        );
+            ContentAccessManager.getListDefaultDatabaseValue());
 
         return new ContentAccessDTO()
             .contentAccessMode(caMode)
@@ -1310,6 +1314,9 @@ public class ConsumerResource implements ConsumerApi {
         catch (UnsupportedOperationException e) {
             log.warn("User service does not allow user lookups, cannot verify person consumer.", e);
         }
+        catch (UserServiceException e) {
+            UserServiceExceptionMapper.map(e, username, this.i18n);
+        }
 
         if (user == null) {
             throw new NotFoundException(this.i18n.tr("User not found: {0}", username));
@@ -1542,7 +1549,8 @@ public class ConsumerResource implements ConsumerApi {
 
         if (updated.getReleaseVer() != null && updated.getReleaseVer().getReleaseVer() != null) {
             String releaseVer = toUpdate.getReleaseVer() == null ?
-                null : toUpdate.getReleaseVer().getReleaseVer();
+                null :
+                toUpdate.getReleaseVer().getReleaseVer();
             if (!updated.getReleaseVer().getReleaseVer().equals(releaseVer)) {
                 log.info("   Updating consumer releaseVer setting.");
                 toUpdate.setReleaseVer(new Release(updated.getReleaseVer().getReleaseVer()));
@@ -1982,7 +1990,8 @@ public class ConsumerResource implements ConsumerApi {
                     List<Entitlement> ents = entitler.bindByProducts(autobindData);
                     entitler.sendEvents(ents);
                 }
-                catch (AutobindDisabledForOwnerException | AutobindHypervisorDisabledException e) {
+                catch (AutobindDisabledForOwnerException | AutobindHypervisorDisabledException |
+                    ProductUnknownRetrievalException e) {
                     log.warn("Guest auto-attach skipped. {}", e.getMessage(), e);
                 }
             }
@@ -2142,9 +2151,9 @@ public class ConsumerResource implements ConsumerApi {
             since = zonedDateTime.toOffsetDateTime();
         }
 
-
         if (!this.contentAccessManager.hasCertChangedSince(consumer, since != null ?
-            Util.toDate(since) : new Date(0))) {
+            Util.toDate(since) :
+            new Date(0))) {
 
             return Response.status(Response.Status.NOT_MODIFIED)
                 .entity("Not modified since date supplied.")
@@ -2277,7 +2286,7 @@ public class ConsumerResource implements ConsumerApi {
     }
 
     @Override
-    @SuppressWarnings({"checkstyle:indentation", "checkstyle:methodlength"})
+    @SuppressWarnings({ "checkstyle:indentation", "checkstyle:methodlength" })
     public Response bind(
         @Verify(Consumer.class) String consumerUuid,
         @Verify(value = Pool.class, nullable = true, subResource = SubResource.ENTITLEMENTS)
@@ -2313,13 +2322,25 @@ public class ConsumerResource implements ConsumerApi {
             // I hate double negatives, but if they have accepted all
             // terms, we want comeToTerms to be true.
             long subTermsStart = System.currentTimeMillis();
-
-            if (subAdapter.hasUnacceptedSubscriptionTerms(owner.getKey())) {
-                return Response.serverError().build();
+            ExceptionMessage message;
+            try {
+                if (subAdapter.hasUnacceptedSubscriptionTerms(owner.getKey())) {
+                    message = new ExceptionMessage(
+                        i18n.tr("You must first accept Red Hat''s Terms and conditions. Please visit {0}",
+                        "https://www.redhat.com/wapps/tnc/ackrequired?site=candlepin" +
+                        "&event=attachSubscription"));
+                    return Response.serverError().entity(message).build();
+                }
             }
-
-            log.debug("Checked if consumer has unaccepted subscription terms in {}ms",
-                (System.currentTimeMillis() - subTermsStart));
+            catch (SubscriptionUnknownTermsException e) {
+                message = new ExceptionMessage(
+                    i18n.tr("Unable to determine the state of the subscription terms"));
+                return Response.serverError().entity(message).build();
+            }
+            finally {
+                log.debug("Checked if consumer has unaccepted subscription terms in {}ms",
+                    (System.currentTimeMillis() - subTermsStart));
+            }
         }
         catch (CandlepinException e) {
             log.debug(e.getMessage(), e);
@@ -2396,20 +2417,22 @@ public class ConsumerResource implements ConsumerApi {
                 if (owner.isUsingSimpleContentAccess()) {
                     log.debug("Ignoring request to auto-attach. " +
                         "Attaching subscriptions is disabled for org \"{}\" " +
-                        "because simple content access is enabled."
-                        , owner.getKey(), e);
+                        "because simple content access is enabled.", owner.getKey(), e);
                     return Response.status(Response.Status.OK).build();
                 }
                 else {
                     throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
-                        "It is disabled for org \"{0}\"."
-                        , owner.getKey()), e);
+                        "It is disabled for org \"{0}\".", owner.getKey()), e);
                 }
             }
             catch (AutobindHypervisorDisabledException e) {
                 throw new BadRequestException(i18n.tr("Ignoring request to auto-attach. " +
-                        "It is disabled for org \"{0}\" because of the hypervisor autobind setting."
-                    , owner.getKey()), e);
+                    "It is disabled for org \"{0}\" because of the hypervisor autobind setting.",
+                    owner.getKey()), e);
+            }
+            catch (ProductUnknownRetrievalException e) {
+                throw new BadRequestException(i18n.tr("Unable to auto-attach. The products" +
+                    " are not retrievable by their ID's"));
             }
         }
 
@@ -2460,7 +2483,7 @@ public class ConsumerResource implements ConsumerApi {
             // consumerBindUtil.validateServiceLevel(consumer.getOwnerId(), serviceLevel);
             dryRunPools = entitler.getDryRun(consumer, owner, serviceLevel);
         }
-        catch (ForbiddenException e) {
+        catch (ForbiddenException | ProductUnknownRetrievalException e) {
             return Collections.emptyList();
         }
         catch (BadRequestException e) {
@@ -2571,8 +2594,7 @@ public class ConsumerResource implements ConsumerApi {
         }
 
         throw new NotFoundException(i18n.tr(
-            "Entitlement with ID \"{0}\" could not be found.", dbid
-        ));
+            "Entitlement with ID \"{0}\" could not be found.", dbid));
     }
 
     @Override
@@ -2944,11 +2966,10 @@ public class ConsumerResource implements ConsumerApi {
         deletedConsumerCurator.delete(dc);
     }
 
-
     private void addCalculatedAttributes(Entitlement ent) {
         // With no consumer/date, this will not build suggested quantity
-        Map<String, String> calculatedAttributes =
-            calculatedAttributesUtil.buildCalculatedAttributes(ent.getPool(), null);
+        Map<String, String> calculatedAttributes = calculatedAttributesUtil
+            .buildCalculatedAttributes(ent.getPool(), null);
         ent.getPool().setCalculatedAttributes(calculatedAttributes);
     }
 
@@ -2958,8 +2979,6 @@ public class ConsumerResource implements ConsumerApi {
         }
         return null;
     }
-
-
 
     /**
      * Populates the specified entities with data from the provided guestIds.

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1286,7 +1286,8 @@ public class OwnerResource implements OwnerApi {
                 owner = createOwnerFromDTO(new OwnerDTO().key(ownerKey).displayName(ownerKey));
             }
             else {
-                throw new NotFoundException(i18n.tr("owner with key: {0} was not found.", ownerKey));
+                throw new NotFoundException(
+                    i18n.tr("owner with key: {0} was not found.", ownerKey));
             }
         }
 

--- a/src/main/java/org/candlepin/resource/RoleResource.java
+++ b/src/main/java/org/candlepin/resource/RoleResource.java
@@ -26,6 +26,8 @@ import org.candlepin.resource.server.v1.RolesApi;
 import org.candlepin.resource.util.InfoAdapter;
 import org.candlepin.resource.validation.DTOValidator;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.exception.user.UserServiceException;
+import org.candlepin.service.exception.user.UserServiceExceptionMapper;
 import org.candlepin.service.model.RoleInfo;
 import org.candlepin.service.model.UserInfo;
 
@@ -36,6 +38,8 @@ import java.util.Collection;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
+
+
 
 /**
  * API implementation for Role operations
@@ -108,9 +112,15 @@ public class RoleResource implements RolesApi {
             throw new BadRequestException(this.i18n.tr("username is null or empty"));
         }
 
-        UserInfo user = this.userService.findByLogin(username);
-        if (user == null) {
-            throw new NotFoundException(this.i18n.tr("User not found: {0}", username));
+        UserInfo user = null;
+        try {
+            user = this.userService.findByLogin(username);
+            if (user == null) {
+                throw new NotFoundException(this.i18n.tr("User not found: {0}", username));
+            }
+        }
+        catch (UserServiceException e) {
+            UserServiceExceptionMapper.map(e, username, this.i18n);
         }
 
         return user;

--- a/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -36,6 +36,7 @@ import org.candlepin.model.activationkeys.ActivationKeyPool;
 import org.candlepin.policy.js.quantity.QuantityRules;
 import org.candlepin.resource.ConsumerResource;
 import org.candlepin.resource.dto.AutobindData;
+import org.candlepin.service.exception.product.ProductUnknownRetrievalException;
 import org.candlepin.util.ServiceLevelValidator;
 import org.candlepin.version.CertVersionConflictException;
 
@@ -88,7 +89,8 @@ public class ConsumerBindUtil {
 
     public void handleActivationKeys(Consumer consumer, List<ActivationKey> keys,
         boolean autoattachDisabledForOwner)
-        throws AutobindDisabledForOwnerException, AutobindHypervisorDisabledException {
+        throws AutobindDisabledForOwnerException, AutobindHypervisorDisabledException,
+        ProductUnknownRetrievalException {
 
         boolean listSuccess = false;
         boolean scaEnabledForAny = false;
@@ -188,7 +190,8 @@ public class ConsumerBindUtil {
     }
 
     private void handleActivationKeyAutoBind(Consumer consumer, ActivationKey key)
-        throws AutobindDisabledForOwnerException, AutobindHypervisorDisabledException {
+        throws AutobindDisabledForOwnerException, AutobindHypervisorDisabledException,
+        ProductUnknownRetrievalException {
 
         try {
             Set<String> productIds = new HashSet<>();

--- a/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
@@ -14,8 +14,8 @@
  */
 package org.candlepin.service;
 
-import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
-import org.candlepin.service.exception.MalformedCloudRegistrationException;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationAuthorizationException;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationServiceException;
 import org.candlepin.service.model.CloudRegistrationInfo;
 
 
@@ -32,16 +32,31 @@ public interface CloudRegistrationAdapter {
      * @param cloudRegInfo
      *  A CloudRegistrationInfo instance which contains the cloud provider details to process
      *
-     * @throws MalformedCloudRegistrationException
-     *  if the cloud registration info is null, incomplete, or invalid
-     *
      * @throws CloudRegistrationAuthorizationException
      *  if cloud registration is not permitted for the provider or account holder
+     *
+     * @throws CloudRegistrationServiceException
+     *  if there is an exception thrown in the method in the implementation. The subclass of
+     *  the exception will give detail as to the problem
+     *
+     *  CloudRegistrationMissingTypeException
+     *  if the cloud registration info does not contain a value for type
+     *
+     *  CloudRegistrationBadTypeException
+     *  if the cloud registration info contains a value for type that is not on the list
+     *
+     *  CloudRegistrationBadMetadataException
+     *  if the cloud registration info contains meta-data that will not allow for authentication
+     *
+     *  CloudRegistrationAuthorizationException
+     *  if cloud registration is not permitted for the provider or account holder
+     *
+     *  CloudRegistrationUnknownDataException
+     *  if cloud registration is stopped by an unexpected issue
      *
      * @return
      *  the owner key of the owner (organization) to which the cloud user will be registered
      */
     String resolveCloudRegistrationData(CloudRegistrationInfo cloudRegInfo)
-        throws CloudRegistrationAuthorizationException, MalformedCloudRegistrationException;
-
+        throws CloudRegistrationServiceException;
 }

--- a/src/main/java/org/candlepin/service/OwnerServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/OwnerServiceAdapter.java
@@ -14,8 +14,6 @@
  */
 package org.candlepin.service;
 
-
-
 /**
  * The OwnerServiceAdapter defines an interface for hooking into some owner/org-specific operations
  * for additional or external verification of values, or for providing data from alternate sources.

--- a/src/main/java/org/candlepin/service/ProductServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/ProductServiceAdapter.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.service;
 
+import org.candlepin.service.exception.product.ProductUnknownRetrievalException;
 import org.candlepin.service.model.CertificateInfo;
 import org.candlepin.service.model.ProductInfo;
 
@@ -48,7 +49,8 @@ public interface ProductServiceAdapter {
      * @return list of products matching the given string IDs,
      *         empty list if none were found.
      */
-    Collection<? extends ProductInfo> getProductsByIds(String ownerKey, Collection<String> ids);
+    Collection<? extends ProductInfo> getProductsByIds(String ownerKey, Collection<String> ids)
+        throws ProductUnknownRetrievalException;
 
     /**
      * Gets the certificate that defines the given product, creating one

--- a/src/main/java/org/candlepin/service/SubscriptionServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/SubscriptionServiceAdapter.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.service;
 
+import org.candlepin.service.exception.subscription.SubscriptionServiceException;
+import org.candlepin.service.exception.subscription.SubscriptionUnknownRetrievalException;
+import org.candlepin.service.exception.subscription.SubscriptionUnknownTermsException;
 import org.candlepin.service.model.ConsumerInfo;
 import org.candlepin.service.model.SubscriptionInfo;
 
@@ -34,28 +37,32 @@ public interface SubscriptionServiceAdapter {
      * Return all subscriptions.
      * @return all subscriptions.
      */
-    Collection<? extends SubscriptionInfo> getSubscriptions();
+    Collection<? extends SubscriptionInfo> getSubscriptions()
+        throws SubscriptionUnknownRetrievalException;
 
     /**
      * Lookup a specific subscription.
      * @param subscriptionId id of the subscription to return.
      * @return Subscription whose id matches subscriptionId
      */
-    SubscriptionInfo getSubscription(String subscriptionId);
+    SubscriptionInfo getSubscription(String subscriptionId)
+        throws SubscriptionUnknownRetrievalException;
 
     /**
      * List all subscriptions for the given owner.
      * @param ownerKey Owner of the subscriptions.
      * @return all subscriptions for the given owner.
      */
-    Collection<? extends SubscriptionInfo> getSubscriptions(String ownerKey);
+    Collection<? extends SubscriptionInfo> getSubscriptions(String ownerKey)
+        throws SubscriptionUnknownRetrievalException;
 
     /**
      * List all active subscription ids for the given owner.
      * @param ownerKey Owner of the subscriptions.
      * @return ids of all subscriptions for the given owner.
      */
-    Collection<String> getSubscriptionIds(String ownerKey);
+    Collection<String> getSubscriptionIds(String ownerKey)
+        throws SubscriptionUnknownRetrievalException;
 
     /**
      * Search for all subscriptions that provide a given product.
@@ -63,7 +70,8 @@ public interface SubscriptionServiceAdapter {
      * @param productId the main or provided product to look for.
      * @return a list of subscriptions that provide this product.
      */
-    Collection<? extends SubscriptionInfo> getSubscriptionsByProductId(String productId);
+    Collection<? extends SubscriptionInfo> getSubscriptionsByProductId(String productId)
+        throws SubscriptionUnknownRetrievalException;
 
     /**
      * Checks to see if the customer has subscription terms that need to be accepted
@@ -71,7 +79,8 @@ public interface SubscriptionServiceAdapter {
      * @return false if no subscriptions a runtime exception will a localized message
      * if there are terms to be accepted
      */
-    boolean hasUnacceptedSubscriptionTerms(String ownerKey);
+    boolean hasUnacceptedSubscriptionTerms(String ownerKey)
+        throws SubscriptionUnknownTermsException;
 
     /**
      * A pool for a subscription id has been created. Send the activation email
@@ -96,7 +105,8 @@ public interface SubscriptionServiceAdapter {
      * @param email the email address tied to this consumer
      * @param emailLocale the i18n locale for the email
      */
-    void activateSubscription(ConsumerInfo consumer, String email, String emailLocale);
+    void activateSubscription(ConsumerInfo consumer, String email, String emailLocale)
+        throws SubscriptionServiceException;
 
     /**
      * Some subscription services are read-only. This allows us to avoid certain

--- a/src/main/java/org/candlepin/service/UserServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/UserServiceAdapter.java
@@ -14,6 +14,11 @@
  */
 package org.candlepin.service;
 
+import org.candlepin.service.exception.user.UserDisabledException;
+import org.candlepin.service.exception.user.UserLoginNotFoundException;
+import org.candlepin.service.exception.user.UserMissingOwnerException;
+import org.candlepin.service.exception.user.UserServiceException;
+import org.candlepin.service.exception.user.UserUnknownRetrievalException;
 import org.candlepin.service.model.OwnerInfo;
 import org.candlepin.service.model.PermissionBlueprintInfo;
 import org.candlepin.service.model.RoleInfo;
@@ -35,7 +40,7 @@ public interface UserServiceAdapter {
      * @return true if username and password combination are valid.
      * @throws Exception if there was an error validating the user
      */
-    boolean validateUser(String username, String password) throws Exception;
+    boolean validateUser(String username, String password) throws UserServiceException;
 
     // User life cycle
     UserInfo createUser(UserInfo user);
@@ -44,7 +49,8 @@ public interface UserServiceAdapter {
 
     void deleteUser(String username);
 
-    UserInfo findByLogin(String username);
+    UserInfo findByLogin(String username) throws UserUnknownRetrievalException,
+        UserMissingOwnerException, UserDisabledException, UserLoginNotFoundException;
 
     Collection<? extends UserInfo> listUsers();
 
@@ -57,7 +63,8 @@ public interface UserServiceAdapter {
      * @return
      *  a collection of owners to which the user is allowed to register
      */
-    Collection<? extends OwnerInfo> getAccessibleOwners(String username);
+    Collection<? extends OwnerInfo> getAccessibleOwners(String username) throws UserDisabledException,
+        UserLoginNotFoundException, UserUnknownRetrievalException;
 
     // Roles
     RoleInfo createRole(RoleInfo role);

--- a/src/main/java/org/candlepin/service/exception/ServiceException.java
+++ b/src/main/java/org/candlepin/service/exception/ServiceException.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception;
+
+/**
+ * The ServiceException is used to as a base for all exceptions returned from the service adapters
+ */
+public class ServiceException extends Exception {
+    private int status;
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public ServiceException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public ServiceException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public ServiceException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public ServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ServiceException setStatus(int status) {
+        this.status = status;
+        return this;
+    }
+
+    public int getStatus() {
+        return this.status;
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationAuthorizationException.java
+++ b/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationAuthorizationException.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.cloudregistration;
+
+
+
+/**
+ * The CloudRegistrationAuthorizationException is used to reject a registration attempt for a
+ * cloud provider or account holder.
+ */
+public class CloudRegistrationAuthorizationException extends CloudRegistrationServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public CloudRegistrationAuthorizationException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public CloudRegistrationAuthorizationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationAuthorizationException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationAuthorizationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationBadMetadataException.java
+++ b/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationBadMetadataException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.cloudregistration;
+
+/**
+ * The CloudRegistrationBadMetadataException is used to reject a registration attempt for a
+ * cloud provider or account holder.
+ */
+public class CloudRegistrationBadMetadataException extends CloudRegistrationServiceException {
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public CloudRegistrationBadMetadataException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public CloudRegistrationBadMetadataException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationBadMetadataException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationBadMetadataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationBadTypeException.java
+++ b/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationBadTypeException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.cloudregistration;
+
+/**
+ * The CloudRegistrationBadTypeException is used to reject a registration attempt for a
+ * cloud provider or account holder.
+ */
+public class CloudRegistrationBadTypeException extends CloudRegistrationServiceException {
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public CloudRegistrationBadTypeException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public CloudRegistrationBadTypeException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationBadTypeException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationBadTypeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationMissingInfoException.java
+++ b/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationMissingInfoException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.cloudregistration;
+
+/**
+ * The CloudRegistrationBadMetadataException is used to reject a registration attempt for a
+ * cloud provider or account holder.
+ */
+public class CloudRegistrationMissingInfoException extends CloudRegistrationServiceException {
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public CloudRegistrationMissingInfoException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public CloudRegistrationMissingInfoException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationMissingInfoException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationMissingInfoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationMissingTypeException.java
+++ b/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationMissingTypeException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.cloudregistration;
+
+/**
+ * The CloudRegistrationMissingTypeException is used to reject a registration attempt for a
+ * cloud provider or account holder.
+ */
+public class CloudRegistrationMissingTypeException extends CloudRegistrationServiceException {
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public CloudRegistrationMissingTypeException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public CloudRegistrationMissingTypeException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationMissingTypeException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationMissingTypeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationServiceException.java
+++ b/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationServiceException.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.cloudregistration;
+
+import org.candlepin.service.exception.ServiceException;
+
+
+
+/**
+ * The CloudRegistrationServiceException is used to as a base for all exceptions returned from
+ * the cloud registration service adapter. It is useful when the potential number of exceptions
+ *  * exceeds our limit.
+ */
+public class CloudRegistrationServiceException extends ServiceException {
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public CloudRegistrationServiceException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public CloudRegistrationServiceException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationServiceException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationServiceExceptionMapper.java
+++ b/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationServiceExceptionMapper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.cloudregistration;
+
+import org.candlepin.exceptions.BadRequestException;
+import org.candlepin.exceptions.CandlepinException;
+import org.candlepin.exceptions.NotAuthorizedException;
+
+import org.xnap.commons.i18n.I18n;
+
+import javax.ws.rs.core.Response;
+
+
+
+public class CloudRegistrationServiceExceptionMapper {
+    private CloudRegistrationServiceExceptionMapper() { };
+
+    public static void map(CloudRegistrationServiceException e, String providerType, I18n i18n) {
+        if (e instanceof CloudRegistrationAuthorizationException) {
+            throw new NotAuthorizedException(i18n.tr(
+                "Cloud provider or account details could not be resolved to an organization"));
+        }
+        else if (e instanceof CloudRegistrationMissingTypeException) {
+            throw new BadRequestException(i18n.tr(
+                "Request is missing cloud provider type (e.g. amazon, gcp, azure)"));
+        }
+        else if (e instanceof CloudRegistrationBadTypeException) {
+            throw new IllegalArgumentException(i18n.tr(
+                "Unrecognized provider type in request: {0}", providerType));
+        }
+        else if (e instanceof CloudRegistrationBadMetadataException) {
+            throw new BadRequestException(i18n.tr(
+                "Unable to retrieve organization ID with provided meta-data"));
+        }
+        else if (e instanceof CloudRegistrationUnknownDataException) {
+            throw new CandlepinException(Response.Status.fromStatusCode(e.getStatus()),
+                i18n.tr("Unexpected data error from Cloud Registration Service: {0}", e.getMessage()));
+        }
+        else {
+            throw new CandlepinException(Response.Status.fromStatusCode(e.getStatus()),
+                i18n.tr("Unexpected error from Cloud Registration Service: {0}", e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationUnknownDataException.java
+++ b/src/main/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationUnknownDataException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.cloudregistration;
+
+/**
+ * The CloudRegistrationUnknownDataException is used to reject a registration attempt for a
+ * cloud provider or account holder.
+ */
+public class CloudRegistrationUnknownDataException extends CloudRegistrationServiceException {
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public CloudRegistrationUnknownDataException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public CloudRegistrationUnknownDataException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationUnknownDataException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationUnknownDataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/product/ProductServiceException.java
+++ b/src/main/java/org/candlepin/service/exception/product/ProductServiceException.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.product;
+
+import org.candlepin.service.exception.ServiceException;
+
+
+
+/**
+ * The ProductServiceException is used to as a base for all exceptions returned from
+ * the product service adapter. It is useful when the potential number of exceptions
+ *  * exceeds our limit.
+ */
+public class ProductServiceException extends ServiceException {
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public ProductServiceException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public ProductServiceException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public ProductServiceException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public ProductServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/product/ProductUnknownRetrievalException.java
+++ b/src/main/java/org/candlepin/service/exception/product/ProductUnknownRetrievalException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.product;
+
+/**
+ * The ProductUnknownRetrievalException is used to reject a product retrieval for an unexpected
+ * reason.
+ */
+public class ProductUnknownRetrievalException extends ProductServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public ProductUnknownRetrievalException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public ProductUnknownRetrievalException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public ProductUnknownRetrievalException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public ProductUnknownRetrievalException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionActivationNoAdminsException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionActivationNoAdminsException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+/**
+ * The SubscriptionActivationNoAdminsException is used to reject an activation attempt for a
+ * subscription.
+ */
+public class SubscriptionActivationNoAdminsException extends SubscriptionServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionActivationNoAdminsException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionActivationNoAdminsException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionActivationNoAdminsException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionActivationNoAdminsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionActivationNoRedemptionTagException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionActivationNoRedemptionTagException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+/**
+ * The SubscriptionActivationNoRedemptionTagException is used to reject an activation attempt for a
+ *  * subscription.
+ */
+public class SubscriptionActivationNoRedemptionTagException extends SubscriptionServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionActivationNoRedemptionTagException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionActivationNoRedemptionTagException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionActivationNoRedemptionTagException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionActivationNoRedemptionTagException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionActivationNoTagException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionActivationNoTagException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+/**
+ * The SubscriptionActivationNoTagException is used to reject an activation attempt for a subscription.
+ */
+public class SubscriptionActivationNoTagException extends SubscriptionServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionActivationNoTagException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionActivationNoTagException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionActivationNoTagException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionActivationNoTagException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionExpiredTagException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionExpiredTagException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+/**
+ * The SubscriptionExpiredTagException is used to reject an activation attempt for a
+ *  * subscription.
+ */
+public class SubscriptionExpiredTagException extends SubscriptionServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionExpiredTagException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionExpiredTagException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionExpiredTagException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionExpiredTagException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionMissingTagException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionMissingTagException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+/**
+ * The SubscriptionMissingTagException is used to reject an activation attempt for a
+ *  * subscription.
+ */
+public class SubscriptionMissingTagException extends SubscriptionServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionMissingTagException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionMissingTagException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionMissingTagException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionMissingTagException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionNotFoundTagException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionNotFoundTagException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+/**
+ * The SubscriptionNotFoundTagException is used to reject an activation attempt for a
+ *  * subscription.
+ */
+public class SubscriptionNotFoundTagException extends SubscriptionServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionNotFoundTagException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionNotFoundTagException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionNotFoundTagException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionNotFoundTagException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionServiceException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionServiceException.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+import org.candlepin.service.exception.ServiceException;
+
+
+
+/**
+ * The SubscriptionServiceException is used to as a base for all exceptions returned from
+ * the subscription service adapter. It is useful when the potential number of exceptions
+ *  * exceeds our limit.
+ */
+public class SubscriptionServiceException extends ServiceException {
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionServiceException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionServiceException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionServiceException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionServiceExceptionMapper.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionServiceExceptionMapper.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+import org.xnap.commons.i18n.I18n;
+
+
+
+public class SubscriptionServiceExceptionMapper {
+    private SubscriptionServiceExceptionMapper() { };
+
+    public static String map(SubscriptionServiceException e, String dellAssetTag, String ownerKey,
+        I18n i18n) {
+        String message = "";
+        if (e instanceof SubscriptionMissingTagException) {
+            message = i18n.tr(
+                "A subscription was not found for the given Dell service tag: {0}",
+                dellAssetTag);
+        }
+        else if (e instanceof SubscriptionExpiredTagException) {
+            message = i18n.tr("The Dell service tag: {0}, is expired", dellAssetTag);
+        }
+        else if (e instanceof SubscriptionActivationNoAdminsException) {
+            message = i18n.tr("No admins were returned for owner {0}", ownerKey);
+        }
+        else if (e instanceof SubscriptionUnknownActivationException) {
+            message = i18n.tr(
+                "The system is unable to redeem the requested subscription: {0}", dellAssetTag);
+        }
+        else if (e instanceof SubscriptionUsedTagException) {
+            message = i18n.tr(
+                "The Dell service tag: {0}, has already been used to redeem a subscription",
+                dellAssetTag);
+        }
+        else if (e instanceof SubscriptionActivationNoTagException) {
+            message = i18n.tr(
+                "No subscription was activated because there is no Dell Asset Tag",
+                dellAssetTag);
+        }
+        else if (e instanceof SubscriptionActivationNoRedemptionTagException) {
+            message = i18n.tr(
+                "The system is unable to redeem the requested subscription: {0}", dellAssetTag);
+        }
+        else if (e instanceof SubscriptionNotFoundTagException) {
+            message = i18n.tr("The Dell service tag: {0}, could not be found.", dellAssetTag);
+        }
+        else {
+            // Its some other kind of subscription service exception
+            message = i18n.tr(
+                "Unexpected error from Subscription Service: {0}", e.getMessage());
+        }
+        return message;
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionUnknownActivationException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionUnknownActivationException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+/**
+ * The SubscriptionUnknownActivationException is used to reject an activation attempt for a
+ *  * subscription.
+ */
+public class SubscriptionUnknownActivationException extends SubscriptionServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionUnknownActivationException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionUnknownActivationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionUnknownActivationException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionUnknownActivationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionUnknownRetrievalException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionUnknownRetrievalException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+/**
+ * The SubscriptionUnknownRetrievalException is used to reject an activation attempt for a
+ *  * subscription.
+ */
+public class SubscriptionUnknownRetrievalException extends SubscriptionServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionUnknownRetrievalException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionUnknownRetrievalException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionUnknownRetrievalException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionUnknownRetrievalException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionUnknownTermsException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionUnknownTermsException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+/**
+ * The SubscriptionUnknownTermsException is used to reject an activation attempt for a
+ *  * subscription.
+ */
+public class SubscriptionUnknownTermsException extends SubscriptionServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionUnknownTermsException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionUnknownTermsException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionUnknownTermsException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionUnknownTermsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/subscription/SubscriptionUsedTagException.java
+++ b/src/main/java/org/candlepin/service/exception/subscription/SubscriptionUsedTagException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+/**
+ * The SubscriptionUsedTagException is used to reject an activation attempt for a
+ *  * subscription.
+ */
+public class SubscriptionUsedTagException extends SubscriptionServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public SubscriptionUsedTagException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public SubscriptionUsedTagException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionUsedTagException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public SubscriptionUsedTagException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/user/UserCredentialsException.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserCredentialsException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.user;
+
+/**
+ * The UserCredentialsException is used to reject a user validation action.
+ */
+public class UserCredentialsException extends UserServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public UserCredentialsException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public UserCredentialsException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserCredentialsException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserCredentialsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/user/UserDisabledException.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserDisabledException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.user;
+
+/**
+ * The UserDisabledException is used to reject a user validation action.
+ */
+public class UserDisabledException extends UserServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public UserDisabledException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public UserDisabledException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserDisabledException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserDisabledException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/user/UserInvalidException.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserInvalidException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.user;
+
+/**
+ * The UserInvalidException is used to reject a user validation action.
+ */
+public class UserInvalidException extends UserServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public UserInvalidException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public UserInvalidException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserInvalidException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserInvalidException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/user/UserLoginNotFoundException.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserLoginNotFoundException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.user;
+
+/**
+ * The UserIdNotFoundException is used to reject a user validation action.
+ */
+public class UserLoginNotFoundException extends UserServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public UserLoginNotFoundException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public UserLoginNotFoundException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserLoginNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserLoginNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/user/UserMissingException.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserMissingException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.user;
+
+/**
+ * The UserMissingException is used to reject a user validation action.
+ */
+public class UserMissingException extends UserServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public UserMissingException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public UserMissingException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserMissingException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserMissingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/user/UserMissingOwnerException.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserMissingOwnerException.java
@@ -12,21 +12,18 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.service.exception;
-
-
+package org.candlepin.service.exception.user;
 
 /**
- * The MalformedCloudRegistrationException is used to denote malformed or incomplete cloud
- * registration details
+ * The UserMissingOwnerException is used to reject a user validation action.
  */
-public class MalformedCloudRegistrationException extends RuntimeException {
+public class UserMissingOwnerException extends UserServiceException {
 
     /**
      * Constructs a new exception with null as its detail message. The cause is not initialized,
      * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
      */
-    public MalformedCloudRegistrationException() {
+    public UserMissingOwnerException() {
         super();
     }
 
@@ -38,7 +35,7 @@ public class MalformedCloudRegistrationException extends RuntimeException {
      *  the detail message. The detail message is saved for later retrieval by the getMessage()
      *  method.
      */
-    public MalformedCloudRegistrationException(String message) {
+    public UserMissingOwnerException(String message) {
         super(message);
     }
 
@@ -52,7 +49,7 @@ public class MalformedCloudRegistrationException extends RuntimeException {
      *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
      *  value is permitted, and indicates that the cause is nonexistent or unknown.
      */
-    public MalformedCloudRegistrationException(Throwable cause) {
+    public UserMissingOwnerException(Throwable cause) {
         super(cause);
     }
 
@@ -70,7 +67,7 @@ public class MalformedCloudRegistrationException extends RuntimeException {
      *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
      *  value is permitted, and indicates that the cause is nonexistent or unknown.
      */
-    public MalformedCloudRegistrationException(String message, Throwable cause) {
+    public UserMissingOwnerException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/main/java/org/candlepin/service/exception/user/UserServiceException.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserServiceException.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.user;
+
+import org.candlepin.service.exception.ServiceException;
+
+
+
+/**
+ * The UserServiceException is used to as a base for all exceptions returned from
+ * the user service adapter. It is useful when the potential number of exceptions
+ * exceeds our limit.
+ */
+public class UserServiceException extends ServiceException {
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public UserServiceException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public UserServiceException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserServiceException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/user/UserServiceExceptionMapper.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserServiceExceptionMapper.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.user;
+
+import org.candlepin.exceptions.CandlepinException;
+
+import org.xnap.commons.i18n.I18n;
+
+import javax.ws.rs.core.Response;
+
+
+
+public class UserServiceExceptionMapper {
+    private UserServiceExceptionMapper() { };
+
+    public static void map(UserServiceException e, String username, I18n i18n) {
+        if (e instanceof UserInvalidException) {
+            throw new CandlepinException(null,
+                i18n.tr("User '{0}' is not valid.", username));
+        }
+        else if (e instanceof UserMissingOwnerException) {
+            throw new CandlepinException(null,
+                i18n.tr("The system is unable to find an organization for user '{0}'", username));
+        }
+        else if (e instanceof UserMissingException) {
+            throw new CandlepinException(null,
+                i18n.tr("User '{0}' cannot be found.", username));
+        }
+        else if (e instanceof UserUnacceptedTermsException) {
+            throw new CandlepinException(null,
+                i18n.tr("You must first accept Red Hat''s Terms and conditions. " +
+                    "Please visit {0} . You may have to log out of and back into the  " +
+                    "Customer Portal in order to see the terms.",
+                    "https://www.redhat.com/wapps/ugc"));
+        }
+        else if (e instanceof UserDisabledException) {
+            throw new CandlepinException(null,
+                i18n.tr("The user '{0}' has been disabled, if this is a mistake, " +
+                    "please contact customer service.", username));
+        }
+        else if (e instanceof UserCredentialsException) {
+            throw new CandlepinException(null,
+                i18n.tr("Invalid username or password. To create a login, " +
+                    "please visit {0}", "https://www.redhat.com/wapps/ugc/register.html"));
+        }
+        else if (e instanceof UserLoginNotFoundException) {
+            throw new CandlepinException(Response.Status.fromStatusCode(e.getStatus()),
+                i18n.tr("Unable to find user '{0}'", username));
+        }
+        else if (e instanceof UserUnknownValidateException) {
+            throw new CandlepinException(Response.Status.fromStatusCode(e.getStatus()),
+                i18n.tr("Unexpected error during user validation: {0}", e.getMessage()));
+        }
+        else if (e instanceof UserUnknownRetrievalException) {
+            throw new CandlepinException(Response.Status.fromStatusCode(e.getStatus()),
+                i18n.tr("Unexpected retrieval error from User Service: '{0}'", username));
+        }
+        else {
+            throw new CandlepinException(Response.Status.fromStatusCode(e.getStatus()),
+                i18n.tr("Unexpected error from User Service: {0}", e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/user/UserUnacceptedTermsException.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserUnacceptedTermsException.java
@@ -12,21 +12,18 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.service.exception;
-
-
+package org.candlepin.service.exception.user;
 
 /**
- * The CloudRegistrationAuthorizationException is used to reject a registration attempt for a
- * cloud provider or account holder.
+ * The UserUnacceptedTermsException is used to reject a user validation action.
  */
-public class CloudRegistrationAuthorizationException extends RuntimeException {
+public class UserUnacceptedTermsException extends UserServiceException {
 
     /**
      * Constructs a new exception with null as its detail message. The cause is not initialized,
      * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
      */
-    public CloudRegistrationAuthorizationException() {
+    public UserUnacceptedTermsException() {
         super();
     }
 
@@ -38,7 +35,7 @@ public class CloudRegistrationAuthorizationException extends RuntimeException {
      *  the detail message. The detail message is saved for later retrieval by the getMessage()
      *  method.
      */
-    public CloudRegistrationAuthorizationException(String message) {
+    public UserUnacceptedTermsException(String message) {
         super(message);
     }
 
@@ -52,7 +49,7 @@ public class CloudRegistrationAuthorizationException extends RuntimeException {
      *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
      *  value is permitted, and indicates that the cause is nonexistent or unknown.
      */
-    public CloudRegistrationAuthorizationException(Throwable cause) {
+    public UserUnacceptedTermsException(Throwable cause) {
         super(cause);
     }
 
@@ -70,7 +67,7 @@ public class CloudRegistrationAuthorizationException extends RuntimeException {
      *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
      *  value is permitted, and indicates that the cause is nonexistent or unknown.
      */
-    public CloudRegistrationAuthorizationException(String message, Throwable cause) {
+    public UserUnacceptedTermsException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/main/java/org/candlepin/service/exception/user/UserUnknownRetrievalException.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserUnknownRetrievalException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.user;
+
+/**
+ * The UserUnknownRetrievalException is used to reject a user retrieval action.
+ */
+public class UserUnknownRetrievalException extends UserServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public UserUnknownRetrievalException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public UserUnknownRetrievalException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserUnknownRetrievalException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserUnknownRetrievalException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/candlepin/service/exception/user/UserUnknownValidateException.java
+++ b/src/main/java/org/candlepin/service/exception/user/UserUnknownValidateException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.user;
+
+/**
+ * The UserUnknownValidateException is used to reject a user validation action.
+ */
+public class UserUnknownValidateException extends UserServiceException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public UserUnknownValidateException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     */
+    public UserUnknownValidateException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
+     * detail message of cause). This constructor is useful for exceptions that are little more
+     * than wrappers for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserUnknownValidateException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p></p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *  the detail message. The detail message is saved for later retrieval by the getMessage()
+     *  method.
+     *
+     * @param cause
+     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public UserUnknownValidateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -117,6 +117,7 @@ import org.candlepin.policy.js.pool.PoolUpdate;
 import org.candlepin.resource.dto.AutobindData;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.service.exception.subscription.SubscriptionUnknownRetrievalException;
 import org.candlepin.service.model.SubscriptionInfo;
 import org.candlepin.test.MockResultIterator;
 import org.candlepin.test.TestUtil;
@@ -455,7 +456,8 @@ public class PoolManagerTest {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
-    public void testRefreshPoolsOnlyRegeneratesFloatingWhenNecessary() {
+    public void testRefreshPoolsOnlyRegeneratesFloatingWhenNecessary()
+        throws SubscriptionUnknownRetrievalException {
         List<Subscription> subscriptions = new ArrayList<>();
 
         Owner owner = this.getOwner();
@@ -495,7 +497,8 @@ public class PoolManagerTest {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
-    public void testRefreshPoolsOnlyRegeneratesWhenNecessary() {
+    public void testRefreshPoolsOnlyRegeneratesWhenNecessary()
+        throws SubscriptionUnknownRetrievalException {
         List<Subscription> subscriptions = new ArrayList<>();
 
         Owner owner = this.getOwner();
@@ -535,7 +538,8 @@ public class PoolManagerTest {
         assertPoolsAreEqual(TestUtil.copyFromSub(sub), argPool.getValue());
     }
 
-    private void mockSubscriptions(Owner owner, Collection<? extends SubscriptionInfo> subscriptions) {
+    private void mockSubscriptions(Owner owner, Collection<? extends SubscriptionInfo> subscriptions)
+        throws SubscriptionUnknownRetrievalException {
         Set<String> sids = new HashSet<>();
 
         for (SubscriptionInfo subscription : subscriptions) {
@@ -768,7 +772,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void testRefreshPoolsDeletesOrphanedPools() {
+    public void testRefreshPoolsDeletesOrphanedPools()
+        throws SubscriptionUnknownRetrievalException {
         List<Subscription> subscriptions = new ArrayList<>();
         List<Pool> pools = new ArrayList<>();
         Product product = TestUtil.createProduct();
@@ -795,7 +800,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void testRefreshPoolsDeletesOrphanedHostedVirtBonusPool() {
+    public void testRefreshPoolsDeletesOrphanedHostedVirtBonusPool()
+        throws SubscriptionUnknownRetrievalException {
         List<Subscription> subscriptions = new ArrayList<>();
         List<Pool> pools = new ArrayList<>();
         Product product = TestUtil.createProduct();
@@ -828,7 +834,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void testRefreshPoolsSkipsOrphanedEntitlementDerivedPools() {
+    public void testRefreshPoolsSkipsOrphanedEntitlementDerivedPools()
+        throws SubscriptionUnknownRetrievalException {
         List<Subscription> subscriptions = new ArrayList<>();
         List<Pool> pools = new ArrayList<>();
         Product product = TestUtil.createProduct();
@@ -856,7 +863,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void testRefreshPoolsSkipsOrphanedStackDerivedPools() {
+    public void testRefreshPoolsSkipsOrphanedStackDerivedPools()
+        throws SubscriptionUnknownRetrievalException {
         List<Subscription> subscriptions = new ArrayList<>();
         List<Pool> pools = new ArrayList<>();
         Product product = TestUtil.createProduct();
@@ -883,7 +891,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void testRefreshPoolsSkipsDevelopmentPools() {
+    public void testRefreshPoolsSkipsDevelopmentPools()
+        throws SubscriptionUnknownRetrievalException {
         List<Subscription> subscriptions = new ArrayList<>();
         List<Pool> pools = new ArrayList<>();
         Product product = TestUtil.createProduct();
@@ -910,7 +919,8 @@ public class PoolManagerTest {
 
     @SuppressWarnings("rawtypes")
     @Test
-    public void testRefreshPoolsSortsStackDerivedPools() {
+    public void testRefreshPoolsSortsStackDerivedPools()
+        throws SubscriptionUnknownRetrievalException {
         List<Subscription> subscriptions = new ArrayList<>();
         List<Pool> pools = new ArrayList<>();
 
@@ -938,7 +948,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void refreshPoolsCreatingPoolsForExistingSubscriptions() {
+    public void refreshPoolsCreatingPoolsForExistingSubscriptions()
+        throws SubscriptionUnknownRetrievalException {
         List<Subscription> subscriptions = new ArrayList<>();
         List<Pool> pools = new ArrayList<>();
 
@@ -981,7 +992,8 @@ public class PoolManagerTest {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
-    public void refreshPoolsCleanupPoolThatLostVirtLimit() {
+    public void refreshPoolsCleanupPoolThatLostVirtLimit()
+        throws SubscriptionUnknownRetrievalException {
         List<Subscription> subscriptions = new ArrayList<>();
         List<Pool> pools = new ArrayList<>();
 
@@ -1249,7 +1261,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void testRefreshPoolsRemovesExpiredSubscriptionsAlongWithItsPoolsAndEnts() {
+    public void testRefreshPoolsRemovesExpiredSubscriptionsAlongWithItsPoolsAndEnts()
+        throws SubscriptionUnknownRetrievalException {
         PreUnbindHelper preHelper = mock(PreUnbindHelper.class);
 
         Date expiredStart = TestUtil.createDate(2004, 5, 5);
@@ -1350,7 +1363,7 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void testCleanupExpiredPools() {
+    public void testCleanupExpiredPools() throws SubscriptionUnknownRetrievalException {
         Pool p = createPoolWithEntitlements();
         p.setSubscriptionId("subid");
         List<Pool> pools = new LinkedList<>();
@@ -1374,7 +1387,7 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void testCleanupExpiredPoolsReadOnlySubscriptions() {
+    public void testCleanupExpiredPoolsReadOnlySubscriptions() throws SubscriptionUnknownRetrievalException {
         Pool p = createPoolWithEntitlements();
         p.setSubscriptionId("subid");
         List<Pool> pools = List.of(p);
@@ -1468,7 +1481,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void testRefreshPoolsRemovesOtherOwnerPoolsForSameSub() {
+    public void testRefreshPoolsRemovesOtherOwnerPoolsForSameSub()
+        throws SubscriptionUnknownRetrievalException {
         PreUnbindHelper preHelper = mock(PreUnbindHelper.class);
         Owner other = new Owner()
             .setKey("otherkey")
@@ -1584,7 +1598,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void createPoolsForExistingSubscriptionsNoneExist() {
+    public void createPoolsForExistingSubscriptionsNoneExist()
+        throws SubscriptionUnknownRetrievalException {
         Owner owner = this.getOwner();
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator);
 
@@ -1633,7 +1648,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void createPoolsForExistingSubscriptionsPrimaryExist() {
+    public void createPoolsForExistingSubscriptionsPrimaryExist()
+        throws SubscriptionUnknownRetrievalException {
         Owner owner = this.getOwner();
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator);
 
@@ -1675,7 +1691,8 @@ public class PoolManagerTest {
     }
 
     @Test
-    public void createPoolsForExistingSubscriptionsBonusExist() {
+    public void createPoolsForExistingSubscriptionsBonusExist()
+        throws SubscriptionUnknownRetrievalException {
         Owner owner = this.getOwner();
         PoolRules pRules = new PoolRules(manager, mockConfig, entitlementCurator);
 

--- a/src/test/java/org/candlepin/hostedtest/HostedTestCloudRegistrationAdapterTest.java
+++ b/src/test/java/org/candlepin/hostedtest/HostedTestCloudRegistrationAdapterTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.hostedtest;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.candlepin.TestingModules;
+import org.candlepin.auth.CloudRegistrationData;
+import org.candlepin.service.CloudRegistrationAdapter;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationBadMetadataException;
+import org.candlepin.service.exception.cloudregistration.CloudRegistrationMissingInfoException;
+import org.candlepin.service.model.CloudRegistrationInfo;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xnap.commons.i18n.I18n;
+
+
+
+public class HostedTestCloudRegistrationAdapterTest {
+
+    CloudRegistrationAdapter adapter;
+    I18n i18n;
+
+    @BeforeEach
+    public void init() {
+        Injector injector = Guice.createInjector(
+            new TestingModules.ServletEnvironmentModule());
+        i18n = injector.getInstance(I18n.class);
+        HostedTestDataStore ds = new HostedTestDataStore();
+        adapter = new HostedTestCloudRegistrationAdapter(ds);
+    }
+
+    @Test
+    public void testResolveCloudRegistrationData() {
+        CloudRegistrationInfo nullInfo = null;
+        assertThrows(CloudRegistrationMissingInfoException.class,
+            () -> adapter.resolveCloudRegistrationData(nullInfo));
+
+        CloudRegistrationInfo nullMeta = new CloudRegistrationData();
+        assertThrows(CloudRegistrationBadMetadataException.class,
+            () -> adapter.resolveCloudRegistrationData(nullMeta));
+    }
+}

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -91,6 +91,7 @@ import org.candlepin.service.IdentityCertServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.exception.user.UserServiceException;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.ContentOverrideValidator;
 import org.candlepin.util.FactValidator;
@@ -118,6 +119,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+
 
 
 /*
@@ -260,8 +262,7 @@ public class ConsumerResourceCreationTest {
             this.contentOverrideValidator,
             this.consumerContentOverrideCurator,
             this.entCertGenerator,
-            this.environmentContentCurator
-        );
+            this.environmentContentCurator);
 
         this.system = this.initConsumerType();
         this.mockConsumerType(this.system);
@@ -287,7 +288,6 @@ public class ConsumerResourceCreationTest {
         when(consumerCurator.update(any(Consumer.class)))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
-
         when(userService.findByLogin(USER)).thenReturn(user);
         IdentityCertificate cert = new IdentityCertificate();
         cert.setKey("testKey");
@@ -301,7 +301,7 @@ public class ConsumerResourceCreationTest {
             .thenReturn(new ComplianceStatus(new Date()));
     }
 
-    public ConsumerType initConsumerType() {
+    public ConsumerType initConsumerType() throws UserServiceException {
         return new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
     }
 

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -155,6 +155,8 @@ import javax.persistence.PersistenceException;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MultivaluedMap;
 
+
+
 public class OwnerResourceTest extends DatabaseTestFixture {
     private static final String OWNER_NAME = "Jar Jar Binks";
     private CandlepinPoolManager poolManager;
@@ -2311,5 +2313,11 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         assertThrows(NotFoundException.class,
             () -> resource.getOwnerContentAccess("test_owner"));
+    }
+
+    @Test
+    void refreshPoolsBadOwner() {
+        assertThrows(NotFoundException.class,
+            () -> ownerResource.refreshPools("This_key_does_not_exist", false));
     }
 }

--- a/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
+++ b/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
@@ -25,12 +25,14 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.PermissionBlueprint;
 import org.candlepin.model.Role;
 import org.candlepin.model.User;
+import org.candlepin.service.exception.user.UserServiceException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
 
 
 /**
@@ -42,7 +44,7 @@ public class PersonConsumerResourceCreationLiberalNameRules extends
     ConsumerResourceCreationLiberalNameRules {
 
     @Override
-    public ConsumerType initConsumerType() {
+    public ConsumerType initConsumerType() throws UserServiceException {
         ConsumerType systemtype = new ConsumerType(ConsumerType.ConsumerTypeEnum.PERSON);
 
         // create an owner, an ownerperm, and roles for the user we provide

--- a/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationTest.java
@@ -25,12 +25,14 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.PermissionBlueprint;
 import org.candlepin.model.Role;
 import org.candlepin.model.User;
+import org.candlepin.service.exception.user.UserServiceException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
 
 
 /**
@@ -42,7 +44,7 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class PersonConsumerResourceCreationTest extends ConsumerResourceCreationTest {
 
-    public ConsumerType initConsumerType() {
+    public ConsumerType initConsumerType() throws UserServiceException {
         ConsumerType ctype = new ConsumerType(ConsumerType.ConsumerTypeEnum.PERSON);
         this.mockConsumerType(ctype);
 

--- a/src/test/java/org/candlepin/resource/RoleResourceTest.java
+++ b/src/test/java/org/candlepin/resource/RoleResourceTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.candlepin.exceptions.CandlepinException;
+import org.candlepin.exceptions.NotFoundException;
+import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.exception.user.UserDisabledException;
+import org.candlepin.service.exception.user.UserServiceException;
+import org.candlepin.test.DatabaseTestFixture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+
+
+/**
+ * ProductResourceTest
+ */
+public class RoleResourceTest extends DatabaseTestFixture {
+    private RoleResource roleResource;
+    @Mock
+    UserServiceAdapter userServiceAdapter;
+
+    @BeforeEach
+    public void init() throws Exception {
+        super.init();
+        MockitoAnnotations.initMocks(this);
+        roleResource = new RoleResource(this.userServiceAdapter, ownerCurator, permissionBlueprintCurator,
+            i18n, modelTranslator, validator);
+    }
+
+    @Test
+    public void fetchUserByUsernameExceptions() throws UserServiceException {
+        when(userServiceAdapter.findByLogin(anyString())).thenReturn(null);
+        assertThrows(NotFoundException.class, () -> roleResource.fetchUserByUsername("test_user"));
+
+        when(userServiceAdapter.findByLogin(anyString())).thenThrow(UserDisabledException.class);
+        assertThrows(CandlepinException.class, () -> roleResource.fetchUserByUsername("test_user"));
+    }
+}

--- a/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
+++ b/src/test/java/org/candlepin/resource/SubscriptionResourceTest.java
@@ -35,6 +35,7 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.Pool;
 import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.service.exception.subscription.SubscriptionServiceException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,6 @@ import javax.ws.rs.core.Response;
  */
 @ExtendWith(MockitoExtension.class)
 public class SubscriptionResourceTest {
-
     @Mock
     private SubscriptionServiceAdapter subService;
     @Mock
@@ -83,7 +83,7 @@ public class SubscriptionResourceTest {
     }
 
     @Test
-    public void testInvalidIdOnDelete() throws Exception {
+    public void testInvalidIdOnDelete() {
         CandlepinQuery<Pool> cqmock = mock(CandlepinQuery.class);
         when(cqmock.iterator()).thenReturn(Collections.emptyIterator());
         when(poolManager.getPoolsBySubscriptionId(anyString())).thenReturn(cqmock);
@@ -117,7 +117,7 @@ public class SubscriptionResourceTest {
     }
 
     @Test
-    public void activateSubServiceCalled() {
+    public void activateSubServiceCalled() throws SubscriptionServiceException {
         this.config.setProperty(ConfigProperties.STANDALONE, "false");
 
         Consumer consumer = new Consumer()

--- a/src/test/java/org/candlepin/resteasy/filter/AuthenticationFilterTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/AuthenticationFilterTest.java
@@ -45,6 +45,7 @@ import org.candlepin.model.User;
 import org.candlepin.resteasy.AnnotationLocator;
 import org.candlepin.resteasy.MethodLocator;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.exception.user.UserServiceException;
 import org.candlepin.test.DatabaseTestFixture;
 
 import com.google.inject.AbstractModule;
@@ -77,6 +78,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Path;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ResourceInfo;
+
+
 
 /**
  * AuthInterceptorTest
@@ -165,7 +168,7 @@ public class AuthenticationFilterTest extends DatabaseTestFixture {
         when(mockInfo.getResourceClass()).thenReturn(resourceClass);
     }
 
-    private void keycloakSetup() {
+    private void keycloakSetup() throws UserServiceException {
         KeycloakOIDCFacade keycloakOIDCFacade = new KeycloakOIDCFacade(mockReq);
         when(usa.findByLogin(eq("qa@redhat.com"))).thenReturn(
             new User("Test", "redhat", true));

--- a/src/test/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationServiceExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/service/exception/cloudregistration/CloudRegistrationServiceExceptionMapperTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.cloudregistration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.candlepin.TestingModules;
+import org.candlepin.exceptions.BadRequestException;
+import org.candlepin.exceptions.CandlepinException;
+import org.candlepin.exceptions.NotAuthorizedException;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xnap.commons.i18n.I18n;
+
+
+
+public class CloudRegistrationServiceExceptionMapperTest {
+
+    I18n i18n;
+
+    @BeforeEach
+    public void init() {
+        Injector injector = Guice.createInjector(
+            new TestingModules.ServletEnvironmentModule());
+        i18n = injector.getInstance(I18n.class);
+    }
+
+    @Test
+    public void exceptionMappingTest() {
+        String message = "oops";
+        String type = "test_type";
+        assertEquals(i18n.tr("Cloud provider or account details could not be resolved to an organization"),
+            assertThrows(NotAuthorizedException.class,
+                () -> CloudRegistrationServiceExceptionMapper.map(
+                    new CloudRegistrationAuthorizationException(),
+                    type, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("Request is missing cloud provider type (e.g. amazon, gcp, azure)"),
+            assertThrows(BadRequestException.class,
+                () -> CloudRegistrationServiceExceptionMapper.map(new CloudRegistrationMissingTypeException(),
+                    type, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("Unrecognized provider type in request: {0}", type),
+            assertThrows(IllegalArgumentException.class,
+                () -> CloudRegistrationServiceExceptionMapper.map(new CloudRegistrationBadTypeException(),
+                    type, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("Unable to retrieve organization ID with provided meta-data"),
+            assertThrows(BadRequestException.class,
+                () -> CloudRegistrationServiceExceptionMapper.map(new CloudRegistrationBadMetadataException(),
+                    type, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("Unexpected data error from Cloud Registration Service: {0}", message),
+            assertThrows(CandlepinException.class,
+                () -> CloudRegistrationServiceExceptionMapper.map(
+                    new CloudRegistrationUnknownDataException(message),
+                    type, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("Unexpected error from Cloud Registration Service: {0}", message),
+            assertThrows(CandlepinException.class,
+                () -> CloudRegistrationServiceExceptionMapper.map(
+                    new CloudRegistrationServiceException(message),
+                    type, i18n))
+                .getMessage());
+    }
+}

--- a/src/test/java/org/candlepin/service/exception/subscription/SubscriptionServiceExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/service/exception/subscription/SubscriptionServiceExceptionMapperTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.subscription;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.candlepin.TestingModules;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xnap.commons.i18n.I18n;
+
+
+
+public class SubscriptionServiceExceptionMapperTest {
+
+    I18n i18n;
+
+    @BeforeEach
+    public void init() {
+        Injector injector = Guice.createInjector(
+            new TestingModules.ServletEnvironmentModule());
+        i18n = injector.getInstance(I18n.class);
+    }
+
+    @Test
+    public void exceptionMappingTest() {
+        assertEquals(
+            i18n.tr("A subscription was not found for the given Dell service tag: {0}", "service_tag"),
+            SubscriptionServiceExceptionMapper.map(new SubscriptionMissingTagException(),
+                "service_tag", "owner_key", i18n));
+        assertEquals(i18n.tr("The Dell service tag: {0}, is expired", "service_tag"),
+            SubscriptionServiceExceptionMapper.map(new SubscriptionExpiredTagException(),
+                "service_tag", "owner_key", i18n));
+        assertEquals(i18n.tr("No admins were returned for owner {0}", "owner_key"),
+            SubscriptionServiceExceptionMapper.map(new SubscriptionActivationNoAdminsException(),
+                "service_tag", "owner_key", i18n));
+        assertEquals(i18n.tr("The system is unable to redeem the requested subscription: {0}", "service_tag"),
+            SubscriptionServiceExceptionMapper.map(new SubscriptionUnknownActivationException(),
+                "service_tag", "owner_key", i18n));
+        assertEquals(
+            i18n.tr("The Dell service tag: {0}, has already been used to redeem a subscription",
+                "service_tag"),
+            SubscriptionServiceExceptionMapper.map(new SubscriptionUsedTagException(),
+                "service_tag", "owner_key", i18n));
+        assertEquals(
+            i18n.tr("No subscription was activated because there is no Dell Asset Tag", "service_tag"),
+            SubscriptionServiceExceptionMapper.map(new SubscriptionActivationNoTagException(),
+                "service_tag", "owner_key", i18n));
+        assertEquals(i18n.tr("The system is unable to redeem the requested subscription: {0}", "service_tag"),
+            SubscriptionServiceExceptionMapper.map(new SubscriptionActivationNoRedemptionTagException(),
+                "service_tag", "owner_key", i18n));
+        assertEquals(i18n.tr("The Dell service tag: {0}, could not be found.", "service_tag"),
+            SubscriptionServiceExceptionMapper.map(new SubscriptionNotFoundTagException(),
+                "service_tag", "owner_key", i18n));
+        String message = "oops";
+        assertEquals(i18n.tr("Unexpected error from Subscription Service: {0}", message),
+            SubscriptionServiceExceptionMapper.map(new SubscriptionServiceException(message),
+                "service_tag", "owner_key", i18n));
+    }
+}

--- a/src/test/java/org/candlepin/service/exception/user/UserServiceExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/service/exception/user/UserServiceExceptionMapperTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.candlepin.TestingModules;
+import org.candlepin.exceptions.CandlepinException;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xnap.commons.i18n.I18n;
+
+
+
+public class UserServiceExceptionMapperTest {
+
+    I18n i18n;
+
+    @BeforeEach
+    public void init() {
+        Injector injector = Guice.createInjector(
+            new TestingModules.ServletEnvironmentModule());
+        i18n = injector.getInstance(I18n.class);
+    }
+
+    @Test
+    public void exceptionMappingTest() {
+        String username = "test_user";
+        String message = "oops";
+        assertEquals(i18n.tr("User '{0}' is not valid.", username),
+            assertThrows(CandlepinException.class,
+                () -> UserServiceExceptionMapper.map(new UserInvalidException(),
+                    username, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("The system is unable to find an organization for user '{0}'", username),
+            assertThrows(CandlepinException.class,
+                () -> UserServiceExceptionMapper.map(new UserMissingOwnerException(),
+                    username, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("User '{0}' cannot be found.", username),
+            assertThrows(CandlepinException.class,
+                () -> UserServiceExceptionMapper.map(new UserMissingException(),
+                    username, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("You must first accept Red Hat''s Terms and conditions. " +
+            "Please visit {0} . You may have to log out of and back into the  " +
+            "Customer Portal in order to see the terms.",
+            "https://www.redhat.com/wapps/ugc"),
+            assertThrows(CandlepinException.class,
+                () -> UserServiceExceptionMapper.map(new UserUnacceptedTermsException(),
+                    username, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("The user '{0}' has been disabled, if this is a mistake, " +
+            "please contact customer service.", username),
+            assertThrows(CandlepinException.class,
+                () -> UserServiceExceptionMapper.map(new UserDisabledException(),
+                    username, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("Invalid username or password. To create a login, " +
+            "please visit {0}", "https://www.redhat.com/wapps/ugc/register.html"),
+            assertThrows(CandlepinException.class,
+                () -> UserServiceExceptionMapper.map(new UserCredentialsException(),
+                    username, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("Unable to find user '{0}'", username),
+            assertThrows(CandlepinException.class,
+                () -> UserServiceExceptionMapper.map(new UserLoginNotFoundException(),
+                    username, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("Unexpected error during user validation: {0}", message),
+            assertThrows(CandlepinException.class,
+                () -> UserServiceExceptionMapper.map(new UserUnknownValidateException(message),
+                    username, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("Unexpected retrieval error from User Service: '{0}'", username),
+            assertThrows(CandlepinException.class,
+                () -> UserServiceExceptionMapper.map(new UserUnknownRetrievalException(),
+                    username, i18n))
+                .getMessage());
+        assertEquals(i18n.tr("Unexpected error from User Service: {0}", message),
+            assertThrows(CandlepinException.class,
+                () -> UserServiceExceptionMapper.map(new UserServiceException(message),
+                    username, i18n))
+                .getMessage());
+    }
+}

--- a/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
+++ b/src/test/java/org/candlepin/service/impl/DefaultUserServiceAdapterTest.java
@@ -29,6 +29,7 @@ import org.candlepin.model.RoleCurator;
 import org.candlepin.model.User;
 import org.candlepin.model.UserCurator;
 import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.service.exception.user.UserServiceException;
 import org.candlepin.service.model.RoleInfo;
 import org.candlepin.service.model.UserInfo;
 import org.candlepin.test.DatabaseTestFixture;
@@ -42,6 +43,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+
 
 /**
  * DefaultUserServiceAdapterTest
@@ -155,7 +158,7 @@ public class DefaultUserServiceAdapterTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void findByLogin() {
+    public void findByLogin() throws UserServiceException {
         User u = mock(User.class);
         UserCurator curator = mock(UserCurator.class);
         RoleCurator roleCurator = mock(RoleCurator.class);


### PR DESCRIPTION
- Brings the translated messages to Candlepin away from adapter implementation code.
- Allows Candlepin to react to the type of exception instead of simply passing through RuntimeExceptions.