### PR TITLE
[F] CANDLEPIN-819: Added enforcement of the max page size configuration

### DIFF
--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -187,8 +187,8 @@ public class ConfigProperties {
         "candlepin.cache.anonymous.cert.content.max_entries";
 
     // Paging
-    public static final String PAGING_SIZE = "candlepin.paging.default_page_size";
-    public static final String MAX_PAGING_SIZE = "candlepin.paging.max_page_size";
+    public static final String PAGING_DEFAULT_PAGE_SIZE = "candlepin.paging.default_page_size";
+    public static final String PAGING_MAX_PAGE_SIZE = "candlepin.paging.max_page_size";
 
     public static final String SYNC_WORK_DIR = "candlepin.sync.work_dir";
 
@@ -421,8 +421,8 @@ public class ConfigProperties {
             this.put(CACHE_ANON_CERT_CONTENT_TTL, "120000"); // milliseconds
             this.put(CACHE_ANON_CERT_CONTENT_MAX_ENTRIES, "10000");
 
-            this.put(PAGING_SIZE, "10");
-            this.put(MAX_PAGING_SIZE, "1000");
+            this.put(PAGING_DEFAULT_PAGE_SIZE, "10");
+            this.put(PAGING_MAX_PAGE_SIZE, "3000");
 
             this.put(SUSPEND_MODE_ENABLED, "true");
 
@@ -554,11 +554,11 @@ public class ConfigProperties {
      */
     public static final List<ConfigurationValidator> CONFIGURATION_VALIDATORS = new ArrayList<>() {
         {
-            this.add(new IntegerConfigurationValidator(PAGING_SIZE)
+            this.add(new IntegerConfigurationValidator(PAGING_DEFAULT_PAGE_SIZE)
                 .min(1)
-                .lessThan(MAX_PAGING_SIZE));
+                .lessThan(PAGING_MAX_PAGE_SIZE));
 
-            this.add(new IntegerConfigurationValidator(MAX_PAGING_SIZE)
+            this.add(new IntegerConfigurationValidator(PAGING_MAX_PAGE_SIZE)
                 .min(1));
         }
     };

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -647,7 +647,7 @@ public class ConsumerResource implements ConsumerApi {
         }
         // If no paging was specified, force a limit on amount of results
         else {
-            int maxSize = config.getInt(ConfigProperties.MAX_PAGING_SIZE);
+            int maxSize = config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
             if (count > maxSize) {
                 String errmsg = this.i18n.tr("This endpoint does not support returning more than {0} " +
                     "results at a time, please use paging.", maxSize);

--- a/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/src/main/java/org/candlepin/resource/ContentResource.java
@@ -78,7 +78,7 @@ public class ContentResource implements ContentApi {
         }
         // If no paging was specified, force a limit on amount of results
         else {
-            int maxSize = config.getInt(ConfigProperties.MAX_PAGING_SIZE);
+            int maxSize = config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
             if (count > maxSize) {
                 String errmsg = this.i18n.tr("This endpoint does not support returning more than {0} " +
                     "results at a time, please use paging.", maxSize);

--- a/src/main/java/org/candlepin/resource/DeletedConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/DeletedConsumerResource.java
@@ -81,7 +81,7 @@ public class DeletedConsumerResource implements DeletedConsumerApi {
         }
         // If no paging was specified, force a limit on amount of results
         else {
-            int maxSize = config.getInt(ConfigProperties.MAX_PAGING_SIZE);
+            int maxSize = config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
             if (count > maxSize) {
                 String errmsg = this.i18n.tr("This endpoint does not support returning more than {0} " +
                     "results at a time, please use paging.", maxSize);

--- a/src/main/java/org/candlepin/resource/JobResource.java
+++ b/src/main/java/org/candlepin/resource/JobResource.java
@@ -210,7 +210,7 @@ public class JobResource implements JobsApi {
         }
         // If no paging was specified, force a limit on amount of results
         else {
-            int maxSize = config.getInt(ConfigProperties.MAX_PAGING_SIZE);
+            int maxSize = config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
             if (count > maxSize) {
                 String errmsg = this.i18n.tr("This endpoint does not support returning more than {0} " +
                     "results at a time, please use paging.", maxSize);

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -263,7 +263,7 @@ public class OwnerResource implements OwnerApi {
         this.validator = Objects.requireNonNull(validator);
         this.principalProvider = Objects.requireNonNull(principalProvider);
         this.pagingUtilFactory = Objects.requireNonNull(pagingUtilFactory);
-        this.maxPagingSize = this.config.getInt(ConfigProperties.MAX_PAGING_SIZE);
+        this.maxPagingSize = this.config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
     }
 
     /**
@@ -1166,7 +1166,7 @@ public class OwnerResource implements OwnerApi {
         }
         // If no paging was specified, force a limit on amount of results
         else {
-            int maxSize = config.getInt(ConfigProperties.MAX_PAGING_SIZE);
+            int maxSize = config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
             if (count > maxSize) {
                 String errmsg = this.i18n.tr("This endpoint does not support returning more than {0} " +
                     "results at a time, please use paging.", maxSize);

--- a/src/main/java/org/candlepin/resteasy/filter/PageRequestFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/PageRequestFilter.java
@@ -41,18 +41,35 @@ import javax.ws.rs.ext.Provider;
 @Provider
 @Priority(Priorities.USER)
 public class PageRequestFilter implements ContainerRequestFilter {
+
+    private final Configuration config;
     private final javax.inject.Provider<I18n> i18nProvider;
-    private final Configuration configuration;
+
+    private final int defaultPageSize;
+    private final int maxPageSize;
 
     @Inject
-    public PageRequestFilter(javax.inject.Provider<I18n> i18nProvider, Configuration configuration) {
+    public PageRequestFilter(Configuration config, javax.inject.Provider<I18n> i18nProvider) {
+        this.config = Objects.requireNonNull(config);
         this.i18nProvider = Objects.requireNonNull(i18nProvider);
-        this.configuration = Objects.requireNonNull(configuration);
+
+        this.defaultPageSize = this.config.getInt(ConfigProperties.PAGING_DEFAULT_PAGE_SIZE);
+        this.maxPageSize = this.config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
+    }
+
+    private BadRequestException buildPageSizeException(int maxSize) {
+        I18n i18n = this.i18nProvider.get();
+        return new BadRequestException(i18n.tr("page size cannot exceed {0} elements", maxSize));
+    }
+
+    private BadRequestException buildIntegerParsingException(String field) {
+        I18n i18n = this.i18nProvider.get();
+        return new BadRequestException(i18n.tr("param \"{0}\" must be a positive integer", field));
     }
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
-        PageRequest p = null;
+        PageRequest pageRequest = null;
 
         MultivaluedMap<String, String> params = requestContext.getUriInfo().getQueryParameters();
 
@@ -62,42 +79,36 @@ public class PageRequestFilter implements ContainerRequestFilter {
         String sortBy = params.getFirst(PageRequest.SORT_BY_PARAM);
 
         if (page != null || perPage != null || order != null || sortBy != null) {
-            p = new PageRequest();
+            pageRequest = new PageRequest()
+                .setOrder(PageRequest.DEFAULT_ORDER);
 
-            if (order == null) {
-                p.setOrder(PageRequest.DEFAULT_ORDER);
-            }
-            else {
-                p.setOrder(readOrder(order));
+            if (order != null) {
+                pageRequest.setOrder(readOrder(order));
             }
 
-            /* We'll leave it to the curator layer to figure out what to sort by if
-             * sortBy is null. */
-            p.setSortBy(sortBy);
+            // We'll leave it to the curator layer to figure out what to sort by if sortBy is null.
+            pageRequest.setSortBy(sortBy);
 
-            try {
-                if (page == null && perPage != null) {
-                    p.setPage(PageRequest.DEFAULT_PAGE);
-                    p.setPerPage(readInteger(perPage));
+            if (page != null || perPage != null) {
+                pageRequest.setPage(PageRequest.DEFAULT_PAGE)
+                    .setPerPage(this.defaultPageSize);
+
+                if (page != null) {
+                    pageRequest.setPage(this.readInteger(PageRequest.PAGE_PARAM, page));
                 }
-                else if (page != null && perPage == null) {
-                    int pagingSize = this.configuration.getInt(ConfigProperties.PAGING_SIZE);
-                    p.setPage(readInteger(page));
-                    p.setPerPage(pagingSize);
+
+                if (perPage != null) {
+                    int perPageValue = this.readInteger(PageRequest.PER_PAGE_PARAM, perPage);
+                    if (perPageValue > this.maxPageSize) {
+                        throw this.buildPageSizeException(this.maxPageSize);
+                    }
+
+                    pageRequest.setPerPage(perPageValue);
                 }
-                else {
-                    p.setPage(readInteger(page));
-                    p.setPerPage(readInteger(perPage));
-                }
-            }
-            catch (NumberFormatException nfe) {
-                I18n i18n = this.i18nProvider.get();
-                throw new BadRequestException(i18n.tr("offset and limit parameters" +
-                    " must be positive integers"), nfe);
             }
         }
 
-        ResteasyContext.pushContext(PageRequest.class, p);
+        ResteasyContext.pushContext(PageRequest.class, pageRequest);
     }
 
     private Order readOrder(String order) {
@@ -110,20 +121,21 @@ public class PageRequestFilter implements ContainerRequestFilter {
 
         I18n i18n = this.i18nProvider.get();
         throw new BadRequestException(i18n.tr("the order parameter must be either" +
-                " \"ascending\" or \"descending\""));
+            " \"ascending\" or \"descending\""));
     }
 
-    private Integer readInteger(String value) {
-        if (value != null) {
-            int i = Integer.parseInt(value);
+    private int readInteger(String field, String value) {
+        try {
+            int parsed = Integer.parseInt(value);
 
-            if (i <= 0) {
-                I18n i18n = this.i18nProvider.get();
-                throw new NumberFormatException(i18n.tr("Expected a positive integer."));
+            if (parsed <= 0) {
+                throw this.buildIntegerParsingException(field);
             }
-            return i;
-        }
 
-        return null;
+            return parsed;
+        }
+        catch (NumberFormatException e) {
+            throw this.buildIntegerParsingException(field);
+        }
     }
 }

--- a/src/test/java/org/candlepin/config/TestConfig.java
+++ b/src/test/java/org/candlepin/config/TestConfig.java
@@ -60,8 +60,8 @@ public final class TestConfig {
         defaults.put(DatabaseConfigFactory.QUERY_PARAMETER_LIMIT, "32000");
         defaults.put(ConfigProperties.CACHE_ANON_CERT_CONTENT_TTL, "120000");
         defaults.put(ConfigProperties.CACHE_ANON_CERT_CONTENT_MAX_ENTRIES, "10000");
-        defaults.put(ConfigProperties.PAGING_SIZE, "100");
-        defaults.put(ConfigProperties.MAX_PAGING_SIZE, "10000");
+        defaults.put(ConfigProperties.PAGING_DEFAULT_PAGE_SIZE, "100");
+        defaults.put(ConfigProperties.PAGING_MAX_PAGE_SIZE, "10000");
 
         return defaults;
     }

--- a/src/test/java/org/candlepin/resteasy/filter/PageRequestFilterTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/PageRequestFilterTest.java
@@ -16,13 +16,16 @@ package org.candlepin.resteasy.filter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
 import org.candlepin.config.ConfigProperties;
-import org.candlepin.config.Configuration;
+import org.candlepin.config.DevConfig;
+import org.candlepin.config.TestConfig;
 import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.guice.I18nProvider;
 import org.candlepin.paging.PageRequest;
@@ -32,12 +35,14 @@ import org.jboss.resteasy.mock.MockHttpRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.xnap.commons.i18n.I18n;
 
+import java.net.URISyntaxException;
+
+import javax.inject.Provider;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.ContainerRequestContext;
 
@@ -50,33 +55,36 @@ import javax.ws.rs.container.ContainerRequestContext;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class PageRequestFilterTest {
 
-    @Mock
-    private HttpServletRequest mockServletReq;
-
-    private javax.inject.Provider<I18n> i18nProvider;
-    private PageRequestFilter interceptor;
-
-    private MockHttpRequest mockReq;
-    @Mock
-    private ContainerRequestContext mockRequestContext;
-    @Mock
-    private Configuration mockConfiguration;
-
-    private int defaultPageSize = 1000;
+    private DevConfig config;
+    private Provider<I18n> i18nProvider;
 
     @BeforeEach
     public void setUp() {
-        this.i18nProvider = new I18nProvider(() -> this.mockServletReq);
-        doReturn(defaultPageSize).when(mockConfiguration).getInt(ConfigProperties.PAGING_SIZE);
-        interceptor = new PageRequestFilter(this.i18nProvider, this.mockConfiguration);
+        this.config = TestConfig.defaults();
+
+        HttpServletRequest mockServletRequest = mock(HttpServletRequest.class);
+        this.i18nProvider = new I18nProvider(() -> mockServletRequest);
+    }
+
+    private PageRequestFilter buildPageRequestFilter() {
+        return new PageRequestFilter(this.config, this.i18nProvider);
+    }
+
+    private ContainerRequestContext mockRequestContext(String method, String uri) throws URISyntaxException {
+        MockHttpRequest mockRequest = MockHttpRequest.create(method, uri);
+
+        ContainerRequestContext mockRequestContext = mock(ContainerRequestContext.class);
+        doReturn(mockRequest.getUri()).when(mockRequestContext).getUriInfo();
+
+        return mockRequestContext;
     }
 
     @Test
     public void testNoAnything() throws Exception {
-        mockReq = MockHttpRequest.create("GET",
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
             "http://localhost/candlepin/status");
-        when(mockRequestContext.getUriInfo()).thenReturn(mockReq.getUri());
 
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
         interceptor.filter(mockRequestContext);
 
         PageRequest p = ResteasyContext.getContextData(PageRequest.class);
@@ -85,10 +93,10 @@ public class PageRequestFilterTest {
 
     @Test
     public void testBothLimitAndPage() throws Exception {
-        mockReq = MockHttpRequest.create("GET",
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
             "http://localhost/candlepin/status?per_page=10&page=4");
-        when(mockRequestContext.getUriInfo()).thenReturn(mockReq.getUri());
 
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
         interceptor.filter(mockRequestContext);
 
         PageRequest p = ResteasyContext.getContextData(PageRequest.class);
@@ -100,10 +108,13 @@ public class PageRequestFilterTest {
 
     @Test
     public void testNoLimitButPage() throws Exception {
-        mockReq = MockHttpRequest.create("GET",
-            "http://localhost/candlepin/status?page=5");
-        when(mockRequestContext.getUriInfo()).thenReturn(mockReq.getUri());
+        int defaultPageSize = 15;
+        this.config.setProperty(ConfigProperties.PAGING_DEFAULT_PAGE_SIZE, String.valueOf(defaultPageSize));
 
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
+            "http://localhost/candlepin/status?page=5");
+
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
         interceptor.filter(mockRequestContext);
 
         PageRequest p = ResteasyContext.getContextData(PageRequest.class);
@@ -115,10 +126,10 @@ public class PageRequestFilterTest {
 
     @Test
     public void testLimitButNoPage() throws Exception {
-        mockReq = MockHttpRequest.create("GET",
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
             "http://localhost/candlepin/status?per_page=10");
-        when(mockRequestContext.getUriInfo()).thenReturn(mockReq.getUri());
 
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
         interceptor.filter(mockRequestContext);
 
         PageRequest p = ResteasyContext.getContextData(PageRequest.class);
@@ -130,28 +141,28 @@ public class PageRequestFilterTest {
 
     @Test
     public void testBadIntegerValue() throws Exception {
-        mockReq = MockHttpRequest.create("GET",
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
             "http://localhost/candlepin/status?page=foo&per_page=456");
-        when(mockRequestContext.getUriInfo()).thenReturn(mockReq.getUri());
 
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
         assertThrows(BadRequestException.class, () -> interceptor.filter(mockRequestContext));
     }
 
     @Test
     public void testDoesNotAllowPageZero() throws Exception {
-        mockReq = MockHttpRequest.create("GET",
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
             "http://localhost/candlepin/status?page=0&per_page=456");
-        when(mockRequestContext.getUriInfo()).thenReturn(mockReq.getUri());
 
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
         assertThrows(BadRequestException.class, () -> interceptor.filter(mockRequestContext));
     }
 
     @Test
     public void testNoPagingIfJustOrderAndSortBy() throws Exception {
-        mockReq = MockHttpRequest.create("GET",
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
             "http://localhost/candlepin/status?order=asc&sort_by=id");
-        when(mockRequestContext.getUriInfo()).thenReturn(mockReq.getUri());
 
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
         interceptor.filter(mockRequestContext);
 
         PageRequest p = ResteasyContext.getContextData(PageRequest.class);
@@ -162,10 +173,10 @@ public class PageRequestFilterTest {
 
     @Test
     public void testUsesDefaultOrderIfNoOrderProvided() throws Exception {
-        mockReq = MockHttpRequest.create("GET",
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
             "http://localhost/candlepin/status?sort_by=id");
-        when(mockRequestContext.getUriInfo()).thenReturn(mockReq.getUri());
 
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
         interceptor.filter(mockRequestContext);
 
         PageRequest p = ResteasyContext.getContextData(PageRequest.class);
@@ -176,16 +187,47 @@ public class PageRequestFilterTest {
 
     @Test
     public void testDescendingOrder() throws Exception {
-        mockReq = MockHttpRequest.create("GET",
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
             "http://localhost/candlepin/status?order=descending&sort_by=id");
-        when(mockRequestContext.getUriInfo()).thenReturn(mockReq.getUri());
 
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
         interceptor.filter(mockRequestContext);
 
         PageRequest p = ResteasyContext.getContextData(PageRequest.class);
         assertFalse(p.isPaging());
         assertEquals(PageRequest.Order.DESCENDING, p.getOrder());
         assertEquals("id", p.getSortBy());
+    }
+
+    @Test
+    public void testFilterEnforcesMaxPageSize() throws Exception {
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
+            "http://localhost/candlepin/status?per_page=35");
+
+        this.config.setProperty(ConfigProperties.PAGING_MAX_PAGE_SIZE, "30");
+
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
+        BadRequestException exception = assertThrows(BadRequestException.class, () ->
+            interceptor.filter(mockRequestContext));
+
+        String errmsg = exception.getMessage();
+        assertNotNull(errmsg);
+        assertTrue(errmsg.contains("page size cannot exceed"));
+    }
+
+    @Test
+    public void testFilterAllowsMaxPageSize() throws Exception {
+        int maxPageSize = this.config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
+
+        ContainerRequestContext mockRequestContext = this.mockRequestContext("GET",
+            "http://localhost/candlepin/status?per_page=" + maxPageSize);
+
+        PageRequestFilter interceptor = this.buildPageRequestFilter();
+        interceptor.filter(mockRequestContext);
+
+        PageRequest pageRequest = ResteasyContext.getContextData(PageRequest.class);
+        assertNotNull(pageRequest);
+        assertEquals(maxPageSize, pageRequest.getPerPage());
     }
 
 }


### PR DESCRIPTION
- Updated the PageRequestFilter to throw a BadRequestException if a page size is specified larger than the configured max page size
- Increased the default max page size from 1000 to 3000
- Renamed the PAGING_SIZE and MAX_PAGING_SIZE constants to PAGING_DEFAULT_PAGE_SIZE and PAGING_MAX_PAGE_SIZE respectively