### PR TITLE
[M] Upgraded gradle from enterprise to develocity

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,15 +1,14 @@
 plugins {
-    id "com.gradle.enterprise" version "3.17"
+    id "com.gradle.develocity" version "3.17.1"
 }
 
 def runsOnCI = System.getenv("CI") == 'true'
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
-
-        publishAlwaysIf(runsOnCI)
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
+        publishing.onlyIf { runsOnCI }
     }
 }
 


### PR DESCRIPTION
- Switch from the soon-to-be deprecated Gradle Enterprise to Gradle Develocity, along with the necessary configuration adjustments.

Fix this warning from gradle:
WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin:
- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"
- The deprecated "gradleEnterprise.buildScan.termsOfServiceAgree" API has been replaced by "develocity.buildScan.termsOfUseAgree"
- The deprecated "gradleEnterprise.buildScan.publishAlwaysIf(condition)" API has been replaced by "develocity.buildScan.publishing.onlyIf { condition }"
- The "com.gradle.enterprise" plugin has been replaced by "com.gradle.develocity"
