### PR TITLE
[M] CANDLEPIN-743: Fix autoregv2 reauthentication & other flow updates

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
@@ -85,7 +85,7 @@ class CloudRegistrationSpecTest {
         OwnerDTO owner = upstreamClient.createOwner(Owners.random());
         String token = cloudRegistration.cloudAuthorize(owner.getKey(), "test-type", "test_signature");
 
-        assertTokenType(adminClient.MAPPER, token, STANDARD_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, token, STANDARD_TOKEN_TYPE);
         assertNotNull(token);
     }
 
@@ -99,7 +99,7 @@ class CloudRegistrationSpecTest {
         ConsumerDTO consumer = ApiClients.bearerToken(token).consumers()
             .createConsumer(Consumers.random(owner));
 
-        assertTokenType(adminClient.MAPPER, token, STANDARD_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, token, STANDARD_TOKEN_TYPE);
         assertNotNull(consumer);
     }
 
@@ -121,7 +121,7 @@ class CloudRegistrationSpecTest {
         ConsumerDTO consumer = ApiClients.bearerToken(token).consumers()
             .createConsumer(Consumers.random(owner));
         assertNotNull(consumer);
-        assertTokenType(adminClient.MAPPER, token, STANDARD_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, token, STANDARD_TOKEN_TYPE);
     }
 
     @Test
@@ -144,7 +144,7 @@ class CloudRegistrationSpecTest {
         CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
-        assertTokenType(adminClient.MAPPER, result.getToken(), STANDARD_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, result.getToken(), STANDARD_TOKEN_TYPE);
         assertThat(result)
             .isNotNull()
             .returns(owner.getKey(), CloudAuthenticationResultDTO::getOwnerKey)
@@ -171,7 +171,7 @@ class CloudRegistrationSpecTest {
         CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
-        assertTokenType(adminClient.MAPPER, result.getToken(), STANDARD_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, result.getToken(), STANDARD_TOKEN_TYPE);
         assertThat(result)
             .isNotNull()
             .returns(owner.getKey(), CloudAuthenticationResultDTO::getOwnerKey)
@@ -195,7 +195,7 @@ class CloudRegistrationSpecTest {
         CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
-        assertTokenType(adminClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
         assertThat(result)
             .isNotNull()
             .returns(owner.getKey(), CloudAuthenticationResultDTO::getOwnerKey)
@@ -215,7 +215,7 @@ class CloudRegistrationSpecTest {
         CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
-        assertTokenType(adminClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
         assertThat(result)
             .isNotNull()
             .returns(null, CloudAuthenticationResultDTO::getOwnerKey)
@@ -240,7 +240,7 @@ class CloudRegistrationSpecTest {
         CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
-        assertTokenType(adminClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
         assertThat(result)
             .isNotNull()
             .returns(owner.getKey(), CloudAuthenticationResultDTO::getOwnerKey)
@@ -275,7 +275,7 @@ class CloudRegistrationSpecTest {
         CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
-        assertTokenType(adminClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
         assertThat(result)
             .isNotNull()
             .returns(owner.getKey(), CloudAuthenticationResultDTO::getOwnerKey)
@@ -284,7 +284,7 @@ class CloudRegistrationSpecTest {
     }
 
     @Test
-    public void shouldReceiveSameAnonConsumerUuidWhenReAuthenticatingForV2Auth() throws Exception {
+    public void shouldReceiveDifferentAnonTokenDuringV2ReAuthenticationWithKnownOwner() throws Exception {
         ApiClient adminClient = ApiClients.admin();
         OwnerDTO owner = adminClient.owners().createOwner(Owners.random());
         adminClient.hosted().createOwner(owner);
@@ -295,19 +295,58 @@ class CloudRegistrationSpecTest {
         adminClient.hosted().associateProductIdsToCloudOffer(offerId, List.of(StringUtil.random("prod-")));
         adminClient.hosted().associateOwnerToCloudAccount(accountId, owner.getKey());
 
-        CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
+        CloudAuthenticationResultDTO firstResult = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
-        String expectedAnonConsumerUuid = result.getAnonymousConsumerUuid();
+        String expectedAnonConsumerUuid = firstResult.getAnonymousConsumerUuid();
 
-        CloudAuthenticationResultDTO actual = ApiClients.noAuth().cloudAuthorization()
+        CloudAuthenticationResultDTO secondResult = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
-        assertTokenType(adminClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
-        assertThat(actual)
+        assertTokenType(ApiClient.MAPPER, firstResult.getToken(), ANON_TOKEN_TYPE);
+
+        // Check that the same anonymous consumer record (based on uuid) is being used
+        // and that we already have the owner key (even though the owner is not ready for registration)
+        assertThat(secondResult)
             .isNotNull()
             .returns(owner.getKey(), CloudAuthenticationResultDTO::getOwnerKey)
             .returns(expectedAnonConsumerUuid, CloudAuthenticationResultDTO::getAnonymousConsumerUuid)
             .returns(ANON_TOKEN_TYPE, CloudAuthenticationResultDTO::getTokenType);
+
+        // We should have gotten a new token
+        assertThat(secondResult.getToken())
+            .isNotBlank()
+            .isNotEqualTo(firstResult.getToken());
+    }
+
+    @Test
+    public void shouldReceiveDifferentAnonTokenDuringV2ReAuthenticationWithUnknownOwner() throws Exception {
+        ApiClient adminClient = ApiClients.admin();
+        String accountId = StringUtil.random("cloud-account-id-");
+        String instanceId = StringUtil.random("cloud-instance-id-");
+        String offerId = StringUtil.random("cloud-offer-");
+
+        adminClient.hosted().associateProductIdsToCloudOffer(offerId, List.of(StringUtil.random("prod-")));
+
+        CloudAuthenticationResultDTO firstResult = ApiClients.noAuth().cloudAuthorization()
+            .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
+        String expectedAnonConsumerUuid = firstResult.getAnonymousConsumerUuid();
+
+        CloudAuthenticationResultDTO secondResult = ApiClients.noAuth().cloudAuthorization()
+            .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
+
+        assertTokenType(ApiClient.MAPPER, firstResult.getToken(), ANON_TOKEN_TYPE);
+        // Check that the same anonymous consumer record (based on uuid) is being used
+        // and that the owner is null because it is still unknown/not existent
+        assertThat(secondResult)
+            .isNotNull()
+            .returns(null, CloudAuthenticationResultDTO::getOwnerKey)
+            .returns(expectedAnonConsumerUuid, CloudAuthenticationResultDTO::getAnonymousConsumerUuid)
+            .returns(ANON_TOKEN_TYPE, CloudAuthenticationResultDTO::getTokenType);
+
+        // We should have gotten a new token
+        assertThat(secondResult.getToken())
+            .isNotBlank()
+            .isNotEqualTo(firstResult.getToken());
     }
 
     @Test
@@ -411,7 +450,7 @@ class CloudRegistrationSpecTest {
         CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
-        assertTokenType(adminClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
         assertThat(result)
             .isNotNull()
             .returns(owner.getKey(), CloudAuthenticationResultDTO::getOwnerKey)
@@ -445,7 +484,7 @@ class CloudRegistrationSpecTest {
         CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
-        assertTokenType(adminClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
+        assertTokenType(ApiClient.MAPPER, result.getToken(), ANON_TOKEN_TYPE);
         assertThat(result)
             .isNotNull()
             .returns(owner.getKey(), CloudAuthenticationResultDTO::getOwnerKey)
@@ -598,10 +637,12 @@ class CloudRegistrationSpecTest {
         assertThat(jobs.size()).isEqualTo(1);
 
         // Extract the owner key from the job's result data, and make sure the owner exists
+        // and is in SCA mode
         String ownerKey = StringUtils.substringBetween((String) jobs.get(0).getResultData(),
             "owner ", " (anonymous");
         assertThat(adminClient.owners().getOwner(ownerKey))
-            .isNotNull();
+            .isNotNull()
+            .returns("org_environment", OwnerDTO::getContentAccessMode);
     }
 
     private void assertTokenType(ObjectMapper mapper, String token, String expectedTokenType)

--- a/src/main/java/org/candlepin/async/tasks/CloudAccountOrgSetupJob.java
+++ b/src/main/java/org/candlepin/async/tasks/CloudAccountOrgSetupJob.java
@@ -22,6 +22,7 @@ import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobConstraints;
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
+import org.candlepin.controller.ContentAccessManager;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.service.CloudRegistrationAdapter;
@@ -93,6 +94,20 @@ public class CloudAccountOrgSetupJob implements AsyncJob {
                         .setDisplayName(accountData.ownerKey())
                         .setAnonymous(accountData.isAnonymous())
                         .setClaimed(false);
+
+                    // Anonymous orgs should always and only be allowed to be in SCA mode,
+                    // while non-anonymous orgs should use the defaults.
+                    if (accountData.isAnonymous()) {
+                        newOwner.setContentAccessMode(
+                                ContentAccessManager.ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue())
+                            .setContentAccessModeList(
+                                ContentAccessManager.ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
+                    }
+                    else {
+                        newOwner.setContentAccessMode(
+                            ContentAccessManager.ContentAccessMode.getDefault().toDatabaseValue())
+                            .setContentAccessModeList(ContentAccessManager.getListDefaultDatabaseValue());
+                    }
                     ownerCurator.create(newOwner);
                 }
             }

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -18,7 +18,6 @@ import static org.candlepin.config.ConfigurationPrefixes.JPA_CONFIG_PREFIX;
 
 import org.candlepin.async.tasks.ActiveEntitlementJob;
 import org.candlepin.async.tasks.CertificateCleanupJob;
-import org.candlepin.async.tasks.CloudAccountOrgSetupJob;
 import org.candlepin.async.tasks.EntitlerJob;
 import org.candlepin.async.tasks.ExpiredPoolsCleanupJob;
 import org.candlepin.async.tasks.ImportRecordCleanerJob;
@@ -288,8 +287,7 @@ public class ConfigProperties {
         JobCleaner.JOB_KEY,
         ManifestCleanerJob.JOB_KEY,
         UnmappedGuestEntitlementCleanerJob.JOB_KEY,
-        InactiveConsumerCleanerJob.JOB_KEY,
-        CloudAccountOrgSetupJob.JOB_KEY
+        InactiveConsumerCleanerJob.JOB_KEY
     };
 
     // How long (in seconds) to wait for job threads to finish during a graceful Tomcat shutdown

--- a/src/test/java/org/candlepin/model/AnonymousCloudConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/AnonymousCloudConsumerCuratorTest.java
@@ -23,8 +23,6 @@ import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
 
-import com.google.inject.Inject;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -35,9 +33,6 @@ import java.util.List;
 
 
 public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
-
-    @Inject
-    private AnonymousCloudConsumerCurator anonymousCloudConsumerCurator;
 
     @Test
     public void testCreate() throws Exception {


### PR DESCRIPTION
- Fix issue with checking if the relevant pools exist in Candlepin during registration with an anonymous token, which should not be checked when the owner does not even exist upstream of Candlepin. Also re-factored this method to read better.
- Make sure the CloudAccountOrgSetupJob creates anonymous owners with SCA as the current and only possible content access mode.
- Make sure the CloudAccountOrgSetupJob creates non-anonymous owners with the default content access mode and content access mode list.
- Remove CloudAccountOrgSetupJob from the list of scheduled jobs since it isn't one.