### PR TITLE
Remove deprecated liquibase cli option

### DIFF
--- a/bin/scripts/code/setup/cpdb
+++ b/bin/scripts/code/setup/cpdb
@@ -88,7 +88,7 @@ class DbSetup(object):
             classpath = "%s:%s" % (classpath, JBOSS_CLASSPATH)
 
         liquibase_options = "--driver=%s --classpath=%s --changelog-file=%s --url=\"%s\" --username=$DBUSERNAME \
-            --headless=true --hub-mode=OFF" % (
+            --headless=true" % (
             self.driver_class,
             classpath,
             changelog_path,


### PR DESCRIPTION
- Since Liquibase v4.23.0 it no longer reports to liquibase hub and the option was removed.