### PR TITLE
[4.4.4] Cherry-pick autoregv2 fixes in candlepin-4.4.4-HOTFIX

### DIFF
--- a/client/src/main/java/org/candlepin/resource/HostedTestApi.java
+++ b/client/src/main/java/org/candlepin/resource/HostedTestApi.java
@@ -45,6 +45,7 @@ public class HostedTestApi {
     private static final String CONTENT_ID = "content_id";
     private static final String SUBSCRIPTION_ID = "subscription_id";
     private static final String CREATE_CHILDREN_PARAM = "create_children";
+    private static final String OFFERING_TYPE_3P = "3P";
 
     private ApiClient localVarApiClient;
     private int localHostIndex;
@@ -715,7 +716,7 @@ public class HostedTestApi {
      *     the product IDs to associate to an offering ID
      */
     public void associateProductIdsToCloudOffer(String cloudOfferId, Collection<String> productIds) {
-        okhttp3.Call localVarCall = associateProductIdsToCloudOfferCall(cloudOfferId, null, productIds);
+        okhttp3.Call localVarCall = associateProductIdsToCloudOfferCall(cloudOfferId, OFFERING_TYPE_3P, productIds);
         localVarApiClient.execute(localVarCall);
     }
 

--- a/src/main/java/org/candlepin/async/tasks/CloudAccountOrgSetupJob.java
+++ b/src/main/java/org/candlepin/async/tasks/CloudAccountOrgSetupJob.java
@@ -52,7 +52,6 @@ public class CloudAccountOrgSetupJob implements AsyncJob {
     protected static final String CLOUD_ACCOUNT_ID = "cloud_account_id";
     protected static final String OFFERING_ID = "offering_id";
     protected static final String CLOUD_PROVIDER = "cloud_provider";
-    protected static final String OWNER_KEY = "owner_key";
 
     private final CloudRegistrationAdapter cloudAdapter;
     private OwnerCurator ownerCurator;
@@ -79,12 +78,11 @@ public class CloudAccountOrgSetupJob implements AsyncJob {
 
         String accountId = args.getAsString(CLOUD_ACCOUNT_ID);
         String offeringId = args.getAsString(OFFERING_ID);
-        String ownerKey = args.getAsString(OWNER_KEY);
         String cloudProviderShortName = args.getAsString(CLOUD_PROVIDER);
 
         try {
             CloudAccountData accountData = this.cloudAdapter.setupCloudAccountOrg(
-                accountId, offeringId, cloudProviderShortName, ownerKey);
+                accountId, offeringId, cloudProviderShortName);
 
             Owner owner = ownerCurator.getByKey(accountData.ownerKey());
             if (owner == null) {
@@ -197,23 +195,6 @@ public class CloudAccountOrgSetupJob implements AsyncJob {
             return this;
         }
 
-        /**
-         * Sets the owner key for this job
-         *
-         * @param ownerKey
-         *     the owner key to set for this job
-         * @return a reference to this job config
-         */
-        public CloudAccountOrgSetupJobConfig setOwnerKey(String ownerKey) {
-            if (ownerKey != null && ownerKey.isBlank()) {
-                throw new IllegalArgumentException("ownerKey is empty");
-            }
-
-            this.setJobArgument(OWNER_KEY, ownerKey);
-
-            return this;
-        }
-
         @Override
         public void validate() throws JobConfigValidationException {
             super.validate();
@@ -224,7 +205,6 @@ public class CloudAccountOrgSetupJob implements AsyncJob {
                 String accountId = arguments.getAsString(CLOUD_ACCOUNT_ID);
                 String offeringId = arguments.getAsString(OFFERING_ID);
                 String cloudProviderShortName = arguments.getAsString(CLOUD_PROVIDER);
-                String ownerKey = arguments.getAsString(OWNER_KEY);
 
                 if (accountId == null || accountId.isBlank()) {
                     String errmsg = "Cloud Account ID has not been set, or is empty";
@@ -238,11 +218,6 @@ public class CloudAccountOrgSetupJob implements AsyncJob {
 
                 if (cloudProviderShortName == null) {
                     String errmsg = "Cloud provider has not been set";
-                    throw new JobConfigValidationException(errmsg);
-                }
-
-                if (ownerKey != null && ownerKey.isBlank()) {
-                    String errmsg = "Owner key is empty";
                     throw new JobConfigValidationException(errmsg);
                 }
             }

--- a/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
+++ b/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
@@ -246,10 +246,6 @@ public class CloudRegistrationResource implements CloudRegistrationApi {
                 .setCloudOfferingId(authResult.getOfferId())
                 .setCloudProvider(authResult.getCloudProvider());
 
-            if (ownerKey != null && !ownerKey.isBlank()) {
-                jobConfig.setOwnerKey(ownerKey);
-            }
-
             try {
                 this.jobManager.queueJob(jobConfig);
             }

--- a/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/service/CloudRegistrationAdapter.java
@@ -63,9 +63,6 @@ public interface CloudRegistrationAdapter {
      * @param cloudProviderShortName
      *     Shortcut of the cloud provider from which the offering came
      *
-     * @param ownerKey
-     *     An optional param if we have already paired organization with accountId
-     *
      * @throws CouldNotAcquireCloudAccountLockException
      *     Organization is already being created and/or entitled
      *
@@ -75,7 +72,7 @@ public interface CloudRegistrationAdapter {
      * @return key of the organization with entitled offering
      */
     CloudAccountData setupCloudAccountOrg(String cloudAccountID, String cloudOfferingID,
-        String cloudProviderShortName, String ownerKey)
+        String cloudProviderShortName)
         throws CouldNotAcquireCloudAccountLockException, CouldNotEntitleOrganizationException,
             CloudAccountOrgMismatchException;
 

--- a/src/main/java/org/candlepin/service/impl/DefaultCloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultCloudRegistrationAdapter.java
@@ -39,7 +39,7 @@ public class DefaultCloudRegistrationAdapter implements CloudRegistrationAdapter
 
     @Override
     public CloudAccountData setupCloudAccountOrg(String cloudAccountID, String cloudOfferingID,
-        String cloudProviderShortName, String ownerKey) {
+        String cloudProviderShortName) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/candlepin/service/model/CloudAuthenticationResult.java
+++ b/src/main/java/org/candlepin/service/model/CloudAuthenticationResult.java
@@ -57,6 +57,13 @@ public interface CloudAuthenticationResult {
     Set<String> getProductIds();
 
     /**
+     * @return true if the consumer only requires the version 1 cloud registration workflow for the provided
+     *  owner key. The owner key must be populated when the registration only value is set to true. False
+     *  indicates that the consumer requires a version 2 or greater cloud registration logic.
+     */
+    boolean isRegistrationOnly();
+
+    /**
      * @return true if the owner is entitled to the product associated to the cloud offering ID found in
      * the {@link CloudRegistrationInfo} metadata, or false if not entitled
      */

--- a/src/main/java/org/candlepin/testext/hostedtest/HostedTestCloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/testext/hostedtest/HostedTestCloudRegistrationAdapter.java
@@ -186,14 +186,10 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
      */
     @Override
     public CloudAccountData setupCloudAccountOrg(String cloudAccountID, String cloudOfferingID,
-        String cloudProviderShortName, String ownerKey)
+        String cloudProviderShortName)
         throws CouldNotAcquireCloudAccountLockException, CouldNotEntitleOrganizationException {
 
-        if (ownerKey == null) {
-            ownerKey = Util.generateUUID();
-        }
-
-        return new CloudAccountData(ownerKey, false);
+        return new CloudAccountData(Util.generateUUID(), false);
     }
 
     /**

--- a/src/main/java/org/candlepin/testext/hostedtest/HostedTestCloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/testext/hostedtest/HostedTestCloudRegistrationAdapter.java
@@ -56,6 +56,11 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
     private static final String INSTANCE_ID_FIELD_NAME = "instanceId";
     private static final String OFFERING_ID_FIELD_NAME = "cloudOfferingId";
     private static final String OFFERING_TYPE_1P = "1P";
+    private static final String OFFERING_TYPE_GOLD = "gold";
+    private static final String OFFERING_TYPE_CUSTOM = "custom";
+    private static final Set<String> REGISTRATION_ONLY_OFFER_TYPES =
+        Set.of(OFFERING_TYPE_1P, OFFERING_TYPE_GOLD, OFFERING_TYPE_CUSTOM);
+
     private static final ObjectMapper OBJ_MAPPER = ObjectMapperFactory.getObjectMapper();
 
     private final HostedTestDataStore datastore;
@@ -134,12 +139,15 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
         }
 
         String offerType = this.datastore.getOfferTypeForOfferId(offerId);
-        if (OFFERING_TYPE_1P.equals(offerType)) {
+        boolean isRegistrationOnly = offerType == null ?
+            false :
+            REGISTRATION_ONLY_OFFER_TYPES.contains(offerType);
+        String ownerKey = this.datastore.getOwnerKeyForCloudAccountId(accountId);
+        if (ownerKey == null && isRegistrationOnly) {
             throw new CloudRegistrationNotSupportedForOfferingException(
                 "cloud registration v2 is not supported for 1P offerings");
         }
 
-        String ownerKey = this.datastore.getOwnerKeyForCloudAccountId(accountId);
         Set<String> productIds = this.datastore.getProductIdsForOfferId(offerId);
         boolean isEntitled = isOwnerEntitledToProducts(ownerKey, productIds);
 
@@ -172,6 +180,11 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
             @Override
             public Set<String> getProductIds() {
                 return productIds;
+            }
+
+            @Override
+            public boolean isRegistrationOnly() {
+                return isRegistrationOnly;
             }
 
             @Override

--- a/src/main/java/org/candlepin/testext/hostedtest/HostedTestResource.java
+++ b/src/main/java/org/candlepin/testext/hostedtest/HostedTestResource.java
@@ -758,6 +758,11 @@ public class HostedTestResource {
             throw new BadRequestException("cloud offer ID is null");
         }
 
+        String cloudOfferType  = root.get("cloudOfferType").asText();
+        if (cloudOfferType == null) {
+            throw new BadRequestException("cloud offer type is null");
+        }
+
         JsonNode productIdsNode = root.get("productIds");
         if (productIdsNode == null) {
             throw new BadRequestException("productIds is null");
@@ -767,15 +772,7 @@ public class HostedTestResource {
         productIdsNode.elements().forEachRemaining(prod -> productIds.add(prod.asText()));
 
         this.datastore.setProductIdsForCloudOfferId(offerId, productIds);
-
-        JsonNode cloudOfferTypeNode = root.get("cloudOfferType");
-        if (cloudOfferTypeNode != null) {
-            String cloudOfferType = cloudOfferTypeNode.asText();
-            if (cloudOfferType != null && !cloudOfferType.isBlank()) {
-                this.datastore.setOfferTypeForCloudOfferId(offerId, cloudOfferType);
-            }
-        }
-
+        this.datastore.setOfferTypeForCloudOfferId(offerId, cloudOfferType);
     }
 
     @POST

--- a/src/test/java/org/candlepin/async/tasks/CloudAccountOrgSetupJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/CloudAccountOrgSetupJobTest.java
@@ -14,8 +14,15 @@
  */
 package org.candlepin.async.tasks;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
@@ -96,24 +103,9 @@ class CloudAccountOrgSetupJobTest {
     }
 
     @Test
-    void testJobConfigSetOwnerKey() {
-        String ownerKey = TestUtil.randomString();
-        JobConfig config = CloudAccountOrgSetupJob.createJobConfig()
-            .setOwnerKey(ownerKey);
-
-        JobArguments args = config.getJobArguments();
-
-        assertThrows(IllegalArgumentException.class, () -> CloudAccountOrgSetupJob.createJobConfig()
-            .setOwnerKey(""));
-
-        assertTrue(args.containsKey(CloudAccountOrgSetupJob.OWNER_KEY));
-        assertEquals(ownerKey, args.getAsString(CloudAccountOrgSetupJob.OWNER_KEY));
-    }
-
-    @Test
     void ensureJobSuccessWithNewAnonymousOrganization()
         throws JobExecutionException, CouldNotAcquireCloudAccountLockException {
-        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any(), anyString()))
+        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any()))
             .thenReturn(new CloudAccountData("owner_key", true));
 
         CloudAccountOrgSetupJob regJob = new CloudAccountOrgSetupJob(cloudReg, ownerCurator);
@@ -123,8 +115,7 @@ class CloudAccountOrgSetupJobTest {
             CloudAccountOrgSetupJob.createJobConfig()
             .setCloudAccountId(TestUtil.randomString())
             .setCloudOfferingId(offering)
-            .setCloudProvider(TestUtil.randomString())
-            .setOwnerKey(TestUtil.randomString());
+            .setCloudProvider(TestUtil.randomString());
 
         AsyncJobStatus status = mock(AsyncJobStatus.class);
         JobExecutionContext context = spy(new JobExecutionContext(status));
@@ -144,7 +135,7 @@ class CloudAccountOrgSetupJobTest {
     @Test
     void ensureJobSuccessWithNewNonAnonymousOrganization()
         throws JobExecutionException, CouldNotAcquireCloudAccountLockException {
-        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any(), anyString()))
+        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any()))
             .thenReturn(new CloudAccountData("owner_key", false));
 
         CloudAccountOrgSetupJob regJob = new CloudAccountOrgSetupJob(cloudReg, ownerCurator);
@@ -154,8 +145,7 @@ class CloudAccountOrgSetupJobTest {
             CloudAccountOrgSetupJob.createJobConfig()
             .setCloudAccountId(TestUtil.randomString())
             .setCloudOfferingId(offering)
-            .setCloudProvider(TestUtil.randomString())
-            .setOwnerKey(TestUtil.randomString());
+            .setCloudProvider(TestUtil.randomString());
 
         AsyncJobStatus status = mock(AsyncJobStatus.class);
         JobExecutionContext context = spy(new JobExecutionContext(status));
@@ -174,7 +164,7 @@ class CloudAccountOrgSetupJobTest {
 
     @Test
     void ensureJobExceptionThrownIfLockIsNotAcquired() throws CouldNotAcquireCloudAccountLockException {
-        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any(), anyString())).thenThrow(
+        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any())).thenThrow(
             CouldNotAcquireCloudAccountLockException.class);
 
         CloudAccountOrgSetupJob regJob = new CloudAccountOrgSetupJob(cloudReg, ownerCurator);
@@ -183,8 +173,7 @@ class CloudAccountOrgSetupJobTest {
             CloudAccountOrgSetupJob.createJobConfig()
             .setCloudAccountId(TestUtil.randomString())
             .setCloudOfferingId(TestUtil.randomString())
-            .setCloudProvider(TestUtil.randomString())
-            .setOwnerKey(TestUtil.randomString());
+            .setCloudProvider(TestUtil.randomString());
 
         AsyncJobStatus status = mock(AsyncJobStatus.class);
         JobExecutionContext context = spy(new JobExecutionContext(status));
@@ -196,7 +185,7 @@ class CloudAccountOrgSetupJobTest {
     @Test
     void ensureJobExceptionThrownIfCouldNotEntitleOrganization()
         throws CouldNotAcquireCloudAccountLockException {
-        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any(), anyString())).thenThrow(
+        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any())).thenThrow(
             CouldNotEntitleOrganizationException.class);
 
         CloudAccountOrgSetupJob regJob = new CloudAccountOrgSetupJob(cloudReg, ownerCurator);
@@ -205,8 +194,7 @@ class CloudAccountOrgSetupJobTest {
             CloudAccountOrgSetupJob.createJobConfig()
             .setCloudAccountId(TestUtil.randomString())
             .setCloudOfferingId(TestUtil.randomString())
-            .setCloudProvider(TestUtil.randomString())
-            .setOwnerKey(TestUtil.randomString());
+            .setCloudProvider(TestUtil.randomString());
 
 
         AsyncJobStatus status = mock(AsyncJobStatus.class);
@@ -219,7 +207,7 @@ class CloudAccountOrgSetupJobTest {
     @Test
     void shouldThrowJobExceptionWhenCloudAccountOrgMismatchHappens()
         throws CouldNotAcquireCloudAccountLockException {
-        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any(), anyString())).thenThrow(
+        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any())).thenThrow(
             CloudAccountOrgMismatchException.class);
 
         CloudAccountOrgSetupJob regJob = new CloudAccountOrgSetupJob(cloudReg, ownerCurator);
@@ -228,8 +216,7 @@ class CloudAccountOrgSetupJobTest {
             CloudAccountOrgSetupJob.createJobConfig()
             .setCloudAccountId(TestUtil.randomString())
             .setCloudOfferingId(TestUtil.randomString())
-            .setCloudProvider(TestUtil.randomString())
-            .setOwnerKey(TestUtil.randomString());
+            .setCloudProvider(TestUtil.randomString());
 
         AsyncJobStatus status = mock(AsyncJobStatus.class);
         JobExecutionContext context = spy(new JobExecutionContext(status));
@@ -240,7 +227,7 @@ class CloudAccountOrgSetupJobTest {
 
     @Test
     void ensureJobExceptionThrownIllegalState() throws CouldNotAcquireCloudAccountLockException {
-        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any(), anyString()))
+        when(cloudReg.setupCloudAccountOrg(anyString(), anyString(), any()))
             .thenReturn(new CloudAccountData("owner_key", null));
 
         CloudAccountOrgSetupJob regJob = new CloudAccountOrgSetupJob(cloudReg, ownerCurator);
@@ -249,8 +236,7 @@ class CloudAccountOrgSetupJobTest {
             CloudAccountOrgSetupJob.createJobConfig()
                 .setCloudAccountId(TestUtil.randomString())
                 .setCloudOfferingId(TestUtil.randomString())
-                .setCloudProvider(TestUtil.randomString())
-                .setOwnerKey(TestUtil.randomString());
+                .setCloudProvider(TestUtil.randomString());
 
 
         AsyncJobStatus status = mock(AsyncJobStatus.class);
@@ -266,8 +252,7 @@ class CloudAccountOrgSetupJobTest {
             .createJobConfig()
             .setCloudAccountId(TestUtil.randomString())
             .setCloudOfferingId(TestUtil.randomString())
-            .setCloudProvider(TestUtil.randomString())
-            .setOwnerKey(TestUtil.randomString());
+            .setCloudProvider(TestUtil.randomString());
         jobConfig.validate();
     }
 

--- a/src/test/java/org/candlepin/resource/CloudRegistrationResourceTest.java
+++ b/src/test/java/org/candlepin/resource/CloudRegistrationResourceTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.argThat;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -191,7 +191,7 @@ public class CloudRegistrationResourceTest {
 
         CloudAuthenticationResult result = buildMockAuthResult(cloudAccountId, "instanceId",
             TestUtil.randomString(),
-            "ownerKey", "offerId", Set.of("productId"), true);
+            "ownerKey", "offerId", Set.of("productId"), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -209,7 +209,7 @@ public class CloudRegistrationResourceTest {
 
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", instanceId,
             TestUtil.randomString(),
-            "ownerKey", "offerId", Set.of("productId"), true);
+            "ownerKey", "offerId", Set.of("productId"), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -224,7 +224,7 @@ public class CloudRegistrationResourceTest {
             .signature("test-signature");
 
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", "instanceId", null,
-            "ownerKey", "offerId", Set.of("productId"), true);
+            "ownerKey", "offerId", Set.of("productId"), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -242,7 +242,7 @@ public class CloudRegistrationResourceTest {
 
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", "instanceId",
             TestUtil.randomString(),
-            "ownerKey", offerId, Set.of("productId"), true);
+            "ownerKey", offerId, Set.of("productId"), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -257,7 +257,7 @@ public class CloudRegistrationResourceTest {
             .signature("test-signature");
 
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", "instanceId",
-            TestUtil.randomString(), "ownerKey", "offerId", null, true);
+            TestUtil.randomString(), "ownerKey", "offerId", null, true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
         assertThrows(NotAuthorizedException.class, () -> cloudRegResource.cloudAuthorize(dto, 2));
@@ -271,7 +271,7 @@ public class CloudRegistrationResourceTest {
             .signature("test-signature");
 
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", "instanceId",
-            TestUtil.randomString(), "ownerKey", "offerId", Set.of(), true);
+            TestUtil.randomString(), "ownerKey", "offerId", Set.of(), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -288,7 +288,7 @@ public class CloudRegistrationResourceTest {
         String expectedOwnerKey = "ownerKey";
         String prodId = "productId";
         CloudAuthenticationResult result = buildMockAuthResult("cloudAccountId", "instanceId",
-            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), true);
+            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
         Owner owner = new Owner().setKey(expectedOwnerKey);
@@ -328,7 +328,7 @@ public class CloudRegistrationResourceTest {
         String accountId = "cloudAccountId";
         String offeringId = "offerId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, "instanceId",
-            TestUtil.randomString(), null, offeringId, prodIds, true);
+            TestUtil.randomString(), null, offeringId, prodIds, true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -372,7 +372,7 @@ public class CloudRegistrationResourceTest {
         String prodId = "productId";
         String accountId = "cloudAccountId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, "instanceId",
-            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), false);
+            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), false, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
         Owner owner = new Owner().setKey(expectedOwnerKey);
@@ -419,7 +419,7 @@ public class CloudRegistrationResourceTest {
         Set<String> prodIds = Set.of("productId");
         String accountId = "cloudAccountId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, "instanceId",
-            TestUtil.randomString(), expectedOwnerKey, "offerId", prodIds, true);
+            TestUtil.randomString(), expectedOwnerKey, "offerId", prodIds, true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -463,7 +463,7 @@ public class CloudRegistrationResourceTest {
         String prodId = "productId";
         String accountId = "cloudAccountId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, "instanceId",
-            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), true);
+            TestUtil.randomString(), expectedOwnerKey, "offerId", Set.of(prodId), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
         Owner owner = new Owner().setKey(expectedOwnerKey);
@@ -511,7 +511,7 @@ public class CloudRegistrationResourceTest {
         String accountId = "cloudAccountId";
         String instanceId = "instanceId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, instanceId, TestUtil.randomString(),
-            expectedOwnerKey, "offerId", Set.of(prodId), true);
+            expectedOwnerKey, "offerId", Set.of(prodId), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
         Owner owner = new Owner().setKey(expectedOwnerKey);
@@ -558,7 +558,7 @@ public class CloudRegistrationResourceTest {
         String accountId = "cloudAccountId";
         String instanceId = "instanceId";
         CloudAuthenticationResult result = buildMockAuthResult(accountId, instanceId, TestUtil.randomString(),
-            null, "offerId", Set.of(prodId), true);
+            null, "offerId", Set.of(prodId), true, false);
         doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
@@ -598,17 +598,71 @@ public class CloudRegistrationResourceTest {
             () -> cloudRegResource.cloudAuthorize(new CloudRegistrationDTO().type("test_type"), 100));
     }
 
-    @Test
-    public void testCloudAuthorizeV2For1POfferingNotSupported() {
+    @ParameterizedTest(name = "{displayName} {index}: {0} {1}")
+    @NullAndEmptySource
+    public void testCloudAuthorizeV2WithRegistrationOnlyAndMissingOwnerKey(String ownerKey) {
         CloudRegistrationDTO dto = new CloudRegistrationDTO()
             .type("test-type")
             .metadata("test-metadata")
             .signature("test-signature");
 
-        doThrow(new CloudRegistrationNotSupportedForOfferingException()).when(mockCloudRegistrationAdapter)
+        CloudAuthenticationResult result = buildMockAuthResult(TestUtil.randomString(),
+            TestUtil.randomString(), TestUtil.randomString(), ownerKey, TestUtil.randomString(),
+            Set.of(TestUtil.randomString()), false, true);
+        doReturn(result).when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
 
         assertThrows(NotImplementedException.class, () -> cloudRegResource.cloudAuthorize(dto, 2));
+    }
+
+    @Test
+    public void testCloudAuthorizeV2ForUnsupportedCloudOffering() {
+        CloudRegistrationDTO dto = new CloudRegistrationDTO()
+            .type("test-type")
+            .metadata("test-metadata")
+            .signature("test-signature");
+
+        doThrow(new CloudRegistrationNotSupportedForOfferingException())
+            .when(mockCloudRegistrationAdapter)
+            .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
+
+        assertThrows(NotImplementedException.class, () -> cloudRegResource.cloudAuthorize(dto, 2));
+    }
+
+    @Test
+    public void testCloudAuthorizeV2WithRegistrationOnly() {
+        CloudRegistrationDTO dto = new CloudRegistrationDTO()
+            .type("test-type")
+            .metadata("test-metadata")
+            .signature("test-signature");
+
+        String expectedOwnerKey = "ownerKey";
+        CloudAuthenticationResult result = buildMockAuthResult(TestUtil.randomString(),
+            TestUtil.randomString(), TestUtil.randomString(), expectedOwnerKey, TestUtil.randomString(),
+            Set.of(TestUtil.randomString()), false, true);
+        doReturn(result)
+            .when(mockCloudRegistrationAdapter)
+            .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
+
+        String expectedToken = TestUtil.randomString();
+        doReturn(expectedToken)
+            .when(mockTokenGenerator)
+            .buildStandardRegistrationToken(principal, expectedOwnerKey);
+
+        Response response = cloudRegResource.cloudAuthorize(dto, 2);
+
+        assertThat(response)
+            .isNotNull()
+            .returns(200, Response::getStatus)
+            .extracting(Response::getEntity)
+            .isNotNull()
+            .isInstanceOf(CloudAuthenticationResultDTO.class);
+
+        assertThat((CloudAuthenticationResultDTO) response.getEntity())
+            .returns(expectedOwnerKey, CloudAuthenticationResultDTO::getOwnerKey)
+            .returns(null, CloudAuthenticationResultDTO::getAnonymousConsumerUuid)
+            .returns(expectedToken, CloudAuthenticationResultDTO::getToken)
+            .returns(CloudAuthTokenType.STANDARD.toString(), CloudAuthenticationResultDTO::getTokenType);
     }
 
     @Test
@@ -705,8 +759,8 @@ public class CloudRegistrationResourceTest {
     }
 
     private CloudAuthenticationResult buildMockAuthResult(String cloudAccountId, String instanceId,
-        String provider,
-        String ownerKey, String offerId, Set<String> productIds, boolean isEntitled) {
+        String provider, String ownerKey,
+        String offerId, Set<String> productIds, boolean isEntitled, boolean isRegistrationOnly) {
         CloudAuthenticationResult mockResult = mock(CloudAuthenticationResult.class);
         doReturn(cloudAccountId).when(mockResult).getCloudAccountId();
         doReturn(instanceId).when(mockResult).getCloudInstanceId();
@@ -715,6 +769,7 @@ public class CloudRegistrationResourceTest {
         doReturn(offerId).when(mockResult).getOfferId();
         doReturn(productIds).when(mockResult).getProductIds();
         doReturn(isEntitled).when(mockResult).isEntitled();
+        doReturn(isRegistrationOnly).when(mockResult).isRegistrationOnly();
 
         return mockResult;
     }


### PR DESCRIPTION
candlepin-4.4.4-HOTFIX will be used to create a candlepin-4.4.4-_**2**_ build for Hosted, to avoid the extra changes that would come with a 4.4.5 build, so we can get autoregv2 fixes faster in Hosted.