### PR TITLE
[M] CANDLEPIN-318: Added new utility for abstract universal paging logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,6 +217,7 @@ gradleLint {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
+    // options.compilerArgs << "-Xlint:unchecked"
     // options.compilerArgs << "-Xlint:deprecation"
     // options.compilerArgs.addAll(['--release', '8'])
 }

--- a/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -339,7 +339,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     }
 
     private Order createPagingOrder(PageRequest p) {
-        String sortBy = (p.getSortBy() == null) ? AbstractHibernateObject.DEFAULT_SORT_FIELD : p.getSortBy();
+        String sortBy = (p.getSortBy() == null) ? PageRequest.DEFAULT_SORT_FIELD : p.getSortBy();
         PageRequest.Order order = (p.getOrder() == null) ? PageRequest.DEFAULT_ORDER : p.getOrder();
 
         switch (order) {
@@ -353,7 +353,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
     }
 
     private javax.persistence.criteria.Order createPagingOrder(Root<?> root, PageRequest p) {
-        String sortBy = (p.getSortBy() == null) ? AbstractHibernateObject.DEFAULT_SORT_FIELD : p.getSortBy();
+        String sortBy = (p.getSortBy() == null) ? PageRequest.DEFAULT_SORT_FIELD : p.getSortBy();
         PageRequest.Order order = (p.getOrder() == null) ? PageRequest.DEFAULT_ORDER : p.getOrder();
         CriteriaBuilder criteriaBuilder = this.entityManager.get().getCriteriaBuilder();
 

--- a/src/main/java/org/candlepin/model/AbstractHibernateObject.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateObject.java
@@ -69,17 +69,6 @@ public abstract class AbstractHibernateObject<T extends AbstractHibernateObject>
 
     private static final long serialVersionUID = 6677558844288404862L;
 
-    /**
-     * The name of the field to sort by when no sort field is specified by the client.
-     *
-     * @deprecated
-     *  Declared as part of the v1 paging framework. This field will be moved to the paging
-     *  interfaces once implemented.
-     */
-    @Deprecated
-    public static final String DEFAULT_SORT_FIELD = "created";
-
-
     private Date created;
     private Date updated;
 

--- a/src/main/java/org/candlepin/paging/FieldComparatorFactory.java
+++ b/src/main/java/org/candlepin/paging/FieldComparatorFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.paging;
+
+import java.util.Comparator;
+
+
+
+/**
+ * A functional interface for defining a mapping function that converts a field name to a comparator
+ * for the purposes of sorting collections or streams for paged output.
+ *
+ * @param <T>
+ *  the class type for which this factory's mapping logic applies
+ */
+@FunctionalInterface
+public interface FieldComparatorFactory<T> {
+
+    /**
+     * Fetches a comparator which orders elements of this comparator factory's type by using the
+     * value returned by accessor best matching the given field name. The comparator this method
+     * returns should always order elements in ascending order. If the type supported by this
+     * comparator factory has no mapping for the given field name, this method should return null.
+     *
+     * @param fieldName
+     *  the name of the field for which to build a comparator
+     *
+     * @return
+     *  a comparator for this factory's type which compares instances using the appropriate field
+     *  for the given field name; or null if the field name does not have a mapping for the type
+     */
+    Comparator<T> getComparator(String fieldName);
+
+    /**
+     * Gets the default comparator for this type. The default comparator should only be used in
+     * cases where paging is requested, but no sort-by field has been provided.
+     * <p>
+     * The default implementation of this method calls into <tt>getComparator</tt> using the value
+     * defined at <tt>PageRequest.DEFAULT_SORT_FIELD</tt> as the field name. Implementors are
+     * encouraged to provide a more accurate default comparator.
+     *
+     * @return
+     *  a comparator to use for sorting objects of this factory's type when no explicit sort-by
+     *  field has been provided; or null if no default sorting is supported
+     */
+    default Comparator<T> getDefaultComparator() {
+        // This is actually a very bad default, but it's here for backwards compatibility purposes.
+        // Existing solutions use this field whenever the sort-by field is absent, so to be drop-in
+        // compliant, we do the same.
+        return this.getComparator(PageRequest.DEFAULT_SORT_FIELD);
+    }
+
+}

--- a/src/main/java/org/candlepin/paging/Page.java
+++ b/src/main/java/org/candlepin/paging/Page.java
@@ -30,24 +30,27 @@ public class Page<T> {
         return pageData;
     }
 
-    public void setPageData(T pageData) {
+    public Page<T> setPageData(T pageData) {
         this.pageData = pageData;
+        return this;
     }
 
     public Integer getMaxRecords() {
         return maxRecords;
     }
 
-    public void setMaxRecords(Integer maxRecords) {
+    public Page<T> setMaxRecords(Integer maxRecords) {
         this.maxRecords = maxRecords;
+        return this;
     }
 
     public PageRequest getPageRequest() {
         return pageRequest;
     }
 
-    public void setPageRequest(PageRequest pageRequest) {
+    public Page<T> setPageRequest(PageRequest pageRequest) {
         this.pageRequest = pageRequest;
+        return this;
     }
 
 }

--- a/src/main/java/org/candlepin/paging/PageRequest.java
+++ b/src/main/java/org/candlepin/paging/PageRequest.java
@@ -34,6 +34,7 @@ public class PageRequest {
     public static final Integer DEFAULT_PAGE = 1;
     public static final Integer DEFAULT_PER_PAGE = 10;
     public static final Order DEFAULT_ORDER = Order.DESCENDING;
+    public static final String DEFAULT_SORT_FIELD = "created";
 
     private Integer page;
     private Integer perPage;
@@ -44,32 +45,36 @@ public class PageRequest {
         return page;
     }
 
-    public void setPage(Integer page) {
+    public PageRequest setPage(Integer page) {
         this.page = page;
+        return this;
     }
 
     public Integer getPerPage() {
         return perPage;
     }
 
-    public void setPerPage(Integer perPage) {
+    public PageRequest setPerPage(Integer perPage) {
         this.perPage = perPage;
+        return this;
     }
 
     public String getSortBy() {
         return sortBy;
     }
 
-    public void setSortBy(String sortBy) {
+    public PageRequest setSortBy(String sortBy) {
         this.sortBy = sortBy;
+        return this;
     }
 
     public Order getOrder() {
         return order;
     }
 
-    public void setOrder(Order order) {
+    public PageRequest setOrder(Order order) {
         this.order = order;
+        return this;
     }
 
     public boolean isPaging() {

--- a/src/main/java/org/candlepin/paging/PagingUtil.java
+++ b/src/main/java/org/candlepin/paging/PagingUtil.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.paging;
+
+import org.candlepin.exceptions.BadRequestException;
+
+import org.jboss.resteasy.core.ResteasyContext;
+import org.xnap.commons.i18n.I18n;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+
+
+/**
+ * The PagingUtil class provides methods for applying paging to common collections when present in
+ * the request context.
+ *
+ * @param <T>
+ *  the type this util will page
+ */
+public class PagingUtil<T> {
+    private final I18n i18n;
+    private final FieldComparatorFactory<T> comparatorFactory;
+
+    /**
+     * Builds a new PagingUtil with the given internationalization and comparator factory.
+     *
+     * @param i18n
+     *  the internationalization module to use for translating error messages
+     *
+     * @param comparatorFactory
+     *  the comparator factory to use for sorting elements paged by this paging util
+     */
+    public PagingUtil(I18n i18n, FieldComparatorFactory<T> comparatorFactory) {
+        this.i18n = Objects.requireNonNull(i18n);
+        this.comparatorFactory = Objects.requireNonNull(comparatorFactory);
+    }
+
+    /**
+     * Applies any paging in the request context to the given stream. This method returns a copy of
+     * the stream with any sorting, offset, and/or limits applied as specified in the request. If
+     * the request does not define any paging information, this method returns the provided stream
+     * unmodified. If the provided stream is null, this method returns an empty stream.
+     *
+     * @param stream
+     *  the stream to page
+     *
+     * @param count
+     *  the number of expected elements in the stream; used to populate the "max records" header
+     *
+     * @throws BadRequestException
+     *  if the field in the request cannot be resolved by this PagingUtil's field mapper
+     *
+     * @return
+     *  a stream with any paging from the request context applied
+     */
+    public Stream<T> applyPaging(Stream<T> stream, int count) {
+        // Check that we actually have something to page
+        if (stream == null) {
+            stream = Stream.of();
+            count = 0;
+        }
+
+        // Ensure we have a paged request
+        PageRequest pageRequest = ResteasyContext.getContextData(PageRequest.class);
+        if (pageRequest == null) {
+            return stream;
+        }
+
+        // Impl note:
+        // Sorting will always be required (for consistency) if a page request object is
+        // present -- either .isPaging() will be true, or we'll have ordering config.
+        String sortField = pageRequest.getSortBy();
+        Comparator<T> comparator = sortField != null && !sortField.isBlank() ?
+            this.comparatorFactory.getComparator(sortField) :
+            this.comparatorFactory.getDefaultComparator();
+
+        if (comparator == null) {
+            // We need to change up the error message depending on the presence of the sortBy field.
+            String errmsg = sortField != null && !sortField.isBlank() ?
+                this.i18n.tr("Invalid or unsupported sort-by field: {0}", sortField) :
+                this.i18n.tr("Paging requested, but no sort-by field provided");
+
+            throw new BadRequestException(errmsg);
+        }
+
+        // Ordering
+        PageRequest.Order order = Optional.ofNullable(pageRequest.getOrder())
+            .orElse(PageRequest.DEFAULT_ORDER);
+
+        if (order == PageRequest.Order.DESCENDING) {
+            comparator = comparator.reversed();
+        }
+
+        stream = stream.sorted(comparator);
+
+        // Paging
+        if (pageRequest.isPaging()) {
+            int page = pageRequest.getPage();
+            int pageSize = pageRequest.getPerPage();
+            int offset = (page - 1) * pageSize;
+
+            stream = stream.skip(offset)
+                .limit(pageSize);
+
+            // Create a page object for the link header response
+            Page<T> contextPage = new Page<T>()
+                .setMaxRecords(count)
+                .setPageRequest(pageRequest);
+
+            // Note: we don't need to (nor should we) store the page data in the page
+            ResteasyContext.pushContext(Page.class, contextPage);
+        }
+
+        return stream;
+    }
+
+    /**
+     * Converts the given collection to a stream, with any paging in the request context applied.
+     * If the request does not define any paging information, this method returns the a stream
+     * containing all of the elements of the collection in their original, unmodified order;
+     * functionally identical to calling its <tt>.stream()</tt> method. If the provided collection
+     * is null, this method returns an empty stream.
+     *
+     * @param collection
+     *  the collection to page
+     *
+     * @throws BadRequestException
+     *  if the field in the request cannot be resolved by this PagingUtil's field mapper
+     *
+     * @return
+     *  a stream with applied paging from the request context, or null if no collection was provided
+     */
+    public Stream<T> applyPaging(Collection<T> collection) {
+        return collection != null ?
+            this.applyPaging(collection.stream(), collection.size()) :
+            this.applyPaging(Stream.of(), 0);
+    }
+
+}

--- a/src/main/java/org/candlepin/paging/PagingUtilFactory.java
+++ b/src/main/java/org/candlepin/paging/PagingUtilFactory.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.paging;
+
+import org.xnap.commons.i18n.I18n;
+
+import java.util.Objects;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+
+
+/**
+ * Simple provider/factory class for building PagingUtil instances that can be injected into any
+ * classes which need paging functionality.
+ */
+public class PagingUtilFactory {
+
+    private final Provider<I18n> i18nProvider;
+
+    @Inject
+    public PagingUtilFactory(Provider<I18n> i18nProvider) {
+        this.i18nProvider = Objects.requireNonNull(i18nProvider);
+    }
+
+    /**
+     * Fetches a PagingUtil that will use the specified field mapper for handling conversion of the
+     * requested field name string to its matching function.
+     *
+     * @param comparatorFactory
+     *  the comparator factory to pass through to the generated PagingUtil instance
+     *
+     * @return
+     *  a PagingUtil instance backed by the given field comparator factory
+     */
+    public <T> PagingUtil<T> using(FieldComparatorFactory<T> comparatorFactory) {
+        if (comparatorFactory == null) {
+            throw new IllegalArgumentException("comparatorFactory is null");
+        }
+
+        return new PagingUtil<>(this.i18nProvider.get(), comparatorFactory);
+    }
+
+    /**
+     * Fetches a PagingUtil that will use a reflection-based field mapper for the given class to
+     * handling the conversion of field names to functions.
+     * <p>
+     * This can be used in cases where the paged type does not have fields which require special
+     * consideration when sorting, all accessors are available for sorting, and the performance hit
+     * that comes along with using reflection for the lookup is acceptable. In other cases, a custom
+     * comparator factory is recommended.
+     *
+     * @param type
+     *  the class of the objects to be paged
+     *
+     * @param defaultSortField
+     *  the field to sort on if paging is requested but no sort-by field is specified; null to
+     *  disable default sorting
+     *
+     * @return
+     *  a PagingUtil instance backed by a reflection-based field comparator factory for the given
+     *  class type
+     */
+    public <T> PagingUtil<T> forClass(Class<T> type, String defaultSortField) {
+        return this.using(new ReflectionFieldComparatorFactory<>(type, defaultSortField));
+    }
+
+    /**
+     * Fetches a PagingUtil that will use a reflection-based field mapper for the given class to
+     * handling the conversion of field names to functions. If paging is requested, but no sort-by
+     * field is specified, the field mapper will default to the value defined in
+     * <tt>PageRequest.DEFAULT_SORT_FIELD</tt>.
+     * <p>
+     * This can be used in cases where the paged type does not have fields which require special
+     * consideration when sorting, all accessors are available for sorting, and the performance hit
+     * that comes along with using reflection for the lookup is acceptable. In other cases, a custom
+     * comparator factory is recommended.
+     *
+     * @param type
+     *  the class of the objects to be paged
+     *
+     * @return
+     *  a PagingUtil instance backed by a reflection-based field comparator factory for the given
+     *  class type
+     */
+    public <T> PagingUtil<T> forClass(Class<T> type) {
+        // This is actually a very bad default, but it's here for backwards compatibility purposes.
+        // Existing solutions use this field whenever the sort-by field is absent, so to be drop-in
+        // compliant, we do the same.
+        return this.forClass(type, PageRequest.DEFAULT_SORT_FIELD);
+    }
+
+}

--- a/src/main/java/org/candlepin/paging/ReflectionFieldComparatorFactory.java
+++ b/src/main/java/org/candlepin/paging/ReflectionFieldComparatorFactory.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.paging;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+
+
+
+/**
+ * A field comparator factory which uses reflection against a specified class to build comparators
+ * from arbitrary field names.
+ *
+ * @param <T>
+ *  the class type for which this factory's mapping logic applies
+ */
+public class ReflectionFieldComparatorFactory<T> implements FieldComparatorFactory<T> {
+
+    /** A collection of prefixes to apply when mapping field names to accessors */
+    private static final List<String> METHOD_NAME_PREFIXES = List.of("get", "is", "has");
+
+    private final Class<T> type;
+    private final String defaultSortField;
+
+    /**
+     * Creates a new comparator factory for the given class type.
+     *
+     * @param type
+     *  the class to use for mapping field names to functions
+     *
+     * @param defaultSortField
+     *  the field name to attempt to map when building the default comparator
+     *
+     * @throws IllegalArgumentException
+     *  if type is null
+     */
+    public ReflectionFieldComparatorFactory(Class<T> type, String defaultSortField) {
+        if (type == null) {
+            throw new IllegalArgumentException("type is null");
+        }
+
+        this.type = type;
+        this.defaultSortField = defaultSortField;
+    }
+
+    /**
+     * Builds a candidate method name from the given prefix and field name.
+     * <p>
+     * <strong>WARNING:</strong> This method performs no input validation! Only call from a trusted,
+     * pre-validated context.
+     *
+     * @param prefix
+     *  the prefix to apply to the field name
+     *
+     * @param fieldName
+     *  the fieldName to use as the basis for the candidate method name
+     *
+     * @return
+     *  a method name candidate using the given prefix and field name
+     */
+    private String buildMethodNameCandidate(String prefix, String fieldName) {
+        StringBuilder builder = new StringBuilder(prefix)
+            .append(fieldName.substring(0, 1).toUpperCase());
+
+        if (fieldName.length() > 1) {
+            builder.append(fieldName.substring(1));
+        }
+
+        return builder.toString();
+    }
+
+    /**
+     * Gets the extractor function from the underlying type that best matches the given field name.
+     * The extractor function must be a public method that requires zero parameters, have a return
+     * types implementing the Comparable interface, and following the naming convention of
+     * "[prefix][field_name]", where prefix is one of "get", "is", or "has", and "field_name" is the
+     * given field name in title case. If a matching method cannot be found, this method returns null.
+     * <p>
+     * The field name may be specified in either camel case or title case, but should not include
+     * the verb prefix. For example, the method "getProvidedProducts" can be successfully mapped
+     * using the field name values "providedProducts" or "ProvidedProducts", but
+     * <strong>not</strong> "providedproducts".
+     *
+     * @param fieldName
+     *  the name of the field for which to generate an extractor function; case-sensitive. May be
+     *  specified in either camel case or title case without spaces.
+     *
+     * @return
+     *  an extractor function for the specified field name, or null if the field name could not be
+     *  mapped to an accessor method on the underlying type
+     */
+    @SuppressWarnings("unchecked")
+    private Function<? super T, Comparable<? super Comparable>> getExtractorFunction(String fieldName) {
+        if (fieldName == null || fieldName.isBlank()) {
+            return null;
+        }
+
+        for (String prefix : METHOD_NAME_PREFIXES) {
+            String candidate = this.buildMethodNameCandidate(prefix, fieldName);
+
+            try {
+                Method method = this.type.getMethod(candidate);
+                Class<?> returnType = method.getReturnType();
+
+                if (returnType == null || !Comparable.class.isAssignableFrom(returnType)) {
+                    throw new NoSuchMethodException("incomparable return type: " + returnType);
+                }
+
+                return (T instance) -> {
+                    try {
+                        return (Comparable<? super Comparable>) method.invoke(instance);
+                    }
+                    catch (InvocationTargetException | IllegalAccessException e) {
+                        throw new RuntimeException(e); // This shouldn't happen... probably.
+                    }
+                };
+            }
+            catch (NoSuchMethodException e) {
+                // Intentionally left empty
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Comparator<T> getComparator(String fieldName) {
+        Function<? super T, Comparable<? super Comparable>> extractor = this.getExtractorFunction(fieldName);
+        return extractor != null ? Comparator.comparing(extractor) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Comparator<T> getDefaultComparator() {
+        return this.getComparator(this.defaultSortField);
+    }
+
+}

--- a/src/main/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptor.java
+++ b/src/main/java/org/candlepin/resteasy/filter/CandlepinQueryInterceptor.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.resteasy.filter;
 
-import org.candlepin.model.AbstractHibernateObject;
 import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.ResultIterator;
 import org.candlepin.paging.Page;
@@ -126,7 +125,7 @@ public class CandlepinQueryInterceptor implements ContainerResponseFilter {
         // present -- either isPaging() will be true, or we'll have ordering config.
         final String sortField = pageRequest.getSortBy() != null ?
             pageRequest.getSortBy() :
-            AbstractHibernateObject.DEFAULT_SORT_FIELD;
+            PageRequest.DEFAULT_SORT_FIELD;
 
         final PageRequest.Order order = pageRequest.getOrder() != null ?
             pageRequest.getOrder() :

--- a/src/test/java/org/candlepin/paging/Pageable.java
+++ b/src/test/java/org/candlepin/paging/Pageable.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.paging;
+
+
+
+/**
+ * Utility class used by the various paging tests to have a collection of simple objects to page
+ */
+public class Pageable {
+    private final String f1;
+    private final String f2;
+
+    public Pageable() {
+        this.f1 = null;
+        this.f2 = null;
+    }
+
+    public Pageable(String f1, String f2) {
+        this.f1 = f1;
+        this.f2 = f2;
+    }
+
+    public String getFieldOne() {
+        return this.f1;
+    }
+
+    public String getFieldTwo() {
+        return this.f2;
+    }
+
+    public String toString() {
+        return String.format("Pageable [f1: %s, f2: %s]", this.f1, this.f2);
+    }
+}

--- a/src/test/java/org/candlepin/paging/PagingUtilFactoryTest.java
+++ b/src/test/java/org/candlepin/paging/PagingUtilFactoryTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.paging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.jboss.resteasy.core.ResteasyContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.inject.Provider;
+
+
+
+public class PagingUtilFactoryTest {
+
+    private Provider<I18n> i18nProvider;
+
+    @BeforeEach
+    public void beforeEach() {
+        ResteasyContext.clearContextData();
+
+        this.i18nProvider = () -> I18nFactory.getI18n(this.getClass(), Locale.US, I18nFactory.FALLBACK);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        ResteasyContext.clearContextData();
+    }
+
+    private PagingUtilFactory buildPagingUtilFactory() {
+        return new PagingUtilFactory(this.i18nProvider);
+    }
+
+    private void setSortingPageRequestContext(String sortBy, PageRequest.Order order) {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy(sortBy)
+            .setOrder(order);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+    }
+
+    @Test
+    public void testUsingGeneratesUtilUsingFactory() {
+        PagingUtilFactory factory = this.buildPagingUtilFactory();
+
+        // Use a simple comparator factory. It doesn't need to be correct; it just needs to function
+        // enough to not break.
+        FieldComparatorFactory<Pageable> comparatorFactory = spy(new FieldComparatorFactory<Pageable>() {
+            @Override
+            public Comparator<Pageable> getComparator(String fieldName) {
+                return Comparator.comparing(Pageable::getFieldOne);
+            }
+        });
+
+        // Generate a new PagingUtil using our spy factory. We can then verify it's using the test
+        // comparator factory by verifying we see at least one invocation of getComparator.
+        PagingUtil<Pageable> pagingUtil = factory.using(comparatorFactory);
+        assertNotNull(pagingUtil);
+
+        // We still have to put a page request in the context or else the paging util will short
+        // circuit its logic and not do anything at all.
+        this.setSortingPageRequestContext("fieldOne", PageRequest.Order.ASCENDING);
+
+        // Trigger our exception (hopefully)
+        pagingUtil.applyPaging(List.of(new Pageable()));
+
+        // Verify our factory was used to get the comparator
+        verify(comparatorFactory, times(1)).getComparator(eq("fieldOne"));
+    }
+
+    @Test
+    public void testUsingRequiresNonNullInput() {
+        PagingUtilFactory factory = this.buildPagingUtilFactory();
+
+        assertThrows(IllegalArgumentException.class, () -> factory.using(null));
+    }
+
+    @Test
+    public void testForClassWithoutDefaultUsesGenericComparatorFactory() {
+        PagingUtilFactory factory = this.buildPagingUtilFactory();
+
+        PagingUtil<Pageable> pagingUtil = factory.forClass(Pageable.class);
+        assertNotNull(pagingUtil);
+
+        // We can't possibly know *which* comparator factory it's using, but we can expect whatever
+        // it's using will properly order our objects according to the sort-by and order fields in
+        // the page request.
+        this.setSortingPageRequestContext("fieldOne", PageRequest.Order.ASCENDING);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("1", "b"),
+            2, new Pageable("3", "a"),
+            3, new Pageable("2", "c"));
+
+        List<Pageable> expected = List.of(
+            elementMap.get(1),
+            elementMap.get(3),
+            elementMap.get(2));
+
+        List<Pageable> output = pagingUtil.applyPaging(elementMap.values())
+            .toList();
+
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testForClassWithDefaultUsesGenericComparatorFactory() {
+        PagingUtilFactory factory = this.buildPagingUtilFactory();
+
+        PagingUtil<Pageable> pagingUtil = factory.forClass(Pageable.class, "fieldTwo");
+        assertNotNull(pagingUtil);
+
+        // We can't possibly know *which* comparator factory it's using, but we can expect whatever
+        // it's using will properly order our objects according to the default comparator
+        this.setSortingPageRequestContext(null, PageRequest.Order.ASCENDING);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("1", "b"),
+            2, new Pageable("3", "a"),
+            3, new Pageable("2", "c"));
+
+        List<Pageable> expected = List.of(
+            elementMap.get(2),
+            elementMap.get(1),
+            elementMap.get(3));
+
+        List<Pageable> output = pagingUtil.applyPaging(elementMap.values())
+            .toList();
+
+        assertEquals(expected, output);
+    }
+
+    @Test
+    public void testForClassWithoutDefaultRequiresNonNullType() {
+        PagingUtilFactory factory = this.buildPagingUtilFactory();
+
+        assertThrows(IllegalArgumentException.class, () -> factory.forClass(null));
+    }
+
+    @Test
+    public void testForClassWithDefaultRequiresNonNullType() {
+        PagingUtilFactory factory = this.buildPagingUtilFactory();
+
+        assertThrows(IllegalArgumentException.class, () -> factory.forClass(null, "some_default"));
+    }
+
+}

--- a/src/test/java/org/candlepin/paging/PagingUtilTest.java
+++ b/src/test/java/org/candlepin/paging/PagingUtilTest.java
@@ -1,0 +1,586 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.paging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.candlepin.exceptions.BadRequestException;
+
+import org.jboss.resteasy.core.ResteasyContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Stream;
+
+
+
+public class PagingUtilTest {
+
+    /**
+     * Simple comparator factory specifically built for testing paging with the Pageable test object
+     */
+    private static class PageableComparatorFactory implements FieldComparatorFactory<Pageable> {
+        @Override
+        public Comparator<Pageable> getComparator(String fieldName) {
+            if ("fieldOne".equals(fieldName)) {
+                return Comparator.comparing(Pageable::getFieldOne);
+            }
+            else if ("fieldTwo".equals(fieldName)) {
+                return Comparator.comparing(Pageable::getFieldTwo);
+            }
+
+            return null;
+        }
+
+        @Override
+        public Comparator<Pageable> getDefaultComparator() {
+            return this.getComparator("fieldOne");
+        }
+    }
+
+
+    private I18n i18n;
+
+    @BeforeEach
+    public void beforeEach() {
+        ResteasyContext.clearContextData();
+
+        this.i18n = I18nFactory.getI18n(this.getClass(), Locale.US, I18nFactory.FALLBACK);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        ResteasyContext.clearContextData();
+    }
+
+    private PagingUtil<Pageable> buildPagingUtil() {
+        return new PagingUtil<>(this.i18n, new PageableComparatorFactory());
+    }
+
+    public void validateContextPage(PageRequest pageRequest, int maxRecords) {
+        Page page = ResteasyContext.getContextData(Page.class);
+        assertNotNull(page);
+        assertEquals(maxRecords, page.getMaxRecords());
+
+        PageRequest contextPageRequest = page.getPageRequest();
+        assertNotNull(contextPageRequest);
+        assertEquals(pageRequest.getPage(), contextPageRequest.getPage());
+        assertEquals(pageRequest.getPerPage(), contextPageRequest.getPerPage());
+        assertEquals(pageRequest.getSortBy(), contextPageRequest.getSortBy());
+        assertEquals(pageRequest.getOrder(), contextPageRequest.getOrder());
+    }
+
+    @Test
+    public void testNoPagingAppliedToStreamWhenRequestLacksPaging() {
+        List<Pageable> elements = List.of(
+            new Pageable("1", "b"),
+            new Pageable("3", "a"),
+            new Pageable("2", "c"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elements.stream(), elements.size());
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(elements, page);
+
+        Page contextPage = ResteasyContext.getContextData(Page.class);
+        assertNull(contextPage);
+    }
+
+    @Test
+    public void testPageAscendingOrderingAppliedToStream() {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy("fieldOne")
+            .setOrder(PageRequest.Order.ASCENDING);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("1", "b"),
+            2, new Pageable("3", "a"),
+            3, new Pageable("2", "c"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elementMap.values().stream(), elementMap.size());
+
+        assertNotNull(pagedStream);
+
+        List<Pageable> expected = List.of(
+            elementMap.get(1),
+            elementMap.get(3),
+            elementMap.get(2));
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(expected, page);
+
+        // Since we're only ordering, there shouldn't be a page in the request context
+        Page contextPage = ResteasyContext.getContextData(Page.class);
+        assertNull(contextPage);
+    }
+
+    @Test
+    public void testPageDescendingOrderingAppliedToStream() {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy("fieldTwo")
+            .setOrder(PageRequest.Order.DESCENDING);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("1", "b"),
+            2, new Pageable("3", "a"),
+            3, new Pageable("2", "c"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elementMap.values().stream(), elementMap.size());
+
+        assertNotNull(pagedStream);
+
+        List<Pageable> expected = List.of(
+            elementMap.get(3),
+            elementMap.get(1),
+            elementMap.get(2));
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(expected, page);
+
+        // Since we're only ordering, there shouldn't be a page in the request context
+        Page contextPage = ResteasyContext.getContextData(Page.class);
+        assertNull(contextPage);
+    }
+
+    @Test
+    public void testPageLimitAppliedToStream() {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy("fieldOne")
+            .setOrder(PageRequest.Order.ASCENDING)
+            .setPage(1)
+            .setPerPage(3);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("4", "a"),
+            2, new Pageable("3", "c"),
+            3, new Pageable("2", "e"),
+            4, new Pageable("1", "d"),
+            5, new Pageable("5", "b"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elementMap.values().stream(), elementMap.size());
+
+        assertNotNull(pagedStream);
+
+        List<Pageable> expected = List.of(
+            elementMap.get(4),
+            elementMap.get(3),
+            elementMap.get(2));
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(expected, page);
+
+        // Validate the resultant page in the context
+        this.validateContextPage(pageRequest, elementMap.size());
+    }
+
+    @Test
+    public void testPageOffsetAppliedToStream() {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy("fieldOne")
+            .setOrder(PageRequest.Order.ASCENDING)
+            .setPerPage(3)
+            .setPage(2);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("4", "a"),
+            2, new Pageable("3", "c"),
+            3, new Pageable("2", "e"),
+            4, new Pageable("1", "d"),
+            5, new Pageable("5", "b"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elementMap.values().stream(), elementMap.size());
+
+        assertNotNull(pagedStream);
+
+        List<Pageable> expected = List.of(
+            elementMap.get(1),
+            elementMap.get(5));
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(expected, page);
+
+        // Validate the resultant page in the context
+        this.validateContextPage(pageRequest, elementMap.size());
+    }
+
+    @Test
+    public void testDefaultOrderingAppliedToStreamWhenSortByIsUnspecified() {
+        // Since we're not specifying any sorting details, we're expecting
+        // to get the default defined by the PageableComparatorFactory --
+        // "fieldOne" -- in descending order.
+
+        PageRequest pageRequest = new PageRequest()
+            .setPage(1)
+            .setPerPage(3);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("4", "a"),
+            2, new Pageable("3", "c"),
+            3, new Pageable("2", "e"),
+            4, new Pageable("1", "d"),
+            5, new Pageable("5", "b"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elementMap.values().stream(), elementMap.size());
+
+        assertNotNull(pagedStream);
+
+        List<Pageable> expected = List.of(
+            elementMap.get(5),
+            elementMap.get(1),
+            elementMap.get(2));
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(expected, page);
+
+        // Validate the resultant page in the context
+        this.validateContextPage(pageRequest, elementMap.size());
+    }
+
+    @Test
+    public void testNullStreamConvertedToEmptyStream() {
+        Stream<Pageable> pagedStream = this.buildPagingUtil().applyPaging(null, 0);
+        assertNotNull(pagedStream);
+        assertEquals(0, pagedStream.count());
+
+        // No page request in the context, so we shouldn't have one after applying paging
+        Page contextPage = ResteasyContext.getContextData(Page.class);
+        assertNull(contextPage);
+    }
+
+    @Test
+    public void testNullStreamConvertedToEmptyStreamWithPageContext() {
+        PageRequest pageRequest = new PageRequest()
+            .setPage(1)
+            .setPerPage(3);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil().applyPaging(null, 0);
+        assertNotNull(pagedStream);
+        assertEquals(0, pagedStream.count());
+
+        // Even though we tried to return null, we should still populate the page in the context
+        // accordingly
+        this.validateContextPage(pageRequest, 0);
+    }
+
+    @Test
+    public void testNoPagingAppliedToCollectionWhenRequestLacksPaging() {
+        List<Pageable> elements = List.of(
+            new Pageable("1", "b"),
+            new Pageable("3", "a"),
+            new Pageable("2", "c"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elements);
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(elements, page);
+
+        Page contextPage = ResteasyContext.getContextData(Page.class);
+        assertNull(contextPage);
+    }
+
+    @Test
+    public void testPageAscendingOrderingAppliedToCollection() {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy("fieldOne")
+            .setOrder(PageRequest.Order.ASCENDING);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("1", "b"),
+            2, new Pageable("3", "a"),
+            3, new Pageable("2", "c"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elementMap.values());
+
+        assertNotNull(pagedStream);
+
+        List<Pageable> expected = List.of(
+            elementMap.get(1),
+            elementMap.get(3),
+            elementMap.get(2));
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(expected, page);
+
+        // Since we're only ordering, there shouldn't be a page in the request context
+        Page contextPage = ResteasyContext.getContextData(Page.class);
+        assertNull(contextPage);
+    }
+
+    @Test
+    public void testPageDescendingOrderingAppliedToCollection() {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy("fieldTwo")
+            .setOrder(PageRequest.Order.DESCENDING);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("1", "b"),
+            2, new Pageable("3", "a"),
+            3, new Pageable("2", "c"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elementMap.values());
+
+        assertNotNull(pagedStream);
+
+        List<Pageable> expected = List.of(
+            elementMap.get(3),
+            elementMap.get(1),
+            elementMap.get(2));
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(expected, page);
+
+        // Since we're only ordering, there shouldn't be a page in the request context
+        Page contextPage = ResteasyContext.getContextData(Page.class);
+        assertNull(contextPage);
+    }
+
+    @Test
+    public void testPageLimitAppliedToCollection() {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy("fieldOne")
+            .setOrder(PageRequest.Order.ASCENDING)
+            .setPage(1)
+            .setPerPage(3);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("4", "a"),
+            2, new Pageable("3", "c"),
+            3, new Pageable("2", "e"),
+            4, new Pageable("1", "d"),
+            5, new Pageable("5", "b"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elementMap.values());
+
+        assertNotNull(pagedStream);
+
+        List<Pageable> expected = List.of(
+            elementMap.get(4),
+            elementMap.get(3),
+            elementMap.get(2));
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(expected, page);
+
+        // Validate the resultant page in the context
+        this.validateContextPage(pageRequest, elementMap.size());
+    }
+
+    @Test
+    public void testPageOffsetAppliedToCollection() {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy("fieldOne")
+            .setOrder(PageRequest.Order.ASCENDING)
+            .setPerPage(3)
+            .setPage(2);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("4", "a"),
+            2, new Pageable("3", "c"),
+            3, new Pageable("2", "e"),
+            4, new Pageable("1", "d"),
+            5, new Pageable("5", "b"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elementMap.values());
+
+        assertNotNull(pagedStream);
+
+        List<Pageable> expected = List.of(
+            elementMap.get(1),
+            elementMap.get(5));
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(expected, page);
+
+        // Validate the resultant page in the context
+        this.validateContextPage(pageRequest, elementMap.size());
+    }
+
+    @Test
+    public void testDefaultOrderingAppliedToCollectionWhenSortByIsUnspecified() {
+        // Since we're not specifying any sorting details, we're expecting
+        // to get the default defined by the PageableComparatorFactory --
+        // "fieldOne" -- in descending order.
+
+        PageRequest pageRequest = new PageRequest()
+            .setPage(1)
+            .setPerPage(3);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Map<Integer, Pageable> elementMap = Map.of(
+            1, new Pageable("4", "a"),
+            2, new Pageable("3", "c"),
+            3, new Pageable("2", "e"),
+            4, new Pageable("1", "d"),
+            5, new Pageable("5", "b"));
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil()
+            .applyPaging(elementMap.values());
+
+        assertNotNull(pagedStream);
+
+        List<Pageable> expected = List.of(
+            elementMap.get(5),
+            elementMap.get(1),
+            elementMap.get(2));
+
+        List<Pageable> page = pagedStream.toList();
+        assertEquals(expected, page);
+
+        // Validate the resultant page in the context
+        this.validateContextPage(pageRequest, elementMap.size());
+    }
+
+    @Test
+    public void testNullCollectionConvertedToEmptyStream() {
+        Stream<Pageable> pagedStream = this.buildPagingUtil().applyPaging(null);
+        assertNotNull(pagedStream);
+        assertEquals(0, pagedStream.count());
+
+        // No page request in the context, so we shouldn't have one after applying paging
+        Page contextPage = ResteasyContext.getContextData(Page.class);
+        assertNull(contextPage);
+    }
+
+    @Test
+    public void testNullCollectionConvertedToEmptyStreamWithPageContext() {
+        PageRequest pageRequest = new PageRequest()
+            .setPage(1)
+            .setPerPage(3);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        Stream<Pageable> pagedStream = this.buildPagingUtil().applyPaging(null);
+        assertNotNull(pagedStream);
+        assertEquals(0, pagedStream.count());
+
+        // Even though we tried to return null, we should still populate the page in the context
+        // accordingly
+        this.validateContextPage(pageRequest, 0);
+    }
+
+    @Test
+    public void testInvalidSortByFieldTriggersBadRequestExceptionWhenPagingStream() {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy("nonsense_field");
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        PagingUtil<Pageable> pagingUtil = this.buildPagingUtil();
+        Stream<Pageable> input = Stream.of(new Pageable("1", "a"));
+
+        Exception exception = assertThrows(BadRequestException.class, () -> pagingUtil.applyPaging(input, 1));
+        String errmsg = exception.getMessage();
+        assertNotNull(errmsg);
+        assertTrue(errmsg.contains("Invalid or unsupported sort-by field"));
+    }
+
+    @Test
+    public void testInvalidSortByFieldTriggersBadRequestExceptionWhenPagingCollection() {
+        PageRequest pageRequest = new PageRequest()
+            .setSortBy("nonsense_field");
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        PagingUtil<Pageable> pagingUtil = this.buildPagingUtil();
+        List<Pageable> input = List.of(new Pageable("1", "a"));
+
+        Exception exception = assertThrows(BadRequestException.class, () -> pagingUtil.applyPaging(input));
+        String errmsg = exception.getMessage();
+        assertNotNull(errmsg);
+        assertTrue(errmsg.contains("Invalid or unsupported sort-by field"));
+    }
+
+    @Test
+    public void testBadRequestExceptionWhenDefaultSortByIsUnsupportedWhenPagingStream() {
+        // This test verifies a BadRequestException is thrown in the case where the underlying
+        // field comparator factory does not provide a default comparator, and paging has been
+        // requested without specifying the sort-by field.
+        PageRequest pageRequest = new PageRequest()
+            .setPage(1)
+            .setPerPage(1);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        PagingUtil<Pageable> pagingUtil = new PagingUtil<>(this.i18n, field -> null);
+        Stream<Pageable> input = Stream.of(new Pageable("1", "a"));
+
+        Exception exception = assertThrows(BadRequestException.class, () -> pagingUtil.applyPaging(input, 1));
+        String errmsg = exception.getMessage();
+        assertNotNull(errmsg);
+        assertTrue(errmsg.contains("no sort-by field provided"));
+    }
+
+    public void testBadRequestExceptionWhenDefaultSortByIsUnsupportedWhenPagingCollection() {
+        // This test verifies a BadRequestException is thrown in the case where the underlying
+        // field comparator factory does not provide a default comparator, and paging has been
+        // requested without specifying the sort-by field.
+        PageRequest pageRequest = new PageRequest()
+            .setPage(1)
+            .setPerPage(1);
+
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
+
+        PagingUtil<Pageable> pagingUtil = new PagingUtil<>(this.i18n, field -> null);
+        List<Pageable> input = List.of(new Pageable("1", "a"));
+
+        Exception exception = assertThrows(BadRequestException.class, () -> pagingUtil.applyPaging(input));
+        String errmsg = exception.getMessage();
+        assertNotNull(errmsg);
+        assertTrue(errmsg.contains("no sort-by field provided"));
+    }
+}

--- a/src/test/java/org/candlepin/paging/ReflectionFieldComparatorFactoryTest.java
+++ b/src/test/java/org/candlepin/paging/ReflectionFieldComparatorFactoryTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.paging;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+
+
+public class ReflectionFieldComparatorFactoryTest {
+
+    private <T> ReflectionFieldComparatorFactory<T> buildFactory(Class<T> type, String defaultFieldName) {
+        return new ReflectionFieldComparatorFactory<>(type, defaultFieldName);
+    }
+
+    private <T> ReflectionFieldComparatorFactory<T> buildFactory(Class<T> type) {
+        return this.buildFactory(type, null);
+    }
+
+    @Test
+    public void testFactoryRequiresTypeAtBuildTime() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new ReflectionFieldComparatorFactory<>(null, "default field name"));
+    }
+
+    @Test
+    public void testFactoryPermitsNullDefaultFieldName() {
+        assertDoesNotThrow(() -> new ReflectionFieldComparatorFactory<>(Object.class, null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "myField", "MyField" })
+    public void testMethodFoundWithGetPrefix(String fieldName) {
+        Object obj = new Object() {
+            public String getMyField() {
+                return "some value";
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass());
+        assertNotNull(factory.getComparator(fieldName));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "isPresent", "IsPresent" })
+    public void testMethodFoundWithIsPrefix(String fieldName) {
+        Object obj = new Object() {
+            public Boolean getIsPresent() {
+                return true;
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass());
+        assertNotNull(factory.getComparator(fieldName));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "hasMoreFields", "HasMoreFields" })
+    public void testMethodFoundWithHasPrefix(String fieldName) {
+        Object obj = new Object() {
+            public Boolean getHasMoreFields() {
+                return false;
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass());
+        assertNotNull(factory.getComparator(fieldName));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "a", "A" })
+    public void testMethodNameMayBeReallyShort(String fieldName) {
+        Object obj = new Object() {
+            public String getA() {
+                return "A";
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass());
+        assertNotNull(factory.getComparator(fieldName));
+    }
+
+    @Test
+    public void testMethodMustNotRequireParameters() {
+        Object obj = new Object() {
+            public Boolean hasMethodWithParams(String p1) {
+                return true;
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass());
+        assertNull(factory.getComparator("MethodWithParams"));
+    }
+
+    @Test
+    public void testMethodMustReturnAValue() {
+        Object obj = new Object() {
+            public void hasVoidMethod() {
+                // empty
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass());
+        assertNull(factory.getComparator("VoidMethod"));
+    }
+
+    @Test
+    public void testMethodMustReturnComparableValue() {
+        Object obj = new Object() {
+            public Object getNonConformingValue() {
+                return true;
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass());
+        assertNull(factory.getComparator("NonConformingValue"));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = { "", " ", "   " })
+    public void testFactoryIgnoresDefaultForStandardLookup(String emptyFieldName) {
+        Object obj = new Object() {
+            public String getFieldTwo() {
+                return "field two";
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass(), "FieldTwo");
+        assertNull(factory.getComparator(emptyFieldName));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "myField", "MyField" })
+    public void testDefaultMethodFoundWithGetPrefix(String fieldName) {
+        Object obj = new Object() {
+            public String getMyField() {
+                return "some value";
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass(), fieldName);
+        assertNotNull(factory.getDefaultComparator());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "isPresent", "IsPresent" })
+    public void testDefaultMethodFoundWithIsPrefix(String fieldName) {
+        Object obj = new Object() {
+            public Boolean getIsPresent() {
+                return true;
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass(), fieldName);
+        assertNotNull(factory.getDefaultComparator());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "hasMoreFields", "HasMoreFields" })
+    public void testDefaultMethodFoundWithHasPrefix(String fieldName) {
+        Object obj = new Object() {
+            public Boolean getHasMoreFields() {
+                return false;
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass(), fieldName);
+        assertNotNull(factory.getDefaultComparator());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "a", "A" })
+    public void testDefaultMethodNameMayBeReallyShort(String fieldName) {
+        Object obj = new Object() {
+            public String getA() {
+                return "A";
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass(), fieldName);
+        assertNotNull(factory.getDefaultComparator());
+    }
+
+    @Test
+    public void testDefaultMethodMustNotRequireParameters() {
+        Object obj = new Object() {
+            public Boolean hasMethodWithParams(String p1) {
+                return true;
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass(), "MethodWithParams");
+        assertNull(factory.getDefaultComparator());
+    }
+
+    @Test
+    public void testDefaultMethodMustReturnAValue() {
+        Object obj = new Object() {
+            public void hasVoidMethod() {
+                // empty
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass(), "VoidMethod");
+        assertNull(factory.getDefaultComparator());
+    }
+
+    @Test
+    public void testDefaultMethodMustReturnComparableValue() {
+        Object obj = new Object() {
+            public Object getNonConformingValue() {
+                return true;
+            }
+        };
+
+        ReflectionFieldComparatorFactory<?> factory = this.buildFactory(obj.getClass(), "NonConformingValue");
+        assertNull(factory.getDefaultComparator());
+    }
+
+}


### PR DESCRIPTION
- Added a new utility, PagingUtil, which provides methods to apply paging to streams and collections
- Moved AbstractHibernateObject.DEFAULT_SORT_FIELD to PageRequest to better align with the other defaults and to further separate paging logic from the database model
- Updated Page and PageRequest's void mutators to return a reference to the object for fluent-style invocation chaining