### PR TITLE
CANDLEPIN-823: Removed hibernate criteria from select curator classes

### DIFF
--- a/src/main/java/org/candlepin/model/ExporterMetadataCurator.java
+++ b/src/main/java/org/candlepin/model/ExporterMetadataCurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -14,10 +14,9 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.criterion.Restrictions;
-
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.persistence.NoResultException;
 
 
 
@@ -33,16 +32,41 @@ public class ExporterMetadataCurator extends AbstractHibernateCurator<ExporterMe
     }
 
     public ExporterMetadata getByType(String type) {
-        return (ExporterMetadata) this.currentSession().createCriteria(ExporterMetadata.class)
-            .add(Restrictions.eq("type", type))
-            .uniqueResult();
+        if (type == null || type.isBlank()) {
+            return null;
+        }
+
+        String query = "SELECT em FROM ExporterMetadata em WHERE em.type = :type";
+
+        try {
+            return this.getEntityManager()
+                .createQuery(query, ExporterMetadata.class)
+                .setParameter("type", type)
+                .getSingleResult();
+        }
+        catch (NoResultException e) {
+            return null;
+        }
     }
 
     public ExporterMetadata getByTypeAndOwner(String type, Owner owner) {
-        return (ExporterMetadata) this.currentSession().createCriteria(ExporterMetadata.class)
-            .add(Restrictions.eq("type", type))
-            .add(Restrictions.eq("owner", owner))
-            .uniqueResult();
+        if (type == null || type.isBlank() || owner == null) {
+            return null;
+        }
+
+        String query = "SELECT em FROM ExporterMetadata em " +
+            "WHERE em.type = :type AND em.owner.id = :owner_id";
+
+        try {
+            return this.getEntityManager()
+                .createQuery(query, ExporterMetadata.class)
+                .setParameter("type", type)
+                .setParameter("owner_id", owner.getId())
+                .getSingleResult();
+        }
+        catch (NoResultException e) {
+            return null;
+        }
     }
 
 }

--- a/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/DeletedConsumerCuratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -15,15 +15,19 @@
 package org.candlepin.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 import org.candlepin.model.DeletedConsumerCurator.DeletedConsumerQueryArguments;
 import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -80,10 +84,21 @@ public class DeletedConsumerCuratorTest extends DatabaseTestFixture {
         ct = consumerTypeCurator.create(ct);
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testFindByConsumerUuidWithInvalidConsumerUuid(String uuid) {
+        assertNull(deletedConsumerCurator.findByConsumerUuid(uuid));
+    }
+
     @Test
-    public void byConsumerId() {
+    public void testFindByConsumerUuid() {
         DeletedConsumer found = deletedConsumerCurator.findByConsumerUuid("abcde");
         assertEquals("abcde", found.getConsumerUuid());
+    }
+
+    @Test
+    public void testFindByConsumerUuidWithNonExistingDeletedConsumer() {
+        assertNull(deletedConsumerCurator.findByConsumerUuid(TestUtil.randomString()));
     }
 
     @Test
@@ -108,8 +123,14 @@ public class DeletedConsumerCuratorTest extends DatabaseTestFixture {
         assertEquals(1, found.size());
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testCountByConsumerUuidWithInvalidUuid(String uuid) {
+        assertEquals(0, deletedConsumerCurator.countByConsumerUuid(uuid));
+    }
+
     @Test
-    public void countByConsumerId() {
+    public void testCountByConsumerUuid() {
         assertEquals(1, deletedConsumerCurator.countByConsumerUuid("abcde"));
         assertEquals(0, deletedConsumerCurator.countByConsumerUuid("dontfind"));
         assertEquals(1, deletedConsumerCurator.countByConsumerUuid("fghij"));

--- a/src/test/java/org/candlepin/model/ExporterMetadataCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ExporterMetadataCuratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import org.candlepin.test.DatabaseTestFixture;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import java.util.Date;
 
@@ -56,6 +58,12 @@ public class ExporterMetadataCuratorTest extends DatabaseTestFixture {
         assertEquals(emdb.getId(), emfound.getId());
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void getByTypeWithInvalidType(String type) {
+        assertNull(exporterMetadataCurator.getByType(type));
+    }
+
     @Test
     public void getByType() {
         ExporterMetadata em = new ExporterMetadata();
@@ -80,6 +88,18 @@ public class ExporterMetadataCuratorTest extends DatabaseTestFixture {
         assertNotNull(emdb.getOwner().getId());
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void getByTypeAndOwnerWithInvalidType(String type) {
+        Owner owner = createOwner();
+        assertNull(exporterMetadataCurator.getByTypeAndOwner(type, owner));
+    }
+
+    @Test
+    public void getByTypeAndOwnerWithNullOwner() {
+        assertNull(exporterMetadataCurator.getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, null));
+    }
+
     @Test
     public void getByTypeAndOwner() {
         ExporterMetadata em = new ExporterMetadata();
@@ -89,7 +109,18 @@ public class ExporterMetadataCuratorTest extends DatabaseTestFixture {
         em.setOwner(owner);
         ExporterMetadata emdb = exporterMetadataCurator.create(em);
 
+        ExporterMetadata differentTypeMetadata = new ExporterMetadata();
+        differentTypeMetadata.setType(ExporterMetadata.TYPE_SYSTEM);
+        differentTypeMetadata.setExported(new Date());
+        differentTypeMetadata.setOwner(owner);
+        exporterMetadataCurator.create(em);
+
         assertEquals(emdb, exporterMetadataCurator.getByTypeAndOwner(
             ExporterMetadata.TYPE_PER_USER, owner));
+
+        // Owner with no exporter metadata
+        Owner owner2 = createOwner();
+        assertNull(exporterMetadataCurator
+            .getByTypeAndOwner(ExporterMetadata.TYPE_PER_USER, owner2));
     }
 }


### PR DESCRIPTION
- Removed hibernate criteria from DeletedConsumerCurator, EntitlementCertificateCurator, ExporterMetadataCurator, and OwnerCurator.

Note that I did not modify `OwnerCurator.getByKeySecure` method because it is used by `StoreFactory`