### PR TITLE
[M] CANDLEPIN-829: Updated consumer activation key registration testing

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,6 @@ test-logger = { id = "com.adarshr.test-logger", version.ref = "test-logger" }
 artemis-server = { module = "org.apache.activemq:artemis-server", version.ref = "artemis" }
 artemis-stomp = { module = "org.apache.activemq:artemis-stomp-protocol", version.ref = "artemis" }
 assertj = { module = "org.assertj:assertj-core", version = "3.25.3" }
-awaitility = { module = "org.awaitility:awaitility", version = "4.2.1" }
 bouncycastle-prov = { module = "org.bouncycastle:bcprov-jdk18on", version = "1.77"}
 bouncycastle-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version = "1.77"}
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.1.8" }

--- a/spec-tests/build.gradle
+++ b/spec-tests/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     implementation(libs.okhttp.tls)
     implementation(libs.slf4j)
 
-    testImplementation(libs.awaitility)
     testImplementation(libs.jimfs)
 
     testRuntimeOnly(libs.junit.engine)


### PR DESCRIPTION
- Updated the concurrent activation key registration testing to no longer need the external awaitility library, nor need multiple runs to trigger deadlock when it's present