### PR TITLE
[M] Renamed the delete_consumers query parameter on the deleteEnvironment op

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -3159,7 +3159,11 @@ paths:
           $ref: '#/components/responses/default'
 
     delete:
-      description: "Deletes an environment. WARNING: this will delete all consumers in the environment and revoke their entitlement certificates."
+      description: |
+        Deletes the specified environment, unregistering and deleting any consumers registered to
+        the environment with no other remaining environments. If the retain_consumers flag is set to
+        true, no consumer deletion will occur, and any such consumers will be moved to the
+        organization's default content view.
       operationId: deleteEnvironment
       tags:
         - environment
@@ -3169,12 +3173,15 @@ paths:
           required: true
           schema:
             type: string
-        - name: delete_consumers
+        - name: retain_consumers
+          description: |
+            Whether or not to retain affected consumers with no remaining environments. If set to
+            true, affected consumers will be moved to the organization's default content view.
           in: query
           required: false
           schema:
             type: boolean
-            default: true
+            default: false
       security: []
       responses:
         204:

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/EnvironmentClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/EnvironmentClient.java
@@ -29,4 +29,8 @@ public class EnvironmentClient extends EnvironmentApi {
         return super.createConsumerInEnvironment(envId, consumer, consumer.getUsername(), null);
     }
 
+    public void deleteEnvironment(String environmentId) {
+        super.deleteEnvironment(environmentId, false);
+    }
+
 }

--- a/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentPrioritySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentPrioritySpecTest.java
@@ -414,7 +414,7 @@ public class EnvironmentPrioritySpecTest {
             .hasContentRepoType(content2)
             .doesNotHaveContentRepoType(content3);
 
-        ownerClient.environments().deleteEnvironment(env1.getId(), true);
+        ownerClient.environments().deleteEnvironment(env1.getId());
 
         List<EntitlementDTO> entsWithSecondEnvironment = ownerClient.consumers()
             .listEntitlementsWithRegen(consumer.getUuid());
@@ -452,7 +452,7 @@ public class EnvironmentPrioritySpecTest {
             .hasContentRepoType(content2)
             .doesNotHaveContentRepoType(content3);
 
-        ownerClient.environments().deleteEnvironment(env2.getId(), true);
+        ownerClient.environments().deleteEnvironment(env2.getId());
 
         List<EntitlementDTO> entsWithSecondEnvironment = ownerClient.consumers()
             .listEntitlementsWithRegen(consumer.getUuid());
@@ -490,7 +490,7 @@ public class EnvironmentPrioritySpecTest {
             .hasContentRepoType(content2)
             .hasContentRepoType(content3);
 
-        ownerClient.environments().deleteEnvironment(env1.getId(), true);
+        ownerClient.environments().deleteEnvironment(env1.getId());
 
         List<EntitlementDTO> entsWithSecondEnvironment = ownerClient.consumers()
             .listEntitlementsWithRegen(consumer.getUuid());
@@ -529,7 +529,7 @@ public class EnvironmentPrioritySpecTest {
             .doesNotHaveContentRepoType(content3)
             .doesNotHaveContentRepoType(content4);
 
-        ownerClient.environments().deleteEnvironment(env1.getId(), true);
+        ownerClient.environments().deleteEnvironment(env1.getId());
 
         List<EntitlementDTO> entsWithSecondEnvironment = ownerClient.consumers()
             .listEntitlementsWithRegen(consumer.getUuid());

--- a/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
@@ -199,9 +199,9 @@ class EnvironmentResourceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true})
     @NullSource
-    void shouldCleanUpAfterDeletingEnvironment(Boolean deleteConsumers) {
+    @ValueSource(booleans = { false })
+    void shouldCleanUpAfterDeletingEnvironment(Boolean retainConsumers) {
         Consumer consumer1 = createConsumer(this.environment1);
         Consumer consumer2 = createConsumer(this.environment1);
         consumer2.setIdCert(null);
@@ -210,7 +210,7 @@ class EnvironmentResourceTest {
         when(this.envCurator.getEnvironmentConsumers(this.environment1))
             .thenReturn(List.of(consumer1, consumer2));
 
-        this.environmentResource.deleteEnvironment(ENV_ID_1, deleteConsumers);
+        this.environmentResource.deleteEnvironment(ENV_ID_1, retainConsumers);
 
         verify(this.identityCertificateCurator).deleteByIds(anyList());
         verify(this.contentAccessCertificateCurator).deleteByIds(anyList());
@@ -231,14 +231,14 @@ class EnvironmentResourceTest {
         when(this.envCurator.getEnvironmentConsumers(this.environment1))
             .thenReturn(List.of(consumer1, consumer2));
 
-        this.environmentResource.deleteEnvironment(ENV_ID_1, true);
+        this.environmentResource.deleteEnvironment(ENV_ID_1, false);
 
         verify(this.consumerCurator).delete(consumer1);
         verify(this.contentAccessManager).removeContentAccessCert(consumer2);
     }
 
     @Test
-    void shouldRemoveConsumersFromEnvironmentWithoutDeletionWhenDeleteFlagIsFalse() {
+    void shouldRemoveConsumersFromEnvironmentWithoutDeletionWhenRetainFlagIsSet() {
         Consumer consumer1 = createConsumer(this.environment1);
         Consumer consumer2 = createConsumer(this.environment1);
         Environment environment2 = createEnvironment(owner, "env_id_2");
@@ -250,7 +250,7 @@ class EnvironmentResourceTest {
         when(this.envCurator.getEnvironmentConsumers(this.environment1))
             .thenReturn(List.of(consumer1, consumer2));
 
-        this.environmentResource.deleteEnvironment(ENV_ID_1, false);
+        this.environmentResource.deleteEnvironment(ENV_ID_1, true);
 
         verify(this.consumerCurator, never()).delete(any(Consumer.class));
         verify(this.contentAccessManager, times(2)).removeContentAccessCert(consumer2);


### PR DESCRIPTION
- Renamed the delete_consumers query parameter on the deleteEnvironment operation to retain_consumers to better reflect the behavior with respect to legacy/default behavior
- Flipped the default value of the delete_consumers parameter from true to false
- Updated the API documentation for the deleteEnvironment endpoint to include details about the new query parameter and its behavior
- Added a method overload to the EnvironmentClient to allow omitting the retain_consumers parameter