### PR TITLE
[M] CANDLEPIN-773: Regenerate certs when org content prefix changes

### DIFF
--- a/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -816,6 +816,27 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         return count;
     }
 
+    /**
+     * Marks all entitlements assigned to the specified organization as dirty. If the organization
+     * has no entitlements, or the owner does not exist, this method returns 0. The output of this
+     * method does not account for entitlements that are already dirty, and will, in effect, return
+     * the number of entitlements in the organization.
+     *
+     * @param ownerId
+     *  the ID of the organization (owner) for which to flag entitlements
+     *
+     * @return
+     *  the number of entitlements flagged as dirty
+     */
+    public int markEntitlementsDirtyForOwner(String ownerId) {
+        String jpql = "UPDATE Entitlement SET dirty = true WHERE owner.id = :owner_id";
+
+        return this.getEntityManager()
+            .createQuery(jpql)
+            .setParameter("owner_id", ownerId)
+            .executeUpdate();
+    }
+
     @Transactional
     private Page<List<Entitlement>> listByProduct(
         AbstractHibernateObject object, String objectType, String productId, PageRequest pageRequest) {


### PR DESCRIPTION
- Updated the owner-update operation such that entitlements within the org are flagged as dirty and the last-content-update time is updated when the content prefix field is changed as part of the update