### PR TITLE
[M] CANDLEPIN-822: Removed hibernate criteria from select curator classes

### DIFF
--- a/src/main/java/org/candlepin/model/RoleCurator.java
+++ b/src/main/java/org/candlepin/model/RoleCurator.java
@@ -14,13 +14,10 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.criterion.Restrictions;
-
 import java.util.List;
 
 import javax.inject.Singleton;
-
-
+import javax.persistence.NoResultException;
 
 /**
  * RoleCurator
@@ -49,9 +46,16 @@ public class RoleCurator extends AbstractHibernateCurator<Role> {
      * @return the role whose name matches the one given.
      */
     public Role getByName(String name) {
-        return (Role) currentSession().createCriteria(Role.class)
-            .add(Restrictions.eq("name", name))
-            .uniqueResult();
+        String jpql = "SELECT r FROM Role r WHERE r.name = :name";
+
+        try {
+            return getEntityManager().createQuery(jpql, Role.class)
+                .setParameter("name", name)
+                .getSingleResult();
+        }
+        catch (NoResultException e) {
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
- Updated ContentOverrideCurator, RoleCurator, UserCurator and CdnCurator to stop using Hibernate APIs, such as Hibernate criteria and Hibernate implementations of JPA interfaces