### PR TITLE
[M] CANDLEPIN-722: Fix CloudAccountOrgSetupJob owner creation error

### DIFF
--- a/spec-tests/build.gradle
+++ b/spec-tests/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation libraries["commonsCodec"]
     implementation libraries["guava"]
     implementation libraries["commonsIo"]
+    implementation libraries["commonsLang"]
     implementation libraries["oauth"]
 
     testImplementation libraries["jimfs"]

--- a/spec-tests/src/test/java/org/candlepin/spec/ExportSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ExportSpecTest.java
@@ -226,7 +226,7 @@ class ExportSpecTest {
             .associateProductIdsToCloudOffer(offerId, List.of(product1.getId(), product2.getId()));
         adminClient.hosted().associateOwnerToCloudAccount(accountId, owner.getKey());
 
-        CloudAuthenticationResultDTO result = adminClient.cloudAuthorization()
+        CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
         Response response = Request.from(ApiClients.bearerToken(result.getToken()))

--- a/src/main/java/org/candlepin/async/tasks/CloudAccountOrgSetupJob.java
+++ b/src/main/java/org/candlepin/async/tasks/CloudAccountOrgSetupJob.java
@@ -91,6 +91,7 @@ public class CloudAccountOrgSetupJob implements AsyncJob {
                 else {
                     Owner newOwner = new Owner()
                         .setKey(accountData.ownerKey())
+                        .setDisplayName(accountData.ownerKey())
                         .setAnonymous(accountData.isAnonymous())
                         .setClaimed(false);
                     ownerCurator.create(newOwner);

--- a/src/main/java/org/candlepin/testext/hostedtest/HostedTestCloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/testext/hostedtest/HostedTestCloudRegistrationAdapter.java
@@ -29,6 +29,7 @@ import org.candlepin.service.model.CloudRegistrationInfo;
 import org.candlepin.service.model.OwnerInfo;
 import org.candlepin.service.model.SubscriptionInfo;
 import org.candlepin.util.ObjectMapperFactory;
+import org.candlepin.util.Util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -189,7 +190,12 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
     public CloudAccountData setupCloudAccountOrg(String cloudAccountID, String cloudOfferingID,
         CloudProvider cloudProviderShortName, String ownerKey)
         throws CouldNotAcquireCloudAccountLockException, CouldNotEntitleOrganizationException {
-        return new CloudAccountData("owner_key", false);
+
+        if (ownerKey == null) {
+            ownerKey = Util.generateUUID();
+        }
+
+        return new CloudAccountData(ownerKey, false);
     }
 
     /**


### PR DESCRIPTION
- Set Owner.displayName to make sure owner gets created.
- Add spec test to assert that the CloudAccountOrgSetupJob creates an owner when one doesn't exist.
- Update all cloud autoreg auth calls in spec tests to use no authentication (like in reality) instead of admin credentials.