### PR TITLE
CANDLEPIN-140: Remove CandlepinQuery from ConsumerResource and ConsumerCurator

### DIFF
--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -70,7 +70,6 @@ import org.candlepin.exceptions.IseException;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.guice.PrincipalProvider;
 import org.candlepin.model.AsyncJobStatus;
-import org.candlepin.model.CandlepinQuery;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ConsumerCurator.ConsumerQueryArguments;
@@ -1634,14 +1633,16 @@ public class OwnerResource implements OwnerApi {
     }
 
     @Override
-    public CandlepinQuery<ConsumerDTOArrayElement> getHypervisors(
+    public List<ConsumerDTOArrayElement> getHypervisors(
         @Verify(Owner.class) String ownerKey, List<String> hypervisorIds) {
 
         Owner owner = ownerCurator.getByKey(ownerKey);
-        CandlepinQuery<Consumer> query = (hypervisorIds == null || hypervisorIds.isEmpty()) ?
+        List<Consumer> hypervisors = (hypervisorIds == null || hypervisorIds.isEmpty()) ?
             this.consumerCurator.getHypervisorsForOwner(owner.getId()) :
             this.consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getId());
-        return translator.translateQuery(query, ConsumerDTOArrayElement.class);
+        return hypervisors.stream()
+            .map(translator.getStreamMapper(Consumer.class, ConsumerDTOArrayElement.class))
+            .toList();
     }
 
     @Override

--- a/src/test/java/org/candlepin/auth/permissions/ConsumerCuratorPermissionsTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/ConsumerCuratorPermissionsTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 
@@ -48,49 +47,6 @@ public class ConsumerCuratorPermissionsTest extends DatabaseTestFixture {
 
         consumerType = new ConsumerType(CONSUMER_TYPE_NAME);
         consumerTypeCurator.create(consumerType);
-    }
-
-    @Test
-    public void testListForOwnerPermissionFiltering() {
-        User u = setupOnlyMyConsumersPrincipal();
-
-        Consumer c1 = new Consumer()
-            .setName("c1")
-            .setUsername(u.getUsername())
-            .setOwner(owner)
-            .setType(consumerType);
-        consumerCurator.create(c1);
-        Consumer c2 = new Consumer()
-            .setName("c2")
-            .setUsername("anotheruser")
-            .setOwner(owner)
-            .setType(consumerType);
-        consumerCurator.create(c2);
-
-        List<Consumer> results = consumerCurator.listByOwner(owner).list();
-        assertEquals(1, results.size());
-        assertEquals(c1.getName(), results.get(0).getName());
-    }
-
-    @Test
-    public void testListForOwnerEditMineViewAllPermissionFiltering() {
-        User u = setupEditMyConsumersViewAllPrincipal();
-
-        Consumer c1 = new Consumer()
-            .setName("c1")
-            .setUsername(u.getUsername())
-            .setOwner(owner)
-            .setType(consumerType);
-        consumerCurator.create(c1);
-        Consumer c2 = new Consumer()
-            .setName("c2")
-            .setUsername("anotheruser")
-            .setOwner(owner)
-            .setType(consumerType);
-        consumerCurator.create(c2);
-
-        List<Consumer> results = consumerCurator.listByOwner(owner).list();
-        assertEquals(2, results.size());
     }
 
     @Test

--- a/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -1769,7 +1769,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         List<String> hypervisorIds = new LinkedList<>();
         hypervisorIds.add(hypervisorid);
         hypervisorIds.add("not really a hypervisor");
-        List<Consumer> results = consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getId()).list();
+        List<Consumer> results = consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getId());
         assertEquals(1, results.size());
         assertEquals(consumer, results.get(0));
     }
@@ -1791,7 +1791,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         List<String> hypervisorIds = new LinkedList<>();
         hypervisorIds.add(hypervisorid.toUpperCase());
         hypervisorIds.add("NOT really a hypervisor");
-        List<Consumer> results = consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getId()).list();
+        List<Consumer> results = consumerCurator.getHypervisorsBulk(hypervisorIds, owner.getId());
         assertEquals(1, results.size());
         assertEquals(consumer, results.get(0));
     }
@@ -1812,8 +1812,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
             .setHypervisorId(hypervisorId);
         consumerCurator.create(consumer);
         List<Consumer> results = consumerCurator
-            .getHypervisorsBulk(new LinkedList<>(), owner.getId())
-            .list();
+            .getHypervisorsBulk(new LinkedList<>(), owner.getId());
 
         assertEquals(0, results.size());
     }
@@ -1853,7 +1852,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
             .setType(ct);
         consumerCurator.create(nonHypervisor);
 
-        List<Consumer> results = consumerCurator.getHypervisorsForOwner(owner.getId()).list();
+        List<Consumer> results = consumerCurator.getHypervisorsForOwner(owner.getId());
         assertEquals(1, results.size());
         assertEquals(consumer, results.get(0));
     }

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -334,7 +334,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         Map<String, Integer> pQs = new HashMap<>();
         pQs.put(pool.getId(), 1);
         poolManager.entitleByPools(c1, pQs);
-        assertEquals(2, consumerCurator.listByOwner(owner).list().size());
         assertEquals(1, poolCurator.listByOwner(owner).size());
         assertEquals(1, entitlementCurator.listByOwner(owner).size());
 
@@ -345,7 +344,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         ownerResource.deleteOwner(owner.getKey(), true, true);
 
-        assertEquals(0, consumerCurator.listByOwner(owner).list().size());
         assertNull(consumerCurator.findByUuid(c1.getUuid()));
         assertNull(consumerCurator.findByUuid(c2.getUuid()));
         assertEquals(0, poolCurator.listByOwner(owner).size());


### PR DESCRIPTION
- Remove the CandlepinQuery classes from ConsumerResource and ConsumerCurator and their test classes.