### PR TITLE
CANDLEPIN-739: Catch scenario with null event data

### DIFF
--- a/src/main/java/org/candlepin/audit/ActivationListener.java
+++ b/src/main/java/org/candlepin/audit/ActivationListener.java
@@ -16,6 +16,7 @@ package org.candlepin.audit;
 
 import org.candlepin.service.SubscriptionServiceAdapter;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
@@ -45,10 +46,16 @@ public class ActivationListener implements EventListener {
     public void onEvent(Event event) {
         if (event.getType().equals(Event.Type.CREATED) &&
             event.getTarget().equals(Event.Target.POOL)) {
+            JsonNode subscriptionId = null;
             try {
-                String subscriptionId = mapper.readTree(event.getEventData())
-                    .get("subscriptionId").asText();
-                subscriptionService.sendActivationEmail(subscriptionId);
+                if (event.getEventData() != null) {
+                    subscriptionId = mapper.readTree(event.getEventData())
+                        .get("subscriptionId");
+                }
+
+                if (subscriptionId != null) {
+                    subscriptionService.sendActivationEmail(subscriptionId.asText());
+                }
             }
             catch (IOException e) {
                 logError(event, e);

--- a/src/test/java/org/candlepin/audit/ActivationListenerTest.java
+++ b/src/test/java/org/candlepin/audit/ActivationListenerTest.java
@@ -17,6 +17,7 @@ package org.candlepin.audit;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.service.SubscriptionServiceAdapter;
@@ -50,5 +51,15 @@ public class ActivationListenerTest {
         when(event.getEventData()).thenReturn("{\"subscriptionId\":\"sub-id-1\"}");
         listener.onEvent(event);
         verify(subscriptionService, times(1)).sendActivationEmail("sub-id-1");
+    }
+
+    @Test
+    public void testActivationEmailIsNotSentAndNoExceptionWithNullSubscriptionId() {
+        Event event = mock(Event.class);
+        when(event.getTarget()).thenReturn(Event.Target.POOL);
+        when(event.getType()).thenReturn(Event.Type.CREATED);
+        when(event.getEventData()).thenReturn(null);
+        listener.onEvent(event);
+        verifyNoInteractions(subscriptionService);
     }
 }


### PR DESCRIPTION
- Will bypass email sending if event data is null or a subscription id is not in the data