### PR TITLE
[M] CANDLEPIN-235: Removed hibernate criteria from select curator classes

### DIFF
--- a/src/main/java/org/candlepin/model/ConsumerTypeCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerTypeCurator.java
@@ -16,8 +16,6 @@ package org.candlepin.model;
 
 import org.candlepin.model.ConsumerType.ConsumerTypeEnum;
 
-import org.hibernate.criterion.Restrictions;
-
 import java.util.Collection;
 import java.util.List;
 
@@ -133,10 +131,12 @@ public class ConsumerTypeCurator extends AbstractHibernateCurator<ConsumerType> 
      * @param labels
      * @return all types matching the specified labels;
      */
-    @SuppressWarnings("unchecked")
     public List<ConsumerType> getByLabels(Collection<String> labels) {
-        return (List<ConsumerType>) currentSession().createCriteria(ConsumerType.class)
-            .add(Restrictions.in("label", labels)).list();
+        String jpql = "SELECT c FROM ConsumerType c WHERE c.label IN :labels";
+
+        return this.getEntityManager().createQuery(jpql, ConsumerType.class)
+            .setParameter("labels", labels)
+            .getResultList();
     }
 
 }

--- a/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/src/main/java/org/candlepin/model/ContentCurator.java
@@ -16,7 +16,6 @@ package org.candlepin.model;
 
 import com.google.inject.persist.Transactional;
 
-import org.hibernate.criterion.Restrictions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -531,8 +530,17 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
      */
     @Transactional
     public Content getByUuid(String uuid) {
-        return (Content) currentSession().createCriteria(Content.class).setCacheable(true)
-            .add(Restrictions.eq("uuid", uuid)).uniqueResult();
+        String jpql = "SELECT c FROM Content c WHERE c.uuid = :uuid";
+
+        try {
+            return this.getEntityManager().createQuery(jpql, Content.class)
+                .setParameter("uuid", uuid)
+                .setHint("org.hibernate.cacheable", true)
+                .getSingleResult();
+        }
+        catch (NoResultException e) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
- Updated GuestIdCurator, ConsumerTypeCurator, RulesCurator, ContentCurator, ActivationKeyCurator and AnonymousCloudConsumerCurator to stop using Hibernate APIs, such as Hibernate criteria and Hibernate implementations of JPA interfaces