### PR TITLE
[M] CANDLEPIN-891: Updated X.509 certificate extension generation

### DIFF
--- a/src/test/java/org/candlepin/pki/DistinguishedNameTest.java
+++ b/src/test/java/org/candlepin/pki/DistinguishedNameTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
-class DistinguishedNameTest {
+public class DistinguishedNameTest {
 
     private static final String CN_VALUE = "test_name";
     private static final String O_VALUE = "test_org";


### PR DESCRIPTION
- Updated the Authority Key Identifier extension generator to no longer include the issuer in the extension, as this causes some cert processors to be unable to resolve certificate chains
- Updated the Key Usage extension to be flagged as critical