### PR TITLE
CANDLEPIN-269: Added paging to GET /content endpoint

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -2875,6 +2875,11 @@ paths:
         type: java.util.stream.Stream
         isContainer: true
       security: []
+      parameters:
+        - $ref: "#/components/parameters/paging_page"
+        - $ref: "#/components/parameters/paging_per_page"
+        - $ref: "#/components/parameters/paging_order"
+        - $ref: "#/components/parameters/paging_sort_by"
       responses:
         200:
           description: Content successfully listed

--- a/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/src/main/java/org/candlepin/resource/ContentResource.java
@@ -14,13 +14,20 @@
  */
 package org.candlepin.resource;
 
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.Configuration;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.server.v1.ContentDTO;
+import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
+import org.candlepin.model.ContentCurator.ContentQueryArguments;
+import org.candlepin.paging.Page;
+import org.candlepin.paging.PageRequest;
 import org.candlepin.resource.server.v1.ContentApi;
 
+import org.jboss.resteasy.core.ResteasyContext;
 import org.xnap.commons.i18n.I18n;
 
 import java.util.Objects;
@@ -33,18 +40,53 @@ public class ContentResource implements ContentApi {
     private final ContentCurator contentCurator;
     private final I18n i18n;
     private final ModelTranslator modelTranslator;
+    private final Configuration config;
 
     @Inject
-    public ContentResource(ContentCurator contentCurator, I18n i18n, ModelTranslator modelTranslator) {
+    public ContentResource(ContentCurator contentCurator, I18n i18n, ModelTranslator modelTranslator,
+        Configuration config) {
         this.i18n = Objects.requireNonNull(i18n);
         this.contentCurator = Objects.requireNonNull(contentCurator);
         this.modelTranslator = Objects.requireNonNull(modelTranslator);
+        this.config = Objects.requireNonNull(config);
     }
 
     @Override
-    public Stream<ContentDTO> getContents() {
-        return this.contentCurator.listAll()
-            .stream()
+    public Stream<ContentDTO> getContents(Integer page, Integer perPage, String order, String sortBy) {
+        PageRequest pageRequest = ResteasyContext.getContextData(PageRequest.class);
+        ContentQueryArguments queryArgs = new ContentQueryArguments();
+        long count = this.contentCurator.getContentCount();
+
+        if (pageRequest != null) {
+            Page<Stream<ContentDTO>> pageResponse = new Page<>();
+            pageResponse.setPageRequest(pageRequest);
+
+            if (pageRequest.isPaging()) {
+                queryArgs.setOffset((pageRequest.getPage() - 1) * pageRequest.getPerPage())
+                    .setLimit(pageRequest.getPerPage());
+            }
+
+            if (pageRequest.getSortBy() != null) {
+                boolean reverse = pageRequest.getOrder() == PageRequest.DEFAULT_ORDER;
+                queryArgs.addOrder(pageRequest.getSortBy(), reverse);
+            }
+
+            pageResponse.setMaxRecords((int) count);
+
+            // Store the page for the LinkHeaderResponseFilter
+            ResteasyContext.pushContext(Page.class, pageResponse);
+        }
+        // If no paging was specified, force a limit on amount of results
+        else {
+            int maxSize = config.getInt(ConfigProperties.MAX_PAGING_SIZE);
+            if (count > maxSize) {
+                String errmsg = this.i18n.tr("This endpoint does not support returning more than {0} " +
+                    "results at a time, please use paging.", maxSize);
+                throw new BadRequestException(errmsg);
+            }
+        }
+
+        return this.contentCurator.listAll(queryArgs).stream()
             .map(this.modelTranslator.getStreamMapper(Content.class, ContentDTO.class));
     }
 

--- a/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -14,13 +14,16 @@
  */
 package org.candlepin.model;
 
+import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.candlepin.model.ContentCurator.ContentQueryArguments;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
@@ -39,6 +42,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import javax.persistence.LockModeType;
@@ -599,9 +603,8 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         this.contentCurator.flush();
         this.contentCurator.clear();
 
-        assertNotNull(this.contentCurator.get(content1.getUuid()));
-        assertNotNull(this.contentCurator.get(content2.getUuid()));
-        assertNotNull(this.contentCurator.get(content3.getUuid()));
+        assertIterableEquals(List.of(content1, content2, content3), this.contentCurator
+            .getContentsByUuids(List.of(content1.getUuid(), content2.getUuid(), content3.getUuid())));
 
         this.contentCurator.flush();
         this.contentCurator.clear();
@@ -609,9 +612,8 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         int output = this.contentCurator.bulkDeleteByUuids(Set.of(content1.getUuid(), content2.getUuid()));
         assertEquals(2, output);
 
-        assertNull(this.contentCurator.get(content1.getUuid()));
-        assertNull(this.contentCurator.get(content2.getUuid()));
-        assertNotNull(this.contentCurator.get(content3.getUuid()));
+        assertIterableEquals(List.of(content3), this.contentCurator
+            .getContentsByUuids(List.of(content1.getUuid(), content2.getUuid(), content3.getUuid())));
     }
 
     @Test
@@ -831,5 +833,51 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         Set<Content> output = this.contentCurator.getChildrenContentOfProductsByUuids(input);
         assertNotNull(output);
         assertTrue(output.isEmpty());
+    }
+
+    @Test
+    public void testListAllPaged() throws InterruptedException {
+        this.createContent();
+        // Ensures timestamp distinction
+        sleep(1000);
+        Content content2 = this.createContent();
+        sleep(1000);
+        Content content3 = this.createContent();
+        sleep(1000);
+        Content content4 = this.createContent();
+        sleep(1000);
+        Content content5 = this.createContent();
+        this.contentCurator.flush();
+        this.contentCurator.clear();
+
+        ContentQueryArguments args = new ContentQueryArguments();
+        args.setOffset(2);
+        args.setLimit(2);
+        args.addOrder("created", false);
+
+        List result = this.contentCurator.listAll(args);
+        assertEquals(2, result.size());
+        assertIterableEquals(List.of(content3, content4), result);
+
+        args = new ContentQueryArguments();
+        args.setOffset(0);
+        args.setLimit(4);
+        args.addOrder("created", true);
+
+        result = this.contentCurator.listAll(args);
+        assertEquals(4, result.size());
+        assertIterableEquals(List.of(content5, content4, content3, content2), result);
+    }
+
+    @Test
+    public void testGetContentCount() {
+        IntStream.range(0, 5).forEach(entry -> {
+            this.createContent();
+        });
+        this.contentCurator.flush();
+        this.contentCurator.clear();
+
+        Long result = this.contentCurator.getContentCount();
+        assertEquals(5L, result);
     }
 }


### PR DESCRIPTION
- Created new methods in ContentCurator listAll and getContentCount to take QueryArguments
- Updated ConsumerResource method getContents to take paging parameters and use them to call the new curator methods
- Updated candlepin-api-spec.yaml to include the paging parameters