### PR TITLE
CANDLEPIN-734: Added paging to GET /products endpoint

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -6751,6 +6751,11 @@ paths:
       x-java-response:
         type: java.util.stream.Stream
         isContainer: true
+      parameters:
+        - $ref: "#/components/parameters/paging_page"
+        - $ref: "#/components/parameters/paging_per_page"
+        - $ref: "#/components/parameters/paging_order"
+        - $ref: "#/components/parameters/paging_sort_by"
       security: []
       responses:
         200:

--- a/src/main/java/org/candlepin/resource/ProductResource.java
+++ b/src/main/java/org/candlepin/resource/ProductResource.java
@@ -31,8 +31,12 @@ import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCertificateCurator;
 import org.candlepin.model.ProductCurator;
+import org.candlepin.model.ProductCurator.ProductQueryArguments;
+import org.candlepin.paging.Page;
+import org.candlepin.paging.PageRequest;
 import org.candlepin.resource.server.v1.ProductsApi;
 
+import org.jboss.resteasy.core.ResteasyContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
@@ -98,9 +102,42 @@ public class ProductResource implements ProductsApi {
     }
 
     @Override
-    public Stream<ProductDTO> getProducts() {
-        return this.productCurator.listAll()
-            .stream()
+    public Stream<ProductDTO> getProducts(Integer page, Integer perPage, String order, String sortBy) {
+        PageRequest pageRequest = ResteasyContext.getContextData(PageRequest.class);
+
+        ProductQueryArguments queryArgs = new ProductQueryArguments();
+
+        long count = this.productCurator.getProductCount(queryArgs);
+
+        if (pageRequest != null) {
+            Page<Stream<ProductDTO>> pageResponse = new Page<>();
+            pageResponse.setPageRequest(pageRequest);
+
+            if (pageRequest.isPaging()) {
+                queryArgs.setOffset((pageRequest.getPage() - 1) * pageRequest.getPerPage())
+                    .setLimit(pageRequest.getPerPage());
+            }
+
+            if (pageRequest.getSortBy() != null) {
+                boolean reverse = pageRequest.getOrder() == PageRequest.DEFAULT_ORDER;
+                queryArgs.addOrder(pageRequest.getSortBy(), reverse);
+            }
+            pageResponse.setMaxRecords((int) count);
+
+            // Store the page for the LinkHeaderResponseFilter
+            ResteasyContext.pushContext(Page.class, pageResponse);
+        }
+        // If no paging was specified, force a limit on amount of results
+        else {
+            int maxSize = config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
+            if (count > maxSize) {
+                String errmsg = this.i18n.tr("This endpoint does not support returning more than {0} " +
+                    "results at a time, please use paging.", maxSize);
+                throw new BadRequestException(errmsg);
+            }
+        }
+
+        return this.productCurator.listAll(queryArgs).stream()
             .map(this.translator.getStreamMapper(Product.class, ProductDTO.class));
     }
 

--- a/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.config.ConfigProperties;
+import org.candlepin.model.ProductCurator.ProductQueryArguments;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.AttributeValidator;
@@ -54,6 +55,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import javax.persistence.LockModeType;
@@ -1354,4 +1356,40 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         assertEquals(attributes, refreshed.getAttributes());
     }
 
+    @Test
+    public void testListAll() {
+        IntStream.range(0, 3).forEach(element -> {
+            createProduct("test_product-" + element);
+        });
+
+        ProductQueryArguments args = new ProductQueryArguments()
+            .setOffset(0);
+        assertEquals(3, productCurator.listAll(args).size());
+    }
+
+    @Test
+    public void testListAllPaged() {
+        IntStream.range(0, 10).forEach(element -> {
+            createProduct("test_product-" + element);
+        });
+
+        ProductQueryArguments args = new ProductQueryArguments()
+            .setOffset(3)
+            .setLimit(4);
+        List<Product> page = productCurator.listAll(args);
+        assertEquals(4, page.size());
+        assertEquals("test_product-3", page.get(0).getId());
+        assertEquals("test_product-6", page.get(3).getId());
+    }
+
+    @Test
+    public void testGetOwnerCount() {
+        IntStream.range(0, 10).forEach(element -> {
+            createProduct("test_product-" + element);
+        });
+
+        ProductQueryArguments args = new ProductQueryArguments();
+        Long result = productCurator.getProductCount(args);
+        assertEquals(10L, result);
+    }
 }


### PR DESCRIPTION
- Created new method in ProductCurator listAll with ProductQueryArguments
- Updated ProductResource method getProducts to take paging parameters and call the new curator method
- Updated candlepin-api-spec.yaml to include the paging parameters