### PR TITLE
[F] CANDLEPIN-839: Updated schema to support environment content overrides

### DIFF
--- a/src/main/java/org/candlepin/model/ConsumerContentOverride.java
+++ b/src/main/java/org/candlepin/model/ConsumerContentOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -19,6 +19,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotNull;
 
 
 
@@ -31,11 +32,9 @@ import javax.persistence.ManyToOne;
 @DiscriminatorValue("consumer")
 public class ConsumerContentOverride extends ContentOverride<ConsumerContentOverride, Consumer> {
 
-    // TODO: FIXME: This field has no matching field on content, yet is permitted to be null?? If
-    // such an override is created, it'll be lost to the void and sit in the database until it is
-    // manually cleaned up.
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = true)
+    @JoinColumn(nullable = false)
+    @NotNull
     private Consumer consumer;
 
     public ConsumerContentOverride() {

--- a/src/main/java/org/candlepin/model/ContentOverride.java
+++ b/src/main/java/org/candlepin/model/ContentOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -42,7 +42,9 @@ import javax.validation.constraints.Size;
 @Entity
 @Table(name = ContentOverride.DB_TABLE)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorFormula("case when key_id is null then 'consumer' ELSE 'activation_key' end")
+@DiscriminatorFormula("CASE WHEN key_id IS NOT NULL THEN 'activation_key' " +
+    "WHEN environment_id IS NOT NULL THEN 'environment' " +
+    "ELSE 'consumer' END")
 public abstract class ContentOverride<T extends ContentOverride, P extends AbstractHibernateObject> extends
     AbstractHibernateObject<T> {
 
@@ -73,12 +75,6 @@ public abstract class ContentOverride<T extends ContentOverride, P extends Abstr
 
     public ContentOverride() {
         // Intentionally left empty
-    }
-
-    public ContentOverride(String contentLabel, String name, String value) {
-        this.setContentLabel(contentLabel);
-        this.setName(name);
-        this.setValue(value);
     }
 
     public String getId() {

--- a/src/main/java/org/candlepin/model/EnvironmentContentOverride.java
+++ b/src/main/java/org/candlepin/model/EnvironmentContentOverride.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotNull;
+
+
+
+/**
+ * A content override applied to an environment
+ */
+@Entity
+@DiscriminatorValue("environment")
+public class EnvironmentContentOverride extends ContentOverride<EnvironmentContentOverride, Environment> {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    @NotNull
+    private Environment environment;
+
+    /**
+     * Creates a new environment content override
+     */
+    public EnvironmentContentOverride() {
+        // Intentionally left empty
+    }
+
+    /**
+     * Fetches the environment this content override applies to. If the environment has not been
+     * set, this method returns null.
+     *
+     * @return
+     *  the environment to which this content override applies
+     */
+    public Environment getEnvironment() {
+        return environment;
+    }
+
+    /**
+     * Sets the environment to which this content override will apply. If the environment is null,
+     * any previously set value will be cleared.
+     *
+     * @param environment
+     *  the environment to which this content override should be applied, or null to clear any
+     *  existing environment value
+     *
+     * @return
+     *  a reference to this content override instance
+     */
+    public EnvironmentContentOverride setEnvironment(Environment environment) {
+        this.environment = environment;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Environment getParent() {
+        return this.getEnvironment();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EnvironmentContentOverride setParent(Environment parent) {
+        this.setEnvironment(parent);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        Environment environment = this.getEnvironment();
+
+        return String.format("EnvironmentContentOverride [environment: %s, content: %s, name: %s, value: %s]",
+            environment != null ? environment.getName() : null, this.getContentLabel(), this.getName(),
+            this.getValue());
+    }
+
+}

--- a/src/main/java/org/candlepin/model/activationkeys/ActivationKeyContentOverride.java
+++ b/src/main/java/org/candlepin/model/activationkeys/ActivationKeyContentOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -23,31 +23,25 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
+import javax.validation.constraints.NotNull;
+
+
 
 /**
  * ActivationKeyContentOverride
  */
 @Entity
-@XmlRootElement
-@XmlAccessorType(XmlAccessType.PROPERTY)
 @DiscriminatorValue("activation_key")
 public class ActivationKeyContentOverride extends
     ContentOverride<ActivationKeyContentOverride, ActivationKey> {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = true)
+    @JoinColumn(nullable = false)
+    @NotNull
     private ActivationKey key;
 
     public ActivationKeyContentOverride() {
-    }
-
-    public ActivationKeyContentOverride(ActivationKey key, String contentLabel, String name, String value) {
-        super(contentLabel, name, value);
-        this.setKey(key);
+        // Intentionally left empty
     }
 
     /**
@@ -72,16 +66,19 @@ public class ActivationKeyContentOverride extends
     /**
      * @return the parent activation key
      */
-    @XmlTransient
     public ActivationKey getKey() {
         return key;
     }
 
     /**
      * @param key the activation key
+     *
+     * @return
+     *  a reference to this content override
      */
-    public void setKey(ActivationKey key) {
+    public ActivationKeyContentOverride setKey(ActivationKey key) {
         this.key = key;
+        return this;
     }
 
     public ActivationKeyContentOverride setParent(ActivationKey parent) {

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -629,9 +629,11 @@ public class OwnerResource implements OwnerApi {
             else {
                 for (ContentOverrideDTO overrideDTO : dto.getContentOverrides()) {
                     if (overrideDTO != null) {
-                        entity.addContentOverride(
-                            new ActivationKeyContentOverride(entity, overrideDTO.getContentLabel(),
-                                overrideDTO.getName(), overrideDTO.getValue()));
+                        entity.addContentOverride(new ActivationKeyContentOverride()
+                            .setKey(entity)
+                            .setContentLabel(overrideDTO.getContentLabel())
+                            .setName(overrideDTO.getName())
+                            .setValue(overrideDTO.getValue()));
                     }
                 }
             }

--- a/src/main/resources/db/changelog/20240329143555-add_environment_content_override_schema.xml
+++ b/src/main/resources/db/changelog/20240329143555-add_environment_content_override_schema.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+    <changeSet id="20240329143555-1" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="cp_content_override" columnName="environment_id"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="cp_content_override">
+            <column name="environment_id" type="VARCHAR(32)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <addForeignKeyConstraint baseTableName="cp_content_override"
+            baseColumnNames="environment_id"
+            referencedTableName="cp_environment"
+            referencedColumnNames="id"
+            constraintName="fk_content_override_environment"
+            onDelete="CASCADE" />
+    </changeSet>
+
+    <changeSet id="20240329143555-2" author="crog">
+        <!--
+            Scrub the data to ensure we don't have malformed content overrides with both an AK and
+            a consumer set. We'll follow the design's outlined priority and clear the consumer on
+            any row that has a non-null key ID.
+
+            This way we need not worry (as much) about the constraint we'll be adding in the next
+            task.
+        -->
+
+        <sql dbms="mariadb, postgresql">
+            UPDATE cp_content_override SET consumer_id = NULL WHERE key_id IS NOT NULL
+        </sql>
+    </changeSet>
+
+    <changeSet id="20240329143555-3" author="crog">
+        <!--
+            This constraint has to be done as a direct SQL addition, since the "addCheckConstraint"
+            change type is limited to Liquibase "pro" and, frankly, Liquibase is not good enough or
+            valuable enough to justify that cost.
+
+            As an example of one of its many annoyances and shortcomings, at the time of writing,
+            there is not a "constraint exists" precondition check, so we get to deal with that
+            directly as well. Yipee!
+        -->
+        <sql dbms="mariadb, postgresql">
+            ALTER TABLE cp_content_override DROP CONSTRAINT IF EXISTS cp_content_override_entity_type;
+        </sql>
+
+        <sql dbms="mariadb, postgresql, hsqldb">
+            ALTER TABLE cp_content_override ADD CONSTRAINT cp_content_override_entity_type CHECK (
+                (key_id IS NOT NULL AND environment_id IS NULL AND consumer_id IS NULL) OR
+                (key_id IS NULL AND environment_id IS NOT NULL AND consumer_id IS NULL) OR
+                (key_id IS NULL AND environment_id IS NULL AND consumer_id IS NOT NULL)
+            );
+        </sql>
+    </changeSet>
+
+    <changeSet id="20240329143555-4" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="cp_content_override_idx2"/>
+            </not>
+        </preConditions>
+
+        <createIndex indexName="cp_content_override_idx2" tableName="cp_content_override">
+            <column name="environment_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20240329143555-5" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="cp_content_override_idx3"/>
+            </not>
+        </preConditions>
+
+        <createIndex indexName="cp_content_override_idx3" tableName="cp_content_override">
+            <column name="consumer_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -197,4 +197,5 @@
     <include file="db/changelog/20231024083400-hms-environment-changes.xml"/>
     <include file="db/changelog/202401081559-add-claimant-owner-column.xml"/>
     <include file="db/changelog/20240104162911-unrevoke-subscription-certs.xml"/>
+    <include file="db/changelog/20240329143555-add_environment_content_override_schema.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/model/ActivationKeyContentOverrideCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ActivationKeyContentOverrideCuratorTest.java
@@ -56,9 +56,19 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
         activationKeyCurator.create(key);
     }
 
+    private ActivationKeyContentOverride buildActivationKeyContentOverride(ActivationKey key,
+        String contentLabel, String name, String value) {
+
+        return new ActivationKeyContentOverride()
+            .setKey(key)
+            .setContentLabel(contentLabel)
+            .setName(name)
+            .setValue(value);
+    }
+
     @Test
     public void normalCreateAndRetrieve() {
-        ActivationKeyContentOverride cco = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco = this.buildActivationKeyContentOverride(
             key, "test-content", "name", "value");
         activationKeyContentOverrideCurator.create(cco);
 
@@ -70,7 +80,7 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void normalCreateAndUpdate() {
-        ActivationKeyContentOverride cco = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco = this.buildActivationKeyContentOverride(
             key, "test-content", "name", "value");
         activationKeyContentOverrideCurator.create(cco);
 
@@ -85,7 +95,7 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void deleteByName() {
-        ActivationKeyContentOverride cco = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco = this.buildActivationKeyContentOverride(
             key, "test-content", "name", "value");
         activationKeyContentOverrideCurator.create(cco);
 
@@ -97,10 +107,10 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void deleteByLabel() {
-        ActivationKeyContentOverride cco1 = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco1 = this.buildActivationKeyContentOverride(
             key, "test-content", "name1", "value");
         activationKeyContentOverrideCurator.create(cco1);
-        ActivationKeyContentOverride cco2 = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco2 = this.buildActivationKeyContentOverride(
             key, "test-content", "name2", "value");
         activationKeyContentOverrideCurator.create(cco2);
 
@@ -111,10 +121,10 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void deleteByConsumer() {
-        ActivationKeyContentOverride cco1 = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco1 = this.buildActivationKeyContentOverride(
             key, "test-content1", "name1", "value");
         activationKeyContentOverrideCurator.create(cco1);
-        ActivationKeyContentOverride cco2 = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco2 = this.buildActivationKeyContentOverride(
             key, "test-content2", "name2", "value");
         activationKeyContentOverrideCurator.create(cco2);
 
@@ -125,10 +135,10 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void testAddOrUpdateUpdatesValue() {
-        ActivationKeyContentOverride cco1 = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco1 = this.buildActivationKeyContentOverride(
             key, "test-content1", "name1", "value");
         activationKeyContentOverrideCurator.create(cco1);
-        ActivationKeyContentOverride cco2 = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco2 = this.buildActivationKeyContentOverride(
             key, "test-content1", "name1", "value2");
         activationKeyContentOverrideCurator.addOrUpdate(key, cco2);
 
@@ -139,10 +149,10 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void testAddOrUpdateCreatesNew() {
-        ActivationKeyContentOverride cco1 = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco1 = this.buildActivationKeyContentOverride(
             key, "test-content1", "name1", "value");
         activationKeyContentOverrideCurator.create(cco1);
-        ActivationKeyContentOverride cco2 = new ActivationKeyContentOverride(
+        ActivationKeyContentOverride cco2 = this.buildActivationKeyContentOverride(
             key, "test-content2", "name2", "value2");
         activationKeyContentOverrideCurator.addOrUpdate(key, cco2);
 
@@ -152,14 +162,14 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void testCreateOverride() {
-        ActivationKeyContentOverride override = new ActivationKeyContentOverride(key,
+        ActivationKeyContentOverride override = this.buildActivationKeyContentOverride(key,
             "test-repo", "gpgcheck", "1");
         assertEquals(override, this.activationKeyContentOverrideCurator.create(override));
     }
 
     @Test
     public void testCreateOverrideForcesLowercaseName() {
-        ActivationKeyContentOverride override = new ActivationKeyContentOverride(key,
+        ActivationKeyContentOverride override = this.buildActivationKeyContentOverride(key,
             "test-repo", "GpGCheck", "1");
         ActivationKeyContentOverride created = this.activationKeyContentOverrideCurator.create(override);
         assertEquals("gpgcheck", created.getName());
@@ -167,7 +177,7 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void testModifyOverride() {
-        ActivationKeyContentOverride override = new ActivationKeyContentOverride(key,
+        ActivationKeyContentOverride override = this.buildActivationKeyContentOverride(key,
             "test-repo", "GpGCheck", "1");
         ActivationKeyContentOverride created = this.activationKeyContentOverrideCurator.create(override);
         created.setValue("0");
@@ -177,7 +187,7 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void testModifyOverrideForcesNameToLowercase() {
-        ActivationKeyContentOverride override = new ActivationKeyContentOverride(key,
+        ActivationKeyContentOverride override = this.buildActivationKeyContentOverride(key,
             "test-repo", "gpgcheck", "0");
         ActivationKeyContentOverride created = this.activationKeyContentOverrideCurator.create(override);
         created.setName("GPGCHECK");
@@ -187,7 +197,7 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void testRetrieveByName() {
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "test-repo", "gpgcheck", "1"));
         ActivationKeyContentOverride found = activationKeyContentOverrideCurator
             .retrieve(key, "test-repo", "gpgcheck");
@@ -201,7 +211,7 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void testRetrieveByNameIsCaseInsensitive() {
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "test-repo", "gpgcheck", "1"));
         ActivationKeyContentOverride found = activationKeyContentOverrideCurator.retrieve(key, "test-repo",
             "GPGCheck");
@@ -221,9 +231,9 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void testRemoveByName() {
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "test-repo", "gpgcheck", "1"));
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "test-repo", "remaining-override", "remaining"));
         activationKeyContentOverrideCurator.removeByName(key, "test-repo", "gpgcheck");
         List<ActivationKeyContentOverride> remaining = activationKeyContentOverrideCurator.getList(key)
@@ -234,9 +244,9 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void testRemoveByNameCaseInsensitive() {
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "test-repo", "gpgcheck", "1"));
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "test-repo", "remaining-override", "remaining"));
         activationKeyContentOverrideCurator.removeByName(key, "test-repo", "GpGChecK");
         List<ActivationKeyContentOverride> remaining = activationKeyContentOverrideCurator.getList(key)
@@ -247,11 +257,11 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
 
     @Test
     public void testRemoveByContentLabel() {
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "test-repo", "gpgcheck", "1"));
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "test-repo", "foo", "foo-v"));
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "should-remain", "remaining", "true"));
         activationKeyContentOverrideCurator.removeByContentLabel(key, "test-repo");
         List<ActivationKeyContentOverride> remaining = activationKeyContentOverrideCurator.getList(key)
@@ -265,12 +275,12 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
     public void testRemoveByConsumer() {
         ActivationKey key2 = new ActivationKey("other key", owner);
         key2 = activationKeyCurator.create(key2);
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key2,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key2,
             "test-repo", "gpgcheck", "1"));
 
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "test-repo", "gpgcheck", "1"));
-        activationKeyContentOverrideCurator.create(new ActivationKeyContentOverride(key,
+        activationKeyContentOverrideCurator.create(this.buildActivationKeyContentOverride(key,
             "another-test-repo", "gpgcheck", "0"));
         activationKeyContentOverrideCurator.removeByParent(key);
 

--- a/src/test/java/org/candlepin/model/ActivationKeyContentOverrideTest.java
+++ b/src/test/java/org/candlepin/model/ActivationKeyContentOverrideTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.candlepin.model.activationkeys.ActivationKey;
+import org.candlepin.model.activationkeys.ActivationKeyContentOverride;
+
+import org.junit.jupiter.api.Test;
+
+
+
+/**
+ * Test suite for the ActivationKeyContentOverride class
+ */
+public class ActivationKeyContentOverrideTest extends ContentOverrideTest<ActivationKeyContentOverride> {
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    protected ActivationKeyContentOverride getTestInstance() {
+        return new ActivationKeyContentOverride();
+    }
+
+    @Test
+    public void testGetSetKey() {
+        ActivationKey key = new ActivationKey();
+        ActivationKeyContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the key for AKContentOverrides
+        assertNull(override.getKey());
+        assertNull(override.getParent());
+
+        ActivationKeyContentOverride output = override.setKey(key);
+        assertSame(override, output);
+
+        assertEquals(key, output.getKey());
+        assertEquals(key, output.getParent());
+    }
+
+    @Test
+    public void testGetSetNullKey() {
+        ActivationKeyContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the key for AKContentOverrides
+        assertNull(override.getKey());
+        assertNull(override.getParent());
+
+        ActivationKeyContentOverride output = override.setKey(null);
+        assertSame(override, output);
+
+        assertNull(output.getKey());
+        assertNull(output.getParent());
+    }
+
+    @Test
+    public void testGetSetParent() {
+        ActivationKey key = new ActivationKey();
+        ActivationKeyContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the key for AKContentOverrides
+        assertNull(override.getParent());
+        assertNull(override.getKey());
+
+        ActivationKeyContentOverride output = override.setParent(key);
+        assertSame(override, output);
+
+        assertEquals(key, output.getParent());
+        assertEquals(key, output.getKey());
+    }
+
+    @Test
+    public void testGetSetNullParent() {
+        ActivationKeyContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the key for AKContentOverrides
+        assertNull(override.getParent());
+        assertNull(override.getKey());
+
+        ActivationKeyContentOverride output = override.setParent(null);
+        assertSame(override, output);
+
+        assertNull(output.getParent());
+        assertNull(output.getKey());
+    }
+
+    @Test
+    public void testBuildConsumerContentOverride() {
+        String name = "test_name";
+        String label = "test_label";
+        String value = "test_value";
+
+        Consumer consumer = new Consumer();
+
+        ActivationKeyContentOverride akco = new ActivationKeyContentOverride()
+            .setId("test_id")
+            .setName(name)
+            .setContentLabel(label)
+            .setValue(value);
+
+        ConsumerContentOverride cco = akco.buildConsumerContentOverride(consumer);
+
+        assertNotNull(cco);
+        assertEquals(consumer, cco.getConsumer());
+        assertEquals(consumer, cco.getParent());
+        assertNull(cco.getId());
+        assertEquals(name, cco.getName());
+        assertEquals(label, cco.getContentLabel());
+        assertEquals(value, cco.getValue());
+
+        // Munge the data in the original AKCO to verify the generated CCO is not affected
+        akco.setId("updated_id")
+            .setName("updated_name")
+            .setContentLabel("updated_label")
+            .setValue("updated_value");
+
+        assertNull(cco.getId());
+        assertEquals(name, cco.getName());
+        assertEquals(label, cco.getContentLabel());
+        assertEquals(value, cco.getValue());
+    }
+}

--- a/src/test/java/org/candlepin/model/ConsumerContentOverrideTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerContentOverrideTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+
+
+/**
+ * Test suite for the ConsumerContentOverride class
+ */
+public class ConsumerContentOverrideTest extends ContentOverrideTest<ConsumerContentOverride> {
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    protected ConsumerContentOverride getTestInstance() {
+        return new ConsumerContentOverride();
+    }
+
+    @Test
+    public void testGetSetConsumer() {
+        Consumer consumer = new Consumer();
+        ConsumerContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the consumer for EnvContentOverrides
+        assertNull(override.getConsumer());
+        assertNull(override.getParent());
+
+        ConsumerContentOverride output = override.setConsumer(consumer);
+        assertSame(override, output);
+
+        assertEquals(consumer, output.getConsumer());
+        assertEquals(consumer, output.getParent());
+    }
+
+    @Test
+    public void testGetSetNullConsumer() {
+        ConsumerContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the consumer for EnvContentOverrides
+        assertNull(override.getConsumer());
+        assertNull(override.getParent());
+
+        ConsumerContentOverride output = override.setConsumer(null);
+        assertSame(override, output);
+
+        assertNull(output.getConsumer());
+        assertNull(output.getParent());
+    }
+
+    @Test
+    public void testGetSetParent() {
+        Consumer consumer = new Consumer();
+        ConsumerContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the consumer for EnvContentOverrides
+        assertNull(override.getParent());
+        assertNull(override.getConsumer());
+
+        ConsumerContentOverride output = override.setParent(consumer);
+        assertSame(override, output);
+
+        assertEquals(consumer, output.getParent());
+        assertEquals(consumer, output.getConsumer());
+    }
+
+    @Test
+    public void testGetSetNullParent() {
+        ConsumerContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the consumer for EnvContentOverrides
+        assertNull(override.getParent());
+        assertNull(override.getConsumer());
+
+        ConsumerContentOverride output = override.setParent(null);
+        assertSame(override, output);
+
+        assertNull(output.getParent());
+        assertNull(output.getConsumer());
+    }
+
+}

--- a/src/test/java/org/candlepin/model/ContentOverrideTest.java
+++ b/src/test/java/org/candlepin/model/ContentOverrideTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+
+
+/**
+ * Test suite for the ContentOverride tree of objects
+ */
+public abstract class ContentOverrideTest<T extends ContentOverride> {
+
+    /**
+     * Builds and returns a minimally initialized ContentOverride for testing
+     */
+    protected abstract T getTestInstance();
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "test_value" })
+    public void testGetSetID(String value) {
+        T override = this.getTestInstance();
+
+        assertNull(override.getId());
+
+        T output = (T) override.setId(value);
+        assertSame(override, output);
+
+        assertEquals(value, output.getId());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "test_value" })
+    public void testGetSetConetntLabel(String value) {
+        T override = this.getTestInstance();
+
+        assertNull(override.getContentLabel());
+
+        T output = (T) override.setContentLabel(value);
+        assertSame(override, output);
+
+        assertEquals(value, output.getContentLabel());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "test_value" })
+    public void testGetSetName(String value) {
+        T override = this.getTestInstance();
+
+        assertNull(override.getName());
+
+        T output = (T) override.setName(value);
+        assertSame(override, output);
+
+        assertEquals(value, output.getName());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "test_value" })
+    public void testGetSetValue(String value) {
+        T override = this.getTestInstance();
+
+        assertNull(override.getValue());
+
+        T output = (T) override.setValue(value);
+        assertSame(override, output);
+
+        assertEquals(value, output.getValue());
+    }
+
+}

--- a/src/test/java/org/candlepin/model/EnvironmentContentOverrideTest.java
+++ b/src/test/java/org/candlepin/model/EnvironmentContentOverrideTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+
+
+/**
+ * Test suite for the EnvironmentContentOverride class
+ */
+public class EnvironmentContentOverrideTest extends ContentOverrideTest<EnvironmentContentOverride> {
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    protected EnvironmentContentOverride getTestInstance() {
+        return new EnvironmentContentOverride();
+    }
+
+    @Test
+    public void testGetSetEnvironment() {
+        Environment environment = new Environment();
+        EnvironmentContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the environment for EnvContentOverrides
+        assertNull(override.getEnvironment());
+        assertNull(override.getParent());
+
+        EnvironmentContentOverride output = override.setEnvironment(environment);
+        assertSame(override, output);
+
+        assertEquals(environment, output.getEnvironment());
+        assertEquals(environment, output.getParent());
+    }
+
+    @Test
+    public void testGetSetNullEnvironment() {
+        EnvironmentContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the environment for EnvContentOverrides
+        assertNull(override.getEnvironment());
+        assertNull(override.getParent());
+
+        EnvironmentContentOverride output = override.setEnvironment(null);
+        assertSame(override, output);
+
+        assertNull(output.getEnvironment());
+        assertNull(output.getParent());
+    }
+
+    @Test
+    public void testGetSetParent() {
+        Environment environment = new Environment();
+        EnvironmentContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the environment for EnvContentOverrides
+        assertNull(override.getParent());
+        assertNull(override.getEnvironment());
+
+        EnvironmentContentOverride output = override.setParent(environment);
+        assertSame(override, output);
+
+        assertEquals(environment, output.getParent());
+        assertEquals(environment, output.getEnvironment());
+    }
+
+    @Test
+    public void testGetSetNullParent() {
+        EnvironmentContentOverride override = this.getTestInstance();
+
+        // The getParent method is synonymous with fetching the environment for EnvContentOverrides
+        assertNull(override.getParent());
+        assertNull(override.getEnvironment());
+
+        EnvironmentContentOverride output = override.setParent(null);
+        assertSame(override, output);
+
+        assertNull(output.getParent());
+        assertNull(output.getEnvironment());
+    }
+
+}


### PR DESCRIPTION
- Updated the database schema to support environment content overrides
- Added indexes to the consumer_id and the new environment_id
  columns to improve content override lookup performance
- Added a constraint to the content override table to help prevent
  creating overrides in invalid states
- Removed legacy constructors for content overrides and the various
  subclasses
- Removed the allowance of null values on the content override
  subclasses which add a "parent" entity reference
- Removed old XML annotations on the content override entities