### PR TITLE
[M] CANDLEPIN-852: Reverted change to SubjectKeyIdentifierWriter interface

### DIFF
--- a/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
+++ b/src/main/java/org/candlepin/pki/SubjectKeyIdentifierWriter.java
@@ -17,6 +17,9 @@ package org.candlepin.pki;
 import java.io.IOException;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+
 
 /**
  * SubjectKeyIdentifierWriter is an interface to provide the encoded SubjectKeyIdentifier to a certificate.
@@ -60,9 +63,10 @@ public interface SubjectKeyIdentifierWriter {
      * we need to abide by it.
      * </p>
      * @param clientKeyPair the KeyPair of the certificate's subject
+     * @param extensions Other Extensions being placed on this certificate
      * @return DER encoded octet string of the subject key identifier as a byte array
      * @throws IOException thrown if error reading extensions or encoding the KeyIdentifier
      */
-    byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair)
+    byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair, List<X509Extension> extensions)
         throws IOException, NoSuchAlgorithmException;
 }

--- a/src/main/java/org/candlepin/pki/certs/X509CertificateBuilder.java
+++ b/src/main/java/org/candlepin/pki/certs/X509CertificateBuilder.java
@@ -168,7 +168,7 @@ public class X509CertificateBuilder {
         this.addSSLCertificateType(builder);
         this.addKeyUsage(builder);
         this.addAuthorityKeyIdentifier(builder, caCertificate);
-        this.addSubjectKeyIdentifier(builder, this.keyPair);
+        this.addSubjectKeyIdentifier(builder, this.keyPair, this.certExtensions);
         this.addSubjectAltName(builder, this.distinguishedName, this.subjectAltName);
         this.addBasicConstraints(builder);
         this.addExtensions(builder, this.certExtensions);
@@ -202,9 +202,11 @@ public class X509CertificateBuilder {
         }
     }
 
-    private void addSubjectKeyIdentifier(X509v3CertificateBuilder builder, KeyPair keyPair) {
+    private void addSubjectKeyIdentifier(X509v3CertificateBuilder builder, KeyPair keyPair,
+        List<X509Extension> extensions) {
+
         try {
-            byte[] ski = this.subjectKeyIdentifierWriter.getSubjectKeyIdentifier(keyPair);
+            byte[] ski = this.subjectKeyIdentifierWriter.getSubjectKeyIdentifier(keyPair, extensions);
             builder.addExtension(Extension.subjectKeyIdentifier, false, ski);
         }
         catch (NoSuchAlgorithmException | IOException e) {

--- a/src/main/java/org/candlepin/pki/impl/BouncyCastleSubjectKeyIdentifierWriter.java
+++ b/src/main/java/org/candlepin/pki/impl/BouncyCastleSubjectKeyIdentifierWriter.java
@@ -15,23 +15,30 @@
 package org.candlepin.pki.impl;
 
 import org.candlepin.pki.SubjectKeyIdentifierWriter;
+import org.candlepin.pki.X509Extension;
 
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 
 import java.io.IOException;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+
 
 /**
  * Default implementation of SubjectKeyIdentifierWriter.  This implementation is exactly what you might
- * expect but hosted candlepin instances have use cases that require custom SubjectKeyIdentifiers so they may
+ * expect but hosted Candlepin instances have use cases that require custom SubjectKeyIdentifiers so they may
  * write and bind other implementations of the SubjectKeyIdentifierWriter interface.
  */
 public class BouncyCastleSubjectKeyIdentifierWriter implements SubjectKeyIdentifierWriter {
 
     @Override
-    public byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair)
+    public byte[] getSubjectKeyIdentifier(KeyPair clientKeyPair, List<X509Extension> extensions)
         throws IOException, NoSuchAlgorithmException {
-        return new JcaX509ExtensionUtils().createSubjectKeyIdentifier(clientKeyPair.getPublic()).getEncoded();
+
+        return new JcaX509ExtensionUtils()
+            .createSubjectKeyIdentifier(clientKeyPair.getPublic())
+            .getEncoded();
     }
 }

--- a/src/test/java/org/candlepin/pki/impl/BouncyCastleSubjectKeyIdentifierWriterTest.java
+++ b/src/test/java/org/candlepin/pki/impl/BouncyCastleSubjectKeyIdentifierWriterTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.util.List;
+
 
 
 public class BouncyCastleSubjectKeyIdentifierWriterTest {
@@ -38,7 +40,9 @@ public class BouncyCastleSubjectKeyIdentifierWriterTest {
     @Test
     public void getSubjectKeyIdentifier() throws Exception {
         BouncyCastleSubjectKeyIdentifierWriter writer = new BouncyCastleSubjectKeyIdentifierWriter();
-        byte[] actual = writer.getSubjectKeyIdentifier(keyPair);
+
+        byte[] actual = writer.getSubjectKeyIdentifier(keyPair, List.of());
+
         byte[] expected = new JcaX509ExtensionUtils()
             .createSubjectKeyIdentifier(keyPair.getPublic())
             .getEncoded();


### PR DESCRIPTION
- Reverted the change to the SubjectKeyIdentifierWriter interface that removed the list of cert extensions from the getSubjectKeyIdentifier method