### PR TITLE
[M] CANDLEPIN-801: Added registration only to CloudAuthenticationResult

### DIFF
--- a/client/src/main/java/org/candlepin/resource/HostedTestApi.java
+++ b/client/src/main/java/org/candlepin/resource/HostedTestApi.java
@@ -45,6 +45,7 @@ public class HostedTestApi {
     private static final String CONTENT_ID = "content_id";
     private static final String SUBSCRIPTION_ID = "subscription_id";
     private static final String CREATE_CHILDREN_PARAM = "create_children";
+    private static final String OFFERING_TYPE_3P = "3P";
 
     private ApiClient localVarApiClient;
     private int localHostIndex;
@@ -715,7 +716,7 @@ public class HostedTestApi {
      *     the product IDs to associate to an offering ID
      */
     public void associateProductIdsToCloudOffer(String cloudOfferId, Collection<String> productIds) {
-        okhttp3.Call localVarCall = associateProductIdsToCloudOfferCall(cloudOfferId, null, productIds);
+        okhttp3.Call localVarCall = associateProductIdsToCloudOfferCall(cloudOfferId, OFFERING_TYPE_3P, productIds);
         localVarApiClient.execute(localVarCall);
     }
 

--- a/src/main/java/org/candlepin/service/model/CloudAuthenticationResult.java
+++ b/src/main/java/org/candlepin/service/model/CloudAuthenticationResult.java
@@ -57,6 +57,13 @@ public interface CloudAuthenticationResult {
     Set<String> getProductIds();
 
     /**
+     * @return true if the consumer only requires the version 1 cloud registration workflow for the provided
+     *  owner key. The owner key must be populated when the registration only value is set to true. False
+     *  indicates that the consumer requires a version 2 or greater cloud registration logic.
+     */
+    boolean isRegistrationOnly();
+
+    /**
      * @return true if the owner is entitled to the product associated to the cloud offering ID found in
      * the {@link CloudRegistrationInfo} metadata, or false if not entitled
      */

--- a/src/main/java/org/candlepin/testext/hostedtest/HostedTestCloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/testext/hostedtest/HostedTestCloudRegistrationAdapter.java
@@ -56,6 +56,11 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
     private static final String INSTANCE_ID_FIELD_NAME = "instanceId";
     private static final String OFFERING_ID_FIELD_NAME = "cloudOfferingId";
     private static final String OFFERING_TYPE_1P = "1P";
+    private static final String OFFERING_TYPE_GOLD = "gold";
+    private static final String OFFERING_TYPE_CUSTOM = "custom";
+    private static final Set<String> REGISTRATION_ONLY_OFFER_TYPES =
+        Set.of(OFFERING_TYPE_1P, OFFERING_TYPE_GOLD, OFFERING_TYPE_CUSTOM);
+
     private static final ObjectMapper OBJ_MAPPER = ObjectMapperFactory.getObjectMapper();
 
     private final HostedTestDataStore datastore;
@@ -134,12 +139,15 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
         }
 
         String offerType = this.datastore.getOfferTypeForOfferId(offerId);
-        if (OFFERING_TYPE_1P.equals(offerType)) {
+        boolean isRegistrationOnly = offerType == null ?
+            false :
+            REGISTRATION_ONLY_OFFER_TYPES.contains(offerType);
+        String ownerKey = this.datastore.getOwnerKeyForCloudAccountId(accountId);
+        if (ownerKey == null && isRegistrationOnly) {
             throw new CloudRegistrationNotSupportedForOfferingException(
                 "cloud registration v2 is not supported for 1P offerings");
         }
 
-        String ownerKey = this.datastore.getOwnerKeyForCloudAccountId(accountId);
         Set<String> productIds = this.datastore.getProductIdsForOfferId(offerId);
         boolean isEntitled = isOwnerEntitledToProducts(ownerKey, productIds);
 
@@ -172,6 +180,11 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
             @Override
             public Set<String> getProductIds() {
                 return productIds;
+            }
+
+            @Override
+            public boolean isRegistrationOnly() {
+                return isRegistrationOnly;
             }
 
             @Override

--- a/src/main/java/org/candlepin/testext/hostedtest/HostedTestResource.java
+++ b/src/main/java/org/candlepin/testext/hostedtest/HostedTestResource.java
@@ -758,6 +758,11 @@ public class HostedTestResource {
             throw new BadRequestException("cloud offer ID is null");
         }
 
+        String cloudOfferType  = root.get("cloudOfferType").asText();
+        if (cloudOfferType == null) {
+            throw new BadRequestException("cloud offer type is null");
+        }
+
         JsonNode productIdsNode = root.get("productIds");
         if (productIdsNode == null) {
             throw new BadRequestException("productIds is null");
@@ -767,15 +772,7 @@ public class HostedTestResource {
         productIdsNode.elements().forEachRemaining(prod -> productIds.add(prod.asText()));
 
         this.datastore.setProductIdsForCloudOfferId(offerId, productIds);
-
-        JsonNode cloudOfferTypeNode = root.get("cloudOfferType");
-        if (cloudOfferTypeNode != null) {
-            String cloudOfferType = cloudOfferTypeNode.asText();
-            if (cloudOfferType != null && !cloudOfferType.isBlank()) {
-                this.datastore.setOfferTypeForCloudOfferId(offerId, cloudOfferType);
-            }
-        }
-
+        this.datastore.setOfferTypeForCloudOfferId(offerId, cloudOfferType);
     }
 
     @POST

--- a/src/test/java/org/candlepin/resource/CloudRegistrationResourceTest.java
+++ b/src/test/java/org/candlepin/resource/CloudRegistrationResourceTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.argThat;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -191,7 +191,7 @@ public class CloudRegistrationResourceTest {
 
         CloudAuthenticationResult result = buildMockAuthResult(cloudAccountId, "instanceId",
             TestUtil.randomString(),
-            "ownerKey", "offerId", Set.of("productId"), true);
+            "ownerKey", "offerId", Set.of("productId"), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -209,7 +209,7 @@ public class CloudRegistrationResourceTest {
 
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", instanceId,
             TestUtil.randomString(),
-            "ownerKey", "offerId", Set.of("productId"), true);
+            "ownerKey", "offerId", Set.of("productId"), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -224,7 +224,7 @@ public class CloudRegistrationResourceTest {
             .signature("test-signature");
 
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", "instanceId", null,
-            "ownerKey", "offerId", Set.of("productId"), true);
+            "ownerKey", "offerId", Set.of("productId"), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -242,7 +242,7 @@ public class CloudRegistrationResourceTest {
 
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", "instanceId",
             TestUtil.randomString(),
-            "ownerKey", offerId, Set.of("productId"), true);
+            "ownerKey", offerId, Set.of("productId"), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -257,7 +257,7 @@ public class CloudRegistrationResourceTest {
             .signature("test-signature");
 
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", "instanceId",
-            TestUtil.randomString(), "ownerKey", "offerId", null, true);
+            TestUtil.randomString(), "ownerKey", "offerId", null, true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
         assertThrows(NotAuthorizedException.class, () -> cloudRegResource.cloudAuthorize(dto, 2));
@@ -271,7 +271,7 @@ public class CloudRegistrationResourceTest {
             .signature("test-signature");
 
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", "instanceId",
-            TestUtil.randomString(), "ownerKey", "offerId", Set.of(), true);
+            TestUtil.randomString(), "ownerKey", "offerId", Set.of(), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -288,7 +288,7 @@ public class CloudRegistrationResourceTest {
         String expectedOwnerKey = "ownerKey";
         String prodId = "productId";
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", "instanceId",
-            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), true);
+            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
         Owner owner = new Owner().setKey(expectedOwnerKey);
@@ -328,7 +328,7 @@ public class CloudRegistrationResourceTest {
         String accountId = "cloudAccountId";
         String offeringId = "offerId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, "instanceId",
-            TestUtil.randomString(), null, offeringId, prodIds, true);
+            TestUtil.randomString(), null, offeringId, prodIds, true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -372,7 +372,7 @@ public class CloudRegistrationResourceTest {
         String prodId = "productId";
         String accountId = "cloudAccountId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, "instanceId",
-            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), false);
+            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), false, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
         Owner owner = new Owner().setKey(expectedOwnerKey);
@@ -419,7 +419,7 @@ public class CloudRegistrationResourceTest {
         Set<String> prodIds = Set.of("productId");
         String accountId = "cloudAccountId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, "instanceId",
-            TestUtil.randomString(), expectedOwnerKey, "offerId", prodIds, true);
+            TestUtil.randomString(), expectedOwnerKey, "offerId", prodIds, true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -463,7 +463,7 @@ public class CloudRegistrationResourceTest {
         String prodId = "productId";
         String accountId = "cloudAccountId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, "instanceId",
-            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), true);
+            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
         Owner owner = new Owner().setKey(expectedOwnerKey);
@@ -511,7 +511,7 @@ public class CloudRegistrationResourceTest {
         String accountId = "cloudAccountId";
         String instanceId = "instanceId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, instanceId, TestUtil.randomString(),
-            expectedOwnerKey, "offerId", Set.of(prodId), true);
+            expectedOwnerKey, "offerId", Set.of(prodId), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
         Owner owner = new Owner().setKey(expectedOwnerKey);
@@ -558,7 +558,7 @@ public class CloudRegistrationResourceTest {
         String accountId = "cloudAccountId";
         String instanceId = "instanceId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, instanceId, TestUtil.randomString(),
-            null, "offerId", Set.of(prodId), true);
+            null, "offerId", Set.of(prodId), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -598,17 +598,71 @@ public class CloudRegistrationResourceTest {
             () -> cloudRegResource.cloudAuthorize(new CloudRegistrationDTO().type("test_type"), 100));
     }
 
-    @Test
-    public void testCloudAuthorizeV2For1POfferingNotSupported() {
+    @ParameterizedTest(name = "{displayName} {index}: {0} {1}")
+    @NullAndEmptySource
+    public void testCloudAuthorizeV2WithRegistrationOnlyAndMissingOwnerKey(String ownerKey) {
         CloudRegistrationDTO dto = new CloudRegistrationDTO()
             .type("test-type")
             .metadata("test-metadata")
             .signature("test-signature");
 
-        doThrow(new CloudRegistrationNotSupportedForOfferingException()).when(mockCloudRegistrationAdapter)
+        CloudAuthenticationResult result = buildMockAuthResult(TestUtil.randomString(),
+            TestUtil.randomString(), TestUtil.randomString(), ownerKey, TestUtil.randomString(),
+            Set.of(TestUtil.randomString()), false, true);
+        doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
         assertThrows(NotImplementedException.class, () -> cloudRegResource.cloudAuthorize(dto, 2));
+    }
+
+    @Test
+    public void testCloudAuthorizeV2ForUnsupportedCloudOffering() {
+        CloudRegistrationDTO dto = new CloudRegistrationDTO()
+            .type("test-type")
+            .metadata("test-metadata")
+            .signature("test-signature");
+
+        doThrow(new CloudRegistrationNotSupportedForOfferingException())
+            .when(mockCloudRegistrationAdapter)
+            .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
+
+        assertThrows(NotImplementedException.class, () -> cloudRegResource.cloudAuthorize(dto, 2));
+    }
+
+    @Test
+    public void testCloudAuthorizeV2WithRegistrationOnly() {
+        CloudRegistrationDTO dto = new CloudRegistrationDTO()
+            .type("test-type")
+            .metadata("test-metadata")
+            .signature("test-signature");
+
+        String expectedOwnerKey = "ownerKey";
+        CloudAuthenticationResult result = buildMockAuthResult(TestUtil.randomString(),
+            TestUtil.randomString(), TestUtil.randomString(), expectedOwnerKey, TestUtil.randomString(),
+            Set.of(TestUtil.randomString()), false, true);
+        doReturn(result)
+            .when(mockCloudRegistrationAdapter)
+            .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
+
+        String expectedToken = TestUtil.randomString();
+        doReturn(expectedToken)
+            .when(mockTokenGenerator)
+            .buildStandardRegistrationToken(principal, expectedOwnerKey);
+
+        Response response = cloudRegResource.cloudAuthorize(dto, 2);
+
+        assertThat(response)
+            .isNotNull()
+            .returns(200, Response::getStatus)
+            .extracting(Response::getEntity)
+            .isNotNull()
+            .isInstanceOf(CloudAuthenticationResultDTO.class);
+
+        assertThat((CloudAuthenticationResultDTO) response.getEntity())
+            .returns(expectedOwnerKey, CloudAuthenticationResultDTO::getOwnerKey)
+            .returns(null, CloudAuthenticationResultDTO::getAnonymousConsumerUuid)
+            .returns(expectedToken, CloudAuthenticationResultDTO::getToken)
+            .returns(CloudAuthTokenType.STANDARD.toString(), CloudAuthenticationResultDTO::getTokenType);
     }
 
     @Test
@@ -705,8 +759,8 @@ public class CloudRegistrationResourceTest {
     }
 
     private CloudAuthenticationResult buildMockAuthResult(String cloudAccountId, String instanceId,
-        String provider,
-        String ownerKey, String offerId, Set<String> productIds, boolean isEntitled) {
+        String provider, String ownerKey,
+        String offerId, Set<String> productIds, boolean isEntitled, boolean isRegistrationOnly) {
         CloudAuthenticationResult mockResult = mock(CloudAuthenticationResult.class);
         doReturn(cloudAccountId).when(mockResult).getCloudAccountId();
         doReturn(instanceId).when(mockResult).getCloudInstanceId();
@@ -715,6 +769,7 @@ public class CloudRegistrationResourceTest {
         doReturn(offerId).when(mockResult).getOfferId();
         doReturn(productIds).when(mockResult).getProductIds();
         doReturn(isEntitled).when(mockResult).isEntitled();
+        doReturn(isRegistrationOnly).when(mockResult).isRegistrationOnly();
 
         return mockResult;
     }


### PR DESCRIPTION
- Added isRegistrationOnly to CloudAuthenticationResult for cloud offering types that only require registration using a standard cloud authentication token type.
- Removed CloudRegistrationNotSupportedForOfferingException
- Removed some unused variables and white space in CloudRegistrationSpecTest