### PR TITLE
[M] CANDLEPIN-844: Restored an annotation on the reregistration test

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/NotWithMySql.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/NotWithMySql.java
@@ -26,6 +26,9 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation marks a test or test suite to run only when not running against MariaDB/MySql.
+ *
+ * TODO: FIXME: This doesn't actually check the state of the server, it's only checking against an
+ * environment variable set on the *CLIENT* which could lead to incorrect test selection.
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceActivationKeySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceActivationKeySpecTest.java
@@ -31,6 +31,7 @@ import org.candlepin.dto.api.client.v1.ProductDTO;
 import org.candlepin.dto.api.client.v1.ReleaseVerDTO;
 import org.candlepin.resource.client.v1.ActivationKeyApi;
 import org.candlepin.resource.client.v1.OwnerProductApi;
+import org.candlepin.spec.bootstrap.assertions.NotWithMySql;
 import org.candlepin.spec.bootstrap.client.ApiClient;
 import org.candlepin.spec.bootstrap.client.ApiClients;
 import org.candlepin.spec.bootstrap.client.SpecTest;
@@ -102,6 +103,7 @@ public class ConsumerResourceActivationKeySpecTest {
     }
 
     @Test
+    @NotWithMySql
     public void shouldAllowConcurrentReregistrations() throws Exception {
         int keyCount = 3;
         int poolCount = 21;


### PR DESCRIPTION
- Restored an annotation that was removed from the consumer resource test to verify concurrent reregistration which prevented it from running against MySQL backends