### PR TITLE
[M] CANDLEPIN-868: Anon Registration results in Ents with all repos Enabled

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ gsonfire = { module = "io.gsonfire:gson-fire", version = "1.9.0" }
 guice-persist = { module = "com.google.inject.extensions:guice-persist", version.ref = "guice" }
 guice-servlet = { module = "com.google.inject.extensions:guice-servlet", version.ref = "guice" }
 hamcrest = { module = "org.hamcrest:hamcrest-library", version = "2.2" }
-hibernate = { module = "org.hibernate.javax.persistence:hibernate-jpa-2.1-api", version = "1.0.2.Final" }
+hibernate = { module = "javax.persistence:javax.persistence-api", version = "2.2" }
 hibernate-c3p0 = { module = "org.hibernate:hibernate-c3p0", version.ref = "hibernate" }
 hibernate-jcache = { module = "org.hibernate:hibernate-jcache", version.ref = "hibernate" }
 hibernate-jpamodelgen = { module = "org.hibernate:hibernate-jpamodelgen", version.ref = "hibernate" }

--- a/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
@@ -22,7 +22,9 @@ import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.asser
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertThatStatus;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertUnauthorized;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.candlepin.dto.api.client.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.client.v1.CertificateDTO;
@@ -472,11 +474,11 @@ class CloudRegistrationSpecTest {
         String offerId = StringUtil.random("cloud-offer-");
 
         ProductDTO product = adminClient.hosted().createProduct(Products.random());
-        ContentDTO content1 = adminClient.hosted().createContent(Contents.random());
-        ContentDTO content2 = adminClient.hosted().createContent(Contents.random());
+        ContentDTO enabledContent = adminClient.hosted().createContent(Contents.random());
+        ContentDTO disabledContent = adminClient.hosted().createContent(Contents.random());
 
-        adminClient.hosted().addContentToProduct(product.getId(), content1.getId(), true);
-        adminClient.hosted().addContentToProduct(product.getId(), content2.getId(), true);
+        adminClient.hosted().addContentToProduct(product.getId(), enabledContent.getId(), true);
+        adminClient.hosted().addContentToProduct(product.getId(), disabledContent.getId(), false);
         adminClient.hosted().associateProductIdsToCloudOffer(offerId, List.of(product.getId()));
         adminClient.hosted().associateOwnerToCloudAccount(accountId, owner.getKey());
 
@@ -495,10 +497,20 @@ class CloudRegistrationSpecTest {
 
         assertThat(certs).singleElement();
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));
-        assertThat(prodIdToContentIds.get("content_access"))
+        assertThat(prodIdToContentIds.get("anonymous_cloud_content_access"))
             .isNotNull()
             .hasSize(2)
-            .contains(content1.getId(), content2.getId());
+            .contains(enabledContent.getId(), disabledContent.getId());
+
+        // Check that we honor the content enabled/disabled defaults
+        JsonNode content = certs.get(0).get("products").get(0).get("content");
+        JsonNode certEnabledContent = enabledContent.getId().equals(content.get(0).get("id").asText()) ?
+            content.get(0) : content.get(1);
+        JsonNode certDisabledContent = disabledContent.getId().equals(content.get(0).get("id").asText()) ?
+            content.get(0) : content.get(1);
+
+        assertNull(certEnabledContent.get("enabled"));
+        assertFalse(certDisabledContent.get("enabled").asBoolean());
     }
 
     @Test

--- a/src/test/java/org/candlepin/pki/certs/AnonymousCertificateGeneratorTest.java
+++ b/src/test/java/org/candlepin/pki/certs/AnonymousCertificateGeneratorTest.java
@@ -226,7 +226,6 @@ class AnonymousCertificateGeneratorTest {
         doReturn("required-tags").when(content).getRequiredTags();
         doReturn("arches").when(content).getArches();
         doReturn("url").when(content).getContentUrl();
-        doReturn("release-version").when(content).getReleaseVersion();
 
         ProductContentInfo prodContent = mock(ProductContentInfo.class);
         doReturn(content).when(prodContent).getContent();

--- a/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -75,6 +75,7 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.PoolCurator;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCertificateCurator;
+import org.candlepin.model.ProductContent;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.model.Role;
 import org.candlepin.model.RoleCurator;
@@ -735,5 +736,17 @@ public class DatabaseTestFixture {
      */
     protected Configuration getConfigForParameters() {
         return TestConfig.defaults();
+    }
+
+    protected void createProductContent(Owner owner, boolean enabled, Content... contents) {
+        EntityManager entityManager = this.getEntityManager();
+        Product product = createProduct();
+        this.createPool(owner, product);
+
+        for (Content content : contents) {
+            ProductContent productContent = new ProductContent(product, content, enabled);
+            entityManager.persist(productContent);
+        }
+        entityManager.flush();
     }
 }


### PR DESCRIPTION
- Content in anonymous entitlement certificates should not be always overriden to enabled. Instead the default value from the content definition in the IT Product Service should be used, like for other (SCA/Entitlement) certs.
- Refactor OwnerContentCurator.getActiveContentByOwner() to use CTE and to avoid recursive queries.