### PR TITLE
[M] CANDLEPIN-853: Fixed namespace column type for layered entities

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
@@ -110,6 +110,20 @@ public class OwnerProductResourceSpecTest {
     }
 
     @Test
+    public void shouldAllowCreatingProductsInOrgsWithLongKeys() {
+        OwnerDTO owner = ownerApi.createOwner(Owners.random()
+            .key(StringUtil.random("test_org-", 245, StringUtil.CHARSET_NUMERIC_HEX)));
+
+        ProductDTO prod = Products.randomEng();
+
+        ProductDTO created = ownerProductApi.createProduct(owner.getKey(), prod);
+        assertThat(created)
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id", "name")
+            .isEqualTo(prod);
+    }
+
+    @Test
     public void shouldFailWhenFetchingNonExistingProducts() {
         OwnerDTO owner = ownerApi.createOwner(Owners.random());
         assertNotFound(() -> ownerProductApi.getProductById(owner.getKey(), "bad product id"));

--- a/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentSpecTest.java
@@ -147,6 +147,22 @@ class OwnerContentSpecTest {
             .isEqualTo(content);
     }
 
+    @Test
+    public void shouldAllowCreatingProductsInOrgsWithLongKeys() {
+        ApiClient adminClient = ApiClients.admin();
+        OwnerDTO owner = adminClient.owners().createOwner(Owners.random()
+            .key(StringUtil.random("test_org-", 245, StringUtil.CHARSET_NUMERIC_HEX)));
+
+        ContentDTO content = this.getFullyPopulatedContent();
+        ContentDTO created = adminClient.ownerContent().createContent(owner.getKey(), content);
+
+        assertThat(created)
+            .isNotNull()
+            .usingRecursiveComparison()
+            .ignoringFields("uuid", "created", "updated")
+            .isEqualTo(content);
+    }
+
     private static Stream<Arguments> criticalContentStringFieldsAndValues() {
         Set<String> fields = Set.of("label", "name", "type", "vendor");
         List<String> values = Arrays.asList("", null);

--- a/src/main/resources/db/changelog/20240502145033-fix_entity_namespace_type.xml
+++ b/src/main/resources/db/changelog/20240502145033-fix_entity_namespace_type.xml
@@ -1,0 +1,19 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+    <changeSet id="20240502145033-1" author="crog">
+        <modifyDataType tableName="cp_products"
+            columnName="namespace"
+            newDataType="varchar(255)" />
+    </changeSet>
+
+    <changeSet id="20240502145033-2" author="crog">
+        <modifyDataType tableName="cp_contents"
+            columnName="namespace"
+            newDataType="varchar(255)" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -198,4 +198,5 @@
     <include file="db/changelog/202401081559-add-claimant-owner-column.xml"/>
     <include file="db/changelog/20240104162911-unrevoke-subscription-certs.xml"/>
     <include file="db/changelog/20240329143555-add_environment_content_override_schema.xml"/>
+    <include file="db/changelog/20240502145033-fix_entity_namespace_type.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -134,6 +134,22 @@ public class ContentManagerTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testCreateContentInOrgUsingLongKey() {
+        Owner owner = this.createOwner("test-owner".repeat(25));
+        Content content = TestUtil.createContent("c1", "content-1")
+            .setNamespace(owner.getKey())
+            .setLabel("test-label")
+            .setType("test-test")
+            .setVendor("test-vendor");
+
+        assertNull(this.contentCurator.getContentById(owner.getKey(), content.getId()));
+
+        Content output = this.contentManager.createContent(owner, content);
+
+        assertEquals(output, this.contentCurator.getContentById(owner.getKey(), content.getId()));
+    }
+
+    @Test
     public void testUpdateContentNoChange() {
         Owner owner = this.createOwner("test-owner", "Test Owner");
         Content content = TestUtil.createContent("c1", "content-1")

--- a/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -97,6 +97,18 @@ public class ProductManagerTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testCreateProductInOrgUsingLongKey() {
+        Owner owner = this.createOwner("test_owner".repeat(25));
+        ProductInfo productInfo = TestUtil.createProductInfo("p1", "prod1");
+
+        assertNull(this.productCurator.getProductById(owner.getKey(), productInfo.getId()));
+
+        Product output = this.productManager.createProduct(owner, productInfo);
+
+        assertEquals(output, this.productCurator.getProductById(owner.getKey(), productInfo.getId()));
+    }
+
+    @Test
     public void testUpdateProductNoChange() {
         Owner owner = this.createOwner("test-owner", "Test Owner");
         Product product = TestUtil.createProduct("p1", "prod1")

--- a/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
@@ -287,6 +287,29 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testCreateContentInOrgUsingLongKey() {
+        Owner owner = this.createOwner("test_owner".repeat(25));
+        ContentDTO cdto = TestUtil.createContentDTO("test_content");
+        cdto.setLabel("test-label");
+        cdto.setType("test-test");
+        cdto.setVendor("test-vendor");
+
+        assertNull(this.contentCurator.getContentById(owner.getKey(), cdto.getId()));
+
+        ContentDTO output = this.ownerContentResource.createContent(owner.getKey(), cdto);
+
+        assertNotNull(output);
+        assertEquals(cdto.getId(), output.getId());
+
+        Content entity = this.contentCurator.getContentById(owner.getKey(), cdto.getId());
+        assertNotNull(entity);
+        assertEquals(cdto.getName(), entity.getName());
+        assertEquals(cdto.getLabel(), entity.getLabel());
+        assertEquals(cdto.getType(), entity.getType());
+        assertEquals(cdto.getVendor(), entity.getVendor());
+    }
+
+    @Test
     public void testUpdateContent() {
         Owner owner = this.createOwner("test_owner");
         Content content = TestUtil.createContent("test_content", "test_content")

--- a/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
@@ -366,6 +366,23 @@ public class OwnerProductResourceTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testCreateProductInOrgUsingLongKey() {
+        Owner owner = this.createOwner("test_owner".repeat(25));
+        ProductDTO pdto = this.buildTestProductDTO();
+
+        assertNull(this.productCurator.getProductById(owner.getKey(), pdto.getId()));
+
+        ProductDTO result = this.ownerProductResource.createProduct(owner.getKey(), pdto);
+        assertNotNull(result);
+
+        Product entity = this.productCurator.getProductById(owner.getKey(), pdto.getId());
+        assertNotNull(entity);
+
+        ProductDTO expected = this.modelTranslator.translate(entity, ProductDTO.class);
+        assertEquals(expected, result);
+    }
+
+    @Test
     public void testUpdateProductWithAttributes() {
         Map<String, String> attributes = new HashMap<>();
         attributes.put("attrib-1", "value-1");


### PR DESCRIPTION
- Updated the namespace column definition to be the same width as the owner key, which is the primary source for the namespace values