### PR TITLE
[M] CANDLEPIN-733: Created anonymous certificate content cache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ ext {
 }
 
 dependencies {
+    // Cache
+    implementation libraries["caffeine"]
+
     // Commons
     implementation libraries["commonsCodec"]
     implementation libraries["commonsCollections"]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -31,6 +31,7 @@ libraries["artemisServer"] = "org.apache.activemq:artemis-server:2.31.2"
 libraries["artemisStomp"] = "org.apache.activemq:artemis-stomp-protocol:2.31.2"
 libraries["assertj"] = 'org.assertj:assertj-core:3.25.1'
 libraries["awaitility"] = 'org.awaitility:awaitility:4.2.0'
+libraries["caffeine"] = 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 libraries["checkstyle"] = "com.puppycrawl.tools:checkstyle:10.12.7"
 libraries["checkstyleSevntu"] = "com.github.sevntu-checkstyle:sevntu-checks:1.44.1"
 libraries["commonsCodec"] = "commons-codec:commons-codec:1.16.0"

--- a/src/main/java/org/candlepin/cache/AnonymousCertContent.java
+++ b/src/main/java/org/candlepin/cache/AnonymousCertContent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.cache;
+
+import org.candlepin.model.dto.Content;
+
+import java.util.List;
+import java.util.Objects;
+
+public record AnonymousCertContent(String contentAccessDataPayload, List<Content> content) {
+
+    public AnonymousCertContent {
+        Objects.requireNonNull(contentAccessDataPayload);
+        Objects.requireNonNull(content);
+    }
+
+}
+

--- a/src/main/java/org/candlepin/cache/AnonymousCertContentCache.java
+++ b/src/main/java/org/candlepin/cache/AnonymousCertContentCache.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.cache;
+
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.Configuration;
+import org.candlepin.config.ConfigurationException;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Objects;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * A thread safe cache for consumer certificate content. Entries are evicted based on a time-to-live eviction
+ * policy.
+ */
+@Singleton
+public class AnonymousCertContentCache {
+    private Cache<MultiKey, AnonymousCertContent> cache;
+
+    @Inject
+    public AnonymousCertContentCache(Configuration config) throws ConfigurationException {
+        Objects.requireNonNull(config);
+
+        long expirationDuration = config.getLong(ConfigProperties.CACHE_ANON_CERT_CONTENT_TTL);
+        if (expirationDuration <= 0) {
+            String msg = ConfigProperties.CACHE_ANON_CERT_CONTENT_TTL + " value must be larger than 0";
+            throw new ConfigurationException(msg);
+        }
+
+        cache = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMillis(expirationDuration))
+            .build();
+    }
+
+    /**
+     * Retrieves cached {@link AnonymousCertContent} for the provided top level SKU IDs.
+     *
+     * @param skuIds
+     *  the top level SKU IDs to retrieve consumer certificate content for
+     *
+     * @throws IllegalArgumentException
+     *  if the provided SKU IDs are null
+     *
+     * @return
+     *  the cached consumer certificate content for the provided top level SKU IDs
+     */
+    public AnonymousCertContent get(Collection<String> skuIds) {
+        if (skuIds == null) {
+            throw new IllegalArgumentException("sku ID is null");
+        }
+
+        if (skuIds.isEmpty()) {
+            return null;
+        }
+
+        return cache.getIfPresent(new MultiKey(skuIds));
+    }
+
+    /**
+     * Inserts {@link AnonymousCertContent} into the cache for the provided top level SKU IDs. An existing
+     * entry in the cache for the same SKU IDs will be replaced.
+     *
+     * @param skuIds
+     *  the top level SKU IDs to associate the consumer certificate content to in the cache
+     *
+     * @param content
+     *  the consumer certificate content to insert into the cache
+     *
+     * @throws IllegalArgumentException
+     *  if the provided SKU IDs are null or the provided consumer certificate content is null
+     */
+    public void put(Collection<String> skuIds, AnonymousCertContent content) {
+        if (skuIds == null) {
+            throw new IllegalArgumentException("sku ID is null");
+        }
+
+        if (content == null) {
+            throw new IllegalArgumentException("content is null");
+        }
+
+        cache.put(new MultiKey(skuIds), content);
+    }
+
+    /**
+     * Removes the cached {@link AnonymousCertContent} associated to the provided top level SKU IDs.
+     *
+     * @param skuIds
+     *  the top level SKU IDs to remove cached consumer certificate content for
+     *
+     * @throws IllegalArgumentException
+     *  if the provided SKU IDs are null
+     */
+    public void remove(Collection<String> skuIds) {
+        if (skuIds == null) {
+            throw new IllegalArgumentException("sku IDs is null");
+        }
+
+        cache.invalidate(new MultiKey(skuIds));
+    }
+
+    /**
+     * Clears all entries in the cache
+     */
+    public void removeAll() {
+        cache.invalidateAll();
+    }
+
+}

--- a/src/main/java/org/candlepin/cache/MultiKey.java
+++ b/src/main/java/org/candlepin/cache/MultiKey.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.cache;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+
+/*
+ * A key composed of multiple elements. Duplicate elements are removed to form a distinct set including null
+ * values. Comparisons of the MultiKey does not consider ordering of elements.
+ */
+public class MultiKey {
+
+    private HashSet<String> elements;
+
+    public MultiKey(Collection<String> elements) {
+        Objects.requireNonNull(elements);
+
+        this.elements = new HashSet<>(elements);
+    }
+
+    @Override
+    public int hashCode() {
+        return elements.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MultiKey multiKey = (MultiKey) o;
+        return this.elements.equals(multiKey.elements);
+    }
+
+    @Override
+    public String toString() {
+        return "MultiKey [elements=" + elements + "]";
+    }
+
+}
+

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -178,6 +178,7 @@ public class ConfigProperties {
     // Cache
     public static final String CACHE_JMX_STATS = "cache.jmx.statistics";
     public static final String CACHE_CONFIG_FILE_URI = JPA_CONFIG_PREFIX + "hibernate.javax.cache.uri";
+    public static final String CACHE_ANON_CERT_CONTENT_TTL = "candlepin.cache.anon_cert_content_ttl";
 
     public static final String[] ENCRYPTED_PROPERTIES = new String[] {
         DB_PASSWORD,
@@ -410,6 +411,7 @@ public class ConfigProperties {
 
             this.put(CACHE_JMX_STATS, "false");
             this.put(CACHE_CONFIG_FILE_URI, "ehcache.xml");
+            this.put(CACHE_ANON_CERT_CONTENT_TTL, "120000"); // milliseconds
 
             this.put(SUSPEND_MODE_ENABLED, "true");
 

--- a/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -15,6 +15,8 @@
 package org.candlepin.controller;
 
 import org.candlepin.audit.EventSink;
+import org.candlepin.cache.AnonymousCertContent;
+import org.candlepin.cache.AnonymousCertContentCache;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
 import org.candlepin.controller.util.AnonymousContentPrefix;
@@ -223,6 +225,7 @@ public class ContentAccessManager {
     private final AnonymousCloudConsumerCurator anonCloudConsumerCurator;
     private final AnonymousContentAccessCertificateCurator anonContentAccessCertCurator;
     private final ProductServiceAdapter prodAdapter;
+    private final AnonymousCertContentCache contentCache;
 
     private final boolean standalone;
 
@@ -242,7 +245,8 @@ public class ContentAccessManager {
         EventSink eventSink,
         AnonymousCloudConsumerCurator anonCloudConsumerCurator,
         AnonymousContentAccessCertificateCurator anonContentAccessCertCurator,
-        ProductServiceAdapter prodAdapter) {
+        ProductServiceAdapter prodAdapter,
+        AnonymousCertContentCache contentCache) {
 
         this.config = Objects.requireNonNull(config);
         this.pki = Objects.requireNonNull(pki);
@@ -259,6 +263,7 @@ public class ContentAccessManager {
         this.anonCloudConsumerCurator = Objects.requireNonNull(anonCloudConsumerCurator);
         this.anonContentAccessCertCurator = Objects.requireNonNull(anonContentAccessCertCurator);
         this.prodAdapter = Objects.requireNonNull(prodAdapter);
+        this.contentCache = Objects.requireNonNull(contentCache);
         this.standalone = this.config.getBoolean(ConfigProperties.STANDALONE);
     }
 
@@ -870,24 +875,64 @@ public class ContentAccessManager {
         AnonymousContentAccessCertificate cert = consumer.getContentAccessCert();
         Date now = new Date();
 
-        // Generate a new certificate if one does not exist or the existing certificate is expired
-        if (cert == null || cert.getSerial() == null || cert.getSerial().getExpiration().before(now)) {
-            cert = createAnonContentAccessCertificate(consumer);
+        // Return a valid certificate if the anonymous cloud consumer has one
+        if (cert != null && cert.getSerial() != null && cert.getSerial().getExpiration().after(now)) {
+            log.debug("Returning existing and valid anonymous certificate for consumer: \"{}\"",
+                consumer.getUuid());
+            return cert;
         }
 
-        return cert;
+        // Generate a new certificate if one does not exist or the existing certificate is expired.
+        // First attempt to retrieve an already built and cached content access payload based on the
+        // anonymous cloud consumer's top level product IDs, or retrieve the data through adapters if
+        // we hava a cache miss.
+        String payload;
+        List<Content> content;
+        AnonymousCertContent cached = contentCache.get(consumer.getProductIds());
+        if (cached != null) {
+            log.debug("Anonymous content access certificate content retrieved from cache");
+            payload = cached.contentAccessDataPayload();
+            content = cached.content();
+        }
+        else {
+            log.debug("Retrieving anonymous content access certificate content from product adapter");
+            // Get product information from adapters to build the content access certificate
+            List<ProductInfo> products = prodAdapter.getChildrenByProductIds(consumer.getProductIds());
+            if (products == null || products.isEmpty()) {
+                String msg = "Unable to retrieve products for anonymous cloud consumer: " +
+                    consumer.getUuid();
+                throw new RuntimeException(msg);
+            }
+
+            payload = createAnonPayloadAndSignature(products);
+            List<ContentInfo> contentInfo = getContentInfo(products);
+            content = convertContentInfoToContentDto(contentInfo);
+
+            // Cache the generated content for future requests
+            contentCache.put(consumer.getProductIds(), new AnonymousCertContent(payload, content));
+        }
+
+        return createAnonContentAccessCertificate(consumer, payload, content);
     }
 
     private AnonymousContentAccessCertificate createAnonContentAccessCertificate(
-        AnonymousCloudConsumer consumer) throws GeneralSecurityException, IOException {
-        log.info("Generating content access certificate for anonymous cloud consumer: {}",
-            consumer.getUuid());
+        AnonymousCloudConsumer consumer, String payloadAndSignature, List<Content> certificateContent)
+        throws IOException, GeneralSecurityException {
 
-        List<ProductInfo> products = prodAdapter.getChildrenByProductIds(consumer.getProductIds());
-        if (products == null || products.isEmpty()) {
-            String msg = "Unable to retrieve products for anonymous cloud consumer: " + consumer.getUuid();
-            throw new RuntimeException(msg);
+        if (consumer == null) {
+            throw new IllegalArgumentException("anonymous cloud consumer is null");
         }
+
+        if (payloadAndSignature == null) {
+            throw new IllegalArgumentException("content access payload is null");
+        }
+
+        if (certificateContent == null || certificateContent.isEmpty()) {
+            throw new IllegalArgumentException("certificate content is null or empty");
+        }
+
+        log.info("Generating anonymous content access certificate for consumer: \"{}\"",
+            consumer.getUuid());
 
         OffsetDateTime start = OffsetDateTime.now().minusHours(1L);
         OffsetDateTime end = start.plusDays(2L);
@@ -896,29 +941,32 @@ public class ContentAccessManager {
         KeyPair keyPair = this.pki.generateKeyPair();
         byte[] pemEncodedKeyPair = this.pki.getPemEncoded(keyPair.getPrivate());
 
-        List<ContentInfo> contentInfo = getContentInfo(products);
         org.candlepin.model.dto.Product container = new org.candlepin.model.dto.Product();
-        container.setContent(convertContentInfoToContentDto(contentInfo));
+        container.setContent(certificateContent);
         String x509Cert = createX509Cert(consumer.getUuid(), null, serial, keyPair, container,
             BASIC_ENTITLEMENT_TYPE, start, end);
-
-        List<org.candlepin.model.Content> contents = convertContentInfoToContent(contentInfo);
-        Map<org.candlepin.model.Content, Boolean> activeContent = new HashMap<>();
-        contents.forEach(content -> activeContent.put(content, true));
-
-        PromotedContent promotedContent = new PromotedContent(new AnonymousContentPrefix());
-        byte[] payloadBytes = createContentAccessDataPayload(null, activeContent, promotedContent);
 
         AnonymousContentAccessCertificate caCert = new AnonymousContentAccessCertificate();
         caCert.setSerial(serial);
         caCert.setKeyAsBytes(pemEncodedKeyPair);
-        caCert.setCert(x509Cert + createPayloadAndSignature(payloadBytes));
+        caCert.setCert(x509Cert + payloadAndSignature);
         caCert = anonContentAccessCertCurator.create(caCert);
 
         consumer.setContentAccessCert(caCert);
         this.anonCloudConsumerCurator.merge(consumer);
 
         return caCert;
+    }
+
+    private String createAnonPayloadAndSignature(Collection<ProductInfo> prodInfo) throws IOException {
+        List<ContentInfo> contentInfo = getContentInfo(prodInfo);
+        List<org.candlepin.model.Content> contents = convertContentInfoToContent(contentInfo);
+        Map<org.candlepin.model.Content, Boolean> activeContent = new HashMap<>();
+        contents.forEach(content -> activeContent.put(content, true));
+        PromotedContent promotedContent = new PromotedContent(new AnonymousContentPrefix());
+        byte[] data = createContentAccessDataPayload(null, activeContent, promotedContent);
+
+        return createPayloadAndSignature(data);
     }
 
     /**
@@ -969,7 +1017,7 @@ public class ContentAccessManager {
     }
 
     /**
-     * Converts {@link ContentInfo} to {@link org.candlepin.model.Content}
+     * Converts {@link ContentInfo} to {@link org.candlepin.model.Content}.
      *
      * @param contentInfo
      *  the content to convert

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -241,8 +241,6 @@ public class ConsumerResource implements ConsumerApi {
     private final ContentOverrideValidator coValidator;
     private final ConsumerContentOverrideCurator ccoCurator;
     private final EntitlementCertificateGenerator entCertGenerator;
-    private final CloudRegistrationAdapter cloudAdapter;
-    private final PoolCurator poolCurator;
     private final AnonymousCloudConsumerCurator anonymousConsumerCurator;
     private final AnonymousContentAccessCertificateCurator anonymousCertCurator;
 
@@ -337,8 +335,6 @@ public class ConsumerResource implements ConsumerApi {
         this.ccoCurator = Objects.requireNonNull(ccoCurator);
         this.entCertGenerator = Objects.requireNonNull(entCertGenerator);
         this.poolService = Objects.requireNonNull(poolService);
-        this.cloudAdapter = Objects.requireNonNull(cloudAdapter);
-        this.poolCurator = Objects.requireNonNull(poolCurator);
         this.anonymousConsumerCurator = Objects.requireNonNull(anonymousConsumerCurator);
         this.anonymousCertCurator = Objects.requireNonNull(anonymousCertCurator);
 

--- a/src/test/java/org/candlepin/cache/AnonymousCertContentCacheTest.java
+++ b/src/test/java/org/candlepin/cache/AnonymousCertContentCacheTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.ConfigurationException;
+import org.candlepin.config.DevConfig;
+import org.candlepin.config.TestConfig;
+import org.candlepin.model.dto.Content;
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+public class AnonymousCertContentCacheTest {
+
+    private DevConfig config;
+
+    @BeforeEach
+    public void beforeEach() {
+        config = TestConfig.defaults();
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @ValueSource(longs = { 0L, -1000L })
+    public void testCacheCreationWithInvalidDuration(long duration) throws Exception {
+        config.setProperty(ConfigProperties.CACHE_ANON_CERT_CONTENT_TTL, String.valueOf(duration));
+
+        assertThrows(ConfigurationException.class, () -> {
+            new AnonymousCertContentCache(config);
+        });
+    }
+
+    @Test
+    public void testGetWithInvalidSkuIds() throws Exception {
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            cache.get(null);
+        });
+    }
+
+    @Test
+    public void testGetWithEmptySkuIds() throws Exception {
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+        cache.put(List.of(TestUtil.randomString()), getRandomCertContent(2));
+
+        AnonymousCertContent actual = cache.get(List.of());
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void testGetWithContentInCache() throws Exception {
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+
+        List<String> skuIds = List.of(TestUtil.randomString(), TestUtil.randomString());
+        AnonymousCertContent expected = getRandomCertContent(2);
+        cache.put(skuIds, expected);
+
+        AnonymousCertContent actual = cache.get(skuIds);
+
+        assertThat(actual)
+            .isNotNull()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void testGetWithDuplicateSkus() throws Exception {
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+
+        String skuId1 = TestUtil.randomString();
+        List<String> skuIds = new ArrayList<>();
+        skuIds.add(skuId1);
+        skuIds.add(TestUtil.randomString());
+        AnonymousCertContent expected = getRandomCertContent(2);
+        cache.put(skuIds, expected);
+        // Add duplicate entry. The duplicate should be filtered when generating the cache key
+        skuIds.add(skuId1);
+
+        AnonymousCertContent actual = cache.get(skuIds);
+
+        assertThat(actual)
+            .isNotNull()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void testGetWithContentNotInCache() throws Exception {
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+
+        AnonymousCertContent expected = getRandomCertContent(2);
+        cache.put(List.of(TestUtil.randomString(), TestUtil.randomString()), expected);
+
+        AnonymousCertContent actual = cache.get(List.of(TestUtil.randomString()));
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void testGetWithContentInvalidatedByExpirationDuration() throws Exception {
+        long expirationDuration = 2000L;
+        config.setProperty(ConfigProperties.CACHE_ANON_CERT_CONTENT_TTL, String.valueOf(expirationDuration));
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+        List<String> skuIds = List.of(TestUtil.randomString(), TestUtil.randomString());
+        AnonymousCertContent expected = getRandomCertContent(2);
+        cache.put(skuIds, expected);
+
+        // Wait for cache entry to be invalidated
+        Thread.sleep(expirationDuration + 100L);
+        AnonymousCertContent actual = cache.get(skuIds);
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void testPutWithInvalidSkuIds() throws Exception {
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+        AnonymousCertContent content = getRandomCertContent(2);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            cache.put(null, content);
+        });
+    }
+
+    @Test
+    public void testPutWithInvalidContent() throws Exception {
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+        List<String> skuIds = List.of(TestUtil.randomString());
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            cache.put(skuIds, null);
+        });
+    }
+
+    @Test
+    public void testRemoveWithInvalidSkuIds() throws Exception {
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            cache.remove(null);
+        });
+    }
+
+    @Test
+    public void testRemoveWithContentInCache() throws Exception {
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+
+        List<String> skuIds = List.of(TestUtil.randomString(), TestUtil.randomString());
+        cache.put(skuIds, getRandomCertContent(2));
+        cache.put(List.of(TestUtil.randomString()), getRandomCertContent(2));
+
+        cache.remove(skuIds);
+
+        assertNull(cache.get(skuIds));
+    }
+
+    @Test
+    public void testRemoveAll() throws Exception {
+        AnonymousCertContentCache cache = new AnonymousCertContentCache(config);
+
+        List<String> skuIds1 = List.of(TestUtil.randomString(), TestUtil.randomString());
+        List<String> skuIds2 = List.of(TestUtil.randomString(), TestUtil.randomString());
+        List<String> skuIds3 = List.of(TestUtil.randomString(), TestUtil.randomString());
+        List<String> skuIds4 = List.of(TestUtil.randomString(), TestUtil.randomString());
+        cache.put(skuIds1, getRandomCertContent(2));
+        cache.put(skuIds2, getRandomCertContent(4));
+        cache.put(skuIds3, getRandomCertContent(6));
+        cache.put(skuIds4, getRandomCertContent(8));
+
+        cache.removeAll();
+
+        assertNull(cache.get(skuIds1));
+        assertNull(cache.get(skuIds2));
+        assertNull(cache.get(skuIds3));
+        assertNull(cache.get(skuIds4));
+    }
+
+    private AnonymousCertContent getRandomCertContent(int size) {
+        return new AnonymousCertContent(TestUtil.randomString(), getRandomContents(size));
+    }
+
+    private List<Content> getRandomContents(int size) {
+        List<Content> content = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            content.add(getRandomContent());
+        }
+
+        return content;
+    }
+
+    private Content getRandomContent() {
+        Content content = new Content();
+        content.setId(TestUtil.randomString());
+        content.setLabel(TestUtil.randomString());
+        content.setPath(TestUtil.randomString());
+        content.setType(TestUtil.randomString());
+        content.setVendor(TestUtil.randomString());
+
+        return content;
+    }
+
+}

--- a/src/test/java/org/candlepin/config/TestConfig.java
+++ b/src/test/java/org/candlepin/config/TestConfig.java
@@ -58,6 +58,7 @@ public final class TestConfig {
         defaults.put(DatabaseConfigFactory.CASE_OPERATOR_BLOCK_SIZE, "10");
         defaults.put(DatabaseConfigFactory.BATCH_BLOCK_SIZE, "10");
         defaults.put(DatabaseConfigFactory.QUERY_PARAMETER_LIMIT, "32000");
+        defaults.put(ConfigProperties.CACHE_ANON_CERT_CONTENT_TTL, "120000");
 
         return defaults;
     }

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 import org.candlepin.audit.EventSink;
+import org.candlepin.cache.AnonymousCertContentCache;
 import org.candlepin.controller.ContentAccessManager.ContentAccessMode;
 import org.candlepin.model.CertificateSerial;
 import org.candlepin.model.Consumer;
@@ -63,6 +64,7 @@ public class ContentAccessManagerDBTest extends DatabaseTestFixture {
     private X509V3ExtensionUtil x509V3ExtensionUtil;
 
     private EventSink mockEventSink;
+    private AnonymousCertContentCache cache;
 
     @Mock
     private ProductServiceAdapter mockProdAdapter;
@@ -79,6 +81,7 @@ public class ContentAccessManagerDBTest extends DatabaseTestFixture {
             ObjectMapperFactory.getObjectMapper()));
 
         this.mockEventSink = mock(EventSink.class);
+        this.cache = new AnonymousCertContentCache(this.config);
     }
 
     private ContentAccessManager createManager() {
@@ -86,7 +89,7 @@ public class ContentAccessManagerDBTest extends DatabaseTestFixture {
             this.caCertCurator, this.certSerialCurator, this.ownerCurator, this.contentCurator,
             this.consumerCurator, this.consumerTypeCurator, this.environmentCurator, this.caCertCurator,
             this.mockEventSink, this.anonymousCloudConsumerCurator, this.anonymousContentAccessCertCurator,
-            this.mockProdAdapter);
+            this.mockProdAdapter, this.cache);
     }
 
     private Owner createSCAOwner() {

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -29,12 +29,15 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.audit.EventSink;
+import org.candlepin.cache.AnonymousCertContent;
+import org.candlepin.cache.AnonymousCertContentCache;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.DevConfig;
 import org.candlepin.config.TestConfig;
@@ -104,7 +107,9 @@ import org.mockito.stubbing.Answer;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.security.KeyPair;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -151,6 +156,7 @@ public class ContentAccessManagerTest {
     private ObjectMapper objectMapper;
     private PKIUtility pkiUtility;
     private X509V3ExtensionUtil x509V3ExtensionUtil;
+    private AnonymousCertContentCache cache;
 
     private final String entitlementMode = ContentAccessMode.ENTITLEMENT.toDatabaseValue();
     private final String orgEnvironmentMode = ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
@@ -206,6 +212,8 @@ public class ContentAccessManagerTest {
         EntityManager entityManager = mock(EntityManager.class);
         TestUtil.mockTransactionalFunctionality(entityManager, this.mockConsumerCurator,
             this.mockAnonCloudConsumerCurator);
+
+        cache = new AnonymousCertContentCache(config);
     }
 
     public static class PersistSimulator<T extends AbstractHibernateObject> implements Answer<T> {
@@ -232,7 +240,7 @@ public class ContentAccessManagerTest {
             this.mockCertSerialCurator, this.mockOwnerCurator, this.mockContentCurator,
             this.mockConsumerCurator, this.mockConsumerTypeCurator, this.mockEnvironmentCurator,
             this.mockContentAccessCertCurator, this.mockEventSink, this.mockAnonCloudConsumerCurator,
-            this.mockAnonContentAccessCertCurator, this.mockProdAdapter);
+            this.mockAnonContentAccessCertCurator, this.mockProdAdapter, this.cache);
     }
 
     private ContentAccessManager createManager() {
@@ -894,7 +902,7 @@ public class ContentAccessManagerTest {
     }
 
     @Test
-    public void testGetCertificateWithNullAnonymousCloudConsumer() {
+    public void testGetCertificateForAnonConsumerWithNullAnonymousCloudConsumer() {
         this.config.setProperty(ConfigProperties.STANDALONE, "false");
         ContentAccessManager manager = this.createManager();
         AnonymousCloudConsumer consumer = null;
@@ -904,7 +912,7 @@ public class ContentAccessManagerTest {
     }
 
     @Test
-    public void testGetCertificateWithStandaloneMode() {
+    public void testGetCertificateForAnonConsumerWithStandaloneMode() {
         this.config.setProperty(ConfigProperties.STANDALONE, "true");
 
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer();
@@ -920,7 +928,7 @@ public class ContentAccessManagerTest {
     }
 
     @Test
-    public void testGetCertificateWithExistingCertificate() throws Exception {
+    public void testGetCertificateForAnonConsumerWithExistingCertificate() throws Exception {
         this.config.setProperty(ConfigProperties.STANDALONE, "false");
 
         CertificateSerial serial = new CertificateSerial(12345L);
@@ -957,7 +965,7 @@ public class ContentAccessManagerTest {
     }
 
     @Test
-    public void testGetCertificateWithNoExistingCertificate() throws Exception {
+    public void testGetCertificateForAnonConsumerWithNoExistingCertificate() throws Exception {
         this.config.setProperty(ConfigProperties.STANDALONE, "false");
 
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer();
@@ -967,6 +975,7 @@ public class ContentAccessManagerTest {
         consumer.setCloudInstanceId("instance-id");
         consumer.setCloudProviderShortName(TestUtil.randomString());
         consumer.setContentAccessCert(null);
+        consumer.setProductIds(List.of(TestUtil.randomString()));
 
         CertificateSerial expectedSerial = new CertificateSerial(678910L);
         expectedSerial.setExpiration(Util.tomorrow());
@@ -998,7 +1007,67 @@ public class ContentAccessManagerTest {
     }
 
     @Test
-    public void testGetCertificateWithExpiredCertificate() throws Exception {
+    public void testGetCertificateForAnonConsumerWithCachedCertContent() throws Exception {
+        this.config.setProperty(ConfigProperties.STANDALONE, "false");
+
+        List<String> skuIds = List.of(TestUtil.randomString(), TestUtil.randomString());
+        cache.put(skuIds, new AnonymousCertContent(TestUtil.randomString(), getRandomContents(2)));
+
+        AnonymousCloudConsumer consumer = new AnonymousCloudConsumer();
+        consumer.setId("id");
+        consumer.setUuid("uuid");
+        consumer.setCloudAccountId("account-id");
+        consumer.setCloudInstanceId("instance-id");
+        consumer.setCloudProviderShortName(TestUtil.randomString());
+        consumer.setContentAccessCert(null);
+        consumer.setProductIds(skuIds);
+
+        CertificateSerial expectedSerial = new CertificateSerial(678910L);
+        expectedSerial.setExpiration(Util.tomorrow());
+        AnonymousContentAccessCertificate expected = new AnonymousContentAccessCertificate();
+        expected.setId("id-2");
+        expected.setKey("key-2");
+        expected.setCert("cert-2");
+        expected.setSerial(expectedSerial);
+
+        doReturn(expected).when(this.mockAnonContentAccessCertCurator)
+            .create(any(AnonymousContentAccessCertificate.class));
+
+        ContentAccessManager manager = this.createManager();
+        AnonymousContentAccessCertificate actual = manager.getCertificate(consumer);
+
+        assertThat(actual)
+            .isNotNull()
+            .returns(expected.getId(), AnonymousContentAccessCertificate::getId)
+            .returns(expected.getCert(), AnonymousContentAccessCertificate::getCert)
+            .returns(expected.getCreated(), AnonymousContentAccessCertificate::getCreated)
+            .returns(expected.getUpdated(), AnonymousContentAccessCertificate::getUpdated)
+            .returns(expected.getAnonymousCloudConsumer(),
+                AnonymousContentAccessCertificate::getAnonymousCloudConsumer)
+            .returns(expected.getKey(), AnonymousContentAccessCertificate::getKey)
+            .returns(expected.getSerial(), AnonymousContentAccessCertificate::getSerial);
+
+        verify(mockProdAdapter, never()).getChildrenByProductIds(any(Collection.class));
+    }
+
+    @Test
+    public void testGetCertificateForAnonConsumerWithNoExistingCertificateAndNoProdIds() throws Exception {
+        this.config.setProperty(ConfigProperties.STANDALONE, "false");
+
+        AnonymousCloudConsumer consumer = new AnonymousCloudConsumer();
+        consumer.setId("id");
+        consumer.setUuid("uuid");
+        consumer.setCloudAccountId("account-id");
+        consumer.setCloudInstanceId("instance-id");
+        consumer.setCloudProviderShortName(TestUtil.randomString());
+        consumer.setContentAccessCert(null);
+
+        ContentAccessManager manager = this.createManager();
+        assertThrows(RuntimeException.class, () ->manager.getCertificate(consumer));
+    }
+
+    @Test
+    public void testGetCertificateForAnonConsumerWithExpiredCertificate() throws Exception {
         this.config.setProperty(ConfigProperties.STANDALONE, "false");
 
         CertificateSerial expiredSerial = new CertificateSerial(12345L);
@@ -1051,7 +1120,8 @@ public class ContentAccessManagerTest {
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
     @NullAndEmptySource
-    public void testGetCertificateWithInvalidProductInfoFromAdapter(List<String> prods) throws Exception {
+    public void testGetCertificateForAnonConsumerWithInvalidProductInfoFromAdapter(List<String> prods)
+        throws Exception {
         this.config.setProperty(ConfigProperties.STANDALONE, "false");
 
         AnonymousCloudConsumer consumer = new AnonymousCloudConsumer();
@@ -1061,6 +1131,7 @@ public class ContentAccessManagerTest {
         consumer.setCloudInstanceId("instance-id");
         consumer.setCloudProviderShortName(TestUtil.randomString());
         consumer.setContentAccessCert(null);
+        consumer.setProductIds(List.of(TestUtil.randomString()));
 
         doReturn(prods).when(this.mockProdAdapter).getChildrenByProductIds(consumer.getProductIds());
 
@@ -1086,9 +1157,30 @@ public class ContentAccessManagerTest {
         doReturn(content).when(prodContent).getContent();
 
         ProductInfo prodInfo = mock(ProductInfo.class);
+        doReturn("prod-id").when(prodInfo).getId();
         doReturn(List.of(prodContent)).when(prodInfo).getProductContent();
 
         return prodInfo;
+    }
+
+    private List<org.candlepin.model.dto.Content> getRandomContents(int size) {
+        List<org.candlepin.model.dto.Content> content = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            content.add(getRandomContent());
+        }
+
+        return content;
+    }
+
+    private org.candlepin.model.dto.Content getRandomContent() {
+        org.candlepin.model.dto.Content content = new org.candlepin.model.dto.Content();
+        content.setId(TestUtil.randomString());
+        content.setLabel(TestUtil.randomString());
+        content.setPath(TestUtil.randomString());
+        content.setType(TestUtil.randomString());
+        content.setVendor(TestUtil.randomString());
+
+        return content;
     }
 
 }


### PR DESCRIPTION
- Created ConsumerCertificateContentCache to cache cert content
- Added the cache to the ContentAccessManager and attempt to use the cached content when creating anonymous content access certificates
- Removed unused CloudRegistrationAdapter and PoolCurator from the ConsumerResource class

I have some concerns about needing to add an upper bound entry limit to the ConsumerCertificateContentCache to prevent the cache from consuming potentially too much memory.  I created the following jira for determining if we should limit the max number of entries:
https://issues.redhat.com/browse/CANDLEPIN-759