### PR TITLE
[4.3] Fix CertificateCleanupJob fk violation & add back indexes (CANDLEPIN-741)

### DIFF
--- a/src/main/java/org/candlepin/model/CertificateSerialCurator.java
+++ b/src/main/java/org/candlepin/model/CertificateSerialCurator.java
@@ -16,6 +16,8 @@ package org.candlepin.model;
 
 import com.google.inject.persist.Transactional;
 
+import org.hibernate.annotations.QueryHints;
+
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.TimeZone;
 
 import javax.inject.Singleton;
+import javax.persistence.EntityManager;
 import javax.persistence.Query;
 
 
@@ -52,17 +55,60 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
     }
 
     /**
-     * Deletes all revoked cert serials that have expired.
+     * Deletes all cert serials that are both revoked AND expired, and are NOT referenced by any table.
      *
      * @return the total number of serials that were deleted.
      */
     @Transactional
     public int deleteRevokedExpiredSerials() {
-        String hql = "DELETE FROM CertificateSerial c WHERE c.revoked = true" +
-            " AND c.expiration < :cutoff";
-        Query query = this.getEntityManager().createQuery(hql);
-        query.setParameter("cutoff", getExpiryRestriction());
-        return query.executeUpdate();
+        EntityManager entityManager = this.getEntityManager();
+
+        // Impl. note: Under normal circumstances, we should not have to worry about deleting revoked
+        // serials being referenced in any certificate table, because the corresponding certificate is
+        // always deleted when the serial is revoked. However, this avoids bugs such as 2229095, where bad
+        // data caused by accident/bug could make this query fail.
+        //
+        // Also, there doesn't seem to be a way to do this kind of query with JQPL, so we're using native
+        // SQL, and MariaDB does not like table aliases in delete statements, so we have to do this
+        // in 2 queries (select, then delete).
+        List<String> nativeSpaces = List.of(CertificateSerial.class.getName(),
+            SubscriptionsCertificate.class.getName(),
+            EntitlementCertificate.class.getName(),
+            CdnCertificate.class.getName(),
+            IdentityCertificate.class.getName(),
+            ContentAccessCertificate.class.getName(),
+            UeberCertificate.class.getName());
+        String fetchSQL = "SELECT cs.id FROM cp_cert_serial cs " +
+                "LEFT JOIN cp_certificate subc ON cs.id = subc.serial_id " +
+                "LEFT JOIN cp_ent_certificate entc ON cs.id = entc.serial_id " +
+                "LEFT JOIN cp_cdn_certificate cdnc ON cs.id = cdnc.serial_id " +
+                "LEFT JOIN cp_id_cert idc ON cs.id = idc.serial_id " +
+                "LEFT JOIN cp_cont_access_cert scac ON cs.id = scac.serial_id " +
+                "LEFT JOIN cp_ueber_cert uebc ON cs.id = uebc.serial_id " +
+                "WHERE cs.revoked = true " +
+                "AND cs.expiration < ? " +
+                "AND subc.serial_id IS NULL " +
+                "AND entc.serial_id IS NULL " +
+                "AND cdnc.serial_id IS NULL " +
+                "AND idc.serial_id IS NULL " +
+                "AND scac.serial_id IS NULL " +
+                "AND uebc.serial_id IS NULL;";
+
+        List<Long> serials = entityManager.createNativeQuery(fetchSQL)
+            .setHint(QueryHints.NATIVE_SPACES, nativeSpaces)
+            .setParameter(1, getExpiryRestriction())
+            .getResultList();
+
+        String deleteSQL = "DELETE FROM cp_cert_serial WHERE id IN (:serials_to_delete)";
+        nativeSpaces = List.of(CertificateSerial.class.getName());
+        int deleted = 0;
+        for (List<Long> serialsToDeleteBlock : this.partition(serials)) {
+            deleted += entityManager.createNativeQuery(deleteSQL)
+                .setHint(QueryHints.NATIVE_SPACES, nativeSpaces)
+                .setParameter("serials_to_delete", serialsToDeleteBlock)
+                .executeUpdate();
+        }
+        return deleted;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/resources/db/changelog/20230811183400-add-indexes-certificate-cleanup.xml
+++ b/src/main/resources/db/changelog/20230811183400-add-indexes-certificate-cleanup.xml
@@ -8,16 +8,31 @@
 
     <!-- For making the CertificateCleanupJob queries faster -->
     <changeSet id="20230811183400-1" author="wpoteat" dbms="postgresql,hsqldb">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="cp_cont_access_cert_serial_id_idx"/>
+            </not>
+        </preConditions>
         <createIndex tableName="cp_cont_access_cert" indexName="cp_cont_access_cert_serial_id_idx">
             <column name="serial_id"/>
         </createIndex>
     </changeSet>
     <changeSet id="20230811183400-2" author="wpoteat" dbms="postgresql,hsqldb">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="cp_ueber_cert_serial_id_idx"/>
+            </not>
+        </preConditions>
         <createIndex tableName="cp_ueber_cert" indexName="cp_ueber_cert_serial_id_idx">
             <column name="serial_id"/>
         </createIndex>
     </changeSet>
     <changeSet id="20230811183400-3" author="wpoteat" dbms="postgresql,hsqldb">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="cp_consumer_cont_acc_cert_id_idx"/>
+            </not>
+        </preConditions>
         <createIndex tableName="cp_consumer" indexName="cp_consumer_cont_acc_cert_id_idx">
             <column name="cont_acc_cert_id"/>
         </createIndex>

--- a/src/main/resources/db/changelog/20230811183400-add-indexes-certificate-cleanup.xml
+++ b/src/main/resources/db/changelog/20230811183400-add-indexes-certificate-cleanup.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+    <!-- For making the CertificateCleanupJob queries faster -->
+    <changeSet id="20230811183400-1" author="wpoteat" dbms="postgresql,hsqldb">
+        <createIndex tableName="cp_cont_access_cert" indexName="cp_cont_access_cert_serial_id_idx">
+            <column name="serial_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="20230811183400-2" author="wpoteat" dbms="postgresql,hsqldb">
+        <createIndex tableName="cp_ueber_cert" indexName="cp_ueber_cert_serial_id_idx">
+            <column name="serial_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="20230811183400-3" author="wpoteat" dbms="postgresql,hsqldb">
+        <createIndex tableName="cp_consumer" indexName="cp_consumer_cont_acc_cert_id_idx">
+            <column name="cont_acc_cert_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/20240104162911-unrevoke-subscription-certs.xml
+++ b/src/main/resources/db/changelog/20240104162911-unrevoke-subscription-certs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+
+    <property dbms="postgresql,mysql,mariadb" name="unrevoked_value" value="false"/>
+
+    <property dbms="postgresql,mysql,mariadb" name="revoked_value" value="true"/>
+
+    <!--
+        Undo the accidental revoking of certificate serials for SubscriptionCertificates (that are not
+        supposed to be revocable) which happened in changelog 20170301083925-1, and caused a fk violation
+        when the CertificateCleanupJob run in standalone instances.
+     -->
+    <changeSet id="20240104162911-1" author="nmoumoul">
+        <sql dbms="postgresql,mysql,mariadb">
+            UPDATE cp_cert_serial cs SET revoked = ${unrevoked_value}
+                WHERE revoked = ${revoked_value}
+                AND EXISTS (SELECT 1 FROM cp_certificate subcert WHERE subcert.serial_id = cs.id);
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -186,4 +186,5 @@
     <include file="db/changelog/20230220150433-drop-act-key-env-tables.xml"/>
     <include file="db/changelog/20230322103117-reduce-consumer-name.xml"/>
     <include file="db/changelog/20230811183400-add-indexes-certificate-cleanup.xml"/>
+    <include file="db/changelog/20240104162911-unrevoke-subscription-certs.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -185,4 +185,5 @@
     <include file="db/changelog/20230207161633-clear_entity_versions-1.xml"/>
     <include file="db/changelog/20230220150433-drop-act-key-env-tables.xml"/>
     <include file="db/changelog/20230322103117-reduce-consumer-name.xml"/>
+    <include file="db/changelog/20230811183400-add-indexes-certificate-cleanup.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/async/tasks/CertificateCleanupJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/CertificateCleanupJobTest.java
@@ -24,9 +24,9 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.model.ContentAccessCertificate;
 import org.candlepin.model.IdentityCertificate;
 import org.candlepin.model.Owner;
+import org.candlepin.model.SubscriptionsCertificate;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
-import org.candlepin.util.Util;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,64 +36,82 @@ import java.util.Date;
 class CertificateCleanupJobTest extends DatabaseTestFixture {
 
     private static final Date VALID = TestUtil.createDateOffset(2, 0, 0);
-    private static final Date EXPIRED = Util.yesterday();
+    private static final Date EXPIRED = TestUtil.createDateOffset(0, 0, -10);
 
     private Owner owner;
-    private ConsumerType ct;
-    private Consumer consumer1;
-    private Consumer consumer2;
-    private Consumer consumer3;
-    private Consumer consumer4;
 
     private CertificateCleanupJob job;
 
     @BeforeEach
     public void setUp() {
         this.owner = this.createOwner("test-owner", "Test Owner");
-        this.ct = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
-        this.ct = this.consumerTypeCurator.create(ct);
-
-        this.consumer1 = createConsumer(VALID, VALID);
-        this.consumer2 = createConsumer(EXPIRED, VALID);
-        this.consumer3 = createConsumer(VALID, EXPIRED);
-        this.consumer4 = createConsumer(EXPIRED, EXPIRED);
-
         job = injector.getInstance(CertificateCleanupJob.class);
     }
 
     @Test
-    void shouldCleanExpiredCertificates() throws JobExecutionException {
+    void shouldCleanExpiredIdentityAndSimpleContentAccessCertificates() throws JobExecutionException {
+        ConsumerType consumerType = new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
+        consumerType = this.consumerTypeCurator.create(consumerType);
+        Consumer consumer1 = createConsumer(consumerType, VALID, VALID);
+        Consumer consumer2 = createConsumer(consumerType, EXPIRED, VALID);
+        Consumer consumer3 = createConsumer(consumerType, VALID, EXPIRED);
+        Consumer consumer4 = createConsumer(consumerType, EXPIRED, EXPIRED);
+
         job.execute(null);
         this.consumerCurator.flush();
         this.consumerCurator.clear();
 
-        Consumer consumer1 = findConsumer(this.consumer1);
+        consumer1 = findConsumer(consumer1);
         assertNotNull(consumer1.getIdCert());
         assertNotNull(consumer1.getContentAccessCert());
 
-        Consumer consumer2 = findConsumer(this.consumer2);
+        consumer2 = findConsumer(consumer2);
         assertNull(consumer2.getIdCert());
         assertNotNull(consumer2.getContentAccessCert());
 
-        Consumer consumer3 = findConsumer(this.consumer3);
+        consumer3 = findConsumer(consumer3);
         assertNotNull(consumer3.getIdCert());
         assertNull(consumer3.getContentAccessCert());
 
-        Consumer consumer4 = findConsumer(this.consumer4);
+        consumer4 = findConsumer(consumer4);
         assertNull(consumer4.getIdCert());
         assertNull(consumer4.getContentAccessCert());
+    }
+
+    @Test
+    void shouldNotFailWithForeignKeyViolationWhenCleaningUpExpiredAndRevokedSerials()
+        throws JobExecutionException {
+
+        SubscriptionsCertificate subsCert = new SubscriptionsCertificate()
+                .setCreated(new Date())
+                .setUpdated(new Date());
+        subsCert.setKey("key_abc");
+        subsCert.setCert("cert_abcd");
+        CertificateSerial expiredSerial = new CertificateSerial();
+        expiredSerial.setExpiration(TestUtil.createDateOffset(0, 0, -7));
+        subsCert.setSerial(expiredSerial);
+
+        // This should NEVER happen under normal circumstances. Subscription Certificates are not revocable
+        // through any normal code path, and this could only happen through a db schema upgrade accident.
+        expiredSerial.setRevoked(Boolean.TRUE);
+
+        this.subscriptionsCertificateCurator.create(subsCert);
+
+        // This should not fail with a FK violation, even though we have an expired+revoked serial
+        // that is still referenced with a foreign key in another table (cp_certificate
+        job.execute(null);
     }
 
     private Consumer findConsumer(Consumer consumer) {
         return this.consumerCurator.getConsumer(consumer.getUuid());
     }
 
-    private Consumer createConsumer(Date idExpiration, Date caExpiration) {
+    private Consumer createConsumer(ConsumerType consumerType, Date idExpiration, Date caExpiration) {
         Consumer consumer = new Consumer()
             .setName("c1")
             .setUsername("u1")
             .setOwner(owner)
-            .setType(ct)
+            .setType(consumerType)
             .setIdCert(createIdCert(idExpiration))
             .setContentAccessCert(createContentAccessCert(caExpiration));
 


### PR DESCRIPTION
This PR adds back the previously reverted commits for improving the speed of CertificateCleanupJob (9fef94d5f625ae24f530cd0caadae1dc5da3dbec and 7d67a8b1dff719ff12475db63af03c4911a42cc1),
while also fixes the foreign key violation against the cp_certificate table.