### PR TITLE
[F] CANDLEPIN-707: Handle rejection for 1P offering systems

### DIFF
--- a/client/src/main/java/org/candlepin/resource/HostedTestApi.java
+++ b/client/src/main/java/org/candlepin/resource/HostedTestApi.java
@@ -715,16 +715,34 @@ public class HostedTestApi {
      *     the product IDs to associate to an offering ID
      */
     public void associateProductIdsToCloudOffer(String cloudOfferId, Collection<String> productIds) {
-        okhttp3.Call localVarCall = associateProductIdsToCloudOfferCall(cloudOfferId, productIds);
+        okhttp3.Call localVarCall = associateProductIdsToCloudOfferCall(cloudOfferId, null, productIds);
         localVarApiClient.execute(localVarCall);
     }
 
-    public okhttp3.Call associateProductIdsToCloudOfferCall(String cloudOfferId, Collection<String> productIds) {
+    /**
+     * Associates a cloud offering ID to an offering type and a product ID in the hosted test adapters.
+     *
+     * @param cloudOfferId
+     *     the offering ID to associate to a product ID
+     *
+     * @param cloudOfferType
+     *     the offering type to associate to the cloud offering ID
+     *
+     * @param productIds
+     *     the product IDs to associate to an offering ID
+     */
+    public void associateProductIdsToCloudOffer(String cloudOfferId, String cloudOfferType, Collection<String> productIds) {
+        okhttp3.Call localVarCall = associateProductIdsToCloudOfferCall(cloudOfferId, cloudOfferType, productIds);
+        localVarApiClient.execute(localVarCall);
+    }
+
+    public okhttp3.Call associateProductIdsToCloudOfferCall(String cloudOfferId, String cloudOfferType, Collection<String> productIds) {
         String basePath = getBasePath();
 
         Map<String, Object> bodyMap = new HashMap<>();
         bodyMap.put("cloudOfferId", cloudOfferId);
         bodyMap.put("productIds", productIds);
+        bodyMap.put("cloudOfferType", cloudOfferType);
 
         Object body = bodyMap;
 

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/StatusCodeAssertions.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/StatusCodeAssertions.java
@@ -81,6 +81,12 @@ public final class StatusCodeAssertions {
         return assertReturnCode(503, exception);
     }
 
+    public static AbstractThrowableAssert<?, ? extends Throwable> assertNotImplemented(
+        ThrowableAssert.ThrowingCallable callable) {
+        ApiException exception = catchApiException(callable);
+        return assertReturnCode(501, exception);
+    }
+
     public static CandlepinStatusAssert assertThatStatus(
         ThrowableAssert.ThrowingCallable callable) {
         ApiException exception = catchApiException(callable);

--- a/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
@@ -17,6 +17,7 @@ package org.candlepin.spec;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertBadRequest;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertNotFound;
+import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertNotImplemented;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertUnauthorized;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -362,6 +363,21 @@ class CloudRegistrationSpecTest {
         adminClient.hosted().associateOwnerToCloudAccount(accountId, owner.getKey());
 
         assertUnauthorized(() -> adminClient.cloudAuthorization()
+            .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", ""));
+    }
+
+    @Test
+    public void shouldThrowNotImplementedExceptionWith1POfferingForV2Auth()
+        throws Exception {
+        ApiClient adminClient = ApiClients.admin();
+        String accountId = StringUtil.random("cloud-account-id-");
+        String instanceId = StringUtil.random("cloud-instance-id-");
+        String offerId = StringUtil.random("cloud-offer-");
+
+        ProductDTO product = adminClient.hosted().createProduct(Products.random());
+        adminClient.hosted().associateProductIdsToCloudOffer(offerId, "1P", List.of(product.getId()));
+
+        assertNotImplemented(() -> adminClient.cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", ""));
     }
 

--- a/src/main/java/org/candlepin/hostedtest/HostedTestCloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestCloudRegistrationAdapter.java
@@ -17,6 +17,7 @@ package org.candlepin.hostedtest;
 import org.candlepin.service.CloudProvider;
 import org.candlepin.service.CloudRegistrationAdapter;
 import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
+import org.candlepin.service.exception.CloudRegistrationNotSupportedForOfferingException;
 import org.candlepin.service.exception.CouldNotAcquireCloudAccountLockException;
 import org.candlepin.service.exception.CouldNotEntitleOrganizationException;
 import org.candlepin.service.exception.MalformedCloudRegistrationException;
@@ -52,6 +53,7 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
     private static final String ACCOUNT_ID_FIELD_NAME = "accountId";
     private static final String INSTANCE_ID_FIELD_NAME = "instanceId";
     private static final String OFFERING_ID_FIELD_NAME = "cloudOfferingId";
+    private static final String OFFERING_TYPE_1P = "1P";
     private static final ObjectMapper OBJ_MAPPER = ObjectMapperFactory.getObjectMapper();
 
     private final HostedTestDataStore datastore;
@@ -128,6 +130,12 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
         if (offerId == null || offerId.isBlank()) {
             throw new MalformedCloudRegistrationException(
                 "missing offer ID in registration information metadata");
+        }
+
+        String offerType = this.datastore.getOfferTypeForOfferId(offerId);
+        if (OFFERING_TYPE_1P.equals(offerType)) {
+            throw new CloudRegistrationNotSupportedForOfferingException(
+                "cloud registration v2 is not supported for 1P offerings");
         }
 
         String ownerKey = this.datastore.getOwnerKeyForCloudAccountId(accountId);

--- a/src/main/java/org/candlepin/hostedtest/HostedTestDataStore.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestDataStore.java
@@ -84,6 +84,7 @@ public class HostedTestDataStore {
     protected Map<String, Set<String>> productSubscriptionMap;
 
     protected Map<String, Set<String>> cloudOfferIdToProductIds;
+    protected Map<String, String> cloudOfferIdToOfferType;
     protected Map<String, String> cloudAccountIdToOwnerKey;
 
     /**
@@ -103,6 +104,7 @@ public class HostedTestDataStore {
         this.productSubscriptionMap = new ConcurrentHashMap<>();
 
         this.cloudOfferIdToProductIds = new ConcurrentHashMap<>();
+        this.cloudOfferIdToOfferType = new ConcurrentHashMap<>();
         this.cloudAccountIdToOwnerKey = new ConcurrentHashMap<>();
     }
 
@@ -978,6 +980,14 @@ public class HostedTestDataStore {
 
     protected Set<String> getProductIdsForOfferId(String cloudOfferId) {
         return cloudOfferIdToProductIds.get(cloudOfferId);
+    }
+
+    protected void setOfferTypeForCloudOfferId(String cloudOfferId, String cloudOfferType) {
+        cloudOfferIdToOfferType.put(cloudOfferId, cloudOfferType);
+    }
+
+    protected String getOfferTypeForOfferId(String cloudOfferId) {
+        return cloudOfferIdToOfferType.get(cloudOfferId);
     }
 
     protected void setCloudAccountIdForOwnerKey(String cloudAccountId,

--- a/src/main/java/org/candlepin/hostedtest/HostedTestResource.java
+++ b/src/main/java/org/candlepin/hostedtest/HostedTestResource.java
@@ -767,6 +767,15 @@ public class HostedTestResource {
         productIdsNode.elements().forEachRemaining(prod -> productIds.add(prod.asText()));
 
         this.datastore.setProductIdsForCloudOfferId(offerId, productIds);
+
+        JsonNode cloudOfferTypeNode = root.get("cloudOfferType");
+        if (cloudOfferTypeNode != null) {
+            String cloudOfferType = cloudOfferTypeNode.asText();
+            if (cloudOfferType != null && !cloudOfferType.isBlank()) {
+                this.datastore.setOfferTypeForCloudOfferId(offerId, cloudOfferType);
+            }
+        }
+
     }
 
     @POST

--- a/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
+++ b/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
@@ -39,6 +39,7 @@ import org.candlepin.resource.server.v1.CloudRegistrationApi;
 import org.candlepin.service.CloudProvider;
 import org.candlepin.service.CloudRegistrationAdapter;
 import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
+import org.candlepin.service.exception.CloudRegistrationNotSupportedForOfferingException;
 import org.candlepin.service.exception.MalformedCloudRegistrationException;
 import org.candlepin.service.model.CloudAuthenticationResult;
 
@@ -139,6 +140,11 @@ public class CloudRegistrationResource implements CloudRegistrationApi {
         }
         catch (UnsupportedOperationException e) {
             String errmsg = this.i18n.tr("Cloud registration is not supported by this Candlepin instance");
+            throw new NotImplementedException(errmsg, e);
+        }
+        catch (CloudRegistrationNotSupportedForOfferingException e) {
+            String errmsg = this.i18n.tr("Cloud registration is not supported for the type of " +
+                "offering the client is using");
             throw new NotImplementedException(errmsg, e);
         }
         catch (CloudRegistrationAuthorizationException e) {

--- a/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
@@ -15,6 +15,7 @@
 package org.candlepin.service;
 
 import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
+import org.candlepin.service.exception.CloudRegistrationNotSupportedForOfferingException;
 import org.candlepin.service.exception.CouldNotAcquireCloudAccountLockException;
 import org.candlepin.service.exception.CouldNotEntitleOrganizationException;
 import org.candlepin.service.exception.MalformedCloudRegistrationException;
@@ -59,11 +60,15 @@ public interface CloudRegistrationAdapter {
      * @throws CloudRegistrationAuthorizationException
      *     if cloud registration is not permitted for the provider or account holder
      *
+     * @throws CloudRegistrationNotSupportedForOfferingException
+     *     if cloud registration is not supported for the type of offering the client is using
+     *
      * @return the cloud authentication result which contains the owner key, cloud account ID, and
      * product ID
      */
     CloudAuthenticationResult resolveCloudRegistrationDataV2(CloudRegistrationInfo cloudRegInfo)
-        throws CloudRegistrationAuthorizationException, MalformedCloudRegistrationException;
+        throws CloudRegistrationAuthorizationException, MalformedCloudRegistrationException,
+            CloudRegistrationNotSupportedForOfferingException;
 
     /**
      * Create (if one does not already exist) and entitle an owner upstream of Candlepin, for the given

--- a/src/main/java/org/candlepin/service/exception/CloudRegistrationNotSupportedForOfferingException.java
+++ b/src/main/java/org/candlepin/service/exception/CloudRegistrationNotSupportedForOfferingException.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.service.exception;
+
+/**
+ * The CloudRegistrationNotSupportedForOfferingException is used to reject a registration attempt for a
+ * cloud system when that system is using a type of offering that is not supported (e.g. 1P offerings).
+ */
+public class CloudRegistrationNotSupportedForOfferingException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public CloudRegistrationNotSupportedForOfferingException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and
+     * may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *     the detail message. The detail message is saved for later retrieval by the getMessage()
+     *     method.
+     */
+    public CloudRegistrationNotSupportedForOfferingException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and detail
+     * message of cause). This constructor is useful for exceptions that are little more than wrappers
+     * for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *     the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *     value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationNotSupportedForOfferingException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * </p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *     the detail message. The detail message is saved for later retrieval by the getMessage()
+     *     method.
+     *
+     * @param cause
+     *     the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *     value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudRegistrationNotSupportedForOfferingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
- First party (1P) offerings are not supported for the autoregv2 MVP implementation. Handle them gracefully with a meaningful error for the clients.