### PR TITLE
[M] Updated Candlepin health check in dev compose file

### DIFF
--- a/dev-container/docker-compose.yml
+++ b/dev-container/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - "8443:8443"
     healthcheck:
-      test: wget --tries=1 --spider https://localhost:8443/candlepin/status || exit 1
+      test: curl --fail -k https://localhost:8443/candlepin/status
       timeout: 5s
       retries: 10
       start_period: 30s


### PR DESCRIPTION
- updated the Candlepin health check to use curl with insecure option

To replicate the issue run `docker compose -f ./dev-container/docker-compose.yml up -d --wait` from the root of the project directory. Using whe `--wait` option will force the command to wait for all healthy health checks, but Candlepin will fail to change to healthy despite properly starting up. 

Running the current health check by itself returns:

```
wget --tries=1 --spider https://localhost:8443/candlepin/status
Spider mode enabled. Check if remote file exists.
--2024-01-16 10:42:54--  https://localhost:8443/candlepin/status
Resolving localhost (localhost)... ::1, 127.0.0.1
Connecting to localhost (localhost)|::1|:8443... connected.
ERROR: The certificate of ‘localhost’ is not trusted.
ERROR: The certificate of ‘localhost’ doesn't have a known issuer.
```

So, I believe the issue is with the self signed certificates being created in the release pipeline and not locally. So, using the `-k` option with the curl command as a health check resolves the issue.