### PR TITLE
CANDLEPIN-820: Removed hibernate criteria from select curator classes

### DIFF
--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -1265,8 +1265,13 @@ public class ConsumerResource implements ConsumerApi {
             if ((existing.getCapabilities() == null || existing.getCapabilities().isEmpty()) &&
                 existing.getFact(Consumer.Facts.DISTRIBUTOR_VERSION) != null) {
 
-                Set<DistributorVersionCapability> capabilities = distributorVersionCurator
-                    .findCapabilitiesByDistVersion(existing.getFact(Consumer.Facts.DISTRIBUTOR_VERSION));
+                DistributorVersion distributorVersion = distributorVersionCurator
+                    .findByName(existing.getFact(Consumer.Facts.DISTRIBUTOR_VERSION));
+
+                Set<DistributorVersionCapability> capabilities = null;
+                if (distributorVersion != null) {
+                    capabilities = distributorVersion.getCapabilities();
+                }
 
                 this.populateCapabilities(existing, capabilities);
                 change = true;

--- a/src/main/java/org/candlepin/resource/DistributorVersionResource.java
+++ b/src/main/java/org/candlepin/resource/DistributorVersionResource.java
@@ -108,7 +108,7 @@ public class DistributorVersionResource implements DistributorVersionsApi {
             versions = curator.findByCapability(capability);
         }
         else {
-            versions = curator.findAll();
+            versions = curator.listAll();
         }
 
         return versions.stream().map(
@@ -117,7 +117,7 @@ public class DistributorVersionResource implements DistributorVersionsApi {
 
     @Override
     public void delete(String id) {
-        DistributorVersion dv = curator.findById(id);
+        DistributorVersion dv = curator.get(id);
         if (dv != null) {
             curator.delete(dv);
         }
@@ -153,7 +153,7 @@ public class DistributorVersionResource implements DistributorVersionsApi {
     }
 
     private DistributorVersion verifyAndLookupDistributorVersion(String id) {
-        DistributorVersion dv = curator.findById(id);
+        DistributorVersion dv = curator.get(id);
 
         if (dv == null) {
             throw new NotFoundException(i18n.tr("No such distributor version: {0}", id));

--- a/src/main/java/org/candlepin/sync/Exporter.java
+++ b/src/main/java/org/candlepin/sync/Exporter.java
@@ -548,7 +548,7 @@ public class Exporter {
     }
 
     private void exportDistributorVersions(File baseDir) throws IOException {
-        List<DistributorVersion> versions = distVerCurator.findAll();
+        List<DistributorVersion> versions = distVerCurator.listAll();
         if (versions == null || versions.isEmpty()) {
             return;
         }

--- a/src/test/java/org/candlepin/model/ContentAccessCertificateCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentAccessCertificateCuratorTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class ContentAccessCertificateCuratorTest extends DatabaseTestFixture {
+
+    @Test
+    public void testGetForConsumerWithInvalidConsumer() {
+        assertNull(caCertCurator.getForConsumer(null));
+
+        Consumer consumer = new Consumer();
+        // Null consumer ID
+        assertNull(caCertCurator.getForConsumer(consumer));
+
+        consumer.setId("");
+        assertNull(caCertCurator.getForConsumer(consumer));
+
+        consumer.setId("  ");
+        assertNull(caCertCurator.getForConsumer(consumer));
+    }
+
+    @Test
+    public void testGetForConsumerWithHNoExistingCertificate() {
+        Owner owner = createOwner();
+        Consumer consumer = createConsumer(owner);
+
+        SCACertificate actual = caCertCurator.getForConsumer(consumer);
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void testGetForConsumerWithExistingCertificate() {
+        Owner owner1 = createOwner();
+        Owner owner2 = createOwner();
+
+        Consumer consumer1 = createConsumer(owner1);
+        Consumer consumer2 = createConsumer(owner2);
+
+        CertificateSerial serial1 = new CertificateSerial();
+        serial1.setExpiration(TestUtil.createDateOffset(0, 0, 7));
+        certSerialCurator.save(serial1);
+
+        CertificateSerial serial2 = new CertificateSerial();
+        serial2.setExpiration(TestUtil.createDateOffset(0, 0, 7));
+        certSerialCurator.save(serial2);
+
+        SCACertificate cert1 = new SCACertificate();
+        cert1.setConsumer(consumer1);
+        cert1.setKey(TestUtil.randomString());
+        cert1.setCert(TestUtil.randomString());
+        cert1.setSerial(serial1);
+
+        SCACertificate cert2 = new SCACertificate();
+        cert2.setConsumer(consumer2);
+        cert2.setKey(TestUtil.randomString());
+        cert2.setCert(TestUtil.randomString());
+        cert2.setSerial(serial2);
+
+        cert1 = caCertCurator.create(cert1);
+        cert2 = caCertCurator.create(cert2);
+
+        consumer1.setContentAccessCert(cert1);
+        consumer2.setContentAccessCert(cert2);
+
+        SCACertificate actual = caCertCurator.getForConsumer(consumer1);
+
+        assertThat(actual)
+            .isNotNull()
+            .isEqualTo(cert1);
+    }
+
+    @Test
+    public void testDeleteForOwnerWithInvalidOwner() {
+        int actual = caCertCurator.deleteForOwner(null);
+        assertEquals(0, actual);
+
+        Owner owner = new Owner();
+
+        // Null owner key
+        actual = caCertCurator.deleteForOwner(owner);
+        assertEquals(0, actual);
+
+        owner.setKey("  ");
+        actual = caCertCurator.deleteForOwner(owner);
+        assertEquals(0, actual);
+    }
+
+    @Test
+    public void testDeleteForOwner() {
+        Owner owner1 = createOwner();
+        Owner owner2 = createOwner();
+
+        Consumer consumer1 = createConsumer(owner1);
+        Consumer consumer2 = createConsumer(owner2);
+
+        CertificateSerial serial1 = new CertificateSerial();
+        serial1.setExpiration(TestUtil.createDateOffset(0, 0, 7));
+        certSerialCurator.save(serial1);
+
+        CertificateSerial serial2 = new CertificateSerial();
+        serial2.setExpiration(TestUtil.createDateOffset(0, 0, 7));
+        certSerialCurator.save(serial2);
+
+        SCACertificate cert1 = new SCACertificate();
+        cert1.setConsumer(consumer1);
+        cert1.setKey(TestUtil.randomString());
+        cert1.setCert(TestUtil.randomString());
+        cert1.setSerial(serial1);
+
+        SCACertificate cert2 = new SCACertificate();
+        cert2.setConsumer(consumer2);
+        cert2.setKey(TestUtil.randomString());
+        cert2.setCert(TestUtil.randomString());
+        cert2.setSerial(serial2);
+
+        cert1 = caCertCurator.create(cert1);
+        cert2 = caCertCurator.create(cert2);
+
+        consumer1.setContentAccessCert(cert1);
+        consumer2.setContentAccessCert(cert2);
+
+        int actual = caCertCurator.deleteForOwner(owner1);
+
+        assertEquals(1, actual);
+        assertThat(getSCACertificatesFromDB())
+            .isNotNull()
+            .hasSize(1)
+            .containsExactly(cert2);
+    }
+
+    @Test
+    public void testListAllExpired() {
+        CertificateSerial serial = new CertificateSerial();
+        serial.setExpiration(TestUtil.createDateOffset(0, 0, 7));
+        certSerialCurator.save(serial);
+
+        CertificateSerial expiredSerial = new CertificateSerial();
+        expiredSerial.setExpiration(TestUtil.createDateOffset(0, 0, -7));
+        certSerialCurator.save(expiredSerial);
+
+        SCACertificate cert = new SCACertificate();
+        cert.setKey(TestUtil.randomString());
+        cert.setCert(TestUtil.randomString());
+        cert.setSerial(serial);
+
+        SCACertificate expiredCert = new SCACertificate();
+        expiredCert.setKey(TestUtil.randomString());
+        expiredCert.setCert(TestUtil.randomString());
+        expiredCert.setSerial(expiredSerial);
+
+        caCertCurator.create(cert);
+        caCertCurator.create(expiredCert);
+
+        List<CertSerial> actual = caCertCurator.listAllExpired();
+
+        assertThat(actual)
+            .isNotNull()
+            .hasSize(1)
+            .first()
+            .returns(expiredSerial.getSerial().longValue(), CertSerial::serial);
+    }
+
+    @Test
+    public void testDeleteByIdsWithNullOrEmptyIds() {
+        int actual = caCertCurator.deleteByIds(null);
+        assertEquals(0, actual);
+
+        actual = caCertCurator.deleteByIds(List.of());
+        assertEquals(0, actual);
+    }
+
+    @Test
+    public void testDeleteByIds() {
+        CertificateSerial serial1 = new CertificateSerial();
+        serial1.setExpiration(TestUtil.createDateOffset(0, 0, 7));
+        certSerialCurator.save(serial1);
+
+        CertificateSerial serial2 = new CertificateSerial();
+        serial2.setExpiration(TestUtil.createDateOffset(0, 0, 7));
+        certSerialCurator.save(serial2);
+
+        SCACertificate cert1 = new SCACertificate();
+        cert1.setKey(TestUtil.randomString());
+        cert1.setCert(TestUtil.randomString());
+        cert1.setSerial(serial1);
+
+        SCACertificate cert2 = new SCACertificate();
+        cert2.setKey(TestUtil.randomString());
+        cert2.setCert(TestUtil.randomString());
+        cert2.setSerial(serial2);
+
+        cert1 = caCertCurator.create(cert1);
+        cert2 = caCertCurator.create(cert2);
+
+        int deleted = caCertCurator.deleteByIds(List.of(cert1.getId()));
+
+        assertEquals(1, deleted);
+
+        assertThat(getSCACertificatesFromDB())
+            .isNotNull()
+            .singleElement()
+            .isEqualTo(cert2);
+    }
+
+    @Test
+    public void testListCertSerialsWithNullOrEmptyConsumerIds() {
+        List<CertSerial> actual = caCertCurator.listCertSerials(null);
+        assertThat(actual).isEmpty();
+
+        actual = caCertCurator.listCertSerials(List.of());
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    public void testListCertSerials() {
+        Owner owner1 = createOwner();
+        Owner owner2 = createOwner();
+        Owner owner3 = createOwner();
+
+        Consumer consumer1 = createConsumer(owner1);
+        Consumer consumer2 = createConsumer(owner2);
+        Consumer consumer3 = createConsumer(owner3);
+
+        CertificateSerial serial1 = new CertificateSerial();
+        serial1.setExpiration(TestUtil.createDateOffset(0, 0, 7));
+        certSerialCurator.save(serial1);
+
+        CertificateSerial serial2 = new CertificateSerial();
+        serial2.setExpiration(TestUtil.createDateOffset(0, 0, 7));
+        certSerialCurator.save(serial2);
+
+        CertificateSerial serial3 = new CertificateSerial();
+        serial3.setExpiration(TestUtil.createDateOffset(0, 0, 7));
+        certSerialCurator.save(serial3);
+
+        SCACertificate cert1 = new SCACertificate();
+        cert1.setConsumer(consumer1);
+        cert1.setKey(TestUtil.randomString());
+        cert1.setCert(TestUtil.randomString());
+        cert1.setSerial(serial1);
+
+        SCACertificate cert2 = new SCACertificate();
+        cert2.setConsumer(consumer2);
+        cert2.setKey(TestUtil.randomString());
+        cert2.setCert(TestUtil.randomString());
+        cert2.setSerial(serial2);
+
+        SCACertificate cert3 = new SCACertificate();
+        cert3.setConsumer(consumer3);
+        cert3.setKey(TestUtil.randomString());
+        cert3.setCert(TestUtil.randomString());
+        cert3.setSerial(serial3);
+
+        cert1 = caCertCurator.create(cert1);
+        cert2 = caCertCurator.create(cert2);
+        cert3 = caCertCurator.create(cert3);
+
+        consumer1.setContentAccessCert(cert1);
+        consumer2.setContentAccessCert(cert2);
+        consumer3.setContentAccessCert(cert3);
+
+        List<CertSerial> actual = caCertCurator
+            .listCertSerials(List.of(consumer1.getId(), consumer2.getId()));
+
+        assertThat(actual)
+            .isNotNull()
+            .hasSize(2)
+            .extractingResultOf("serial")
+            .containsExactlyInAnyOrder(cert1.getSerial().getSerial().longValue(),
+                cert2.getSerial().getSerial().longValue());
+    }
+
+    private List<SCACertificate> getSCACertificatesFromDB() {
+        String query = "SELECT c FROM SCACertificate c";
+
+        return getEntityManager()
+            .createQuery(query, SCACertificate.class)
+            .getResultList();
+    }
+}

--- a/src/test/java/org/candlepin/model/DistributorVersionCuratorTest.java
+++ b/src/test/java/org/candlepin/model/DistributorVersionCuratorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.List;
+import java.util.Set;
+
+public class DistributorVersionCuratorTest extends DatabaseTestFixture {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testFindByNameWithInvalidName(String name) {
+        DistributorVersion actual = distributorVersionCurator.findByName(name);
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void testFindByNameWithNoExistingDistributorVersion() {
+        DistributorVersion version = new DistributorVersion();
+        version.setDisplayName(TestUtil.randomString());
+        version.setName(TestUtil.randomString());
+        distributorVersionCurator.create(version);
+
+        DistributorVersion actual = distributorVersionCurator.findByName(TestUtil.randomString());
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void testFindByNameWithExistingDistributorVersion() {
+        DistributorVersion version1 = new DistributorVersion();
+        version1.setDisplayName(TestUtil.randomString());
+        version1.setName(TestUtil.randomString());
+        version1 = distributorVersionCurator.create(version1);
+
+        DistributorVersion version2 = new DistributorVersion();
+        version2.setDisplayName(TestUtil.randomString());
+        version2.setName(TestUtil.randomString());
+        distributorVersionCurator.create(version2);
+
+        DistributorVersion actual = distributorVersionCurator.findByName(version1.getName());
+
+        assertThat(actual)
+            .isNotNull()
+            .isEqualTo(version1);
+    }
+
+    @Test
+    public void testFindByNameSearchWithNullName() {
+        List<DistributorVersion> actual = distributorVersionCurator.findByNameSearch(null);
+
+        assertThat(actual)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    public void testFindByNameSearch() {
+        String name = TestUtil.randomString();
+        DistributorVersion version1 = new DistributorVersion();
+        version1.setDisplayName(TestUtil.randomString());
+        version1.setName(name);
+        version1 = distributorVersionCurator.create(version1);
+
+        String substringOfName = name.substring(1, name.length() - 1);
+        DistributorVersion version2 = new DistributorVersion();
+        version2.setDisplayName(TestUtil.randomString());
+        version2.setName(substringOfName);
+        version2 = distributorVersionCurator.create(version2);
+
+        DistributorVersion version3 = new DistributorVersion();
+        version3.setDisplayName(TestUtil.randomString());
+        version3.setName(TestUtil.randomString());
+        distributorVersionCurator.create(version3);
+
+        List<DistributorVersion> actual = distributorVersionCurator
+            .findByNameSearch(substringOfName);
+
+        assertThat(actual)
+            .isNotNull()
+            .containsExactlyInAnyOrder(version1, version2);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testFindByCapabilityWithInvalidCapabilityName(String name) {
+        List<DistributorVersion> actual = distributorVersionCurator.findByCapability(name);
+
+        assertThat(actual)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    public void testFindByCapability() {
+        DistributorVersionCapability capability1 = new DistributorVersionCapability();
+        capability1.setName(TestUtil.randomString());
+
+        DistributorVersion version1 = new DistributorVersion();
+        version1.setDisplayName(TestUtil.randomString());
+        version1.setName(TestUtil.randomString());
+        version1.setCapabilities(Set.of(capability1));
+        version1 = distributorVersionCurator.create(version1);
+
+        DistributorVersionCapability capability2 = new DistributorVersionCapability();
+        capability2.setName(TestUtil.randomString());
+
+        DistributorVersion version2 = new DistributorVersion();
+        version2.setDisplayName(TestUtil.randomString());
+        version2.setName(TestUtil.randomString());
+        version2.setCapabilities(Set.of(capability2));
+        distributorVersionCurator.create(version2);
+
+        List<DistributorVersion> actual = distributorVersionCurator
+            .findByCapability(capability1.getName());
+
+        assertThat(actual)
+            .isNotNull()
+            .singleElement()
+            .isEqualTo(version1);
+    }
+}

--- a/src/test/java/org/candlepin/sync/ExporterTest.java
+++ b/src/test/java/org/candlepin/sync/ExporterTest.java
@@ -491,7 +491,7 @@ public class ExporterTest {
         dv.setCapabilities(dvcSet);
         List<DistributorVersion> dvList = new ArrayList<>();
         dvList.add(dv);
-        when(dvc.findAll()).thenReturn(dvList);
+        when(dvc.listAll()).thenReturn(dvList);
 
         when(ctc.listAll()).thenReturn(List.of(new ConsumerType("system")));
 


### PR DESCRIPTION
- Removed hibernate criteria from DistributorVersionCurator, ProductCertificateCurator, and ContentAccessCertificateCurator.
- Added missing java docs to curator methods.
- Added mising unit tests for ContentAccessCertificateCurator and DistributorVersionCurator.