### PR TITLE
[M] Build Github actions spec test containers using docker compose build

### DIFF
--- a/.github/containers/mariadb.docker-compose.yml
+++ b/.github/containers/mariadb.docker-compose.yml
@@ -21,8 +21,10 @@ services:
       retries: 10
 
   candlepin:
-    image: ${CANDLEPIN_IMAGE}
     container_name: candlepin
+    build:
+      context: ${GITHUB_WORKSPACE}
+      dockerfile: ./.github/containers/Dockerfile
     environment:
       JPA_CONFIG_HIBERNATE_DIALECT: org.hibernate.dialect.MySQL5InnoDBDialect
       JPA_CONFIG_HIBERNATE_CONNECTION_DRIVER_CLASS: org.mariadb.jdbc.Driver

--- a/.github/containers/postgres.docker-compose.yml
+++ b/.github/containers/postgres.docker-compose.yml
@@ -20,8 +20,10 @@ services:
       retries: 10
 
   candlepin:
-    image: ${CANDLEPIN_IMAGE}
     container_name: candlepin
+    build:
+      context: ${GITHUB_WORKSPACE}
+      dockerfile: ./.github/containers/Dockerfile
     environment:
       JPA_CONFIG_HIBERNATE_DIALECT: org.hibernate.dialect.PostgreSQL92Dialect
       JPA_CONFIG_HIBERNATE_CONNECTION_DRIVER_CLASS: org.postgresql.Driver

--- a/.github/workflows/spec_tests.yml
+++ b/.github/workflows/spec_tests.yml
@@ -1,5 +1,5 @@
 ---
-name: Build Candlepin image and run spec tests
+name: Run spec tests
 
 on:
   pull_request:
@@ -11,77 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_image:
-    name: build Candlepin image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Install packages
-        if: ${{ ! github.event.pull_request.head.repo.fork }}
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install \
-            git-core \
-            buildah
-
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Rebase
-        uses: ./.github/actions/rebase
-
-      - name: Log in to the registry
-        if: ${{ ! github.event.pull_request.head.repo.fork }}
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build Candlepin image
-        if: ${{ ! github.event.pull_request.head.repo.fork }}
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: ghcr.io/candlepin/gha_build
-          tags: pr-${{ github.event.pull_request.number }}
-          containerfiles: ./.github/containers/Dockerfile
-
-      - name: Push to registry
-        if: ${{ ! github.event.pull_request.head.repo.fork }}
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ghcr.io/candlepin/gha_build
-          tags: pr-${{ github.event.pull_request.number }}
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and export
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        uses: docker/build-push-action@v5
-        with:
-          file: ./.github/containers/Dockerfile
-          tags: ghcr.io/candlepin/gha_build:pr-${{ github.event.pull_request.number }}
-          outputs: type=docker,dest=/tmp/gha_build.tar
-
-      - name: Upload artifact
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: gha_build
-          path: /tmp/gha_build.tar
-
   spec_tests:
     name: spec tests
     runs-on: ubuntu-latest
@@ -91,7 +20,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    needs: build_image
     strategy:
       fail-fast: false
       matrix:
@@ -135,25 +63,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull candlepin image
-        if: ${{ ! github.event.pull_request.head.repo.fork }}
-        shell: bash
-        run: docker image pull ghcr.io/candlepin/gha_build:pr-${{ github.event.pull_request.number }}
-
       - name: Set up Docker Buildx
         if: ${{ github.event.pull_request.head.repo.fork }}
         uses: docker/setup-buildx-action@v3
-
-      - name: Download artifact
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        uses: actions/download-artifact@v3
-        with:
-          name: gha_build
-          path: /tmp
-
-      - name: Load image
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        run: docker load --input /tmp/gha_build.tar
 
       - if: matrix.mode == 'standalone'
         name: Add standalone env variable
@@ -175,10 +87,9 @@ jobs:
       - name: Create Candlepin and database containers
         shell: bash
         run: |
-          echo "CANDLEPIN_IMAGE=ghcr.io/candlepin/gha_build:pr-${{ github.event.pull_request.number }}" >> ./.github/containers/.env
           BRIDGE_NETWORK=$(docker network ls --filter=name=github_network_ --format="{{ .Name }}")
           echo "NETWORK=$BRIDGE_NETWORK" >> ./.github/containers/.env
-          docker compose -f ./.github/containers/${{ matrix.database }}.docker-compose.yml --env-file ./.github/containers/.env up -d --wait
+          docker compose -f ./.github/containers/${{ matrix.database }}.docker-compose.yml --env-file ./.github/containers/.env up --build -d --wait
 
       - name: Set up Java
         uses: actions/setup-java@v3


### PR DESCRIPTION
- Removed the Github actions build_image job
- Added build section to spec Github actions docker-compose files

Instead of using a Github actions job to build an image and push to the Github container registry for non-forked PRs and then pulling the image when we are running `docker compose up`, we can use the `--build` option when running `docker compose up` and build the image and then run the container in the same command.

Also, for forked PRs we won't have to upload and download the image tar file, we can just run `docker compose up` with the `--build` option.

Build of a forked PR to verify that the changes are compatible with forked PRs: https://github.com/candlepin/candlepin/actions/runs/6856289293/job/18643172392