### PR TITLE
[M] Use the 'latest' libvirt images from cloud.centos.org

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,7 +78,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define("el8", primary: true) do |vm_config|
-    vm_config.vm.box = "generic/centos8s"
+    vm_config.vm.box = "centos.cloud/centos8s"
+    vm_config.vm.box_url = "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-latest.x86_64.vagrant-libvirt.box"
     vm_config.vm.host_name = "candlepin-el8.example.com"
 
     # Vagrant allows to create a forwarded port mapping which allows access to a specific port
@@ -92,7 +93,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define("el9", autostart: false) do |vm_config|
-    vm_config.vm.box = "generic/centos9s"
+    vm_config.vm.box = "centos.cloud/centos9s"
+    vm_config.vm.box_url = "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-latest.x86_64.vagrant-libvirt.box"
     vm_config.vm.host_name = "candlepin-el9.example.com"
     vm_config.vm.provision "shell", inline: "dnf update -y dnf ca-certificates"
     configure_ansible_provisioning(vm_config)


### PR DESCRIPTION
- Centos devs now provide a '-latest' link/version of their libvirt images, which are frequently updated, and so are preferred to the outdated generic centos versions from app.vagrantup.com.