### PR TITLE
[M] CANDLEPIN-902: Removed usage of Hibernate Criteria in Permissions classes

### DIFF
--- a/src/main/java/org/candlepin/auth/permissions/ActivationKeyPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ActivationKeyPermission.java
@@ -19,8 +19,6 @@ import org.candlepin.auth.SubResource;
 import org.candlepin.model.Owner;
 import org.candlepin.model.activationkeys.ActivationKey;
 
-import org.hibernate.criterion.Criterion;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -87,16 +85,6 @@ public class ActivationKeyPermission extends TypedPermission<ActivationKey> {
     public boolean canAccessTarget(ActivationKey target, SubResource subresource, Access required) {
         return target != null && this.ownerId.equals(target.getOwnerId()) &&
             this.access.provides(required);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        // deprecated functionality; never return anything from this, as dynamically modifying
-        // arbitrary queries is error prone and a maintenance nightmare.
-        return null;
     }
 
     /**

--- a/src/main/java/org/candlepin/auth/permissions/AnonymousCloudConsumerPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/AnonymousCloudConsumerPermission.java
@@ -20,9 +20,6 @@ import org.candlepin.model.AnonymousCloudConsumer;
 import org.candlepin.model.AnonymousCloudConsumer_;
 import org.candlepin.model.Owner;
 
-import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Restrictions;
-
 import java.util.Objects;
 
 import javax.persistence.criteria.CriteriaBuilder;
@@ -40,15 +37,6 @@ public class AnonymousCloudConsumerPermission extends TypedPermission<AnonymousC
 
     public AnonymousCloudConsumerPermission(AnonymousCloudConsumer consumer) {
         this.consumer = Objects.requireNonNull(consumer);
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        if (AnonymousCloudConsumer.class.equals(entityClass)) {
-            return Restrictions.idEq(consumer.getId());
-        }
-
-        return null;
     }
 
     @Override

--- a/src/main/java/org/candlepin/auth/permissions/AsyncJobStatusPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/AsyncJobStatusPermission.java
@@ -20,8 +20,6 @@ import org.candlepin.auth.SubResource;
 import org.candlepin.model.AsyncJobStatus;
 import org.candlepin.model.Owner;
 
-import org.hibernate.criterion.Criterion;
-
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
@@ -65,12 +63,6 @@ public class AsyncJobStatusPermission extends TypedPermission<AsyncJobStatus> {
     @Override
     public Owner getOwner() {
         // This permission is not specific to any owner.
-        return null;
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        // This behavior is deprecated. Always return null.
         return null;
     }
 

--- a/src/main/java/org/candlepin/auth/permissions/AttachPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/AttachPermission.java
@@ -20,9 +20,6 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.model.Pool_;
 
-import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Restrictions;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -59,15 +56,6 @@ public class AttachPermission extends TypedPermission<Pool> {
         }
 
         return false;
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        if (entityClass.equals(Pool.class)) {
-            return Restrictions.eq("owner", owner);
-        }
-
-        return null;
     }
 
     /**

--- a/src/main/java/org/candlepin/auth/permissions/ConsumerEntitlementPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ConsumerEntitlementPermission.java
@@ -20,8 +20,6 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
 
-import org.hibernate.criterion.Criterion;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -49,11 +47,6 @@ public class ConsumerEntitlementPermission extends TypedPermission<Entitlement> 
     @Override
     public boolean canAccessTarget(Entitlement target, SubResource subResource, Access required) {
         return target.getConsumer().getUuid().equals(consumer.getUuid());
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        return null;
     }
 
     /**

--- a/src/main/java/org/candlepin/auth/permissions/ConsumerOrgHypervisorPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ConsumerOrgHypervisorPermission.java
@@ -19,9 +19,6 @@ import org.candlepin.auth.SubResource;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Owner_;
 
-import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Restrictions;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -53,15 +50,6 @@ public class ConsumerOrgHypervisorPermission extends TypedPermission<Owner> {
         return subResource.equals(SubResource.HYPERVISOR) &&
             Access.READ_ONLY.provides(required) &&
             this.owner.getKey().equals(target.getKey());
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        if (entityClass.equals(Owner.class)) {
-            return Restrictions.eq("key", owner.getKey());
-        }
-
-        return null;
     }
 
     /**

--- a/src/main/java/org/candlepin/auth/permissions/ConsumerPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ConsumerPermission.java
@@ -20,9 +20,6 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.Consumer_;
 import org.candlepin.model.Owner;
 
-import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Restrictions;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -51,14 +48,6 @@ public class ConsumerPermission extends TypedPermission<Consumer> {
     public boolean canAccessTarget(Consumer target, SubResource subResource,
         Access required) {
         return this.consumer.getUuid().equals(target.getUuid());
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        if (entityClass.equals(Consumer.class)) {
-            return Restrictions.idEq(consumer.getId());
-        }
-        return null;
     }
 
     /**

--- a/src/main/java/org/candlepin/auth/permissions/ConsumerServiceLevelsPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/ConsumerServiceLevelsPermission.java
@@ -20,9 +20,6 @@ import org.candlepin.model.Consumer;
 import org.candlepin.model.Owner;
 import org.candlepin.model.Owner_;
 
-import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Restrictions;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -54,14 +51,6 @@ public class ConsumerServiceLevelsPermission extends TypedPermission<Owner> {
     public boolean canAccessTarget(Owner target, SubResource subResource, Access required) {
         return target.getKey().equals(owner.getKey()) &&
             subResource.equals(SubResource.SERVICE_LEVELS) && access.provides(required);
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        if (entityClass.equals(Owner.class)) {
-            return Restrictions.eq("key", owner.getKey());
-        }
-        return null;
     }
 
     /**

--- a/src/main/java/org/candlepin/auth/permissions/OwnerActivationKeyPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/OwnerActivationKeyPermission.java
@@ -18,8 +18,6 @@ import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Owner;
 
-import org.hibernate.criterion.Criterion;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -92,16 +90,6 @@ public class OwnerActivationKeyPermission extends TypedPermission<Owner> {
         return target != null && this.ownerId.equals(target.getId()) &&
             subresource == SubResource.ACTIVATION_KEYS &&
             this.access.provides(required);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        // deprecated functionality; never return anything from this, as dynamically modifying
-        // arbitrary queries is error prone and a maintenance nightmare.
-        return null;
     }
 
     /**

--- a/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/OwnerPermission.java
@@ -28,9 +28,6 @@ import org.candlepin.model.Pool_;
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.model.activationkeys.ActivationKey_;
 
-import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Restrictions;
-
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -70,27 +67,6 @@ public class OwnerPermission implements Permission, Serializable {
         // If asked to verify access to an object that does not implement Owned,
         // as far as this permission goes, we probably have to deny access.
         return false;
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        if (Owner.class.equals(entityClass)) {
-            return Restrictions.eq("key", owner.getKey());
-        }
-        else if (Consumer.class.equals(entityClass)) {
-            return Restrictions.eq("ownerId", owner.getId());
-        }
-        else if (Pool.class.equals(entityClass)) {
-            return Restrictions.eq("owner", owner);
-        }
-        else if (ActivationKey.class.equals(entityClass)) {
-            return Restrictions.eq("owner", owner);
-        }
-        else if (Environment.class.equals(entityClass)) {
-            return Restrictions.eq("owner", owner);
-        }
-
-        return null;
     }
 
     /**

--- a/src/main/java/org/candlepin/auth/permissions/OwnerPoolsPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/OwnerPoolsPermission.java
@@ -18,8 +18,6 @@ import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Owner;
 
-import org.hibernate.criterion.Criterion;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -49,11 +47,6 @@ public class OwnerPoolsPermission extends TypedPermission<Owner> {
             (subResource.equals(SubResource.POOLS) ||
                 subResource.equals(SubResource.SUBSCRIPTIONS)) &&
                     access.provides(required);
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        return null;
     }
 
     /**

--- a/src/main/java/org/candlepin/auth/permissions/Permission.java
+++ b/src/main/java/org/candlepin/auth/permissions/Permission.java
@@ -18,8 +18,6 @@ import org.candlepin.auth.Access;
 import org.candlepin.auth.SubResource;
 import org.candlepin.model.Owner;
 
-import org.hibernate.criterion.Criterion;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -32,25 +30,6 @@ import javax.persistence.criteria.Predicate;
 public interface Permission {
 
     boolean canAccess(Object target, SubResource subResource, Access access);
-
-    /**
-     * Permissions have the ability to add restrictions to a hibernate queries which use
-     * AbstractHibernateCurator#createSecureCriteria.
-     *
-     * This allows us to do things like limit the results from a database query based
-     * on the principal, while still allowing the database to do the filtering and
-     * use pagination.
-     *
-     * While you can just return null here in many cases, it is often a good idea to
-     * explicitly include the objects you know you will be accessing with this permission.
-     * The results of this method are or'd together for all permissions on the principal,
-     * which could cause something to be hidden from you because another permission
-     * filtered it out, but you specified nothing.
-     *
-     * @param entityClass Type of object being queried.
-     * @return The modified Criteria query to be run.
-     */
-    Criterion getCriteriaRestrictions(Class entityClass);
 
     /**
      * Fetches a predicate to add to a JPA query to limit the results.

--- a/src/main/java/org/candlepin/auth/permissions/UserUserPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/UserUserPermission.java
@@ -20,9 +20,6 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.User;
 import org.candlepin.model.User_;
 
-import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Restrictions;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Predicate;
@@ -49,14 +46,6 @@ public class UserUserPermission extends TypedPermission<User> {
     public boolean canAccessTarget(User target, SubResource subResource,
         Access required) {
         return target.getUsername().equals(username);
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        if (entityClass.equals(User.class)) {
-            return Restrictions.eq("username", username);
-        }
-        return null;
     }
 
     /**

--- a/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
+++ b/src/main/java/org/candlepin/auth/permissions/UsernameConsumersPermission.java
@@ -22,9 +22,6 @@ import org.candlepin.model.Entitlement;
 import org.candlepin.model.Owner;
 import org.candlepin.service.model.UserInfo;
 
-import org.hibernate.criterion.Criterion;
-import org.hibernate.criterion.Restrictions;
-
 import java.io.Serializable;
 
 import javax.persistence.criteria.CriteriaBuilder;
@@ -83,15 +80,6 @@ public class UsernameConsumersPermission implements Permission, Serializable {
         }
 
         return false;
-    }
-
-    @Override
-    public Criterion getCriteriaRestrictions(Class entityClass) {
-        if (entityClass.equals(Consumer.class)) {
-            return Restrictions.eq("username", user.getUsername());
-        }
-
-        return null;
     }
 
     /**

--- a/src/test/java/org/candlepin/auth/permissions/ActivationKeyPermissionTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/ActivationKeyPermissionTest.java
@@ -100,7 +100,6 @@ public class ActivationKeyPermissionTest {
         ActivationKeyPermission perm = new ActivationKeyPermission(owner, Access.ALL);
 
         // These should always return null
-        assertNull(perm.getCriteriaRestrictions(ActivationKey.class));
         assertNull(perm.getQueryRestriction(ActivationKey.class, mock(CriteriaBuilder.class),
             mock(From.class)));
     }

--- a/src/test/java/org/candlepin/auth/permissions/AnonymousCloudConsumerPermissionTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/AnonymousCloudConsumerPermissionTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.candlepin.model.AnonymousCloudConsumer;
 import org.candlepin.test.TestUtil;
 
-import org.hibernate.criterion.Criterion;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -36,23 +35,6 @@ public class AnonymousCloudConsumerPermissionTest {
     @Test
     public void testAnonymousCloudConsumerWithNullAnonymousCloudConsumer() {
         assertThrows(NullPointerException.class, () -> new AnonymousCloudConsumerPermission(null));
-    }
-
-    @Test
-    public void testGetCriteriaRestrictionsWithUnknownClass() {
-        AnonymousCloudConsumer consumer = new AnonymousCloudConsumer()
-            .setId("id")
-            .setUuid("uuid")
-            .setCloudAccountId("cloudAccountId")
-            .setCloudInstanceId("instanceId")
-            .setProductIds(List.of("productId"))
-            .setCloudProviderShortName(TestUtil.randomString());
-
-        AnonymousCloudConsumerPermission permission = new AnonymousCloudConsumerPermission(consumer);
-
-        Criterion criterion = permission.getCriteriaRestrictions(List.class);
-
-        assertNull(criterion);
     }
 
     @Test

--- a/src/test/java/org/candlepin/auth/permissions/OwnerActivationKeyPermissionTest.java
+++ b/src/test/java/org/candlepin/auth/permissions/OwnerActivationKeyPermissionTest.java
@@ -94,7 +94,6 @@ public class OwnerActivationKeyPermissionTest {
         OwnerActivationKeyPermission perm = new OwnerActivationKeyPermission(owner, Access.ALL);
 
         // These should always return null
-        assertNull(perm.getCriteriaRestrictions(Owner.class));
         assertNull(perm.getQueryRestriction(Owner.class, mock(CriteriaBuilder.class), mock(From.class)));
     }
 


### PR DESCRIPTION
- Updated Permissions classes to stop using Hibernate APIs, such as Hibernate criteria and Hibernate implementations of JPA interfaces.