### PR TITLE
[M] Add a product to the 'Donald Duck' test organization

### DIFF
--- a/bin/deployment/test_data.json
+++ b/bin/deployment/test_data.json
@@ -650,7 +650,29 @@
             "name": "donaldduck",
             "displayName": "Donald Duck",
             "contentAccessModeList": "entitlement,org_environment",
-            "contentAccessMode": "org_environment"
+            "contentAccessMode": "org_environment",
+            "products": [
+                {
+                    "name": "Duck OS Premium Architecture Bits",
+                    "id": "6050",
+                    "version": "6.1",
+                    "arch": "ppc64",
+                    "provided_products": [
+                        "37060"
+                    ],
+                    "attributes": {
+                        "sockets": 2,
+                        "vcpu": 4,
+                        "warning_period": 30
+                    },
+                    "content": [
+                        [
+                            6000,
+                            false
+                        ]
+                    ]
+                }
+            ]
         }
     ],
     "users": [


### PR DESCRIPTION
The test data are used by the subscription-manager integration tests. Since entitlement mode will be disabled, the tests are being migrated to SCA.

---

Specifically, I'm trying to fix the `testRegisterWithKey` that fails in https://github.com/candlepin/subscription-manager-cockpit/pull/70 (see the source code [failing line](https://github.com/candlepin/subscription-manager-cockpit/blob/5529ef7a04287facef6d229468944a875f077c4b/test/check-subscriptions#L317-L318)).

Will this fix our issue, will it show up in the list of installed products? I don't know how to test it directly, I don't have a control over the Candlepin that runs the Cockpit tests.