### PR TITLE
[M] Updated jira_check.yml to run on pull_request_target

### DIFF
--- a/.github/workflows/jira_check.yml
+++ b/.github/workflows/jira_check.yml
@@ -2,7 +2,7 @@
 name: Run Jira Check
 
 on:
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 # Cancel in-progress PR verification workflows. We only care about verifying the latest commit.


### PR DESCRIPTION
- Updated jira_check.yml to run on pull_request_target instead of pull_request so that the jira validation can access secrets for PRs from forked repos.