### PR TITLE
[M] CANDLEPIN-736: Updated entitlement certificate namespace logic

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CertificateAssert.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CertificateAssert.java
@@ -98,6 +98,10 @@ public class CertificateAssert extends AbstractAssert<CertificateAssert, X509Cer
         return hasExtensionValue(OID.entitlementType(), type);
     }
 
+    public CertificateAssert hasEntitlementNamespace(String namespace) {
+        return hasExtensionValue(OID.entitlementNamespace(), namespace);
+    }
+
     public CertificateAssert hasContentRepoEnabled(ContentDTO content) {
         return hasExtensionValue(OID.contentRepoEnabled(content), "1");
     }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/cert/X509Cert.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/cert/X509Cert.java
@@ -15,6 +15,7 @@
 package org.candlepin.spec.bootstrap.client.cert;
 
 import org.candlepin.dto.api.client.v1.CertificateDTO;
+import org.candlepin.dto.api.client.v1.EntitlementDTO;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -34,6 +35,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -58,6 +60,40 @@ public class X509Cert {
         JsonNode certs = entitlement.get("certificates");
         String cert = certs.get(0).get("cert").asText();
         return new X509Cert(parseCertificate(cert));
+    }
+
+    /**
+     * Parses the certificate data from the given entitlement and returns an X509Cert object
+     * containing the parsed data. If the entitlement is null, has no certificates, or contains a
+     * null certificate, this function returns null.
+     * <p>
+     * <strong>Warning:</strong> If the entitlement has multiple certificates, only the first will
+     * be parsed and returned.
+     *
+     * @param entitlement
+     *  the entitlement from which to pull a certificate to parse
+     *
+     * @return
+     *  a X509Cert instance containing the parsed certificate data, or null if the entitlement had
+     *  no certificate
+     */
+    public static X509Cert fromEnt(EntitlementDTO entitlement) {
+        if (entitlement == null) {
+            return null;
+        }
+
+        Set<CertificateDTO> certificates = entitlement.getCertificates();
+        if (certificates == null || certificates.isEmpty()) {
+            return null;
+        }
+
+        // This should only ever return one cert, probably.
+        CertificateDTO certificate = certificates.iterator().next();
+        if (certificate == null) {
+            return null;
+        }
+
+        return new X509Cert(parseCertificate(certificate.getCert()));
     }
 
     public static X509Certificate parseCertificate(String certStr) {

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/OID.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/OID.java
@@ -54,4 +54,7 @@ public final class OID {
         return REDHAT_OID + "8";
     }
 
+    public static String entitlementNamespace() {
+        return REDHAT_OID + "9";
+    }
 }

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceSpecTest.java
@@ -129,7 +129,6 @@ class EntitlementResourceSpecTest {
             .hasSize(1);
     }
 
-
     @Test
     public void shouldAllowConsumerToChangeQuantity() {
         ProductDTO product = ownerProductApi.createProduct(owner.getKey(), Products.random()

--- a/src/main/java/org/candlepin/model/Pool.java
+++ b/src/main/java/org/candlepin/model/Pool.java
@@ -920,6 +920,19 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
     }
 
     /**
+     * Fetches the namespace of the product for this pool. If the pool does not yet have a product,
+     * or the product is not namespaced, this method returns null.
+     *
+     * @return
+     *  the namespace of the product for this pool, or null if the pool does not have a namespaced
+     *  product
+     */
+    public String getProductNamespace() {
+        Product product = this.getProduct();
+        return product != null ? product.getNamespace() : null;
+    }
+
+    /**
      * Fetches the marketing name of the product for this pool. If the pool does not yet have a
      * product, or the pool does not define a marketing name, this method returns null.
      *

--- a/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultEntitlementCertServiceAdapter.java
@@ -334,13 +334,16 @@ public class DefaultEntitlementCertServiceAdapter extends BaseEntitlementCertSer
 
     public Set<X509ExtensionWrapper> prepareV3Extensions(Pool pool) {
         Set<X509ExtensionWrapper> result = v3extensionUtil.getExtensions();
+
         String entTypeOID = OIDUtil.getOid(OIDUtil.Namespace.ENTITLEMENT_TYPE);
-        String productOID = OIDUtil.getOid(OIDUtil.Namespace.ENTITLEMENT_NAMESPACE);
-        X509ExtensionWrapper typeExtension = new X509ExtensionWrapper(entTypeOID, false, "Basic");
-        X509ExtensionWrapper productExtension = new X509ExtensionWrapper(
-            productOID, false, pool.getProduct().getNamespace());
-        result.add(typeExtension);
-        result.add(productExtension);
+        result.add(new X509ExtensionWrapper(entTypeOID, false, "Basic"));
+
+        String namespace = pool.getProductNamespace();
+        if (namespace != null && !namespace.isBlank()) {
+            String entNamespaceOID = OIDUtil.getOid(OIDUtil.Namespace.ENTITLEMENT_NAMESPACE);
+            result.add(new X509ExtensionWrapper(entNamespaceOID, false, namespace));
+        }
+
         return result;
     }
 


### PR DESCRIPTION
- Updated the logic for entitlement certificate generation to only include the top-level product namespace OID if the namespace is a non-null, non-blank value
- Added additional spec tests to verify the presence or non-presence of the entitlement namespace OID in the certificates
- Updated the unit tests for entitlement namespace extension generation