### PR TITLE
[M] CANDLEPIN-845: Added retry logic for database connection failures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,8 +252,6 @@ Or the kubernetes container with
 
 `podman play kube candlepin-deployment.yaml []/--down`
 
-Note that the `podman play kube` command does not currently have functionality that forces a healthy health check before attempting to start dependent containers like docker compose does. So, it is possible that the database container does not start before the Candlepin container attempts to run migrations causing the Candlepin container to fail to start. In this case, once the database container is running, simply restart the Candlepin container using `podman restart [Candlepin container ID]`.
-
 ### Configure Candlepin Container
 
 This topic provides information on how to configure the Candlepin container.

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -28,7 +28,7 @@ import org.candlepin.async.tasks.RevokeEntitlementsJob;
 import org.candlepin.async.tasks.UnmappedGuestEntitlementCleanerJob;
 import org.candlepin.config.validation.ConfigurationValidator;
 import org.candlepin.config.validation.IntegerConfigurationValidator;
-import org.candlepin.guice.CandlepinContextListener;
+import org.candlepin.database.MigrationManagementLevel;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -179,6 +179,10 @@ public class ConfigProperties {
     public static final String DB_URL = JPA_CONFIG_PREFIX + "hibernate.connection.url";
     public static final String DB_USERNAME = JPA_CONFIG_PREFIX + "hibernate.connection.username";
     public static final String DB_PASSWORD = JPA_CONFIG_PREFIX + "hibernate.connection.password";
+
+    // Database
+    public static final String DB_MAX_CONNECTION_ATTEMPTS = "candlepin.db.max_connection_attempts";
+    public static final String DB_CONNECTION_RETRY_INTERVAL = "candlepin.db.retry_interval";
 
     // Cache
     public static final String CACHE_JMX_STATS = "cache.jmx.statistics";
@@ -350,6 +354,10 @@ public class ConfigProperties {
         {
             this.put(CANDLEPIN_URL, "https://localhost");
 
+            // Database connection
+            this.put(DB_CONNECTION_RETRY_INTERVAL, "5"); // seconds
+            this.put(DB_MAX_CONNECTION_ATTEMPTS, "3");
+
             this.put(JWT_ISSUER, "Candlepin");
             this.put(JWT_TOKEN_TTL, "600"); // seconds
             this.put(ANON_JWT_TOKEN_TTL, "172800"); // seconds
@@ -415,7 +423,7 @@ public class ConfigProperties {
             // submit one when registering.
             this.put(HIDDEN_RESOURCES, "environments");
             this.put(HIDDEN_CAPABILITIES, "");
-            this.put(DB_MANAGE_ON_START, CandlepinContextListener.DBManagementLevel.NONE.getName());
+            this.put(DB_MANAGE_ON_START, MigrationManagementLevel.NONE.getName());
             this.put(SSL_VERIFY, "false");
 
             this.put(FAIL_ON_UNKNOWN_IMPORT_PROPERTIES, "false");
@@ -568,6 +576,12 @@ public class ConfigProperties {
                 .lessThan(PAGING_MAX_PAGE_SIZE));
 
             this.add(new IntegerConfigurationValidator(PAGING_MAX_PAGE_SIZE)
+                .min(1));
+
+            this.add(new IntegerConfigurationValidator(DB_CONNECTION_RETRY_INTERVAL)
+                .min(1));
+
+            this.add(new IntegerConfigurationValidator(DB_MAX_CONNECTION_ATTEMPTS)
                 .min(1));
         }
     };

--- a/src/main/java/org/candlepin/config/validation/ConfigurationValidatorUtil.java
+++ b/src/main/java/org/candlepin/config/validation/ConfigurationValidatorUtil.java
@@ -44,11 +44,22 @@ public final class ConfigurationValidatorUtil {
      * @param config
      *  used to retrieve the configuration values based on configuration keys
      *
+     * @throws IllegalArgumentException
+     *  if the provided validators or the configuration is null
+     *
      * @throws RuntimeException
      *  if there is an invalid configuration
      */
     public static void validateConfigurations(Collection<ConfigurationValidator> validators,
         Configuration config) {
+        if (validators == null) {
+            throw new IllegalArgumentException("validators is null");
+        }
+
+        if (config == null) {
+            throw new IllegalArgumentException("config is null");
+        }
+
         Set<String> failures =  validators.stream()
             .flatMap(validator -> validator.validate(config).stream())
             .collect(Collectors.toSet());

--- a/src/main/java/org/candlepin/database/DatabaseConnectionManager.java
+++ b/src/main/java/org/candlepin/database/DatabaseConnectionManager.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.database;
+
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.Configuration;
+
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Objects;
+
+/**
+ * Class for creating and maintaining a connection to the database.
+ */
+public class DatabaseConnectionManager {
+    private static Logger log = LoggerFactory.getLogger(DatabaseConnectionManager.class);
+
+    private Configuration config;
+    private Connection connection;
+
+    /**
+     * Creates a database connection based on the defined configuration values.
+     *
+     * @throws LiquibaseException
+     *  if unable to establish a connection to the database
+     *
+     * @throws ReflectiveOperationException
+     *  if unable to load the database driver
+     *
+     * @param config
+     *  used to retrieve the database configuration values needed to establish a connection
+     */
+    public DatabaseConnectionManager(Configuration config)
+        throws LiquibaseException, ReflectiveOperationException {
+        this.config = Objects.requireNonNull(config);
+
+        loadDatabaseDriver();
+        this.connection = createConnection();
+    }
+
+    /**
+     * @return the established database connection
+     */
+    public Connection getConnection() {
+        return this.connection;
+    }
+
+    /**
+     * Creates a {@link Database} object based on the database configuration.
+     *
+     * @throws LiquibaseException
+     *  if unable to create the {@link Database} from the database connection
+     *
+     * @return the database created from the database connection
+     */
+    public Database getDatabase() throws LiquibaseException {
+        JdbcConnection jdbcConnection = new JdbcConnection(this.connection);
+
+        return DatabaseFactory.getInstance()
+            .findCorrectDatabaseImplementation(jdbcConnection);
+    }
+
+    /**
+     * Creates a database connection based on database configuration values. If a connection is not initially
+     * created, further attempts will be made to create a connection. If a connection cannot be created after
+     * the configured max attempts, then a {@link LiquibaseException} will be thrown.
+     *
+     * @throws LiquibaseException
+     *  if unable to create a database connection after max retry attempts
+     *
+     * @return
+     *  the database connection
+     */
+    private Connection createConnection() throws LiquibaseException {
+        int attemptNumber = 1;
+        int maxAttempts = config.getInt(ConfigProperties.DB_MAX_CONNECTION_ATTEMPTS);
+
+        while (attemptNumber <= maxAttempts) {
+            log.info("Attempt {} out of {} to connect to the database.", attemptNumber, maxAttempts);
+            try {
+                return DriverManager.getConnection(
+                    config.getString(ConfigProperties.DB_URL),
+                    config.getString(ConfigProperties.DB_USERNAME),
+                    config.getString(ConfigProperties.DB_PASSWORD));
+            }
+            catch (SQLException e) {
+                log.error(e.getMessage(), e);
+            }
+
+            waitForConnectionRetryDelay();
+
+            attemptNumber++;
+        }
+
+        String msg = "Failed to establish database connection after maximum retry attempts.";
+        throw new LiquibaseException(msg);
+    }
+
+    /**
+     * Waits a configured amount of time between database connection attempts.
+     *
+     * @throws LiquibaseException
+     *  if the thread has been interrupted
+     */
+    private void waitForConnectionRetryDelay() throws LiquibaseException {
+        int retryInterval = config.getInt(ConfigProperties.DB_CONNECTION_RETRY_INTERVAL);
+        try {
+            // Convert retry interval from seconds to milliseconds
+            Thread.sleep(Long.valueOf(retryInterval) * 1000);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new LiquibaseException(e);
+        }
+    }
+
+    protected void loadDatabaseDriver() throws ReflectiveOperationException {
+        Class.forName(config.getString(ConfigProperties.DB_DRIVER_CLASS))
+            .getDeclaredConstructor()
+            .newInstance();
+    }
+}
+

--- a/src/main/java/org/candlepin/database/MigrationManagementLevel.java
+++ b/src/main/java/org/candlepin/database/MigrationManagementLevel.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.database;
+
+/**
+ * Defines the option on how to handle database migrations.
+ */
+public enum MigrationManagementLevel {
+    /**
+     * Do not attempt to run the database migrations
+     */
+    NONE("NONE"),
+    /**
+     * Changesets that have not yet been applied should be reported
+     */
+    REPORT("REPORT"),
+    /**
+     * Do not proceed with startup if there are changesets that have not been applied
+     */
+    HALT("HALT"),
+    /**
+     * Apply the changesets that have not yet been applied
+     */
+    MANAGE("MANAGE");
+
+    private String name;
+
+    MigrationManagementLevel(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+}

--- a/src/main/java/org/candlepin/database/MigrationManager.java
+++ b/src/main/java/org/candlepin/database/MigrationManager.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.database;
+
+import static org.candlepin.config.ConfigProperties.DB_MANAGE_ON_START;
+
+import org.candlepin.config.Configuration;
+
+import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.command.CommandScope;
+import liquibase.command.core.StatusCommandStep;
+import liquibase.command.core.UpdateCommandStep;
+import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep;
+import liquibase.database.Database;
+import liquibase.exception.LiquibaseException;
+import liquibase.parser.core.xml.XMLChangeLogSAXParser;
+import liquibase.resource.ClassLoaderResourceAccessor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Class for managing database migrations.
+ */
+public class MigrationManager {
+    private static Logger log = LoggerFactory.getLogger(MigrationManager.class);
+
+    private static final String CHANGELOG_FILE_NAME = "db/changelog/changelog-update.xml";
+
+    private Configuration config;
+    private DatabaseConnectionManager connectionManager;
+
+    public MigrationManager(Configuration config, DatabaseConnectionManager connectionManager) {
+        this.config = Objects.requireNonNull(config);
+        this.connectionManager = Objects.requireNonNull(connectionManager);
+    }
+
+    /**
+     * Runs the liquibase changesets based on the manage on startup configuration value.
+     *
+     * @throws RuntimeException
+     *  if unable to determine the migration level
+     *
+     * @throws LiquibaseException
+     *  if unable to run the migrations
+     */
+    public void migrate() throws LiquibaseException {
+        String migrationConfig = config.getString(DB_MANAGE_ON_START);
+        log.info("Liquibase startup management set to {}", migrationConfig);
+        MigrationManagementLevel migrationLevel = null;
+        try {
+            migrationLevel = MigrationManagementLevel.valueOf(migrationConfig.toUpperCase());
+        }
+        catch (IllegalArgumentException iae) {
+            log.error("The value {} of parameter '{}' is not allowed", migrationConfig, DB_MANAGE_ON_START);
+            throw new RuntimeException(iae.getMessage());
+        }
+
+        if (MigrationManagementLevel.NONE.equals(migrationLevel)) {
+            return;
+        }
+
+        Database database = connectionManager.getDatabase();
+        List<ChangeSet> unrunChangeSets = getUnrunChangeSets(database);
+        if (unrunChangeSets.isEmpty()) {
+            log.info("Candlepin database is up to date!");
+        }
+        else {
+            Stream<String> csStream = unrunChangeSets.stream()
+                .map(changeset ->
+                String.format("file: %s, changeset: %s", changeset.getFilePath(), changeset.getId()));
+
+            switch (migrationLevel) {
+                case REPORT:
+                    log.warn("Database has {} unrun changeset(s): \n{}", unrunChangeSets.size(),
+                        csStream.collect(Collectors.joining("\n  ", "  ", "")));
+                    break;
+                case HALT:
+                    log.error("Database has {} unrun changeset(s); halting startup...\n{}",
+                        unrunChangeSets.size(), csStream.collect(Collectors.joining("\n  ", "  ", "")));
+                    throw new RuntimeException("The database is missing Liquibase changeset(s)");
+                case MANAGE:
+                    log.info("Calling liquibase to update the database");
+                    log.info("Database has {} unrun changeset(s): \n{}", unrunChangeSets.size(),
+                        csStream.collect(Collectors.joining("\n  ", "  ", "")));
+                    executeUpdate(database);
+                    log.info("Update complete");
+                    break;
+                default:
+                    throw new RuntimeException("Cannot determine database management mode.");
+            }
+        }
+    }
+
+    /**
+     * Reads the list of unrun changesets from the database supplied based on the changelog.
+     *
+     * @param database
+     *  used to verify if the changelog changeset has been applied or not
+     *
+     * @throws LiquibaseException
+     *  if there is an issue with reading the changesets
+     *
+     * @return List of unrun changesets
+     */
+    protected List<ChangeSet> getUnrunChangeSets(Database database) throws LiquibaseException {
+        try {
+            DatabaseChangeLog changeLog = new XMLChangeLogSAXParser()
+                .parse(CHANGELOG_FILE_NAME, new ChangeLogParameters(), new ClassLoaderResourceAccessor());
+
+            return new StatusCommandStep()
+                .listUnrunChangeSets(null, null, changeLog, database);
+        }
+        catch (Exception e) {
+            throw new LiquibaseException(e.getMessage());
+        }
+    }
+
+    protected void executeUpdate(Database database) throws LiquibaseException {
+        CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+            .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, database)
+            .addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, CHANGELOG_FILE_NAME);
+        commandScope.execute();
+    }
+}

--- a/src/test/java/org/candlepin/config/validation/ConfigurationValidatorUtilTest.java
+++ b/src/test/java/org/candlepin/config/validation/ConfigurationValidatorUtilTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.config.validation;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.DevConfig;
+import org.candlepin.config.TestConfig;
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConfigurationValidatorUtilTest {
+
+    private DevConfig config;
+
+    @BeforeEach
+    public void init() {
+        this.config = TestConfig.defaults();
+    }
+
+    @Test
+    public void testValidateConfigurationsWithNullValidators() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            ConfigurationValidatorUtil.validateConfigurations(null, config);
+        });
+    }
+
+    @Test
+    public void testValidateConfigurationsWithNullConfiguration() {
+        List<ConfigurationValidator> validators = new ArrayList<>();
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            ConfigurationValidatorUtil.validateConfigurations(validators, null);
+        });
+    }
+
+    @Test
+    public void testValidateConfigurations() {
+        String key1 = TestUtil.randomString();
+        String key2 = TestUtil.randomString();
+
+        IntegerConfigurationValidator validator1 = new IntegerConfigurationValidator(key1)
+            .min(0)
+            .lessThan(ConfigProperties.PAGING_MAX_PAGE_SIZE);
+        ConfigurationValidator validator2 = new IntegerConfigurationValidator(key2)
+            .min(0);
+
+        config.setProperty(key1, "100");
+        config.setProperty(key2, "1000");
+
+        List<ConfigurationValidator> validators = List.of(validator1, validator2);
+
+        ConfigurationValidatorUtil.validateConfigurations(validators, config);
+
+        // Assert no exceptions
+    }
+
+    @Test
+    public void testValidateConfigurationsWithValidationException() {
+        String key1 = TestUtil.randomString();
+        String key2 = TestUtil.randomString();
+
+        IntegerConfigurationValidator validator = new IntegerConfigurationValidator(key1)
+            .min(0)
+            .lessThan(key2);
+        ConfigurationValidator invalidValidator = new IntegerConfigurationValidator(key2)
+            .max(0);
+
+        config.setProperty(key1, "100");
+        config.setProperty(key2, "1000");
+
+        assertThrows(RuntimeException.class, () -> {
+            ConfigurationValidatorUtil.validateConfigurations(List.of(validator, invalidValidator), config);
+        });
+    }
+}

--- a/src/test/java/org/candlepin/database/DatabaseConnectionManagerTest.java
+++ b/src/test/java/org/candlepin/database/DatabaseConnectionManagerTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.database;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.DevConfig;
+import org.candlepin.config.TestConfig;
+import org.candlepin.test.TestUtil;
+
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class DatabaseConnectionManagerTest {
+
+    private DevConfig config;
+
+    @BeforeEach
+    public void init() {
+        this.config = TestConfig.defaults();
+    }
+
+    @Test
+    public void testConstructorWithNullConfiguration() {
+        assertThrows(NullPointerException.class, () -> new DatabaseConnectionManager(null));
+    }
+
+    @Test
+    public void testGetConnectionWithValidConnection() throws Exception {
+        String url = TestUtil.randomString();
+        String username = TestUtil.randomString();
+        String password = TestUtil.randomString();
+        config.setProperty(ConfigProperties.DB_URL, url);
+        config.setProperty(ConfigProperties.DB_USERNAME, username);
+        config.setProperty(ConfigProperties.DB_PASSWORD, password);
+        config.setProperty(ConfigProperties.DB_CONNECTION_RETRY_INTERVAL, "1");
+        config.setProperty(ConfigProperties.DB_MAX_CONNECTION_ATTEMPTS, "1");
+        config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.HALT.getName());
+
+        try (MockedStatic<DriverManager> manager = Mockito.mockStatic(DriverManager.class);
+            MockedStatic<DatabaseFactory> dbFactory = Mockito.mockStatic(DatabaseFactory.class)) {
+
+            Connection mockConnection = Mockito.mock(Connection.class);
+            manager.when(() -> DriverManager.getConnection(url, username, password))
+                .thenReturn(mockConnection);
+
+            DatabaseConnectionManager conManager = new DatabaseConnectionManager(config) {
+                @Override
+                protected void loadDatabaseDriver() {
+                    // Intentionally left blank
+                }
+            };
+
+            Connection actual = conManager.getConnection();
+
+            assertThat(actual)
+                .isEqualTo(mockConnection);
+
+            manager.verify(() -> DriverManager.getConnection(url, username, password));
+        }
+    }
+
+    @Test
+    public void testGetConnectionWithUnsuccesfulConnection() throws Exception {
+        String url = TestUtil.randomString();
+        String username = TestUtil.randomString();
+        String password = TestUtil.randomString();
+        config.setProperty(ConfigProperties.DB_URL, url);
+        config.setProperty(ConfigProperties.DB_USERNAME, username);
+        config.setProperty(ConfigProperties.DB_PASSWORD, password);
+        config.setProperty(ConfigProperties.DB_CONNECTION_RETRY_INTERVAL, "1");
+        int maxRetryAttempts = 3;
+        config.setProperty(ConfigProperties.DB_MAX_CONNECTION_ATTEMPTS, String.valueOf(maxRetryAttempts));
+        config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.HALT.getName());
+
+        try (MockedStatic<DriverManager> manager = Mockito.mockStatic(DriverManager.class);
+            MockedStatic<DatabaseFactory> dbFactory = Mockito.mockStatic(DatabaseFactory.class)) {
+
+            manager.when(() -> DriverManager.getConnection(url, username, password))
+                .thenThrow(SQLException.class);
+
+            assertThrows(LiquibaseException.class, () -> new DatabaseConnectionManager(config) {
+                @Override
+                protected void loadDatabaseDriver() {
+                    // Intentionally left blank
+                }
+            });
+
+            manager.verify(() -> DriverManager.getConnection(url, username, password),
+                times(maxRetryAttempts));
+        }
+    }
+
+    @Test
+    public void testGetConnectionWithEventualValidConnection() throws Exception {
+        String url = TestUtil.randomString();
+        String username = TestUtil.randomString();
+        String password = TestUtil.randomString();
+        config.setProperty(ConfigProperties.DB_URL, url);
+        config.setProperty(ConfigProperties.DB_USERNAME, username);
+        config.setProperty(ConfigProperties.DB_PASSWORD, password);
+        config.setProperty(ConfigProperties.DB_CONNECTION_RETRY_INTERVAL, "1");
+        int maxRetryAttempts = 3;
+        config.setProperty(ConfigProperties.DB_MAX_CONNECTION_ATTEMPTS, String.valueOf(maxRetryAttempts));
+        config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.HALT.getName());
+
+        try (MockedStatic<DriverManager> manager = Mockito.mockStatic(DriverManager.class);
+            MockedStatic<DatabaseFactory> dbFactory = Mockito.mockStatic(DatabaseFactory.class)) {
+
+            // Fail to connect the first two times and connect on the third and final attempt
+            Connection mockConnection = Mockito.mock(Connection.class);
+            manager.when(() -> DriverManager.getConnection(url, username, password))
+                .thenThrow(SQLException.class, SQLException.class)
+                .thenReturn(mockConnection);
+
+            DatabaseConnectionManager conManager = new DatabaseConnectionManager(config) {
+                @Override
+                protected void loadDatabaseDriver() {
+                    // Intentionally left blank
+                }
+            };
+
+            Connection actual = conManager.getConnection();
+
+            assertThat(actual)
+                .isEqualTo(mockConnection);
+
+            manager.verify(() -> DriverManager.getConnection(url, username, password),
+                times(maxRetryAttempts));
+        }
+    }
+
+    @Test
+    public void testGetDatabase() throws Exception {
+        String url = TestUtil.randomString();
+        String username = TestUtil.randomString();
+        String password = TestUtil.randomString();
+        config.setProperty(ConfigProperties.DB_URL, url);
+        config.setProperty(ConfigProperties.DB_USERNAME, username);
+        config.setProperty(ConfigProperties.DB_PASSWORD, password);
+        config.setProperty(ConfigProperties.DB_CONNECTION_RETRY_INTERVAL, "1");
+        config.setProperty(ConfigProperties.DB_MAX_CONNECTION_ATTEMPTS, "1");
+        config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.HALT.getName());
+
+        try (MockedStatic<DriverManager> manager = Mockito.mockStatic(DriverManager.class);
+            MockedStatic<DatabaseFactory> dbFactory = Mockito.mockStatic(DatabaseFactory.class)) {
+
+            Connection mockConnection = Mockito.mock(Connection.class);
+            manager.when(() -> DriverManager.getConnection(url, username, password))
+                .thenReturn(mockConnection);
+
+            DatabaseFactory mockFactory = mock(DatabaseFactory.class);
+            Database mockDatabase = mock(Database.class);
+            doReturn(mockDatabase).when(mockFactory)
+                .findCorrectDatabaseImplementation(any(JdbcConnection.class));
+            dbFactory.when(DatabaseFactory::getInstance).thenReturn(mockFactory);
+
+            DatabaseConnectionManager conManager = new DatabaseConnectionManager(config) {
+                @Override
+                protected void loadDatabaseDriver() {
+                    // Intentionally left blank
+                }
+            };
+
+            Database actual = conManager.getDatabase();
+
+            assertThat(actual)
+                .isEqualTo(mockDatabase);
+        }
+    }
+}

--- a/src/test/java/org/candlepin/database/MigrationManagerTest.java
+++ b/src/test/java/org/candlepin/database/MigrationManagerTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.database;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.DevConfig;
+import org.candlepin.config.TestConfig;
+import org.candlepin.test.TestUtil;
+
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class MigrationManagerTest {
+    @Mock
+    private DatabaseConnectionManager connectionManager;
+    @Mock
+    private Database database;
+
+    private DevConfig config;
+
+    @BeforeEach
+    public void beforeEach() {
+        config = TestConfig.defaults();
+    }
+
+    @Test
+    public void testMigrateWithUnknownMigrationLevel() {
+        config.setProperty(ConfigProperties.DB_MANAGE_ON_START, TestUtil.randomString());
+
+        MigrationManager migrationManager = new MigrationManager(config, connectionManager);
+
+        assertThrows(RuntimeException.class, () -> migrationManager.migrate());
+    }
+
+    @Test
+    public void testMigrateWithNoneMigrationLevel() throws Exception {
+        config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.NONE.toString());
+        doReturn(database).when(connectionManager).getDatabase();
+
+        MigrationManager migrationManager = spy(new MigrationManager(config, connectionManager));
+
+        migrationManager.migrate();
+
+        verify(migrationManager, never()).getUnrunChangeSets(database);
+        verify(migrationManager, never()).executeUpdate(database);
+    }
+
+    @Test
+    public void testMigrateWithReportMigrationLevel() throws Exception {
+        config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.REPORT.toString());
+        doReturn(database).when(connectionManager).getDatabase();
+
+        MigrationManager migrationManager = spy(new MigrationManager(config, connectionManager) {
+            @Override
+            protected List<ChangeSet> getUnrunChangeSets(Database database) {
+                ChangeSet changeSet = new ChangeSet("21220101",
+                    "tester",
+                    true,
+                    true,
+                    "db/changelog/21220101-test.xml",
+                    null,
+                    null,
+                    Mockito.mock(DatabaseChangeLog.class));
+
+                return List.of(changeSet);
+            }
+        });
+
+        migrationManager.migrate();
+
+        verify(migrationManager).getUnrunChangeSets(database);
+        verify(migrationManager, never()).executeUpdate(database);
+    }
+
+    @Test
+    public void testMigrateWithHaltMigrationLevel() throws Exception {
+        config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.HALT.toString());
+        doReturn(database).when(connectionManager).getDatabase();
+
+        MigrationManager migrationManager = spy(new MigrationManager(config, connectionManager) {
+            @Override
+            protected List<ChangeSet> getUnrunChangeSets(Database database) {
+                ChangeSet changeSet = new ChangeSet("21220101",
+                    "tester",
+                    true,
+                    true,
+                    "db/changelog/21220101-test.xml",
+                    null,
+                    null,
+                    Mockito.mock(DatabaseChangeLog.class));
+
+                return List.of(changeSet);
+            }
+        });
+
+        assertThrows(RuntimeException.class, () -> migrationManager.migrate());
+    }
+
+    @Test
+    public void testMigrateWithManageMigrationLevelAndNoUnrunChanges() throws Exception {
+        config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.MANAGE.toString());
+        doReturn(database).when(connectionManager).getDatabase();
+
+        MigrationManager migrationManager = spy(new MigrationManager(config, connectionManager) {
+            @Override
+            protected List<ChangeSet> getUnrunChangeSets(Database database) {
+                return List.of();
+            }
+
+            @Override
+            protected void executeUpdate(Database database) {
+                // Intentionally left blank
+            }
+        });
+
+        migrationManager.migrate();
+
+        verify(migrationManager).getUnrunChangeSets(database);
+        verify(migrationManager, never()).executeUpdate(database);
+    }
+
+    @Test
+    public void testMigrateWithManageMigrationLevelAndUnrunChanges() throws Exception {
+        config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.MANAGE.toString());
+        doReturn(database).when(connectionManager).getDatabase();
+
+        MigrationManager migrationManager = spy(new MigrationManager(config, connectionManager) {
+            @Override
+            protected List<ChangeSet> getUnrunChangeSets(Database database) {
+                ChangeSet changeSet = new ChangeSet("21220101",
+                    "tester",
+                    true,
+                    true,
+                    "db/changelog/21220101-test.xml",
+                    null,
+                    null,
+                    Mockito.mock(DatabaseChangeLog.class));
+
+                return List.of(changeSet);
+            }
+
+            @Override
+            protected void executeUpdate(Database database) {
+                // Intentionally left blank
+            }
+        });
+
+        migrationManager.migrate();
+
+        verify(migrationManager).getUnrunChangeSets(database);
+        verify(migrationManager).executeUpdate(database);
+    }
+}


### PR DESCRIPTION
    - Moved database connection and migration logic from
      CandlepinContextListener to a new DatabaseConnectionManager class and
      a new MigrationManager class.
    - Added database connection retry logic for when Candlepin is starting
      and fails to connect to the database.
    - Added max retry attempts and retry interval configurations to be used
      for the database connection retry logic.
    - Removed documentation in CONTRIBUTING.md regarding needing to
      restart the candlepin container when using podman play kube command.