### PR TITLE
CANDLEPIN-269: Added paging to GET /content endpoint

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -2875,6 +2875,11 @@ paths:
         type: java.util.stream.Stream
         isContainer: true
       security: []
+      parameters:
+        - $ref: "#/components/parameters/paging_page"
+        - $ref: "#/components/parameters/paging_per_page"
+        - $ref: "#/components/parameters/paging_order"
+        - $ref: "#/components/parameters/paging_sort_by"
       responses:
         200:
           description: Content successfully listed

--- a/spec-tests/src/test/java/org/candlepin/spec/ContentResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ContentResourceSpecTest.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.spec;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.candlepin.dto.api.client.v1.AttributeDTO;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 @SpecTest
 public class ContentResourceSpecTest {
@@ -221,6 +223,32 @@ public class ContentResourceSpecTest {
         // Verify that the content's arch was inherited by the product
         String actualArch = productOutput2.get("content").get(0).get("arches").get(0).asText();
         assertEquals("ppc64", actualArch);
+    }
+
+    @Test
+    public void shouldListContentPagedAndSorted() throws InterruptedException {
+        ApiClient adminClient = ApiClients.admin();
+
+        OwnerDTO owner =  adminClient.owners().createOwner(Owners.random());
+        String ownerKey = owner.getKey();
+
+        // Ensure that there is data for this test.
+        // Most likely, there will already be data left from other test runs that will show up
+        IntStream.range(0, 5).forEach(entry -> {
+            adminClient.ownerContent().createContent(ownerKey, Contents.random());
+        });
+
+        List<ContentDTO> contents = adminClient.content().getContents(1, 4, "asc", "created");
+        assertThat(contents)
+            .isNotNull()
+            .hasSize(4);
+        assertThat(contents.get(0).getCreated().compareTo(contents.get(1).getCreated()))
+            .isLessThanOrEqualTo(0);
+        assertThat(contents.get(1).getCreated().compareTo(contents.get(2).getCreated()))
+            .isLessThanOrEqualTo(0);
+        assertThat(contents.get(2).getCreated().compareTo(contents.get(3).getCreated()))
+            .isLessThanOrEqualTo(0);
+
     }
 
     private ContentDTO createContent(String ownerKey, String contentUrl, String arches) {

--- a/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/src/main/java/org/candlepin/resource/ContentResource.java
@@ -19,10 +19,14 @@ import org.candlepin.dto.api.server.v1.ContentDTO;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
+import org.candlepin.paging.Page;
+import org.candlepin.paging.PageRequest;
 import org.candlepin.resource.server.v1.ContentApi;
 
+import org.jboss.resteasy.core.ResteasyContext;
 import org.xnap.commons.i18n.I18n;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -42,9 +46,15 @@ public class ContentResource implements ContentApi {
     }
 
     @Override
-    public Stream<ContentDTO> getContents() {
-        return this.contentCurator.listAll()
-            .stream()
+    public Stream<ContentDTO> getContents(Integer page, Integer perPage, String order, String sortBy) {
+        PageRequest pageRequest = ResteasyContext.getContextData(PageRequest.class);
+        Page<List<Content>> p = this.contentCurator.listAllPaged(pageRequest);
+
+        // Store the page for the LinkHeaderResponseFilter
+        ResteasyContext.pushContext(Page.class, p);
+
+        return p == null ? Stream.empty() :
+            p.getPageData().stream()
             .map(this.modelTranslator.getStreamMapper(Content.class, ContentDTO.class));
     }
 

--- a/src/test/java/org/candlepin/resource/ContentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ContentResourceTest.java
@@ -64,8 +64,8 @@ public class ContentResourceTest {
     public void testGetContents() {
         when(cc.listAll()).thenReturn(new LinkedList<>());
 
-        resource.getContents();
-        verify(cc, atLeastOnce()).listAll();
+        resource.getContents(null, null, null, null);
+        verify(cc, atLeastOnce()).listAllPaged(null);
     }
 
     @Test


### PR DESCRIPTION
- Created new method in ContentCurator listAllPaged
- Updated ConsumerResource for getContents to take paging parameters and call the new curator method
- Updated candlepin-api-spec.yaml to include the paging parameters