### PR TITLE
[M] CANDLEPIN-446: Added PR commit validation for Jira Target Version field

### DIFF
--- a/.github/scripts/jira_target_version_check.py
+++ b/.github/scripts/jira_target_version_check.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import unicode_literals
+
+import os
+import re
+import sys
+
+from atlassian import Jira
+
+import requests
+
+JIRA_URL = 'https://issues.redhat.com'
+TARGET_VERSION_FIELD_ID = 'customfield_12319940'
+TARGET_VERSION_FIELD_NAME = 'Target Version'
+
+github_token = os.environ.get('GITHUB_TOKEN_PSW')
+if not github_token:
+    raise EnvironmentError('GITHUB_TOKEN_PSW not specified')
+
+pr_number = os.environ.get('PR_NUMBER')
+if not github_token:
+    raise EnvironmentError('PR_NUMBER not specified')
+
+jira_token = os.environ.get('JIRA_TOKEN')
+if not jira_token:
+    raise EnvironmentError('JIRA_TOKEN not provided')
+
+pr = requests.get('https://api.github.com/repos/candlepin/candlepin/pulls/{pr}'.format(pr=pr_number),
+                  headers={'Authorization': 'token {}'.format(github_token)}).json()
+target = pr['base']['ref']
+
+pr_target_version = None
+if target == 'main':
+    pr_target_version = ''
+else:
+    version_match = re.search('^candlepin-(.*)-HOTFIX$', target)
+    if version_match:
+        pr_target_version = version_match.group(1)
+    if not pr_target_version:
+        print('Skipping because target branch is not main or HOTFIX branch')
+        sys.exit(0)
+
+jira = Jira(
+    JIRA_URL,
+    token=jira_token
+)
+
+pr_commits = requests.get('https://api.github.com/repos/candlepin/candlepin/pulls/{pr}/commits'.format(pr=pr_number),
+                          headers={'Authorization': 'token {}'.format(github_token)}).json()
+
+for commit in pr_commits:
+    message = commit['commit']['message']
+    first_line = message.split('\n')[0]
+    jira_key_match = re.search('^(CANDLEPIN-\d+)', first_line)
+    if not jira_key_match:
+        continue
+
+    jira_key = jira_key_match.group(1)
+    jira_target_versions = jira.issue_field_value(jira_key, TARGET_VERSION_FIELD_ID)
+
+    # If there is no Jira target version field value defined for the Jira task then the task is expected to merge into main
+    if not jira_target_versions:
+        if not pr_target_version:
+            continue
+        else:
+            print("Expected PR target branch to be '" + pr_target_version + "' for '" + jira_key + "', but was main")
+            sys.exit(1)
+
+    # It is an error state to have more than one target versions defined for a Jira issue
+    if len(jira_target_versions) > 1:
+        print("More than one Jira version defined for '" + TARGET_VERSION_FIELD_NAME + "' field for '" + jira_key + "'")
+        sys.exit(1)
+
+    jira_target_version = jira_target_versions[0]["name"]
+
+    if jira_target_version != pr_target_version:
+        # Changing to 'main' for better logging
+        if not pr_target_version:
+            pr_target_version = 'main'
+
+        print("PR target branch '" + pr_target_version + "' does not equal the target version field value '" + jira_target_version + "' for Jira issue '" + jira_key + "'")
+        sys.exit(1)

--- a/.github/workflows/jira_check.yml
+++ b/.github/workflows/jira_check.yml
@@ -1,0 +1,49 @@
+---
+name: Run Jira Check
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+# Cancel in-progress PR verification workflows. We only care about verifying the latest commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  target_version_validation:
+    name: target version validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mask secrets
+        shell: bash
+        run: |
+          echo "::add-mask::${{ secrets.CANDLEPIN_JIRA_TOKEN }}"
+          echo "::add-mask::${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install packages
+        shell: bash
+        run: sudo apt-get install -y python3 python3-pip python3-requests git-core
+
+      - name: Install python dependencies
+        run: pip install atlassian-python-api
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Rebase
+        uses: ./.github/actions/rebase
+
+      - name: Validate target version field
+        run: |
+          chmod +x ./.github/scripts/jira_target_version_check.py
+          ./.github/scripts/jira_target_version_check.py
+        env:
+          JIRA_TOKEN: ${{ secrets.CANDLEPIN_JIRA_TOKEN }}
+          GITHUB_TOKEN_PSW: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+


### PR DESCRIPTION
- Created a Github Actions workflow and script for validating that the target branch for a PR that references a Jira that has a defined 'Target Version' field value.

I included a couple of runs that I did testing some of the possible outcomes of the Jira target version field validation.

- Example of the wrong PR target branch: https://github.com/candlepin/candlepin/actions/runs/8910712833/job/24470503727?pr=4693
- Example of multiple target versions being defined in Jira: https://github.com/candlepin/candlepin/actions/runs/8910712833/job/24470554065
- Example of a Jira issue that does not exist being in a commit message: https://github.com/candlepin/candlepin/actions/runs/8910773318/job/24470687335?pr=4693