### PR TITLE
CANDLEPIN-804: Created kube file for candlepin-dev image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,13 +238,19 @@ ENTRYPOINT ["/opt/tomcat/bin/catalina.sh", "run"]
 
 The Candlepin development image is designed to run right after pulling the image using default Candlepin and Tomcat configurations as well as a default certificate and key for TLS communication and encryption. Since this certificate and key is packaged in a publicly available container image, the use of the Candlepin development image should **not** be used in a production environment to avoid security risks.
 
-The following is an example on how to run the Candlepin development container using the docker compose file.
+The following is an example on how to run the Candlepin development container using a docker compose file or a kubernetes file via podman.
 
-The compose file is in the dev-container directory that will pull that development image and the most
-current PostgreSQL image. The configuration settings are in that compose file as environment variables. Refer to the [default configuration](#development-image-default-configurations) section for details on the Candlepin development container's default configurations. Once configured
-you can start and stop(remove) the container with
+Two compose files are in the dev-container directory. They will pull the development image and the most
+current PostgreSQL image. The configuration settings are in those compose files as environment variables.
+Refer to the [default configuration](#development-image-default-configurations) section for details on the Candlepin development container's default configurations.
+
+Once configured you can start and stop(remove) the docker container with
 
 ``` docker compose up/down```
+
+Or the kubernetes container with 
+
+```podman play kube candlepin-deployment.yaml []/--down```
 
 
 ### Configure Candlepin Container

--- a/dev-container/candlepin-deployment.yaml
+++ b/dev-container/candlepin-deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: candlepin
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:latest
+          env:
+              - name: POSTGRES_DB
+                value: candlepin
+              - name: POSTGRES_HOST_AUTH_METHOD
+                value: trust
+              - name: POSTGRES_PASSWORD
+                value: candlepin
+              - name: POSTGRES_USER
+                value: candlepin
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c  
+                - exec pg_isready -U candlepin -d candlepin -h localhost
+            failureThreshold: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 5432
+              hostPort: 5432
+              protocol: TCP
+          resources: {}
+          restartPolicy: Always
+        - name: candlepin
+          image: quay.io/candlepin/candlepin:dev-latest
+          env:
+            - name: CANDLEPIN_AUTH_CLOUD_ENABLE
+              value: "false"
+            - name: CANDLEPIN_AUTH_TRUSTED_ENABLE
+              value: "true"
+            - name: CANDLEPIN_STANDALONE
+              value: "false"
+            - name: JPA_CONFIG_HIBERNATE_CONNECTION_URL
+              value: jdbc:postgresql://postgres/candlepin
+            - name: MODULE_CONFIG_HOSTED_CONFIGURATION_MODULE
+              value: org.candlepin.testext.hostedtest.HostedTestModule
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec curl --fail -k https://localhost:8443/candlepin/status
+            failureThreshold: 10
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          ports:
+            - containerPort: 8443
+              hostPort: 8443
+              protocol: TCP
+          resources: {}
+          restartPolicy: Always
+status: {}


### PR DESCRIPTION
- Converted from docker-compose.yml via Kompose tool
- Uses the most recent Candlepin dev image and the newest Postres image
- The Candlepin container start does not have actual pause based on the Postgres container startup as 'podman play kube' does not have the Sidecar feature from Kubernetes yet
- The Postgres container starts quickly and does not adversely affect the Candlepin container startup
- A single command 'podman play kube candlepin-deployment.yaml' will bring everything up for use