### PR TITLE
Updated branch listing for sonar tests

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -84,7 +84,7 @@ jobs:
           name: unit_test_reports
 
       - name: Analyze
-        if: ${{ fromJson(steps.get_pr_data.outputs.data).base.ref == 'main' || fromJson(steps.get_pr_data.outputs.data).base.ref startsWtih('test*')}}
+        if: ${{ fromJson(steps.get_pr_data.outputs.data).base.ref == 'main' || startsWith(fromJson(steps.get_pr_data.outputs.data).base.ref, 'feature/') }}
         uses: gradle/gradle-build-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Will now fire when base branch is prepended with 'feature/'

A previous PR was pushed to main instead of my fork. This should fix it.