### PR TITLE
[M] CANDLEPIN-907: Updated cp_anonymous_certificate cert column to longblob

### DIFF
--- a/src/main/resources/db/changelog/20240802101300-update-anon-cert-table-cert-column.xml
+++ b/src/main/resources/db/changelog/20240802101300-update-anon-cert-table-cert-column.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+    <changeSet id="20240802101300-1" author="jalbrech" dbms="mysql,mariadb,hsqldb">
+        <modifyDataType tableName="cp_anonymous_certificates"
+            columnName="cert"
+            newDataType="${cert.type}" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -199,4 +199,5 @@
     <include file="db/changelog/20240104162911-unrevoke-subscription-certs.xml"/>
     <include file="db/changelog/20240329143555-add_environment_content_override_schema.xml"/>
     <include file="db/changelog/20240502145033-fix_entity_namespace_type.xml"/>
+    <include file="db/changelog/20240802101300-update-anon-cert-table-cert-column.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/datatypes.xml
+++ b/src/main/resources/db/changelog/datatypes.xml
@@ -13,7 +13,8 @@
     <property name="serial.type" value="BIGINT" dbms="mysql,mariadb,hsqldb"/>
     <property name="serial.type" value="int8" dbms="postgresql"/>
 
-    <property name="cert.type" value="BLOB" dbms="mysql,mariadb,hsqldb"/>
+    <property name="cert.type" value="BLOB(1G)" dbms="hsqldb"/>
+    <property name="cert.type" value="LONGBLOB" dbms="mysql,mariadb"/>
     <property name="cert.type" value="bytea" dbms="postgresql"/>
 
     <property name="blob.type" value="BLOB" dbms="mysql,mariadb,hsqldb"/>
@@ -22,4 +23,3 @@
     <property name="text.type" value="TEXT" dbms="postgresql,hsqldb"/>
     <property name="text.type" value="LONGTEXT" dbms="mysql,mariadb"/>
 </databaseChangeLog>
-


### PR DESCRIPTION
- Updated cp_anonymous_certificate cert column to longblob as products with lots of content would cause database errors when attempting to insert the certificate into the column.

The longblob data type is also used for the cert column in the cp_ent_certificate table. Since the anonymous certificate's cert column is populated the same way that an entitlement certificate is, it makes sense to use the same type.

Verified by deploying to MySQL locally and checking the columns:

```
MariaDB [candlepin]> SHOW COLUMNS from cp_anonymous_certificates;
+------------+-------------+------+-----+---------+-------+
| Field      | Type        | Null | Key | Default | Extra |
+------------+-------------+------+-----+---------+-------+
| id         | varchar(32) | NO   | PRI | NULL    |       |
| created    | datetime    | YES  |     | NULL    |       |
| updated    | datetime    | YES  |     | NULL    |       |
| cert       | longblob    | YES  |     | NULL    |       |
| privatekey | blob        | NO   |     | NULL    |       |
| serial_id  | bigint(20)  | YES  | MUL | NULL    |       |
+------------+-------------+------+-----+---------+-------+
```