### PR TITLE
[M] CANDLEPIN-758: Update/add foreign keys around cp_anonymous_certificates

### DIFF
--- a/src/main/resources/db/changelog/20240101162555-update-anon-cert-foreign-key.xml
+++ b/src/main/resources/db/changelog/20240101162555-update-anon-cert-foreign-key.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+    <changeSet id="20240101162555-1" author="nmoumoul">
+        <preConditions onFail="MARK_RAN">
+            <foreignKeyConstraintExists foreignKeyName="fk_cp_anonymous_cloud_consumers_cert"/>
+        </preConditions>
+
+        <comment>Drop the fk because it uses CASCADE on delete</comment>
+        <dropForeignKeyConstraint baseTableName="cp_anonymous_cloud_consumers"
+            constraintName="fk_cp_anonymous_cloud_consumers_cert"/>
+    </changeSet>
+
+    <changeSet id="20240101162555-2" author="nmoumoul">
+        <comment>Recreate the fk with NO ACTION on delete</comment>
+        <addForeignKeyConstraint baseTableName="cp_anonymous_cloud_consumers"
+            baseColumnNames="cont_acc_cert_id"
+            referencedTableName="cp_anonymous_certificates"
+            referencedColumnNames="id"
+            constraintName="cp_anonymous_cloud_consumers_cert_fk"
+            onDelete="NO ACTION"
+            onUpdate="NO ACTION" />
+    </changeSet>
+
+    <changeSet id="20240101162555-3" author="nmoumoul">
+        <comment>Add foreign key for serial</comment>
+        <addForeignKeyConstraint
+             baseColumnNames="serial_id"
+             baseTableName="cp_anonymous_certificates"
+             constraintName="anon_cont_acc_serial_fk"
+             onDelete="NO ACTION"
+             onUpdate="NO ACTION"
+             referencedColumnNames="id"
+             referencedTableName="cp_cert_serial" />
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -193,4 +193,5 @@
     <include file="db/changelog/20231003113535-entity_layering_schema.xml"/>
     <include file="db/changelog/20231003163700-rename_pool_locked_field.xml"/>
     <include file="db/changelog/20231211101743-add-pool-dirty-product-column.xml"/>
+    <include file="db/changelog/20240101162555-update-anon-cert-foreign-key.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/model/AnonymousCloudConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/AnonymousCloudConsumerCuratorTest.java
@@ -17,6 +17,7 @@ package org.candlepin.model;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.collection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.candlepin.test.DatabaseTestFixture;
@@ -29,7 +30,7 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
-
+import java.util.Set;
 
 
 public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
@@ -235,4 +236,57 @@ public class AnonymousCloudConsumerCuratorTest extends DatabaseTestFixture {
             .getResultList();
     }
 
+    @Test
+    public void unlinksAnonymousContentAccessCerts() {
+        AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
+            .setCloudAccountId("cloudAccount1")
+            .setCloudInstanceId("cloudInstance1")
+            .setCloudOfferingId("cloudOffering1")
+            .setCloudProviderShortName("GCP")
+            .setProductIds(Set.of("SKU1"));
+        AnonymousCloudConsumer consumer2 = new AnonymousCloudConsumer()
+            .setCloudAccountId("cloudAccount2")
+            .setCloudInstanceId("cloudInstance2")
+            .setCloudOfferingId("cloudOffering2")
+            .setCloudProviderShortName("GCP")
+            .setProductIds(Set.of("SKU2"));
+
+        AnonymousContentAccessCertificate caCert1 = createExpiredAnonymousContentAccessCert(consumer);
+        AnonymousContentAccessCertificate caCert2 = createExpiredAnonymousContentAccessCert(consumer2);
+        consumer.setContentAccessCert(caCert1);
+        consumer2.setContentAccessCert(caCert2);
+        this.anonymousCloudConsumerCurator.create(consumer);
+        this.anonymousCloudConsumerCurator.create(consumer2);
+
+        int unlinkedConsumers = this.anonymousCloudConsumerCurator.unlinkAnonymousCertificates(List.of(
+            caCert1.getId(),
+            caCert2.getId()));
+        this.anonymousCloudConsumerCurator.flush();
+        this.anonymousCloudConsumerCurator.clear();
+
+        assertEquals(2, unlinkedConsumers);
+        for (AnonymousCloudConsumer c : this.anonymousCloudConsumerCurator.listAll()) {
+            assertNull(c.getContentAccessCert());
+        }
+    }
+
+    @Test
+    public void noAnonymousContentAccessCertsToUnlink() {
+        assertEquals(0, anonymousCloudConsumerCurator.unlinkAnonymousCertificates(null));
+        assertEquals(0, anonymousCloudConsumerCurator.unlinkAnonymousCertificates(List.of()));
+        assertEquals(0, anonymousCloudConsumerCurator.unlinkAnonymousCertificates(List.of("UnknownId")));
+    }
+
+    private AnonymousContentAccessCertificate createExpiredAnonymousContentAccessCert(
+        AnonymousCloudConsumer consumer) {
+
+        AnonymousContentAccessCertificate certificate = new AnonymousContentAccessCertificate();
+        certificate.setKey("crt_key");
+        certificate.setSerial(new CertificateSerial(Util.yesterday()));
+        certificate.setCert("cert_1");
+        consumer.setContentAccessCert(certificate);
+        certificate.setId(null);
+        certSerialCurator.create(certificate.getSerial());
+        return anonymousContentAccessCertCurator.create(certificate);
+    }
 }

--- a/src/test/java/org/candlepin/model/AnonymousCloudConsumerTest.java
+++ b/src/test/java/org/candlepin/model/AnonymousCloudConsumerTest.java
@@ -440,10 +440,12 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
 
     @Test
     public void testUpdateToAnonymousContentAccessCertificate() {
+        CertificateSerial serial = new CertificateSerial();
+        this.certSerialCurator.create(serial);
         AnonymousContentAccessCertificate certificate = new AnonymousContentAccessCertificate();
         certificate.setCert("cert-1");
         certificate.setKey("key-1");
-        certificate.setSerial(new CertificateSerial(12345L));
+        certificate.setSerial(serial);
 
         certificate = anonymousContentAccessCertCurator.create(certificate);
 
@@ -462,10 +464,12 @@ public class AnonymousCloudConsumerTest extends DatabaseTestFixture {
 
         consumer = anonymousCloudConsumerCurator.create(consumer);
 
+        CertificateSerial expectedSerial = new CertificateSerial();
+        this.certSerialCurator.create(expectedSerial);
         AnonymousContentAccessCertificate expectedCert = new AnonymousContentAccessCertificate();
         expectedCert.setCert("cert-2");
         expectedCert.setKey("key-2");
-        expectedCert.setSerial(new CertificateSerial(678910L));
+        expectedCert.setSerial(expectedSerial);
         expectedCert = anonymousContentAccessCertCurator.create(expectedCert);
         consumer.setContentAccessCert(expectedCert);
 


### PR DESCRIPTION
- Update the foreign key from cp_anonymous_cloud_consumers to cp_anonymous_certificates to not be CASCADE on delete, and make sure the CertificateCleanupJob unlinks those consumers before deleting their certs to avoid this constraint.
- Add missing foreign key from cp_anonymous_certificates to cp_cert_serial.