### PR TITLE
[M] Do not specify owner query param in Autoreg spec tests

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/ConsumerClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/ConsumerClient.java
@@ -80,6 +80,9 @@ public class ConsumerClient extends ConsumerApi {
     public ConsumerDTO createPersonConsumer(ConsumerDTO consumer, String username) {
         return super.createConsumer(consumer, username, consumer.getOwner().getKey(), null, true);
     }
+    public ConsumerDTO createConsumerWithoutOwner(ConsumerDTO consumer) {
+        return super.createConsumer(consumer, null, null, null, true);
+    }
 
     public JsonNode bindPool(String consumerUuid, String poolId, Integer quantity) {
         return getJsonNode(super.bind(consumerUuid, poolId, null, quantity, "",

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Consumers.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Consumers.java
@@ -31,6 +31,10 @@ public final class Consumers {
         throw new UnsupportedOperationException();
     }
 
+    public static ConsumerDTO randomNoOwner() {
+        return random((NestedOwnerDTO) null);
+    }
+
     public static ConsumerDTO random(OwnerDTO owner) {
         return random(owner != null ? Owners.toNested(owner) : null);
     }

--- a/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
@@ -100,7 +100,7 @@ class CloudRegistrationSpecTest {
         upstreamClient.createOwner(owner);
         String token = cloudRegistration.cloudAuthorize(owner.getKey(), "test-type", "test_signature");
         ConsumerDTO consumer = ApiClients.bearerToken(token).consumers()
-            .createConsumer(Consumers.random(owner));
+            .createConsumerWithoutOwner(Consumers.randomNoOwner());
 
         assertTokenType(ApiClient.MAPPER, token, STANDARD_TOKEN_TYPE);
         assertNotNull(consumer);
@@ -123,7 +123,7 @@ class CloudRegistrationSpecTest {
         upstreamClient.createOwner(owner);
         String token = cloudRegistration.cloudAuthorize(owner.getKey(), "test-type", "");
         ConsumerDTO consumer = ApiClients.bearerToken(token).consumers()
-            .createConsumer(Consumers.random(owner));
+            .createConsumerWithoutOwner(Consumers.randomNoOwner());
         assertNotNull(consumer);
         assertTokenType(ApiClient.MAPPER, token, STANDARD_TOKEN_TYPE);
     }
@@ -520,7 +520,7 @@ class CloudRegistrationSpecTest {
         assertTokenType(ApiClient.MAPPER, result.getToken(), STANDARD_TOKEN_TYPE);
 
         ConsumerDTO consumer = ApiClients.bearerToken(result.getToken()).consumers()
-            .createConsumer(Consumers.random(owner));
+            .createConsumerWithoutOwner(Consumers.randomNoOwner());
 
         assertNotNull(consumer);
     }
@@ -545,7 +545,7 @@ class CloudRegistrationSpecTest {
 
         // The Org does not exist at all in the backend services upstream of Candlepin yet
         assertThatStatus(() -> ApiClients.bearerToken(result.getToken()).consumers()
-            .createConsumer(Consumers.random(ownerDTO)))
+            .createConsumerWithoutOwner(Consumers.randomNoOwner()))
             .isTooMany()
             .hasHeaderWithValue("retry-after", 300);
 
@@ -554,7 +554,7 @@ class CloudRegistrationSpecTest {
 
         // The Org exists upstream of Candlepin, but does not have SKU(s) subscribed to it yet
         assertThatStatus(() -> ApiClients.bearerToken(result.getToken()).consumers()
-            .createConsumer(Consumers.random(ownerDTO)))
+            .createConsumerWithoutOwner(Consumers.randomNoOwner()))
             .isTooMany()
             .hasHeaderWithValue("retry-after", 180);
 
@@ -562,7 +562,7 @@ class CloudRegistrationSpecTest {
 
         // No product and no owner exist in Candlepin
         assertThatStatus(() -> ApiClients.bearerToken(result.getToken()).consumers()
-            .createConsumer(Consumers.random(ownerDTO)))
+            .createConsumerWithoutOwner(Consumers.randomNoOwner()))
             .isTooMany()
             .hasHeaderWithValue("retry-after", 60);
 
@@ -570,7 +570,7 @@ class CloudRegistrationSpecTest {
         // Just owner exist in Candlepin
         adminClient.owners().createOwner(ownerDTO);
         assertThatStatus(() -> ApiClients.bearerToken(result.getToken()).consumers()
-            .createConsumer(Consumers.random(ownerDTO)))
+            .createConsumerWithoutOwner(Consumers.randomNoOwner()))
             .isTooMany()
             .hasHeaderWithValue("retry-after", 30);
 
@@ -578,7 +578,7 @@ class CloudRegistrationSpecTest {
         adminClient.ownerProducts().createProduct(ownerDTO.getKey(), productDTO);
         adminClient.owners().createPool(ownerDTO.getKey(), Pools.random(productDTO));
         ConsumerDTO consumer = ApiClients.bearerToken(result.getToken()).consumers()
-            .createConsumer(Consumers.random(ownerDTO));
+            .createConsumerWithoutOwner(Consumers.randomNoOwner());
 
         assertThat(consumer)
             .isNotNull()
@@ -604,21 +604,33 @@ class CloudRegistrationSpecTest {
         admin.hosted().associateProductIdsToCloudOffer(offerId, List.of(productDTO.getId()));
 
         admin.hosted().createOwner(anonOwner);
+
+        // Autoregistration v2 before the owner is associated with a cloud account, will result
+        // in a response that includes an anonymous token, and has a null owner (since one may not
+        // even exist yet).
+        CloudAuthenticationResultDTO anonTokenResponse = ApiClients.noAuth().cloudAuthorization()
+            .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
+        assertThat(anonTokenResponse.getTokenType()).isEqualTo("CP-Anonymous-Cloud-Registration");
+        assertThat(anonTokenResponse.getOwnerKey()).isNull();
+        ApiClient anonClient = ApiClients.bearerToken(anonTokenResponse.getToken());
+
         admin.hosted().associateOwnerToCloudAccount(accountId, anonOwner.getKey());
         admin.hosted().createSubscription(Subscriptions.random(anonOwner, productDTO));
         admin.owners().createOwner(anonOwner);
         admin.ownerProducts().createProduct(anonOwner.getKey(), productDTO);
-
-        CloudAuthenticationResultDTO anonToken = ApiClients.noAuth().cloudAuthorization()
-            .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
-        ApiClient anonClient = ApiClients.bearerToken(anonToken.getToken());
-
         admin.owners().createPool(anonOwner.getKey(), Pools.random(productDTO));
 
-        CloudAuthenticationResultDTO token = ApiClients.noAuth().cloudAuthorization()
+        // Autoregistration v2 after the owner is fully ready, will result
+        // in a response that includes a standard token, and also has an owner,
+        // although that value is not actually set as a query parameter during registration
+        // by the client (since the owner key is already included in the token itself.
+        CloudAuthenticationResultDTO standardTokenResponse = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
-        ApiClient client = ApiClients.bearerToken(token.getToken());
-        client.consumers().createConsumer(Consumers.random(anonOwner));
+        assertThat(standardTokenResponse.getTokenType()).isEqualTo("CP-Cloud-Registration");
+        assertThat(standardTokenResponse.getOwnerKey()).isNotNull().isEqualTo(anonOwner.getKey());
+        ApiClient client = ApiClients.bearerToken(standardTokenResponse.getToken());
+
+        client.consumers().createConsumerWithoutOwner(Consumers.randomNoOwner());
 
         AsyncJobStatusDTO job = owners.claim(anonOwner.getKey(),
             new ClaimantOwner().claimantOwnerKey(destOwner.getKey()));
@@ -626,9 +638,9 @@ class CloudRegistrationSpecTest {
         assertThatJob(job).isFinished();
 
         // Create more consumers after owner is claimed
-        anonClient.consumers().createConsumer(Consumers.random(anonOwner));
-        client.consumers().createConsumer(Consumers.random(anonOwner));
-        client.consumers().createConsumer(Consumers.random(anonOwner));
+        anonClient.consumers().createConsumerWithoutOwner(Consumers.randomNoOwner());
+        client.consumers().createConsumerWithoutOwner(Consumers.randomNoOwner());
+        client.consumers().createConsumerWithoutOwner(Consumers.randomNoOwner());
 
         // Anon owner should be left with no consumers
         List<ConsumerDTOArrayElement> anonConsumers = owners.listOwnerConsumers(anonOwner.getKey());

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
@@ -816,11 +816,11 @@ public class OwnerResourceSpecTest {
         CloudAuthenticationResultDTO result = ApiClients.noAuth().cloudAuthorization()
             .cloudAuthorizeV2(accountId, instanceId, offerId, "test-type", "");
 
-        ApiClient anonClient = ApiClients.bearerToken(result.getToken());
+        ApiClient tokenClient = ApiClients.bearerToken(result.getToken());
         List<ConsumerDTO> consumers = List.of(
-            anonClient.consumers().createConsumer(Consumers.random(anonOwner)),
-            anonClient.consumers().createConsumer(Consumers.random(anonOwner)),
-            anonClient.consumers().createConsumer(Consumers.random(anonOwner))
+            tokenClient.consumers().createConsumerWithoutOwner(Consumers.randomNoOwner()),
+            tokenClient.consumers().createConsumerWithoutOwner(Consumers.randomNoOwner()),
+            tokenClient.consumers().createConsumerWithoutOwner(Consumers.randomNoOwner())
         );
         List<CertificateDTO> oldIdCerts = consumers.stream().map(ConsumerDTO::getIdCert).toList();
         List<CertificateDTO> oldScaCerts = fetchCertsOf(consumers, admin);

--- a/src/main/java/org/candlepin/auth/CloudConsumerPrincipal.java
+++ b/src/main/java/org/candlepin/auth/CloudConsumerPrincipal.java
@@ -42,6 +42,10 @@ public class CloudConsumerPrincipal extends Principal {
         return this.owner.getKey();
     }
 
+    public String getOwnerKey() {
+        return this.owner.getKey();
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {


### PR DESCRIPTION
- When subman uses cloud autoregistration tokens for registration it does not set the owner as a query parameter. In the case of standard autoreg tokens, the owner key is extracted from the token itself. In the case of anonymous autoreg tokens, the owner may not even exist yet, so an owner key is not included in the token at all. This change updates our tests to not set an owner query param in order to be more in line with the real scenario.
- We now extract the owner key from the newly created CloudConsumerPrincipal, instead of using the owner query param which should be empty in a realistic scenario.