### PR TITLE
[M] Improved hosted test framework support for large JSON files

### DIFF
--- a/bin/scripts/upstream_data_injector.sh
+++ b/bin/scripts/upstream_data_injector.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+for file in $@; do
+    echo "Injecting subscriptions from JSON file: ${file}"
+    curl -k -u admin:admin -X POST -F "file=@${file}" "https://localhost:8443/candlepin/hostedtest/import/subscriptions"
+done


### PR DESCRIPTION
- Updated the way JSON files are processed when injecting upstream data to support larger files and minimize likelyhood of hitting out-of-memory errors
- Restored the upstream_data_injector script to simplify the process of uploading several files in one command