### PR TITLE
[F] Add CloudAccountOrgSetupJob org mismatch case exception

### DIFF
--- a/src/main/java/org/candlepin/async/tasks/CloudAccountOrgSetupJob.java
+++ b/src/main/java/org/candlepin/async/tasks/CloudAccountOrgSetupJob.java
@@ -26,6 +26,7 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.service.CloudProvider;
 import org.candlepin.service.CloudRegistrationAdapter;
+import org.candlepin.service.exception.CloudAccountOrgMismatchException;
 import org.candlepin.service.exception.CouldNotAcquireCloudAccountLockException;
 import org.candlepin.service.exception.CouldNotEntitleOrganizationException;
 import org.candlepin.service.model.CloudAccountData;
@@ -101,7 +102,8 @@ public class CloudAccountOrgSetupJob implements AsyncJob {
             log.info("Entitled offering {} to owner {} (anonymous: {}).", offeringId,
                 accountData.ownerKey(), accountData.isAnonymous());
         }
-        catch (CouldNotEntitleOrganizationException | CouldNotAcquireCloudAccountLockException e) {
+        catch (CouldNotEntitleOrganizationException | CouldNotAcquireCloudAccountLockException |
+            CloudAccountOrgMismatchException e) {
             throw new JobExecutionException(e.getMessage(), e, false);
         }
     }

--- a/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.service;
 
+import org.candlepin.service.exception.CloudAccountOrgMismatchException;
 import org.candlepin.service.exception.CloudRegistrationAuthorizationException;
 import org.candlepin.service.exception.CloudRegistrationNotSupportedForOfferingException;
 import org.candlepin.service.exception.CouldNotAcquireCloudAccountLockException;
@@ -96,6 +97,7 @@ public interface CloudRegistrationAdapter {
      */
     CloudAccountData setupCloudAccountOrg(String cloudAccountID, String cloudOfferingID,
         CloudProvider cloudProviderShortName, String ownerKey)
-        throws CouldNotAcquireCloudAccountLockException, CouldNotEntitleOrganizationException;
+        throws CouldNotAcquireCloudAccountLockException, CouldNotEntitleOrganizationException,
+            CloudAccountOrgMismatchException;
 
 }

--- a/src/main/java/org/candlepin/service/exception/CloudAccountOrgMismatchException.java
+++ b/src/main/java/org/candlepin/service/exception/CloudAccountOrgMismatchException.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.service.exception;
+
+
+/**
+ * The CloudAccountOrgMismatchException indicates that there was a conflict (HTTP status code 409)
+ * regarding the cloud account's organization key upstream of Candlepin, when trying to entitle that
+ * organization. Candlepin should retry to entitle it until that conflict is resolved.
+ */
+public class CloudAccountOrgMismatchException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with null as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to initCause(java.lang.Throwable).
+     */
+    public CloudAccountOrgMismatchException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and
+     * may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     *
+     * @param message
+     *     the detail message. The detail message is saved for later retrieval by the getMessage()
+     *     method.
+     */
+    public CloudAccountOrgMismatchException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of
+     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and detail
+     * message of cause). This constructor is useful for exceptions that are little more than wrappers
+     * for other throwables (for example, PrivilegedActionException).
+     *
+     * @param cause
+     *     the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *     value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudAccountOrgMismatchException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * </p>
+     * Note that the detail message associated with cause is not automatically incorporated in this
+     * exception's detail message.
+     *
+     * @param message
+     *     the detail message. The detail message is saved for later retrieval by the getMessage()
+     *     method.
+     *
+     * @param cause
+     *     the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
+     *     value is permitted, and indicates that the cause is nonexistent or unknown.
+     */
+    public CloudAccountOrgMismatchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
- Defines adapter interface exception in case the cloud account setup cannot be done yet due to an org key conflict upstream of Candlepin.