### PR TITLE
[M] CANDLEPIN-819: Added max page size option for request paging

### DIFF
--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -293,6 +293,10 @@ public class ConfigProperties {
     // How long (in seconds) to wait for job threads to finish during a graceful Tomcat shutdown
     public static final String ASYNC_JOBS_THREAD_SHUTDOWN_TIMEOUT = "candlepin.async.thread.shutdown.timeout";
 
+    // The maximum allowable size for pages; defaults to 3000
+    public static final String PAGING_MAX_PAGE_SIZE = "candlepin.paging.max_page_size";
+
+
     /**
      * Fetches a string representing the prefix for all per-job configuration for the specified job.
      * The job key or class name may be used, but the usage must be consistent.
@@ -535,6 +539,9 @@ public class ConfigProperties {
             this.put(DatabaseConfigFactory.CASE_OPERATOR_BLOCK_SIZE, "100");
             this.put(DatabaseConfigFactory.BATCH_BLOCK_SIZE, "500");
             this.put(DatabaseConfigFactory.QUERY_PARAMETER_LIMIT, "32000");
+
+            // Paging defaults
+            this.put(PAGING_MAX_PAGE_SIZE, "3000");
         }
     };
 }

--- a/src/main/java/org/candlepin/resteasy/filter/PageRequestFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/PageRequestFilter.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.resteasy.filter;
 
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.Configuration;
 import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.paging.PageRequest;
 import org.candlepin.paging.PageRequest.Order;
@@ -39,16 +41,32 @@ import javax.ws.rs.ext.Provider;
 @Provider
 @Priority(Priorities.USER)
 public class PageRequestFilter implements ContainerRequestFilter {
+    private final Configuration config;
     private final javax.inject.Provider<I18n> i18nProvider;
 
+    private final int maxPageSize;
+
     @Inject
-    public PageRequestFilter(javax.inject.Provider<I18n> i18nProvider) {
+    public PageRequestFilter(Configuration config, javax.inject.Provider<I18n> i18nProvider) {
+        this.config = Objects.requireNonNull(config);
         this.i18nProvider = Objects.requireNonNull(i18nProvider);
+
+        this.maxPageSize = this.config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
+    }
+
+    private BadRequestException buildPageSizeException(int maxSize) {
+        I18n i18n = this.i18nProvider.get();
+        return new BadRequestException(i18n.tr("page size cannot exceed {0} elements", maxSize));
+    }
+
+    private BadRequestException buildIntegerParsingException(String field) {
+        I18n i18n = this.i18nProvider.get();
+        return new BadRequestException(i18n.tr("param \"{0}\" must be a positive integer", field));
     }
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
-        PageRequest p = null;
+        PageRequest pageRequest = null;
 
         MultivaluedMap<String, String> params = requestContext.getUriInfo().getQueryParameters();
 
@@ -58,41 +76,36 @@ public class PageRequestFilter implements ContainerRequestFilter {
         String sortBy = params.getFirst(PageRequest.SORT_BY_PARAM);
 
         if (page != null || perPage != null || order != null || sortBy != null) {
-            p = new PageRequest();
+            pageRequest = new PageRequest()
+                .setOrder(PageRequest.DEFAULT_ORDER);
 
-            if (order == null) {
-                p.setOrder(PageRequest.DEFAULT_ORDER);
-            }
-            else {
-                p.setOrder(readOrder(order));
+            if (order != null) {
+                pageRequest.setOrder(readOrder(order));
             }
 
-            /* We'll leave it to the curator layer to figure out what to sort by if
-             * sortBy is null. */
-            p.setSortBy(sortBy);
+            // We'll leave it to the curator layer to figure out what to sort by if sortBy is null.
+            pageRequest.setSortBy(sortBy);
 
-            try {
-                if (page == null && perPage != null) {
-                    p.setPage(PageRequest.DEFAULT_PAGE);
-                    p.setPerPage(readInteger(perPage));
+            if (page != null || perPage != null) {
+                pageRequest.setPage(PageRequest.DEFAULT_PAGE)
+                    .setPerPage(PageRequest.DEFAULT_PER_PAGE);
+
+                if (page != null) {
+                    pageRequest.setPage(this.readInteger(PageRequest.PAGE_PARAM, page));
                 }
-                else if (page != null && perPage == null) {
-                    p.setPage(readInteger(page));
-                    p.setPerPage(PageRequest.DEFAULT_PER_PAGE);
+
+                if (perPage != null) {
+                    int perPageValue = this.readInteger(PageRequest.PER_PAGE_PARAM, perPage);
+                    if (perPageValue > this.maxPageSize) {
+                        throw this.buildPageSizeException(this.maxPageSize);
+                    }
+
+                    pageRequest.setPerPage(perPageValue);
                 }
-                else {
-                    p.setPage(readInteger(page));
-                    p.setPerPage(readInteger(perPage));
-                }
-            }
-            catch (NumberFormatException nfe) {
-                I18n i18n = this.i18nProvider.get();
-                throw new BadRequestException(i18n.tr("offset and limit parameters" +
-                    " must be positive integers"), nfe);
             }
         }
 
-        ResteasyContext.pushContext(PageRequest.class, p);
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
     }
 
     private Order readOrder(String order) {
@@ -105,20 +118,21 @@ public class PageRequestFilter implements ContainerRequestFilter {
 
         I18n i18n = this.i18nProvider.get();
         throw new BadRequestException(i18n.tr("the order parameter must be either" +
-                " \"ascending\" or \"descending\""));
+            " \"ascending\" or \"descending\""));
     }
 
-    private Integer readInteger(String value) {
-        if (value != null) {
-            int i = Integer.parseInt(value);
+    private int readInteger(String field, String value) {
+        try {
+            int parsed = Integer.parseInt(value);
 
-            if (i <= 0) {
-                I18n i18n = this.i18nProvider.get();
-                throw new NumberFormatException(i18n.tr("Expected a positive integer."));
+            if (parsed <= 0) {
+                throw this.buildIntegerParsingException(field);
             }
-            return i;
-        }
 
-        return null;
+            return parsed;
+        }
+        catch (NumberFormatException e) {
+            throw this.buildIntegerParsingException(field);
+        }
     }
 }


### PR DESCRIPTION
- Added a new option, candlepin.paging.max_page_size, for controlling the maximum size of a given page request; defaults to 3000
- Updated the PageRequestFilter to throw a BadRequestException if a page size is specified larger than the configured max page size