### PR TITLE
CANDLEPIN-802: Create Owner for TrustedUserPrincipal during consumer registration

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/ConsumerClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/ConsumerClient.java
@@ -74,7 +74,8 @@ public class ConsumerClient extends ConsumerApi {
     }
 
     public ConsumerDTO createConsumer(ConsumerDTO consumer) {
-        return super.createConsumer(consumer, null, consumer.getOwner().getKey(), null, true);
+        String ownerKey = consumer.getOwner() != null ? consumer.getOwner().getKey() : null;
+        return super.createConsumer(consumer, null, ownerKey, null, true);
     }
 
     public ConsumerDTO createPersonConsumer(ConsumerDTO consumer, String username) {

--- a/src/main/java/org/candlepin/service/impl/DefaultOwnerServiceAdapter.java
+++ b/src/main/java/org/candlepin/service/impl/DefaultOwnerServiceAdapter.java
@@ -14,14 +14,7 @@
  */
 package org.candlepin.service.impl;
 
-import org.candlepin.model.OwnerCurator;
 import org.candlepin.service.OwnerServiceAdapter;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xnap.commons.i18n.I18n;
-
-import javax.inject.Inject;
 
 
 
@@ -29,16 +22,6 @@ import javax.inject.Inject;
  * default SubscriptionAdapter implementation
  */
 public class DefaultOwnerServiceAdapter implements OwnerServiceAdapter {
-    private static Logger log = LoggerFactory.getLogger(DefaultOwnerServiceAdapter.class);
-
-    private OwnerCurator ownerCurator;
-    private I18n i18n;
-
-    @Inject
-    public DefaultOwnerServiceAdapter(OwnerCurator ownerCurator, I18n i18n) {
-        this.ownerCurator = ownerCurator;
-        this.i18n = i18n;
-    }
 
     /**
      * {@inheritDoc}

--- a/src/test/java/org/candlepin/resource/AnonymousConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/AnonymousConsumerResourceCreationTest.java
@@ -84,6 +84,7 @@ import org.candlepin.resource.validation.DTOValidator;
 import org.candlepin.service.CloudRegistrationAdapter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
@@ -189,6 +190,8 @@ public class AnonymousConsumerResourceCreationTest {
     private AnonymousCloudConsumerCurator anonymousConsumerCurator;
     @Mock
     private AnonymousContentAccessCertificateCurator anonymousCertCurator;
+    @Mock
+    private OwnerServiceAdapter ownerService;
 
     protected ModelTranslator modelTranslator;
 
@@ -223,7 +226,7 @@ public class AnonymousConsumerResourceCreationTest {
             this.dtoValidator, this.principalProvider, this.contentOverrideValidator,
             this.consumerContentOverrideCurator, this.entCertGenerator, this.poolService,
             this.environmentContentCurator, this.cloudRegistrationAdapter, this.poolCurator,
-            this.anonymousConsumerCurator, this.anonymousCertCurator
+            this.anonymousConsumerCurator, this.anonymousCertCurator, ownerService
         );
 
         this.system = this.initConsumerType();

--- a/src/test/java/org/candlepin/resource/ConsumerContentOverrideResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerContentOverrideResourceTest.java
@@ -14,9 +14,12 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.async.JobManager;
 import org.candlepin.audit.EventFactory;
@@ -62,6 +65,7 @@ import org.candlepin.resource.validation.DTOValidator;
 import org.candlepin.service.CloudRegistrationAdapter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
@@ -169,6 +173,8 @@ public class ConsumerContentOverrideResourceTest extends DatabaseTestFixture {
     private AnonymousCloudConsumerCurator anonymousConsumerCurator;
     @Mock
     private AnonymousContentAccessCertificateCurator anonymousCertCurator;
+    @Mock
+    private OwnerServiceAdapter ownerService;
 
     private Consumer consumer;
     private ContentOverrideValidator contentOverrideValidator;
@@ -231,7 +237,8 @@ public class ConsumerContentOverrideResourceTest extends DatabaseTestFixture {
             this.cloudAdapter,
             this.poolCurator,
             this.anonymousConsumerCurator,
-            this.anonymousCertCurator
+            this.anonymousCertCurator,
+            this.ownerService
         );
     }
 

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -14,9 +14,18 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.candlepin.async.JobManager;
 import org.candlepin.audit.EventFactory;
@@ -86,6 +95,7 @@ import org.candlepin.resource.validation.DTOValidator;
 import org.candlepin.service.CloudRegistrationAdapter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
@@ -207,6 +217,8 @@ public class ConsumerResourceCreationTest {
     private AnonymousCloudConsumerCurator anonymousConsumerCurator;
     @Mock
     private AnonymousContentAccessCertificateCurator anonymousCertCurator;
+    @Mock
+    private OwnerServiceAdapter ownerService;
     protected ModelTranslator modelTranslator;
 
     private I18n i18n;
@@ -271,7 +283,8 @@ public class ConsumerResourceCreationTest {
             this.cloudRegistrationAdapter,
             this.poolCurator,
             this.anonymousConsumerCurator,
-            this.anonymousCertCurator
+            this.anonymousCertCurator,
+            this.ownerService
         );
 
         this.system = this.initConsumerType();

--- a/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -28,10 +28,8 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -109,6 +107,7 @@ import org.candlepin.resource.validation.DTOValidator;
 import org.candlepin.service.CloudRegistrationAdapter;
 import org.candlepin.service.EntitlementCertServiceAdapter;
 import org.candlepin.service.IdentityCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
 import org.candlepin.service.ProductServiceAdapter;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.UserServiceAdapter;
@@ -233,6 +232,8 @@ public class ConsumerResourceUpdateTest {
     private AnonymousCloudConsumerCurator anonymousConsumerCurator;
     @Mock
     private AnonymousContentAccessCertificateCurator anonymousCertCurator;
+    @Mock
+    private OwnerServiceAdapter ownerService;
 
     private ModelTranslator translator;
 
@@ -296,7 +297,9 @@ public class ConsumerResourceUpdateTest {
             this.cloudRegistrationAdapter,
             this.poolCurator,
             this.anonymousConsumerCurator,
-            this.anonymousCertCurator);
+            this.anonymousCertCurator,
+            this.ownerService
+        );
 
         when(this.complianceRules.getStatus(any(Consumer.class), any(Date.class), any(Boolean.class),
             any(Boolean.class))).thenReturn(new ComplianceStatus(new Date()));

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -41,7 +41,6 @@ import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobException;
 import org.candlepin.async.JobManager;
 import org.candlepin.async.tasks.ImportJob;
-import org.candlepin.audit.EventAdapter;
 import org.candlepin.audit.EventFactory;
 import org.candlepin.audit.EventSink;
 import org.candlepin.auth.Access;
@@ -189,7 +188,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
     private EventSink mockEventSink;
     private EventFactory mockEventFactory;
-    private EventAdapter mockEventAdapter;
 
     private ManifestManager mockManifestManager;
     private OwnerManager ownerManager;
@@ -200,13 +198,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     private ServiceLevelValidator serviceLevelValidator;
     private ConsumerTypeValidator consumerTypeValidator;
 
-    private JobManager jobManager;
     private Owner owner;
     private Product product;
-    private Set<String> typeLabels;
-    private List<String> skus;
-    private List<String> subscriptionIds;
-    private List<String> contracts;
 
     @BeforeEach
     public void setUp() {
@@ -220,17 +213,11 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         contentAccessManager = this.injector.getInstance(ContentAccessManager.class);
         pagingUtilFactory = this.injector.getInstance(PagingUtilFactory.class);
 
-        this.jobManager = mock(JobManager.class);
-
         this.owner = this.ownerCurator.create(new Owner()
             .setKey(OWNER_NAME)
             .setDisplayName(OWNER_NAME));
 
         product = this.createProduct();
-        typeLabels = null;
-        skus = null;
-        subscriptionIds = null;
-        contracts = null;
 
         // Setup mocks and other such things...
         this.mockActivationKeyCurator = mock(ActivationKeyCurator.class);
@@ -249,7 +236,6 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         this.mockEventSink = mock(EventSink.class);
         this.mockEventFactory = mock(EventFactory.class);
-        this.mockEventAdapter = mock(EventAdapter.class);
 
         this.mockManifestManager = mock(ManifestManager.class);
         this.ownerManager = mock(OwnerManager.class);
@@ -258,7 +244,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         this.principalProvider = mock(PrincipalProvider.class);
         this.pagingUtilFactory = mock(PagingUtilFactory.class);
 
-        this.ownerServiceAdapter = new DefaultOwnerServiceAdapter(this.mockOwnerCurator, this.i18n);
+        this.ownerServiceAdapter = new DefaultOwnerServiceAdapter();
         this.serviceLevelValidator = new ServiceLevelValidator(this.i18n, this.mockPoolManager,
             this.mockOwnerCurator);
         this.consumerTypeValidator = new ConsumerTypeValidator(this.mockConsumerTypeCurator, this.i18n);


### PR DESCRIPTION
- Updated createOwnerIfNeeded to create owner if it is missing for TrustedUserPrincipal.