### PR TITLE
[M] CANDLEPIN-783: Generate new Identity cert for claimed systems

### DIFF
--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -703,6 +703,20 @@ public class ConsumerResource implements ConsumerApi {
                     consumer = this.regenerateIdentityCertificate(consumer);
                 }
             }
+            else {
+                // When anonymous orgs get claimed, identity certs are revoked, so we need to regenerate
+                // them for cloud VM consumers that check in right after the claiming happened.
+                //
+                // Also, because there is a case where a hypervisor may not be (yet, or at all) a registered
+                // system it may not have an identity certificate, we don't want to generate one for it.
+                // Here we're making the (reasonably safe) assumption that a hypervisor being run as a
+                // cloud VM is not a realistic setup.
+                if (!this.consumerTypeCurator.getConsumerType(consumer).isType(ConsumerTypeEnum.HYPERVISOR)) {
+                    log.info("Regenerating identity certificate for consumer with null identity cert: {}",
+                        uuid);
+                    consumer = this.regenerateIdentityCertificate(consumer);
+                }
+            }
 
             // enrich with subscription data
             consumer.setCanActivate(subAdapter.canActivateSubscription(consumer));

--- a/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -790,7 +790,7 @@ public class ConsumerResourceTest {
     }
 
     @Test
-    public void doesNotGeneratesMissingIdCert() throws Exception {
+    public void doesGenerateMissingIdCert() throws Exception {
         Consumer consumer = createConsumer(createOwner());
         ComplianceStatus status = new ComplianceStatus();
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class), anyBoolean()))
@@ -799,7 +799,7 @@ public class ConsumerResourceTest {
 
         ConsumerDTO c = consumerResource.getConsumer(consumer.getUuid());
 
-        assertNull(c.getIdCert());
+        assertNotNull(c.getIdCert());
     }
 
     @Test


### PR DESCRIPTION
- When anonymous organizations are claimed, their systems are migrated to a new org, and their identity certificates are revoked. When the systems check in for the first time after the claiming, they need to have a new Identity cert generated.