### PR TITLE
[M] CANDLEPIN-776: Updated the content prefix field name in EnvironmentDTO

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -8798,7 +8798,7 @@ components:
               type: string
             description:
               type: string
-            content_prefix:
+            contentPrefix:
               type: string
             owner:
               $ref: "#/components/schemas/NestedOwnerDTO"


### PR DESCRIPTION
- Renamed EnvironmentDTO.content_prefix to .contentPrefix to better match the existing field name formatting conventions