### PR TITLE
[M] CANDLEPIN-272: Removed cp query in ImportRecordCurator and RoleCurator 

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -5228,7 +5228,7 @@ paths:
       operationId: getImports
       security: []
       x-java-response:
-        type: Iterable
+        type: java.util.stream.Stream
         isContainer: true
       parameters:
         - name: owner_key

--- a/src/main/java/org/candlepin/async/tasks/ImportRecordCleanerJob.java
+++ b/src/main/java/org/candlepin/async/tasks/ImportRecordCleanerJob.java
@@ -75,7 +75,7 @@ public class ImportRecordCleanerJob implements AsyncJob {
 
         int deleted = 0;
         for (Owner owner : this.ownerCurator.listAll().list()) {
-            List<ImportRecord> records = this.importRecordCurator.findRecords(owner).list();
+            List<ImportRecord> records = this.importRecordCurator.findRecords(owner);
 
             if (toKeep < records.size()) {
                 // records are already sorted by date, so just shave off of the end

--- a/src/main/java/org/candlepin/model/ImportRecordCurator.java
+++ b/src/main/java/org/candlepin/model/ImportRecordCurator.java
@@ -14,9 +14,7 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Order;
-import org.hibernate.criterion.Restrictions;
+import java.util.List;
 
 import javax.inject.Singleton;
 
@@ -39,11 +37,14 @@ public class ImportRecordCurator extends AbstractHibernateCurator<ImportRecord> 
      * @param owner the {@link Owner}
      * @return the import records
      */
-    public CandlepinQuery<ImportRecord> findRecords(Owner owner) {
-        DetachedCriteria criteria = DetachedCriteria.forClass(ImportRecord.class)
-            .add(Restrictions.eq("owner", owner))
-            .addOrder(Order.desc("created"));
+    public List<ImportRecord> findRecords(Owner owner) {
+        String jpql = "SELECT ir FROM ImportRecord ir " +
+            "WHERE ir.owner.id = :owner_id " +
+            "ORDER BY created DESC";
 
-        return this.cpQueryFactory.<ImportRecord>buildQuery(this.currentSession(), criteria);
+        return this.getEntityManager()
+            .createQuery(jpql, ImportRecord.class)
+            .setParameter("owner_id", owner.getId())
+            .getResultList();
     }
 }

--- a/src/main/java/org/candlepin/model/RoleCurator.java
+++ b/src/main/java/org/candlepin/model/RoleCurator.java
@@ -14,10 +14,10 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Restrictions;
 
-import javax.inject.Inject;
+import java.util.List;
+
 import javax.inject.Singleton;
 
 
@@ -28,20 +28,19 @@ import javax.inject.Singleton;
 @Singleton
 public class RoleCurator extends AbstractHibernateCurator<Role> {
 
-    private CandlepinQueryFactory cpQueryFactory;
-
-    @Inject
-    public RoleCurator(CandlepinQueryFactory cpQueryFactory) {
+    public RoleCurator() {
         super(Role.class);
-        this.cpQueryFactory = cpQueryFactory;
     }
 
-    public CandlepinQuery<Role> listForOwner(Owner o) {
-        DetachedCriteria criteria = DetachedCriteria.forClass(Role.class)
-            .createCriteria("permissions")
-            .add(Restrictions.eq("owner", o));
+    public List<Role> listForOwner(Owner owner) {
+        String jpql = "SELECT r FROM PermissionBlueprint pb " +
+            "JOIN Role r ON r.id = pb.role.id " +
+            "WHERE pb.owner.id = :owner_id";
 
-        return this.cpQueryFactory.<Role>buildQuery(this.currentSession(), criteria);
+        return this.getEntityManager()
+            .createQuery(jpql, Role.class)
+            .setParameter("owner_id", owner.getId())
+            .getResultList();
     }
 
     /**

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -82,6 +82,7 @@ import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.ExporterMetadata;
 import org.candlepin.model.ExporterMetadataCurator;
+import org.candlepin.model.ImportRecord;
 import org.candlepin.model.ImportRecordCurator;
 import org.candlepin.model.InvalidOrderKeyException;
 import org.candlepin.model.Owner;
@@ -1543,12 +1544,13 @@ public class OwnerResource implements OwnerApi {
     }
 
     @Override
-    public Iterable<ImportRecordDTO> getImports(
+    public Stream<ImportRecordDTO> getImports(
         @Verify(Owner.class) String ownerKey) {
         Owner owner = findOwnerByKey(ownerKey);
 
-        return this.translator.translateQuery(this.importRecordCurator.findRecords(owner),
-            ImportRecordDTO.class);
+        return this.importRecordCurator.findRecords(owner)
+            .stream()
+            .map(this.translator.getStreamMapper(ImportRecord.class, ImportRecordDTO.class));
     }
 
     @Override

--- a/src/test/java/org/candlepin/async/tasks/ImportRecordCleanerJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/ImportRecordCleanerJobTest.java
@@ -99,7 +99,7 @@ public class ImportRecordCleanerJobTest extends DatabaseTestFixture {
         verify(context, times(1)).setJobResult(captor.capture());
         Object result = captor.getValue();
 
-        List<ImportRecord> records = this.importRecordCurator.findRecords(owner).list();
+        List<ImportRecord> records = this.importRecordCurator.findRecords(owner);
 
         assertEquals(10, records.size());
         assertEquals("Deleted 3 import records.", result);
@@ -128,7 +128,7 @@ public class ImportRecordCleanerJobTest extends DatabaseTestFixture {
         verify(context, times(1)).setJobResult(captor.capture());
         Object result = captor.getValue();
 
-        List<ImportRecord> records = this.importRecordCurator.findRecords(owner).list();
+        List<ImportRecord> records = this.importRecordCurator.findRecords(owner);
 
         assertEquals(7, records.size());
         assertEquals("No import records were deleted.", result);
@@ -168,8 +168,8 @@ public class ImportRecordCleanerJobTest extends DatabaseTestFixture {
         verify(context, times(1)).setJobResult(captor.capture());
         Object result = captor.getValue();
 
-        assertEquals(10, importRecordCurator.findRecords(owner1).list().size());
-        assertEquals(4, importRecordCurator.findRecords(owner2).list().size());
+        assertEquals(10, importRecordCurator.findRecords(owner1).size());
+        assertEquals(4, importRecordCurator.findRecords(owner2).size());
         assertEquals("Deleted 13 import records.", result);
     }
 
@@ -237,7 +237,7 @@ public class ImportRecordCleanerJobTest extends DatabaseTestFixture {
         int expectedDeletedRecords = existingRecords - keep;
         int expectedKeptRecords = existingRecords > keep ? keep : existingRecords;
 
-        assertEquals(expectedKeptRecords, importRecordCurator.findRecords(owner).list().size());
+        assertEquals(expectedKeptRecords, importRecordCurator.findRecords(owner).size());
         if (expectedDeletedRecords > 0) {
             assertEquals("Deleted " + expectedDeletedRecords + " import records.", result);
         }

--- a/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/UndoImportsJobTest.java
@@ -129,8 +129,8 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         assertEquals(Arrays.asList(pool7, pool8, pool9), this.poolService.listPoolsByOwner(owner2).list());
         assertEquals(metadata1, exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner1));
         assertEquals(metadata2, exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner2));
-        assertEquals(0, this.importRecordCurator.findRecords(owner1).list().size());
-        assertEquals(0, this.importRecordCurator.findRecords(owner2).list().size());
+        assertEquals(0, this.importRecordCurator.findRecords(owner1).size());
+        assertEquals(0, this.importRecordCurator.findRecords(owner2).size());
 
         JobConfig config = UndoImportsJob.createJobConfig()
             .setOwner(owner1);
@@ -153,11 +153,11 @@ public class UndoImportsJobTest extends DatabaseTestFixture {
         assertEquals(metadata2, exportCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner2));
         assertNull(owner1.getUpstreamConsumer());
 
-        List<ImportRecord> records = this.importRecordCurator.findRecords(owner1).list();
+        List<ImportRecord> records = this.importRecordCurator.findRecords(owner1);
         assertEquals(1, records.size());
         assertEquals(ImportRecord.Status.DELETE, records.get(0).getStatus());
 
-        assertEquals(0, this.importRecordCurator.findRecords(owner2).list().size());
+        assertEquals(0, this.importRecordCurator.findRecords(owner2).size());
     }
 
     protected Pool createPool(String name, Owner owner, boolean keepSourceSub, PoolType type) {

--- a/src/test/java/org/candlepin/model/RoleTest.java
+++ b/src/test/java/org/candlepin/model/RoleTest.java
@@ -70,7 +70,7 @@ public class RoleTest extends DatabaseTestFixture {
         Role r1 = createRole(owner);
         createRole(o2);
 
-        List<Role> roles = roleCurator.listForOwner(owner).list();
+        List<Role> roles = roleCurator.listForOwner(owner);
         assertEquals(1, roles.size());
         assertEquals(r1, roles.get(0));
         assertEquals(1, roles.get(0).getUsers().size());


### PR DESCRIPTION
- Removed the use of CandlepinQuery in ImportRecordCurator
- Removed the use of CandlepinQuery in RoleCurator