### PR TITLE
[M] CANDLEPIN-878: Updated Vagrant el8 to use AlmaLinux instead of CentOS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,8 +78,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define("el8", primary: true) do |vm_config|
-    vm_config.vm.box = "centos.cloud/centos8s"
-    vm_config.vm.box_url = "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-latest.x86_64.vagrant-libvirt.box"
+    vm_config.vm.box = "almalinux/8"
     vm_config.vm.host_name = "candlepin-el8.example.com"
 
     # Vagrant allows to create a forwarded port mapping which allows access to a specific port

--- a/ansible/roles/candlepin/tasks/main.yml
+++ b/ansible/roles/candlepin/tasks/main.yml
@@ -9,7 +9,7 @@
   ansible.builtin.include_tasks:
     file: el8/el8_tasks.yml
   when:
-    - ansible_distribution in ["CentOS", "RedHat"]
+    - ansible_distribution in ["CentOS", "AlmaLinux", "RedHat"]
     - ansible_distribution_major_version == "8"
   tags:
     - always


### PR DESCRIPTION
- Replaced Centos Stream 8 for AlmaLinux 8 for the el8 Vagrant box. This is due to the cs8 end of life changing the repository URLs and causing issues standing up the el8 Vagrant VM.

To test the changes, run `vagrant up el8`