### PR TITLE
[M] Added additional documentation for podman play kube health checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,10 +248,11 @@ Once configured you can start and stop(remove) the docker container with
 
 `docker compose up/down`
 
-Or the kubernetes container with 
+Or the kubernetes container with
 
 `podman play kube candlepin-deployment.yaml []/--down`
 
+Note that the `podman play kube` command does not currently have functionality that forces a healthy health check before attempting to start dependent containers like docker compose does. So, it is possible that the database container does not start before the Candlepin container attempts to run migrations causing the Candlepin container to fail to start. In this case, once the database container is running, simply restart the Candlepin container using `podman restart [Candlepin container ID]`.
 
 ### Configure Candlepin Container
 


### PR DESCRIPTION
- Added documentation explaining how to get the Candlepin container to start in the case that the database container does not start before the Candlepin container attempts to run the database migrations when using the podman play kube command.

For this issue, I created the following card for adding retry logic for connecting to the DB.  This would allow the Candlepin container to eventually connect to the DB container and continue running migrations.

https://issues.redhat.com/browse/CANDLEPIN-845