### PR TITLE
CANDLEPIN-169: Removed CP Query from Activation Key

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -4391,7 +4391,7 @@ paths:
         - owner
       operationId: ownerActivationKeys
       x-java-response:
-        type: Iterable
+        type: java.util.stream.Stream
         isContainer: true
       parameters:
         - name: owner_key

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1018,14 +1018,15 @@ public class OwnerResource implements OwnerApi {
     }
 
     @Override
-    public CandlepinQuery<ActivationKeyDTO> ownerActivationKeys(
+    public Stream<ActivationKeyDTO> ownerActivationKeys(
         @Verify(value = Owner.class, subResource = SubResource.ACTIVATION_KEYS) String ownerKey,
         String keyName) {
 
         Owner owner = findOwnerByKey(ownerKey);
 
-        CandlepinQuery<ActivationKey> keys = this.activationKeyCurator.listByOwner(owner, keyName);
-        return translator.translateQuery(keys, ActivationKeyDTO.class);
+        List<ActivationKey> keys = this.activationKeyCurator.listByOwner(owner, keyName);
+        return keys.stream()
+            .map(this.translator.getStreamMapper(ActivationKey.class, ActivationKeyDTO.class));
     }
 
     @Override

--- a/src/test/java/org/candlepin/resource/ActivationKeyContentOverrideResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ActivationKeyContentOverrideResourceTest.java
@@ -108,7 +108,7 @@ public class ActivationKeyContentOverrideResourceTest extends DatabaseTestFixtur
     }
 
     private List<ContentOverrideDTO> stripTimestamps(Iterable<ContentOverrideDTO> list) {
-        return stripTimestamps(StreamSupport.stream(list.spliterator(), false).collect(Collectors.toList()));
+        return stripTimestamps(StreamSupport.stream(list.spliterator(), false).toList());
     }
 
     private long sizeOf(Iterable<ContentOverrideDTO> list) {
@@ -139,7 +139,7 @@ public class ActivationKeyContentOverrideResourceTest extends DatabaseTestFixtur
         List<ContentOverrideDTO> expected = overrides.stream()
             .map(this.modelTranslator.getStreamMapper(ActivationKeyContentOverride.class,
                 ContentOverrideDTO.class))
-            .collect(Collectors.toList());
+            .toList();
 
         List<ContentOverrideDTO> actual = this.resource
             .listActivationKeyContentOverrides(key.getId())
@@ -169,7 +169,7 @@ public class ActivationKeyContentOverrideResourceTest extends DatabaseTestFixtur
         List<ContentOverrideDTO> expected = overrides.stream()
             .map(this.modelTranslator.getStreamMapper(ActivationKeyContentOverride.class,
                 ContentOverrideDTO.class))
-            .collect(Collectors.toList());
+            .toList();
 
         List<ContentOverrideDTO> actual = this.resource
             .deleteActivationKeyContentOverrides(key.getId(), Arrays.asList(toDeleteDTO))

--- a/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -28,10 +28,8 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -143,7 +141,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-
 
 
 /**
@@ -296,7 +293,8 @@ public class ConsumerResourceUpdateTest {
             this.cloudRegistrationAdapter,
             this.poolCurator,
             this.anonymousConsumerCurator,
-            this.anonymousCertCurator);
+            this.anonymousCertCurator
+        );
 
         when(this.complianceRules.getStatus(any(Consumer.class), any(Date.class), any(Boolean.class),
             any(Boolean.class))).thenReturn(new ComplianceStatus(new Date()));

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -81,7 +81,6 @@ import org.candlepin.exceptions.ForbiddenException;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.AsyncJobStatus;
-import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerCurator.ConsumerQueryArguments;
@@ -1111,12 +1110,10 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertNotNull(key.getId());
         assertEquals(key.getOwner().getId(), owner.getId());
         assertEquals(key.getReleaseVer().getReleaseVer(), "release1");
-        CandlepinQuery<ActivationKeyDTO> result = ownerResource.ownerActivationKeys(owner.getKey(), null);
+        List<ActivationKeyDTO> result = ownerResource.ownerActivationKeys(owner.getKey(), null).toList();
 
         assertNotNull(result);
-        List<ActivationKeyDTO> keys = result.list();
-
-        assertEquals(1, keys.size());
+        assertEquals(1, result.size());
     }
 
     @Test
@@ -1137,15 +1134,13 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertEquals(key.getOwner().getId(), owner.getId());
         assertEquals(key.getReleaseVer().getReleaseVer(), "release2");
 
-        CandlepinQuery<ActivationKeyDTO> result = ownerResource.ownerActivationKeys(owner.getKey(), "dd");
+        List<ActivationKeyDTO> result = ownerResource.ownerActivationKeys(owner.getKey(), "dd").toList();
         assertNotNull(result);
-        List<ActivationKeyDTO> keys = result.list();
-        assertEquals(1, keys.size());
+        assertEquals(1, result.size());
 
-        result = ownerResource.ownerActivationKeys(owner.getKey(), null);
+        result = ownerResource.ownerActivationKeys(owner.getKey(), null).toList();
         assertNotNull(result);
-        keys = result.list();
-        assertEquals(2, keys.size());
+        assertEquals(2, result.size());
     }
 
     @Test


### PR DESCRIPTION
Classes affected:

- ActivationKeyResource
- ActivationKeyCurator
- ConsumerResource
- OwnerResource
- ContentOverrideCurator