### PR TITLE
[F] CANDLEPIN-840: Added endpoints for environment content overrides

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -3359,6 +3359,147 @@ paths:
         default:
           $ref: '#/components/responses/default'
 
+  /environments/{environment_id}/content_overrides:
+    get:
+      description: |
+        Fetches the overrides to be applied to all consumers in the given environment. If the environment has
+        no overrides, this endpoint returns an empty list.
+      operationId: getEnvironmentContentOverrides
+      tags:
+        - environment
+      parameters:
+        - name: environment_id
+          in: path
+          description: |
+            The ID of the environment for which to fetch content overrides
+          required: true
+          schema:
+            type: string
+      x-java-response:
+        type: java.util.stream.Stream
+        isContainer: true
+      security: []
+      responses:
+        200:
+          description: |
+            A list of content overrides for the specified environment
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContentOverrideDTO'
+        404:
+          description: |
+            An environment with the specified ID does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExceptionMessage'
+        default:
+          $ref: '#/components/responses/default'
+    put:
+      description: |
+        Adds one or more new content overrides or updates existing overrides for the given environment, then
+        returns a list containing all known, updated overrides for the environment. If the list contains
+        multiple values for a given content override, any previous value(s) will be overwritten.
+      operationId: putEnvironmentContentOverrides
+      tags:
+        - environment
+      parameters:
+        - name: environment_id
+          in: path
+          description: |
+            The ID of the environment in which to add or update content overrides
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: A list containing the content overrides to apply to the environment
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/ContentOverrideDTO'
+      x-java-response:
+        type: java.util.stream.Stream
+        isContainer: true
+      security: []
+      responses:
+        200:
+          description: |
+            An updated list of all known content overrides for the specified environment
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContentOverrideDTO'
+        404:
+          description: |
+            An environment with the specified ID does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExceptionMessage'
+    delete:
+      description: |
+        Removes one or more content overrides from the given environment. If the list of content overrides to
+        remove is empty, or the list contains one or more entries without a label, all content overrides for
+        the specified environment will be removed. If the list contains one or more entries with a label but
+        without an override name (key), all overrides for that label will be removed. If no matching overrides
+        could be found, no change will be made to the environment.
+
+        Regardless of which, if any, content overrides are removed, this endpoint returns a list containing
+        the remaining overrides on the specified environment.
+      operationId: deleteEnvironmentContentOverrides
+      tags:
+        - environment
+      parameters:
+        - name: environment_id
+          in: path
+          description: |
+            The ID of the environment from which to remove content overrides
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: |
+          A list containing the content overrides to remove from the environment. The overrides need not be
+          fully populated, as the value is ignored entirely during removal; and depending on the behavior
+          desired, the name or label fields may not be needed, either. See the description for the operation
+          itself for more details.
+        required: false
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/ContentOverrideDTO'
+      x-java-response:
+        type: java.util.stream.Stream
+        isContainer: true
+      security: []
+      responses:
+        200:
+          description: |
+            An update list of all remaining content overrides for the specified environment
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContentOverrideDTO'
+        404:
+          description: |
+            An environment with the specified ID does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExceptionMessage'
+
   /entitlements:
     get:
       description: Retrieves list of Entitlements. This endpoint supports paging with query parameters. For more details please visit https://www.candlepinproject.org/docs/candlepin/pagination.html#paginating-results-from-candlepin
@@ -8629,8 +8770,10 @@ components:
           properties:
             name:
               type: string
+              maxLength: 255
             contentLabel:
               type: string
+              maxLength: 255
             value:
               type: string
               maxLength: 2048

--- a/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentContentOverrideSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentContentOverrideSpecTest.java
@@ -1,0 +1,814 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.environments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertBadRequest;
+import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertNotFound;
+
+import org.candlepin.dto.api.client.v1.ContentOverrideDTO;
+import org.candlepin.dto.api.client.v1.EnvironmentDTO;
+import org.candlepin.dto.api.client.v1.OwnerDTO;
+import org.candlepin.spec.bootstrap.client.ApiClient;
+import org.candlepin.spec.bootstrap.client.ApiClients;
+import org.candlepin.spec.bootstrap.client.SpecTest;
+import org.candlepin.spec.bootstrap.data.builder.ContentOverrides;
+import org.candlepin.spec.bootstrap.data.builder.Environments;
+import org.candlepin.spec.bootstrap.data.builder.Owners;
+
+import org.assertj.core.api.ListAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+
+
+@SpecTest
+public class EnvironmentContentOverrideSpecTest {
+
+    private ListAssert<ContentOverrideDTO> assertEnvironmentContentOverrides(ApiClient client,
+        EnvironmentDTO environment) {
+
+        List<ContentOverrideDTO> overrides = client.environments()
+            .getEnvironmentContentOverrides(environment.getId());
+
+        return assertThat(overrides);
+    }
+
+    private EnvironmentDTO createEnvironment(ApiClient client) {
+        OwnerDTO owner = client.owners()
+            .createOwner(Owners.random());
+
+        return client.owners()
+            .createEnv(owner.getKey(), Environments.random());
+    }
+
+    @Test
+    public void shouldAllowCreatingEnvironmentContentOverrides() {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random();
+        ContentOverrideDTO co2 = ContentOverrides.random();
+        ContentOverrideDTO co3 = ContentOverrides.random();
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2));
+
+        assertThat(overrides1)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2));
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2));
+
+        // Add a third element to ensure the result is the union of all overrides submitted thus far
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co3));
+
+        assertThat(overrides2)
+            .hasSize(3)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2, co3));
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .hasSize(3)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2, co3));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void shouldThrowBadRequestOnCreationWithNullOrEmptyLabel(String label) {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random()
+            .contentLabel(label);
+        ContentOverrideDTO co2 = ContentOverrides.random();
+        ContentOverrideDTO co3 = ContentOverrides.random();
+
+        assertBadRequest(() -> adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2, co3)));
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void shouldThrowBadRequestOnCreationWithNullOrEmptyAttribute(String attrib) {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random()
+            .name(attrib);
+        ContentOverrideDTO co2 = ContentOverrides.random();
+        ContentOverrideDTO co3 = ContentOverrides.random();
+
+        assertBadRequest(() -> adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2, co3)));
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void shouldThrowBadRequestOnCreationWithNullOrEmptyValue(String value) {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random()
+            .value(value);
+        ContentOverrideDTO co2 = ContentOverrides.random();
+        ContentOverrideDTO co3 = ContentOverrides.random();
+
+        assertBadRequest(() -> adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2, co3)));
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    public void shouldThrowNotFoundExceptionWithInvalidEnvironmentIdOnFetch() {
+        ApiClient adminClient = ApiClients.admin();
+
+        assertNotFound(() -> adminClient.environments()
+            .getEnvironmentContentOverrides("badEnvId"));
+    }
+
+    @Test
+    public void shouldAllowUpdatingEnvironmentContentOverrides() {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random();
+        ContentOverrideDTO co2 = ContentOverrides.random();
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2));
+
+        assertThat(overrides1)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2));
+
+        // Update the value on one of our content overrides and submit it
+        ContentOverrideDTO co3 = new ContentOverrideDTO()
+            .name(co2.getName())
+            .contentLabel(co2.getContentLabel())
+            .value("updated_value");
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co3));
+
+        assertThat(overrides2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co3))
+            .doesNotContain(co2);
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co3))
+            .doesNotContain(co2);
+    }
+
+    @Test
+    public void shouldNotShareContentOverridesBetweenEnvironments() {
+        ApiClient adminClient = ApiClients.admin();
+
+        OwnerDTO owner1 = adminClient.owners().createOwner(Owners.random());
+        OwnerDTO owner2 = adminClient.owners().createOwner(Owners.random());
+        EnvironmentDTO environment1 = adminClient.owners().createEnv(owner1.getKey(), Environments.random());
+        EnvironmentDTO environment2 = adminClient.owners().createEnv(owner1.getKey(), Environments.random());
+        EnvironmentDTO environment3 = adminClient.owners().createEnv(owner2.getKey(), Environments.random());
+
+        ContentOverrideDTO co1 = ContentOverrides.random();
+        ContentOverrideDTO co2 = ContentOverrides.random();
+        ContentOverrideDTO co3 = ContentOverrides.random();
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment1.getId(), List.of(co1));
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment2.getId(), List.of(co2));
+
+        List<ContentOverrideDTO> overrides3 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment3.getId(), List.of(co3));
+
+        assertThat(overrides1)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co1);
+
+        assertThat(overrides2)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co2);
+
+        assertThat(overrides3)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co3);
+
+        assertEnvironmentContentOverrides(adminClient, environment1)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co1);
+
+        assertEnvironmentContentOverrides(adminClient, environment2)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co2);
+
+        assertEnvironmentContentOverrides(adminClient, environment3)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co3);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"name", "NAME", "NAme", "label", "LABEL", "LaBeL"})
+    public void shouldRejectChangesForProtectedAttributes(String attribute) {
+        ApiClient adminClient = ApiClients.admin();
+
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+        ContentOverrideDTO override = ContentOverrides.random()
+            .name(attribute);
+
+        assertBadRequest(() -> adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(override)));
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"name", "NAME", "NAme", "label", "LABEL", "LaBeL"})
+    public void shouldRejectAllChangesIfAnyOverrideContainsProtectedAttributes(String attribute) {
+        ApiClient adminClient = ApiClients.admin();
+
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+        ContentOverrideDTO co1 = ContentOverrides.random();
+        ContentOverrideDTO co2 = ContentOverrides.random().name(attribute);
+        ContentOverrideDTO co3 = ContentOverrides.random();
+
+        assertBadRequest(() -> adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2, co3)));
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    public void shouldUpdateContentOverrideValueForAttributeWithDifferentCase() {
+        ApiClient adminClient = ApiClients.admin();
+
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+        ContentOverrideDTO co1 = new ContentOverrideDTO()
+            .contentLabel("content_label")
+            .name("override")
+            .value("value");
+        ContentOverrideDTO co2 = new ContentOverrideDTO()
+            .contentLabel(co1.getContentLabel())
+            .name("OvErRiDE")
+            .value("updated_value");
+        ContentOverrideDTO expected = new ContentOverrideDTO()
+            .contentLabel(co1.getContentLabel())
+            .name(co1.getName())
+            .value(co2.getValue());
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1));
+
+        assertThat(overrides1)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co1);
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co2));
+
+        assertThat(overrides2)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(expected);
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldUseLastValueWhenDuplicateValuesAreProvided() {
+        ApiClient adminClient = ApiClients.admin();
+
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+        ContentOverrideDTO co1 = new ContentOverrideDTO()
+            .contentLabel("content_label")
+            .name("override")
+            .value("value");
+        ContentOverrideDTO co2 = new ContentOverrideDTO()
+            .contentLabel(co1.getContentLabel())
+            .name("OvErRiDE")
+            .value("updated_value");
+        ContentOverrideDTO expected = new ContentOverrideDTO()
+            .contentLabel(co1.getContentLabel())
+            .name(co1.getName())
+            .value(co2.getValue());
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2));
+
+        assertThat(overrides1)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(expected);
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void shouldAllowDeletingAllEnvironmentContentOverridesWithNullOrEmptyList(
+        List<ContentOverrideDTO> input) {
+
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random();
+        ContentOverrideDTO co2 = ContentOverrides.random();
+        ContentOverrideDTO co3 = ContentOverrides.random();
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2, co3));
+
+        assertThat(overrides1)
+            .hasSize(3)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2, co3));
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .deleteEnvironmentContentOverrides(environment.getId(), input);
+
+        assertThat(overrides2)
+            .isNotNull()
+            .isEmpty();
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void shouldNotAffectOtherEnvironmentsWhenDeletingAllOverridesWithNullOrEmptyList(
+        List<ContentOverrideDTO> input) {
+
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment1 = this.createEnvironment(adminClient);
+        EnvironmentDTO environment2 = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random();
+        ContentOverrideDTO co2 = ContentOverrides.random();
+        ContentOverrideDTO co3 = ContentOverrides.random();
+        ContentOverrideDTO co4 = ContentOverrides.random();
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment1.getId(), List.of(co1, co2));
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment2.getId(), List.of(co3, co4));
+
+        assertThat(overrides1)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2));
+
+        assertThat(overrides2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co3, co4));
+
+        List<ContentOverrideDTO> overrides3 = adminClient.environments()
+            .deleteEnvironmentContentOverrides(environment1.getId(), input);
+
+        assertThat(overrides3)
+            .isNotNull()
+            .isEmpty();
+
+        assertEnvironmentContentOverrides(adminClient, environment1)
+            .isNotNull()
+            .isEmpty();
+
+        assertEnvironmentContentOverrides(adminClient, environment2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co3, co4));
+    }
+
+    @Test
+    public void shouldAllowDeletingAllEnvironmentContentOverridesWithLabellessElement() {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random();
+        ContentOverrideDTO co2 = ContentOverrides.random();
+        ContentOverrideDTO co3 = ContentOverrides.random();
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2, co3));
+
+        assertThat(overrides1)
+            .hasSize(3)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2, co3));
+
+        ContentOverrideDTO toDelete = new ContentOverrideDTO()
+            .name("attrib")
+            .value("value");
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .deleteEnvironmentContentOverrides(environment.getId(), List.of(toDelete));
+
+        assertThat(overrides2)
+            .isNotNull()
+            .isEmpty();
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    public void shouldNotAffectOtherEnvironmentsWhenDeletingAllOverridesWithLabellessElement() {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment1 = this.createEnvironment(adminClient);
+        EnvironmentDTO environment2 = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random();
+        ContentOverrideDTO co2 = ContentOverrides.random();
+        ContentOverrideDTO co3 = ContentOverrides.random();
+        ContentOverrideDTO co4 = ContentOverrides.random();
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment1.getId(), List.of(co1, co2));
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment2.getId(), List.of(co3, co4));
+
+        assertThat(overrides1)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2));
+
+        assertThat(overrides2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co3, co4));
+
+        ContentOverrideDTO toDelete = new ContentOverrideDTO()
+            .name("attrib")
+            .value("value");
+
+        List<ContentOverrideDTO> overrides3 = adminClient.environments()
+            .deleteEnvironmentContentOverrides(environment1.getId(), List.of(toDelete));
+
+        assertThat(overrides3)
+            .isNotNull()
+            .isEmpty();
+
+        assertEnvironmentContentOverrides(adminClient, environment1)
+            .isNotNull()
+            .isEmpty();
+
+        assertEnvironmentContentOverrides(adminClient, environment2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co3, co4));
+    }
+
+    @Test
+    public void shouldAllowDeletingMultipleEnvironmentContentOverridesByLabel() {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random()
+            .contentLabel("label1");
+        ContentOverrideDTO co2 = ContentOverrides.random()
+            .contentLabel("label1");
+        ContentOverrideDTO co3 = ContentOverrides.random()
+            .contentLabel("label2");
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2, co3));
+
+        assertThat(overrides1)
+            .hasSize(3)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2, co3));
+
+        ContentOverrideDTO toDelete = new ContentOverrideDTO()
+            .contentLabel("label1");
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .deleteEnvironmentContentOverrides(environment.getId(), List.of(toDelete));
+
+        assertThat(overrides2)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co3);
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co3);
+    }
+
+    @Test
+    public void shouldNotAffectOtherEnvironmentsWhenDeletingMultipleOverridesByLabel() {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment1 = this.createEnvironment(adminClient);
+        EnvironmentDTO environment2 = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random()
+            .contentLabel("label1");
+        ContentOverrideDTO co2 = ContentOverrides.random()
+            .contentLabel("label2");
+        ContentOverrideDTO co3 = ContentOverrides.random()
+            .contentLabel("label1");
+        ContentOverrideDTO co4 = ContentOverrides.random()
+            .contentLabel("label2");
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment1.getId(), List.of(co1, co2));
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment2.getId(), List.of(co3, co4));
+
+        assertThat(overrides1)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2));
+
+        assertThat(overrides2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co3, co4));
+
+        ContentOverrideDTO toDelete = new ContentOverrideDTO()
+            .contentLabel("label1");
+
+        List<ContentOverrideDTO> overrides3 = adminClient.environments()
+            .deleteEnvironmentContentOverrides(environment1.getId(), List.of(toDelete));
+
+        assertThat(overrides3)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co2);
+
+        assertEnvironmentContentOverrides(adminClient, environment1)
+            .singleElement()
+            .usingRecursiveComparison()
+            .ignoringFields("created", "updated")
+            .isEqualTo(co2);
+
+        assertEnvironmentContentOverrides(adminClient, environment2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co3, co4))
+            .doesNotContain(co1);
+    }
+
+    @Test
+    public void shouldAllowDeletingMultipleEnvironmentContentOverridesByAttribute() {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random()
+            .contentLabel("label1")
+            .name("attrib1");
+        ContentOverrideDTO co2 = ContentOverrides.random()
+            .contentLabel("label2")
+            .name("attrib1");
+        ContentOverrideDTO co3 = ContentOverrides.random()
+            .contentLabel("label2")
+            .name("attrib2");
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2, co3));
+
+        assertThat(overrides1)
+            .hasSize(3)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2, co3));
+
+        ContentOverrideDTO toDelete = new ContentOverrideDTO()
+            .contentLabel("label1")
+            .name("attrib1");
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .deleteEnvironmentContentOverrides(environment.getId(), List.of(toDelete));
+
+        assertThat(overrides2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co2, co3))
+            .doesNotContain(co1);
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co2, co3))
+            .doesNotContain(co1);
+    }
+
+    @Test
+    public void shouldNotAffectOtherEnvironmentsWhenDeletingMultipleOverridesByAttribute() {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment1 = this.createEnvironment(adminClient);
+        EnvironmentDTO environment2 = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random()
+            .contentLabel("label1")
+            .name("attrib1");
+        ContentOverrideDTO co2 = ContentOverrides.random()
+            .contentLabel("label2")
+            .name("attrib1");
+        ContentOverrideDTO co3 = ContentOverrides.random()
+            .contentLabel("label1")
+            .name("attrib1");
+        ContentOverrideDTO co4 = ContentOverrides.random()
+            .contentLabel("label2")
+            .name("attrib1");
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment1.getId(), List.of(co1, co2));
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment2.getId(), List.of(co3, co4));
+
+        assertThat(overrides1)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2));
+
+        assertThat(overrides2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co3, co4));
+
+        ContentOverrideDTO toDelete = new ContentOverrideDTO()
+            .contentLabel("label1")
+            .name("attrib1");
+
+        List<ContentOverrideDTO> overrides3 = adminClient.environments()
+            .deleteEnvironmentContentOverrides(environment1.getId(), List.of(toDelete));
+
+        assertThat(overrides3)
+            .hasSize(1)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co2))
+            .doesNotContain(co1, co3, co4);
+
+        assertEnvironmentContentOverrides(adminClient, environment1)
+            .hasSize(1)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co2))
+            .doesNotContain(co1, co3, co4);
+
+        assertEnvironmentContentOverrides(adminClient, environment2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co3, co4));
+    }
+
+    @Test
+    public void shouldNotChangeEnvironmentWithMismatchedContentOverride() {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random();
+        ContentOverrideDTO co2 = ContentOverrides.random();
+        ContentOverrideDTO co3 = ContentOverrides.random();
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2, co3));
+
+        assertThat(overrides1)
+            .hasSize(3)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2, co3));
+
+        // This should not match at all with the overrides created above
+        ContentOverrideDTO toDelete = ContentOverrides.random();
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .deleteEnvironmentContentOverrides(environment.getId(), List.of(toDelete));
+
+        assertThat(overrides2)
+            .hasSize(3)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2, co3));
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .hasSize(3)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2, co3));
+    }
+
+    @Test
+    public void shouldAllowDeletingEnvironmentContentOverridesWithMultipleCriteria() {
+        ApiClient adminClient = ApiClients.admin();
+        EnvironmentDTO environment = this.createEnvironment(adminClient);
+
+        ContentOverrideDTO co1 = ContentOverrides.random()
+            .contentLabel("label1");
+        ContentOverrideDTO co2 = ContentOverrides.random()
+            .contentLabel("label1");
+        ContentOverrideDTO co3 = ContentOverrides.random()
+            .contentLabel("label2")
+            .name("attrib1");
+        ContentOverrideDTO co4 = ContentOverrides.random()
+            .contentLabel("label2")
+            .name("attrib2");
+        ContentOverrideDTO co5 = ContentOverrides.random()
+            .contentLabel("label3")
+            .name("attrib3");
+
+        List<ContentOverrideDTO> overrides1 = adminClient.environments()
+            .putEnvironmentContentOverrides(environment.getId(), List.of(co1, co2, co3, co4, co5));
+
+        assertThat(overrides1)
+            .hasSize(5)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co1, co2, co3, co4, co5));
+
+        ContentOverrideDTO deleteByLabel = new ContentOverrideDTO()
+            .contentLabel("label1");
+        ContentOverrideDTO deleteByAttrib = new ContentOverrideDTO()
+            .contentLabel("label2")
+            .name("attrib1");
+        ContentOverrideDTO mismatched = ContentOverrides.random();
+
+        List<ContentOverrideDTO> toDelete = List.of(deleteByLabel, deleteByAttrib, mismatched);
+
+        List<ContentOverrideDTO> overrides2 = adminClient.environments()
+            .deleteEnvironmentContentOverrides(environment.getId(), toDelete);
+
+        assertThat(overrides2)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co4, co5));
+
+        assertEnvironmentContentOverrides(adminClient, environment)
+            .hasSize(2)
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("created", "updated")
+            .containsExactlyInAnyOrderElementsOf(List.of(co4, co5));
+    }
+}

--- a/src/main/java/org/candlepin/dto/api/v1/ContentOverrideTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ContentOverrideTranslator.java
@@ -56,6 +56,7 @@ public class ContentOverrideTranslator implements ObjectTranslator<ContentOverri
     @Override
     public ContentOverrideDTO populate(ModelTranslator translator, ContentOverride source,
         ContentOverrideDTO dest) {
+
         if (source == null) {
             throw new IllegalArgumentException("source is null");
         }

--- a/src/main/java/org/candlepin/model/ConsumerContentOverride.java
+++ b/src/main/java/org/candlepin/model/ConsumerContentOverride.java
@@ -54,15 +54,6 @@ public class ConsumerContentOverride extends ContentOverride<ConsumerContentOver
      * {@inheritDoc}
      */
     @Override
-    public ConsumerContentOverride setParent(Consumer parent) {
-        this.setConsumer(parent);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public Consumer getParent() {
         return this.getConsumer();
     }

--- a/src/main/java/org/candlepin/model/ContentOverride.java
+++ b/src/main/java/org/candlepin/model/ContentOverride.java
@@ -113,8 +113,6 @@ public abstract class ContentOverride<T extends ContentOverride, P extends Abstr
         return value;
     }
 
-    public abstract T setParent(P parent);
-
     public abstract P getParent();
 
     /**

--- a/src/main/java/org/candlepin/model/ContentOverrideCurator.java
+++ b/src/main/java/org/candlepin/model/ContentOverrideCurator.java
@@ -14,8 +14,6 @@
  */
 package org.candlepin.model;
 
-import com.google.inject.persist.Transactional;
-
 import org.hibernate.criterion.Restrictions;
 
 import java.util.List;
@@ -105,37 +103,6 @@ public abstract class ContentOverrideCurator<T extends ContentOverride<T, Parent
         }
 
         return null;
-    }
-
-    @Transactional
-    public T addOrUpdate(Parent parent, ContentOverride override) {
-        if (parent == null) {
-            throw new IllegalArgumentException("parent is null");
-        }
-
-        if (override == null) {
-            throw new IllegalArgumentException("override is null");
-        }
-
-        T current = this.retrieve(parent, override.getContentLabel(), override.getName());
-
-        if (current != null) {
-            current.setValue(override.getValue());
-
-            current = this.merge(current);
-        }
-        else {
-            current = this.createOverride();
-
-            current.setParent(parent);
-            current.setContentLabel(override.getContentLabel());
-            current.setName(override.getName());
-            current.setValue(override.getValue());
-
-            current = this.create(current);
-        }
-
-        return current;
     }
 
     /**

--- a/src/main/java/org/candlepin/model/EnvironmentContentOverride.java
+++ b/src/main/java/org/candlepin/model/EnvironmentContentOverride.java
@@ -81,15 +81,6 @@ public class EnvironmentContentOverride extends ContentOverride<EnvironmentConte
      * {@inheritDoc}
      */
     @Override
-    public EnvironmentContentOverride setParent(Environment parent) {
-        this.setEnvironment(parent);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String toString() {
         Environment environment = this.getEnvironment();
 

--- a/src/main/java/org/candlepin/model/EnvironmentContentOverrideCurator.java
+++ b/src/main/java/org/candlepin/model/EnvironmentContentOverrideCurator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import javax.inject.Singleton;
+
+/**
+ * EnvironmentContentOverrideCurator
+ */
+@Singleton
+public class EnvironmentContentOverrideCurator extends
+    ContentOverrideCurator<EnvironmentContentOverride, Environment> {
+
+    public EnvironmentContentOverrideCurator() {
+        super(EnvironmentContentOverride.class, "environment");
+    }
+
+    @Override
+    protected EnvironmentContentOverride createOverride() {
+        return new EnvironmentContentOverride();
+    }
+}

--- a/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -334,7 +334,7 @@ public class ActivationKeyResource implements ActivationKeyApi {
 
         return this.contentOverrideCurator.getList(key)
             .stream()
-            .map(this.translator.getStreamMapper(ActivationKeyContentOverride.class,
+            .map(this.translator.getStreamMapper(ContentOverride.class,
                 ContentOverrideDTO.class));
     }
 
@@ -358,10 +358,10 @@ public class ActivationKeyResource implements ActivationKeyApi {
                 else {
                     String name = dto.getName();
                     if (StringUtils.isBlank(name)) {
-                        this.contentOverrideCurator.removeByContentLabel(key, dto.getContentLabel());
+                        this.contentOverrideCurator.removeByContentLabel(key, label);
                     }
                     else {
-                        this.contentOverrideCurator.removeByName(key, dto.getContentLabel(), name);
+                        this.contentOverrideCurator.removeByName(key, label, name);
                     }
                 }
             }

--- a/src/test/java/org/candlepin/model/ActivationKeyContentOverrideCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ActivationKeyContentOverrideCuratorTest.java
@@ -134,33 +134,6 @@ public class ActivationKeyContentOverrideCuratorTest extends DatabaseTestFixture
     }
 
     @Test
-    public void testAddOrUpdateUpdatesValue() {
-        ActivationKeyContentOverride cco1 = this.buildActivationKeyContentOverride(
-            key, "test-content1", "name1", "value");
-        activationKeyContentOverrideCurator.create(cco1);
-        ActivationKeyContentOverride cco2 = this.buildActivationKeyContentOverride(
-            key, "test-content1", "name1", "value2");
-        activationKeyContentOverrideCurator.addOrUpdate(key, cco2);
-
-        List<ActivationKeyContentOverride> ccoList = activationKeyContentOverrideCurator.listAll();
-        assertEquals(1, ccoList.size());
-        assertEquals("value2", ccoList.get(0).getValue());
-    }
-
-    @Test
-    public void testAddOrUpdateCreatesNew() {
-        ActivationKeyContentOverride cco1 = this.buildActivationKeyContentOverride(
-            key, "test-content1", "name1", "value");
-        activationKeyContentOverrideCurator.create(cco1);
-        ActivationKeyContentOverride cco2 = this.buildActivationKeyContentOverride(
-            key, "test-content2", "name2", "value2");
-        activationKeyContentOverrideCurator.addOrUpdate(key, cco2);
-
-        List<ActivationKeyContentOverride> ccoList = activationKeyContentOverrideCurator.listAll();
-        assertEquals(2, ccoList.size());
-    }
-
-    @Test
     public void testCreateOverride() {
         ActivationKeyContentOverride override = this.buildActivationKeyContentOverride(key,
             "test-repo", "gpgcheck", "1");

--- a/src/test/java/org/candlepin/model/ConsumerContentOverrideTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerContentOverrideTest.java
@@ -66,35 +66,4 @@ public class ConsumerContentOverrideTest extends ContentOverrideTest<ConsumerCon
         assertNull(output.getParent());
     }
 
-    @Test
-    public void testGetSetParent() {
-        Consumer consumer = new Consumer();
-        ConsumerContentOverride override = this.getTestInstance();
-
-        // The getParent method is synonymous with fetching the consumer for EnvContentOverrides
-        assertNull(override.getParent());
-        assertNull(override.getConsumer());
-
-        ConsumerContentOverride output = override.setParent(consumer);
-        assertSame(override, output);
-
-        assertEquals(consumer, output.getParent());
-        assertEquals(consumer, output.getConsumer());
-    }
-
-    @Test
-    public void testGetSetNullParent() {
-        ConsumerContentOverride override = this.getTestInstance();
-
-        // The getParent method is synonymous with fetching the consumer for EnvContentOverrides
-        assertNull(override.getParent());
-        assertNull(override.getConsumer());
-
-        ConsumerContentOverride output = override.setParent(null);
-        assertSame(override, output);
-
-        assertNull(output.getParent());
-        assertNull(output.getConsumer());
-    }
-
 }

--- a/src/test/java/org/candlepin/model/ContentOverrideTest.java
+++ b/src/test/java/org/candlepin/model/ContentOverrideTest.java
@@ -51,7 +51,7 @@ public abstract class ContentOverrideTest<T extends ContentOverride> {
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = { "test_value" })
-    public void testGetSetConetntLabel(String value) {
+    public void testGetSetContentLabel(String value) {
         T override = this.getTestInstance();
 
         assertNull(override.getContentLabel());
@@ -77,8 +77,22 @@ public abstract class ContentOverrideTest<T extends ContentOverride> {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = { "test_value-1", "TEST-VALUE-2", "TeSt_VaLuE-3" })
+    public void testNameAlwaysStoredAsLowerCase(String value) {
+        T override = this.getTestInstance();
+
+        assertNull(override.getName());
+
+        T output = (T) override.setName(value);
+        assertSame(override, output);
+
+        String expected = value.toLowerCase();
+        assertEquals(expected, override.getName());
+    }
+
+    @ParameterizedTest
     @NullAndEmptySource
-    @ValueSource(strings = { "test_value" })
+    @ValueSource(strings = { "test_value", "TeSt_ValUe-2" })
     public void testGetSetValue(String value) {
         T override = this.getTestInstance();
 

--- a/src/test/java/org/candlepin/model/EnvironmentContentOverrideTest.java
+++ b/src/test/java/org/candlepin/model/EnvironmentContentOverrideTest.java
@@ -66,35 +66,4 @@ public class EnvironmentContentOverrideTest extends ContentOverrideTest<Environm
         assertNull(output.getParent());
     }
 
-    @Test
-    public void testGetSetParent() {
-        Environment environment = new Environment();
-        EnvironmentContentOverride override = this.getTestInstance();
-
-        // The getParent method is synonymous with fetching the environment for EnvContentOverrides
-        assertNull(override.getParent());
-        assertNull(override.getEnvironment());
-
-        EnvironmentContentOverride output = override.setParent(environment);
-        assertSame(override, output);
-
-        assertEquals(environment, output.getParent());
-        assertEquals(environment, output.getEnvironment());
-    }
-
-    @Test
-    public void testGetSetNullParent() {
-        EnvironmentContentOverride override = this.getTestInstance();
-
-        // The getParent method is synonymous with fetching the environment for EnvContentOverrides
-        assertNull(override.getParent());
-        assertNull(override.getEnvironment());
-
-        EnvironmentContentOverride output = override.setParent(null);
-        assertSame(override, output);
-
-        assertNull(output.getParent());
-        assertNull(output.getEnvironment());
-    }
-
 }

--- a/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ActivationKeyResourceTest.java
@@ -43,6 +43,7 @@ import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyContentOverrideCurator;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
 import org.candlepin.policy.activationkey.ActivationKeyRules;
+import org.candlepin.resource.validation.DTOValidator;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.ContentOverrideValidator;
@@ -61,6 +62,7 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
 
     private static int poolid = 0;
 
+    private DTOValidator dtoValidator;
     private ServiceLevelValidator serviceLevelValidator;
     private ActivationKeyResource activationKeyResource;
     private ActivationKeyRules activationKeyRules;
@@ -76,6 +78,7 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
         activationKeyResource = injector.getInstance(ActivationKeyResource.class);
         activationKeyRules = injector.getInstance(ActivationKeyRules.class);
 
+        this.dtoValidator = new DTOValidator(this.i18n);
         this.mockActivationKeyCurator = mock(ActivationKeyCurator.class);
         this.serviceLevelValidator = mock(ServiceLevelValidator.class);
         this.poolService = mock(PoolService.class);
@@ -88,7 +91,7 @@ public class ActivationKeyResourceTest extends DatabaseTestFixture {
     private ActivationKeyResource buildActivationKeyResource() {
         return new ActivationKeyResource(this.mockActivationKeyCurator, this.i18n, this.poolService,
             this.serviceLevelValidator, this.activationKeyRules, this.productCurator, this.modelTranslator,
-            this.validator, this.akcoCurator, this.coValidator);
+            this.dtoValidator, this.akcoCurator, this.coValidator);
     }
 
     @Test

--- a/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
@@ -50,12 +50,14 @@ import org.candlepin.model.ContentCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentContentCurator;
+import org.candlepin.model.EnvironmentContentOverrideCurator;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.IdentityCertificateCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.SCACertificate;
 import org.candlepin.resource.validation.DTOValidator;
 import org.candlepin.test.TestUtil;
+import org.candlepin.util.ContentOverrideValidator;
 import org.candlepin.util.RdbmsExceptionTranslator;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -94,7 +96,9 @@ class EnvironmentResourceTest {
     @Mock
     private JobManager jobManager;
     @Mock
-    private DTOValidator validator;
+    private DTOValidator dtoValidator;
+    @Mock
+    private ContentOverrideValidator contentOverrideValidator;
     @Mock
     private ContentAccessManager contentAccessManager;
     @Mock
@@ -107,9 +111,11 @@ class EnvironmentResourceTest {
     private EntitlementCurator entitlementCurator;
     @Mock
     private EntitlementCertificateService entCertService;
+    @Mock
+    private EnvironmentContentOverrideCurator envContentOverrideCurator;
+
     private I18n i18n;
     private ModelTranslator translator;
-
     private EnvironmentResource environmentResource;
 
     private Owner owner;
@@ -135,14 +141,19 @@ class EnvironmentResourceTest {
             this.rdbmsExceptionTranslator,
             this.translator,
             this.jobManager,
-            this.validator,
+            this.dtoValidator,
+            this.contentOverrideValidator,
             this.contentAccessManager,
             this.certificateSerialCurator,
             this.identityCertificateCurator,
             this.contentAccessCertificateCurator,
             this.entitlementCurator,
-            this.entCertService);
+            this.entCertService,
+            this.envContentOverrideCurator);
 
+        // TODO: Stop doing this! Globally shared data means every test in the suite has to account
+        // for this or risk counts/queries not returning precise results! Just create the objects in
+        // the test as necessary!
         this.owner = TestUtil.createOwner("owner1");
         this.environment1 = createEnvironment(owner, ENV_ID_1);
     }

--- a/src/test/java/org/candlepin/resource/RoleResourceTest.java
+++ b/src/test/java/org/candlepin/resource/RoleResourceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.exceptions.NotFoundException;
+import org.candlepin.resource.validation.DTOValidator;
 import org.candlepin.service.UserServiceAdapter;
 import org.candlepin.service.exception.user.UserDisabledException;
 import org.candlepin.test.DatabaseTestFixture;
@@ -33,25 +34,29 @@ import org.mockito.MockitoAnnotations;
  * ProductResourceTest
  */
 public class RoleResourceTest extends DatabaseTestFixture {
-    private RoleResource roleResource;
-    @Mock
-    UserServiceAdapter userServiceAdapter;
 
+    @Mock
+    private UserServiceAdapter mockUserServiceAdapter;
+
+    private DTOValidator dtoValidator;
+    private RoleResource roleResource;
 
     @BeforeEach
     public void init() throws Exception {
         super.init();
         MockitoAnnotations.initMocks(this);
-        roleResource = new RoleResource(this.userServiceAdapter, ownerCurator, permissionBlueprintCurator,
-            i18n, modelTranslator, validator);
+
+        this.dtoValidator = new DTOValidator(this.i18n);
+        this.roleResource = new RoleResource(this.mockUserServiceAdapter, this.ownerCurator,
+            this.permissionBlueprintCurator, this.i18n, this.modelTranslator, this.dtoValidator);
     }
 
     @Test
     public void fetchUserByUsernameExceptions() {
-        when(userServiceAdapter.findByLogin(anyString())).thenReturn(null);
+        when(this.mockUserServiceAdapter.findByLogin(anyString())).thenReturn(null);
         assertThrows(NotFoundException.class, () -> roleResource.fetchUserByUsername("test_user"));
 
-        when(userServiceAdapter.findByLogin(anyString())).thenThrow(UserDisabledException.class);
+        when(this.mockUserServiceAdapter.findByLogin(anyString())).thenThrow(UserDisabledException.class);
         assertThrows(UserDisabledException.class, () -> roleResource.fetchUserByUsername("test_user"));
     }
 }

--- a/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -51,12 +51,14 @@ import org.candlepin.model.Content;
 import org.candlepin.model.ContentAccessCertificateCurator;
 import org.candlepin.model.ContentCurator;
 import org.candlepin.model.DeletedConsumerCurator;
+import org.candlepin.model.DistributorVersionCurator;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.EntitlementCertificate;
 import org.candlepin.model.EntitlementCertificateCurator;
 import org.candlepin.model.EntitlementCurator;
 import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentContentCurator;
+import org.candlepin.model.EnvironmentContentOverrideCurator;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.ExporterMetadataCurator;
 import org.candlepin.model.GuestIdCurator;
@@ -84,7 +86,6 @@ import org.candlepin.model.UserCurator;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKeyContentOverrideCurator;
 import org.candlepin.model.activationkeys.ActivationKeyCurator;
-import org.candlepin.resource.validation.DTOValidator;
 import org.candlepin.resteasy.AnnotationLocator;
 import org.candlepin.resteasy.MethodLocator;
 import org.candlepin.resteasy.ResourceLocatorMap;
@@ -154,10 +155,12 @@ public class DatabaseTestFixture {
     protected ContentAccessCertificateCurator caCertCurator;
     protected ContentCurator contentCurator;
     protected DeletedConsumerCurator deletedConsumerCurator;
+    protected DistributorVersionCurator distributorVersionCurator;
     protected EntitlementCurator entitlementCurator;
     protected EntitlementCertificateCurator entitlementCertificateCurator;
     protected EnvironmentCurator environmentCurator;
     protected EnvironmentContentCurator environmentContentCurator;
+    protected EnvironmentContentOverrideCurator environmentContentOverrideCurator;
     protected ExporterMetadataCurator exporterMetadataCurator;
     protected GuestIdCurator guestIdCurator;
     protected IdentityCertificateCurator identityCertificateCurator;
@@ -189,8 +192,7 @@ public class DatabaseTestFixture {
     protected TestingInterceptor securityInterceptor;
     protected DateSourceForTesting dateSource;
     protected I18n i18n;
-    protected Provider<I18n> i18nProvider = () -> i18n;
-    protected DTOValidator validator;
+    protected Provider<I18n> i18nProvider;
 
     @BeforeAll
     public static void initClass() {
@@ -243,8 +245,7 @@ public class DatabaseTestFixture {
         loadFromInjector();
 
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-
-        this.validator = new DTOValidator(this.i18n);
+        this.i18nProvider = () -> this.i18n;
 
         // Because all candlepin operations are running in the CandlepinRequestScope
         // we'll force the instance creations to be done inside the scope.
@@ -285,10 +286,13 @@ public class DatabaseTestFixture {
         caCertCurator = this.injector.getInstance(ContentAccessCertificateCurator.class);
         contentCurator = this.injector.getInstance(ContentCurator.class);
         deletedConsumerCurator = this.injector.getInstance(DeletedConsumerCurator.class);
+        distributorVersionCurator = this.injector.getInstance(DistributorVersionCurator.class);
         entitlementCurator = this.injector.getInstance(EntitlementCurator.class);
         entitlementCertificateCurator = this.injector.getInstance(EntitlementCertificateCurator.class);
         environmentCurator = this.injector.getInstance(EnvironmentCurator.class);
         environmentContentCurator = this.injector.getInstance(EnvironmentContentCurator.class);
+        environmentContentOverrideCurator = this.injector
+            .getInstance(EnvironmentContentOverrideCurator.class);
         exporterMetadataCurator = this.injector.getInstance(ExporterMetadataCurator.class);
         guestIdCurator = this.injector.getInstance(GuestIdCurator.class);
         identityCertificateCurator = this.injector.getInstance(IdentityCertificateCurator.class);


### PR DESCRIPTION
- Added endpoints for managing environment content overrides
- Updated consumer content override fetching to include layered overrides from any environments applicable to the consumer
- Removed .setParent from ContentOverride and its subclasses
- Updated the migration of content overrides from activation keys to consumers in ConsumerBindUtil to no longer fetch and persist each override individually (or multiple times)
- Added tests and updated testing logic where applicable