### PR TITLE
[M] CANDLEPIN-856: Support environment deletion without deleting consumers

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -3169,6 +3169,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: delete_consumers
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: true
       security: []
       responses:
         204:

--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
@@ -1477,7 +1477,7 @@ public class ContentAccessSpecTest {
             .isNotNull();
         Long initialSerial = oldCerts.get(0).getSerial().getSerial();
 
-        adminClient.environments().deleteEnvironment(env1.getId());
+        adminClient.environments().deleteEnvironment(env1.getId(), true);
 
         List<CertificateDTO> newCerts = consumerClient.consumers().fetchCertificates(consumer.getUuid());
         assertThat(newCerts)

--- a/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentPrioritySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentPrioritySpecTest.java
@@ -414,7 +414,7 @@ public class EnvironmentPrioritySpecTest {
             .hasContentRepoType(content2)
             .doesNotHaveContentRepoType(content3);
 
-        ownerClient.environments().deleteEnvironment(env1.getId());
+        ownerClient.environments().deleteEnvironment(env1.getId(), true);
 
         List<EntitlementDTO> entsWithSecondEnvironment = ownerClient.consumers()
             .listEntitlementsWithRegen(consumer.getUuid());
@@ -452,7 +452,7 @@ public class EnvironmentPrioritySpecTest {
             .hasContentRepoType(content2)
             .doesNotHaveContentRepoType(content3);
 
-        ownerClient.environments().deleteEnvironment(env2.getId());
+        ownerClient.environments().deleteEnvironment(env2.getId(), true);
 
         List<EntitlementDTO> entsWithSecondEnvironment = ownerClient.consumers()
             .listEntitlementsWithRegen(consumer.getUuid());
@@ -490,7 +490,7 @@ public class EnvironmentPrioritySpecTest {
             .hasContentRepoType(content2)
             .hasContentRepoType(content3);
 
-        ownerClient.environments().deleteEnvironment(env1.getId());
+        ownerClient.environments().deleteEnvironment(env1.getId(), true);
 
         List<EntitlementDTO> entsWithSecondEnvironment = ownerClient.consumers()
             .listEntitlementsWithRegen(consumer.getUuid());
@@ -529,7 +529,7 @@ public class EnvironmentPrioritySpecTest {
             .doesNotHaveContentRepoType(content3)
             .doesNotHaveContentRepoType(content4);
 
-        ownerClient.environments().deleteEnvironment(env1.getId());
+        ownerClient.environments().deleteEnvironment(env1.getId(), true);
 
         List<EntitlementDTO> entsWithSecondEnvironment = ownerClient.consumers()
             .listEntitlementsWithRegen(consumer.getUuid());


### PR DESCRIPTION
- If an environment was deleted, any consumers in the environment that did not belong to any other environment were also deleted. For console.redhat.com content templates, we did not want this behavior. With deleteConsumers set to false, we left the consumers environment-less.