### PR TITLE
[4.4.1] CANDLEPIN-833: Updated CloudAuthenticationResult validation

### DIFF
--- a/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
+++ b/src/main/java/org/candlepin/resource/CloudRegistrationResource.java
@@ -334,6 +334,18 @@ public class CloudRegistrationResource implements CloudRegistrationApi {
      *  if a required field does no meet the validation requirements
      */
     private void validateCloudAuthenticationResult(CloudAuthenticationResult result) {
+        if (result.isRegistrationOnly()) {
+            String ownerKey = result.getOwnerKey();
+            if (ownerKey == null || ownerKey.isBlank()) {
+                String errmsg = this.i18n.tr("Cloud registration is not supported for the type of " +
+                    "offering the client is using");
+
+                throw new NotImplementedException(errmsg);
+            }
+
+            return;
+        }
+
         String cloudAccountId = result.getCloudAccountId();
         if (cloudAccountId == null || cloudAccountId.isBlank()) {
             String errmsg = this.i18n.tr("cloud account ID could not be resolved");
@@ -367,14 +379,6 @@ public class CloudRegistrationResource implements CloudRegistrationApi {
             String errmsg = this.i18n.tr("product IDs could not be resolved");
 
             throw new CloudRegistrationAuthorizationException(errmsg);
-        }
-
-        String ownerKey = result.getOwnerKey();
-        if (result.isRegistrationOnly() && (ownerKey == null || ownerKey.isBlank())) {
-            String errmsg = this.i18n.tr("Cloud registration is not supported for the type of " +
-                "offering the client is using");
-
-            throw new NotImplementedException(errmsg);
         }
     }
 }

--- a/src/main/java/org/candlepin/testext/hostedtest/HostedTestCloudRegistrationAdapter.java
+++ b/src/main/java/org/candlepin/testext/hostedtest/HostedTestCloudRegistrationAdapter.java
@@ -157,17 +157,17 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
         return new CloudAuthenticationResult() {
             @Override
             public String getCloudAccountId() {
-                return accountId;
+                return isRegistrationOnly ? null : accountId;
             }
 
             @Override
             public String getCloudInstanceId() {
-                return instanceId;
+                return isRegistrationOnly ? null : instanceId;
             }
 
             @Override
             public String getCloudProvider() {
-                return "aws";
+                return isRegistrationOnly ? null : "aws";
             }
 
             @Override
@@ -177,12 +177,12 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
 
             @Override
             public String getOfferId() {
-                return offerId;
+                return isRegistrationOnly ? null : offerId;
             }
 
             @Override
             public Set<String> getProductIds() {
-                return productIds;
+                return isRegistrationOnly ? null : productIds;
             }
 
             @Override
@@ -192,7 +192,7 @@ public class HostedTestCloudRegistrationAdapter implements CloudRegistrationAdap
 
             @Override
             public boolean isEntitled() {
-                return isEntitled;
+                return isRegistrationOnly || isEntitled;
             }
         };
     }

--- a/src/test/java/org/candlepin/resource/CloudRegistrationResourceTest.java
+++ b/src/test/java/org/candlepin/resource/CloudRegistrationResourceTest.java
@@ -640,9 +640,8 @@ public class CloudRegistrationResourceTest {
             .signature("test-signature");
 
         String expectedOwnerKey = "ownerKey";
-        CloudAuthenticationResult result = buildMockAuthResult(TestUtil.randomString(),
-            TestUtil.randomString(), TestUtil.randomString(), expectedOwnerKey, TestUtil.randomString(),
-            Set.of(TestUtil.randomString()), false, true);
+        CloudAuthenticationResult result = buildMockAuthResult(null, null, null, expectedOwnerKey, null,
+            null, false, true);
         doReturn(result)
             .when(mockCloudRegistrationAdapter)
             .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
@@ -666,6 +665,29 @@ public class CloudRegistrationResourceTest {
             .returns(null, CloudAuthenticationResultDTO::getAnonymousConsumerUuid)
             .returns(expectedToken, CloudAuthenticationResultDTO::getToken)
             .returns(CloudAuthTokenType.STANDARD.toString(), CloudAuthenticationResultDTO::getTokenType);
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0} {1}")
+    @NullAndEmptySource
+    public void testCloudAuthorizeV2WithRegistrationOnlyAndInvalidOwnerKey(String ownerKey) {
+        CloudRegistrationDTO dto = new CloudRegistrationDTO()
+            .type("test-type")
+            .metadata("test-metadata")
+            .signature("test-signature");
+
+        String expectedOwnerKey = "ownerKey";
+        CloudAuthenticationResult result = buildMockAuthResult(null, null, null, ownerKey, null,
+            null, false, true);
+        doReturn(result)
+            .when(mockCloudRegistrationAdapter)
+            .resolveCloudRegistrationDataV2(getCloudRegistrationData(dto));
+
+        String expectedToken = TestUtil.randomString();
+        doReturn(expectedToken)
+            .when(mockTokenGenerator)
+            .buildStandardRegistrationToken(principal, expectedOwnerKey);
+
+        assertThrows(NotImplementedException.class, () -> cloudRegResource.cloudAuthorize(dto, 2));
     }
 
     @Test


### PR DESCRIPTION
- Updated CloudRegistrationResource.validateCloudAuthenticationResult to only validate the owner key when CloudAuthenticationResult has a true registration only value.

Changes cherry-picked from commit 058abe56ec156550311bbdd43dcfc3e75d70e339