### PR TITLE
[M] Updated deprecated gradle step in CI

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -38,7 +38,8 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Run checkstyle
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: checkstyle
+        run: ./gradlew checkstyle

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -83,17 +83,18 @@ jobs:
           name: unit_test_reports
           allow_forks: true
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Analyze
         if: ${{ fromJson(steps.get_pr_data.outputs.data).base.ref == 'main' || startsWith(fromJson(steps.get_pr_data.outputs.data).base.ref, 'feature/') }}
-        uses: gradle/gradle-build-action@v3
+        run: ./gradlew sonar -x coverage
+          -Dsonar.scm.provider=git
+          -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+          -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }}
+          -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+          -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
+          -Dorg.gradle.jvmargs=-Xmx1g
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          arguments: sonar -x coverage
-            -Dsonar.scm.provider=git
-            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
-            -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }}
-            -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
-            -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
-            -Dorg.gradle.jvmargs=-Xmx1g

--- a/.github/workflows/sonar_branch_analysis.yml
+++ b/.github/workflows/sonar_branch_analysis.yml
@@ -49,12 +49,13 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Run unit tests & Analyze
-        uses: gradle/gradle-build-action@v3
+        run: ./gradlew test coverage sonar
+          -Dsonar.branch.name=${{ inputs.branch-name || github.ref_name }}
+          -Dorg.gradle.jvmargs=-Xmx1g
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          arguments: test coverage sonar
-            -Dsonar.branch.name=${{ inputs.branch-name || github.ref_name }}
-            -Dorg.gradle.jvmargs=-Xmx1g

--- a/.github/workflows/spec_tests.yml
+++ b/.github/workflows/spec_tests.yml
@@ -67,10 +67,11 @@ jobs:
           echo "CANDLEPIN_AUTH_CLOUD_ENABLE=true" >> .env
           echo "MODULE_CONFIG_MANIFESTGEN_CONFIGURATION_MODULE=org.candlepin.testext.manifestgen.ManifestGeneratorModule" >> .env
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Build Candlepin war file
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: war -Ptest_extensions=hostedtest,manifestgen
+        run: ./gradlew war -Ptest_extensions=hostedtest,manifestgen
 
       - name: Create Candlepin and database containers
         shell: bash
@@ -80,11 +81,9 @@ jobs:
           docker compose -f ./.github/containers/${{ matrix.database }}.docker-compose.yml --env-file ./.github/containers/.env up --build -d --wait
 
       - name: Run Spec tests
-        uses: gradle/gradle-build-action@v3
+        run: ./gradlew spec
         env:
           MYSQL_IN_USE: ${{ matrix.database == 'mariadb' }}
-        with:
-          arguments: spec
 
       - name: Collect docker logs on failure
         if: failure()

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -39,10 +39,11 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Run unit tests
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: test coverage
+        run: ./gradlew test coverage
 
       - name: Save PR number to file
         run: echo ${{ github.event.number }} > PR_NUMBER.txt

--- a/.github/workflows/validate_translations.yml
+++ b/.github/workflows/validate_translations.yml
@@ -38,7 +38,8 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
       - name: Run validate translation
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: validate_translation
+        run: ./gradlew validate_translation


### PR DESCRIPTION
Gradle actions will be deprecated and triggering gradle actions using arguments will be removed in v4 recommended approach for projects that include gradlew wrapper to use that.
[Deprecating gradle
](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle) [Recommended approach](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)