### PR TITLE
[M] Additional fixes for the entity layering database migration

### DIFF
--- a/src/main/resources/db/changelog/20231003113535-entity_layering_schema.xml
+++ b/src/main/resources/db/changelog/20231003113535-entity_layering_schema.xml
@@ -373,6 +373,9 @@
                 best BOOLEAN NOT NULL DEFAULT false,
                 PRIMARY KEY (uuid));
 
+            CREATE INDEX tmp_agp_idx1 ON tmp_active_global_products (pid);
+            CREATE INDEX tmp_agc_idx1 ON tmp_active_global_contents (cid);
+
             -- Collect "active" global products and their children
             INSERT INTO tmp_active_global_products (uuid, pid, new_uuid, best)
                 WITH RECURSIVE parent_child_map(parent_uuid, child_uuid) AS (
@@ -508,7 +511,7 @@
                     FROM tmp_active_global_products agp
                     JOIN cp2_product_provided_products old_ppp ON old_ppp.product_uuid = agp.uuid
                     JOIN cp2_products old_child ON old_child.uuid = old_ppp.provided_product_uuid)
-                SELECT agp_parent.new_uuid, agp_child.new_uuid
+                SELECT DISTINCT agp_parent.new_uuid, agp_child.new_uuid
                     FROM product_map pmap
                     JOIN tmp_active_global_products agp_parent ON agp_parent.pid = pmap.product_id
                     JOIN tmp_active_global_products agp_child ON agp_child.pid = pmap.child_id;
@@ -533,6 +536,9 @@
                 new_uuid VARCHAR(32) NOT NULL,
                 best BOOLEAN NOT NULL DEFAULT false,
                 PRIMARY KEY (owner_id, uuid));
+
+            CREATE INDEX tmp_acp_idx1 ON tmp_active_custom_products (pid);
+            CREATE INDEX tmp_acc_idx1 ON tmp_active_custom_contents (cid);
 
             -- Collect "active" custom products and their children
             INSERT INTO tmp_active_custom_products (owner_id, uuid, pid, new_uuid, best)
@@ -672,7 +678,7 @@
                     FROM tmp_active_custom_products acp
                     JOIN cp2_product_provided_products old_ppp ON old_ppp.product_uuid = acp.uuid
                     JOIN cp2_products old_child ON old_child.uuid = old_ppp.provided_product_uuid)
-                SELECT acp_parent.new_uuid, acp_child.new_uuid
+                SELECT DISTINCT acp_parent.new_uuid, acp_child.new_uuid
                     FROM product_map pmap
                     JOIN tmp_active_custom_products acp_parent ON acp_parent.owner_id = pmap.owner_id AND acp_parent.pid = pmap.product_id
                     JOIN tmp_active_custom_products acp_child ON acp_child.owner_id = pmap.owner_id AND acp_child.pid = pmap.child_id;
@@ -686,11 +692,14 @@
                     FROM cp_pool pool
                     JOIN cp2_products prod ON prod.uuid = pool.product_uuid);
 
+            CREATE INDEX ppmap_idx1 ON tmp_pool_product_map (pool_id);
+            CREATE INDEX ppmap_idx2 ON tmp_pool_product_map (product_id);
+
             UPDATE cp_pool pool SET product_uuid = (
                 SELECT COALESCE(acp.new_uuid, agp.new_uuid)
                     FROM tmp_pool_product_map pmap
-                    LEFT JOIN tmp_active_custom_products acp ON acp.owner_id = pmap.owner_id AND acp.pid = pmap.product_id
-                    LEFT JOIN tmp_active_global_products agp ON agp.pid = pmap.product_id
+                    LEFT JOIN tmp_active_custom_products acp ON acp.owner_id = pmap.owner_id AND acp.pid = pmap.product_id AND acp.best = true
+                    LEFT JOIN tmp_active_global_products agp ON agp.pid = pmap.product_id AND agp.best = true
                     WHERE pool.id = pmap.pool_id);
 
 


### PR DESCRIPTION
- Added a DISTINCT to the product UUID selection while migrating provided products to avoid failing out when multiple products are mapped to the same children
- Added conditions to the left joins of the cp_pool update statement to avoid returning multiple results from the subquery in cases where a given environment has multiple active products mapped
- Added indexes to select columns on the temporary tables to avoid unnecessary table scans during the various updates