### PR TITLE
CANDLEPIN-234: Added paging to GET /deleted_consumers endpoint

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -2952,6 +2952,10 @@ paths:
             type: string
             format: date-time
           description: Filter deleted consumers to those on or after this date
+        - $ref: "#/components/parameters/paging_page"
+        - $ref: "#/components/parameters/paging_per_page"
+        - $ref: "#/components/parameters/paging_order"
+        - $ref: "#/components/parameters/paging_sort_by"
       x-java-response:
         type: java.util.stream.Stream
         isContainer: true

--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/InactiveConsumerCleanerJobSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/InactiveConsumerCleanerJobSpecTest.java
@@ -113,7 +113,7 @@ public class InactiveConsumerCleanerJobSpecTest {
         assertGone(() -> consumerApi.getConsumer(inactiveConsumer1Uuid));
         // Verify that the inactive consumer has been moved to the deleted_consumers table.
         List<DeletedConsumerDTO> deletedConsumers = deletedConsumerApi
-            .listByDate(inactiveConsumer.getCreated());
+            .listByDate(inactiveConsumer.getCreated(), 1, 50, "desc", "created");
         // Assert that other tests might have created an inactive consumer
         assertThat(deletedConsumers).hasSizeGreaterThanOrEqualTo(1);
         Optional<DeletedConsumerDTO> deletedConsumer = deletedConsumers.stream()

--- a/src/main/java/org/candlepin/resource/DeletedConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/DeletedConsumerResource.java
@@ -14,15 +14,22 @@
  */
 package org.candlepin.resource;
 
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.Configuration;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.server.v1.DeletedConsumerDTO;
+import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.model.DeletedConsumer;
 import org.candlepin.model.DeletedConsumerCurator;
+import org.candlepin.model.DeletedConsumerCurator.DeletedConsumerQueryArguments;
+import org.candlepin.paging.Page;
+import org.candlepin.paging.PageRequest;
 import org.candlepin.resource.server.v1.DeletedConsumerApi;
-import org.candlepin.util.Util;
+
+import org.jboss.resteasy.core.ResteasyContext;
+import org.xnap.commons.i18n.I18n;
 
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -33,21 +40,56 @@ import javax.inject.Inject;
  */
 public class DeletedConsumerResource implements DeletedConsumerApi {
     private final DeletedConsumerCurator deletedConsumerCurator;
+    private final I18n i18n;
     private final ModelTranslator translator;
+    private final Configuration config;
 
     @Inject
-    public DeletedConsumerResource(DeletedConsumerCurator deletedConsumerCurator,
-        ModelTranslator translator) {
+    public DeletedConsumerResource(DeletedConsumerCurator deletedConsumerCurator, I18n i18n,
+        ModelTranslator translator, Configuration config) {
+        this.i18n = Objects.requireNonNull(i18n);
         this.deletedConsumerCurator = Objects.requireNonNull(deletedConsumerCurator);
         this.translator = Objects.requireNonNull(translator);
+        this.config = Objects.requireNonNull(config);
     }
 
     @Override
-    public Stream<DeletedConsumerDTO> listByDate(OffsetDateTime date) {
-        List<DeletedConsumer> deletedConsumers = date != null ?
-            this.deletedConsumerCurator.findByDate(Util.toDate(date)) :
-            this.deletedConsumerCurator.listAll();
-        return deletedConsumers.stream()
+    public Stream<DeletedConsumerDTO> listByDate(OffsetDateTime date, Integer page, Integer perPage,
+        String order, String sortBy) {
+        PageRequest pageRequest = ResteasyContext.getContextData(PageRequest.class);
+        DeletedConsumerQueryArguments queryArgs = new DeletedConsumerQueryArguments();
+        long count = this.deletedConsumerCurator.getDeletedConsumerCount(queryArgs);
+
+        if (pageRequest != null) {
+            Page<Stream<DeletedConsumerDTO>> pageResponse = new Page<>();
+            pageResponse.setPageRequest(pageRequest);
+
+            if (pageRequest.isPaging()) {
+                queryArgs.setOffset((pageRequest.getPage() - 1) * pageRequest.getPerPage())
+                    .setLimit(pageRequest.getPerPage());
+            }
+
+            if (pageRequest.getSortBy() != null) {
+                boolean reverse = pageRequest.getOrder() == PageRequest.DEFAULT_ORDER;
+                queryArgs.addOrder(pageRequest.getSortBy(), reverse);
+            }
+
+            pageResponse.setMaxRecords((int) count);
+
+            // Store the page for the LinkHeaderResponseFilter
+            ResteasyContext.pushContext(Page.class, pageResponse);
+        }
+        // If no paging was specified, force a limit on amount of results
+        else {
+            int maxSize = config.getInt(ConfigProperties.MAX_PAGING_SIZE);
+            if (count > maxSize) {
+                String errmsg = this.i18n.tr("This endpoint does not support returning more than {0} " +
+                    "results at a time, please use paging.", maxSize);
+                throw new BadRequestException(errmsg);
+            }
+        }
+
+        return this.deletedConsumerCurator.listAll(queryArgs).stream()
             .map(this.translator.getStreamMapper(DeletedConsumer.class, DeletedConsumerDTO.class));
     }
 }

--- a/src/test/java/org/candlepin/resource/DeletedConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/DeletedConsumerResourceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resource;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.candlepin.config.DevConfig;
+import org.candlepin.config.TestConfig;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.SimpleModelTranslator;
+import org.candlepin.dto.api.server.v1.DeletedConsumerDTO;
+import org.candlepin.dto.api.v1.DeletedConsumerTranslator;
+import org.candlepin.exceptions.BadRequestException;
+import org.candlepin.model.DeletedConsumer;
+import org.candlepin.model.DeletedConsumerCurator;
+import org.candlepin.model.DeletedConsumerCurator.DeletedConsumerQueryArguments;
+import org.candlepin.paging.PageRequest;
+
+import org.jboss.resteasy.core.ResteasyContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.time.OffsetDateTime;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+
+
+@ExtendWith(MockitoExtension.class)
+public class DeletedConsumerResourceTest {
+    private ModelTranslator modelTranslator;
+    private DeletedConsumerCurator deletedConsumerCurator;
+    private I18n i18n;
+
+    private DevConfig config;
+    private DeletedConsumerResource deletedConsumerResource;
+
+    @BeforeEach
+    public void setUp() {
+        this.config = TestConfig.defaults();
+        this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
+        this.deletedConsumerCurator = mock(DeletedConsumerCurator.class);
+        this.modelTranslator = new SimpleModelTranslator();
+        this.modelTranslator.registerTranslator(new DeletedConsumerTranslator(), DeletedConsumer.class,
+            DeletedConsumerDTO.class);
+        this.deletedConsumerResource = new DeletedConsumerResource(this.deletedConsumerCurator, i18n,
+            modelTranslator, config);
+    }
+
+    @Test
+    public void testListByDate() {
+        when(deletedConsumerCurator.listAll(any(DeletedConsumerQueryArguments.class))).
+            thenReturn(new LinkedList<>());
+        ResteasyContext.pushContext(PageRequest.class,
+            new PageRequest()
+                .setPage(1)
+                .setPerPage(10)
+                .setSortBy("created"));
+        deletedConsumerResource.listByDate(OffsetDateTime.now(), 1, 10, "asc", "created");
+        verify(deletedConsumerCurator, atLeastOnce()).listAll(any(DeletedConsumerQueryArguments.class));
+        ResteasyContext.popContextData(PageRequest.class);
+    }
+
+    @Test
+    public void testGetContentsOverMaxNoPaging() {
+        when(deletedConsumerCurator.getDeletedConsumerCount(any(DeletedConsumerQueryArguments.class)))
+            .thenReturn(10001L);
+        assertThrows(BadRequestException.class, () -> deletedConsumerResource.listByDate(
+            null, null, null, null, null));
+    }
+
+    @Test
+    public void testGetContentsNoPaging() {
+        when(deletedConsumerCurator.getDeletedConsumerCount(any(DeletedConsumerQueryArguments.class)))
+            .thenReturn(1L);
+        when(deletedConsumerCurator.listAll(any(DeletedConsumerQueryArguments.class)))
+            .thenReturn(List.of(new DeletedConsumer()));
+        assertEquals(1, deletedConsumerResource.listByDate(null, null, null, null, null).toList().size());
+    }
+}


### PR DESCRIPTION
- Created new method in DeletedConsumerCurator listAll with DeletedConsumerQueryArguments
- Updated DeletedConsumerResource method listByDate to take paging parameters and call the new curator method
- Updated candlepin-api-spec.yaml to include the paging parameters