### PR TITLE
[M] Added innodb deadlock logging to mariadb GH actions container

### DIFF
--- a/.github/containers/mariadb.docker-compose.yml
+++ b/.github/containers/mariadb.docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   mariadb:
     image: mariadb:10.6.14
-    command: --transaction-isolation=READ-COMMITTED
+    command: --transaction-isolation=READ-COMMITTED --innodb-print-all-deadlocks=ON
     container_name: mariadb
     environment:
       MARIADB_USER: candlepin


### PR DESCRIPTION
- Added --innodb-print-all-deadlocks=ON to the mariadb container used to run SpecTests in GH actions to provide more information on deadlock issues.

This will help in CANDLEPIN-841 investigation. We will be able to download the logs and get more information on a deadlock if we run into the issue again.