### PR TITLE
[M] CANDLEPIN-912: Updated product endpoints to support improved querying

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -6076,23 +6076,93 @@ paths:
         - name: product
           in: query
           description: |
-            The ID of a product to fetch. If defined, the list of products returned by this method
-            will only include those matching the given ID. May be specified multiple times to filter
-            on multiple product IDs.
+            The ID of a product to fetch. If defined, the list of products returned by this endpoint will
+            only include those matching the given ID. May be specified multiple times to filter on multiple
+            product IDs. If multiple IDs are provided, any products matching any of the provided IDs will
+            be returned.
           required: false
           schema:
             type: array
             items:
               type: string
-        - name: omit_global
+        - name: name
           in: query
           description: |
-            whether or not to limit the lookup to only products defined within the organization's
-            namespace, excluding any globally defined products
+            The names of products to fetch. If defined, the list of products returned by this endpoint
+            will only include those matching the given names (case-insensitive). May be specified multiple
+            times to filter on multiple names. If multiple names are provided, any products matching any
+            of the provided names will be returned.
           required: false
           schema:
-            type: boolean
-            default: false
+            type: array
+            items:
+              type: string
+        - name: active
+          in: query
+          description: |
+            A value indicating how 'active' products should be considered when fetching products, where
+            'active' is defined as a product that is currently in use by a subscription with a start time
+            in the past and that has not yet expired, or in use by a product which itself is considered
+            'active.' Must be one of 'include', 'exclude', or 'exclusive' indicating that active products
+            should be included along with inactive products, excluded (omitted) from the results, or
+            exclusively selected as the only products to return.
+            Defaults to 'exclusive'.
+          required: false
+          schema:
+            type: string
+            enum:
+              - include
+              - exclude
+              - exclusive
+            default: exclusive
+            example:
+              include:
+                value: include
+                description: |
+                  indicates the query should include matching active products, along with any inactive
+                  products
+              exclude:
+                value: exclude
+                description: |
+                  indicates the query should exclude, or omit, active products, returning only matching
+                  inactive products
+              exclusive:
+                value: exclusive
+                description: |
+                  indicates the query should only include matching active products, excluding any inactive
+                  products
+        - name: custom
+          in: query
+          description: |
+            A value indicating how custom products are considered when fetching products, where 'custom'
+            is defined as a product that did not originate from a refresh operation nor manifest import.
+            Must be one of 'include', 'exclude', or 'exclusive' indicating that custom products should
+            be passively included, excluded or omitted from the output, or exclusively selected
+            as the only products to return.
+          required: false
+          schema:
+            type: string
+            enum:
+              - include
+              - exclude
+              - exclusive
+            default: include
+            example:
+              include:
+                value: include
+                description: |
+                  indicates the query should include matching custom products, along with any matching
+                  globally defined products
+              exclude:
+                value: exclude
+                description: |
+                  indicates the query should exclude, or omit, custom products, returning only matching
+                  globally defined products
+              exclusive:
+                value: exclusive
+                description: |
+                  indicates the query should only include matching custom products, excluding any globally
+                  defined products
       responses:
         200:
           description: Retrieves a list of products by owner
@@ -6988,10 +7058,108 @@ paths:
         type: java.util.stream.Stream
         isContainer: true
       parameters:
-        - $ref: "#/components/parameters/paging_page"
-        - $ref: "#/components/parameters/paging_per_page"
-        - $ref: "#/components/parameters/paging_order"
-        - $ref: "#/components/parameters/paging_sort_by"
+        - name: owner
+          in: query
+          description: |
+            The key of an owner to use to limit the product search. If defined, the list of products returned
+            by this endpoint will only include those available to the given owner. May be specified multiple
+            times to filter by multiple owners. If multiple owners are provided, products available to
+            any of the provided owners will be returned.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: product
+          in: query
+          description: |
+            The ID of a product to fetch. If defined, the list of products returned by this endpoint will
+            only include those matching the given ID. May be specified multiple times to filter on multiple
+            product IDs. If multiple IDs are provided, any products matching any of the provided IDs will
+            be returned.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: name
+          in: query
+          description: |
+            The names of products to fetch. If defined, the list of products returned by this endpoint
+            will only include those matching the given names (case-insensitive). May be specified multiple
+            times to filter on multiple names. If multiple names are provided, any products matching any
+            of the provided names will be returned.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: active
+          in: query
+          description: |
+            A value indicating how 'active' products should be considered when fetching products, where
+            'active' is defined as a product that is currently in use by a subscription with a start time
+            in the past and that has not yet expired, or in use by a product which itself is considered
+            'active.' Must be one of 'include', 'exclude', or 'exclusive' indicating that active products
+            should be included along with inactive products, excluded (omitted) from the results, or
+            exclusively selected as the only products to return.
+            Defaults to 'exclusive'.
+          required: false
+          schema:
+            type: string
+            enum:
+              - include
+              - exclude
+              - exclusive
+            default: exclusive
+            example:
+              include:
+                value: include
+                description: |
+                  indicates the query should include matching active products, along with any inactive
+                  products
+              exclude:
+                value: exclude
+                description: |
+                  indicates the query should exclude, or omit, active products, returning only matching
+                  inactive products
+              exclusive:
+                value: exclusive
+                description: |
+                  indicates the query should only include matching active products, excluding any inactive
+                  products
+        - name: custom
+          in: query
+          description: |
+            A value indicating how custom products are considered when fetching products, where 'custom'
+            is defined as a product that did not originate from a refresh operation nor manifest import.
+            Must be one of 'include', 'exclude', or 'exclusive' indicating that custom products should
+            be passively included, excluded or omitted from the output, or exclusively selected
+            as the only products to return.
+          required: false
+          schema:
+            type: string
+            enum:
+              - include
+              - exclude
+              - exclusive
+            default: include
+            example:
+              include:
+                value: include
+                description: |
+                  indicates the query should include matching custom products, along with any matching
+                  globally defined products
+              exclude:
+                value: exclude
+                description: |
+                  indicates the query should exclude, or omit, custom products, returning only matching
+                  globally defined products
+              exclusive:
+                value: exclusive
+                description: |
+                  indicates the query should only include matching custom products, excluding any globally
+                  defined products
       security: []
       responses:
         200:
@@ -9481,12 +9649,12 @@ components:
         - $ref: '#/components/schemas/TimestampedEntity'
         - type: object
           properties:
-            id:
-              type: string
-              example: 5051
             uuid:
               type: string
               example: ff808081554a3e4101554a3e9033005d
+            id:
+              type: string
+              example: 5051
             name:
               type: string
               example: Admin OS Developer Bits

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/JobStatusAssert.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/JobStatusAssert.java
@@ -143,6 +143,40 @@ public class JobStatusAssert extends AbstractAssert<JobStatusAssert, AsyncJobSta
     }
 
     /**
+     * Verifies the job has a given name
+     *
+     * @return this instance
+     */
+    public JobStatusAssert isNamed(String name) {
+        if (name == null && this.actual.getName() != null) {
+            failWithMessage("Expected job name to be null, but was: \"%s\"", this.actual.getName());
+        }
+
+        if (name != null && !name.equals(this.actual.getName())) {
+            failWithMessage("Expected job name to be \"%s\", but was: \"%s\"", this.actual.getName());
+        }
+
+        return this;
+    }
+
+    /**
+     * Verifies the job is of the given type, specified by job key.
+     *
+     * @return this instance
+     */
+    public JobStatusAssert isType(String jobKey) {
+        if (jobKey == null && this.actual.getKey() != null) {
+            failWithMessage("Expected job type/key to be null, but was: \"%s\"", this.actual.getKey());
+        }
+
+        if (jobKey != null && !jobKey.equals(this.actual.getKey())) {
+            failWithMessage("Expected job type/key to be \"%s\", but was: \"%s\"", this.actual.getKey());
+        }
+
+        return this;
+    }
+
+    /**
      * Verifies whether the job result contains the given text.
      *
      * @return this instance

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Request.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Request.java
@@ -20,6 +20,7 @@ import org.candlepin.spec.bootstrap.client.ApiClient;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -254,6 +255,43 @@ public class Request {
 
         this.queryParams.computeIfAbsent(key, (k) -> new ArrayList<>())
             .add(value);
+
+        return this;
+    }
+
+    /**
+     * Adds the given collection of values as query parameters to the request. Any existing values already
+     * defined for the query parameter will be retained, and the new values in the given collection will
+     * be appended. If the values collection is null or empty, it will be silently ignored and no changes
+     * will be made to the query parameter.
+     * As with the single-value form of this method, adding multiple values for a given parameter will
+     * cause all of the values to be individually mapped in the request. For example, if the query parameter
+     * "key" is assigned to values "a", "b", and "c", the request URI will contain the string
+     * "key=a&key=b&key=c".
+     *
+     * @param key
+     *  the query parameter name, or key, to set; cannot be null or empty
+     *
+     * @param values
+     *  the collection of values to assign to the query parameter
+     *
+     * @throws IllegalArgumentException
+     *  if the key is null or empty
+     *
+     * @return
+     *  a reference to this Request
+     */
+    public Request addQueryParam(String key, Collection<String> values) {
+        if (key == null || key.isEmpty()) {
+            throw new IllegalArgumentException("key is null or empty");
+        }
+
+        if (values == null || values.isEmpty()) {
+            return this;
+        }
+
+        this.queryParams.computeIfAbsent(key, (k) -> new ArrayList<>())
+            .addAll(values);
 
         return this;
     }

--- a/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
@@ -18,6 +18,7 @@ import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.collection;
+import static org.candlepin.spec.bootstrap.assertions.JobStatusAssert.assertThatJob;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertBadRequest;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertForbidden;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertNotFound;
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.candlepin.dto.api.client.v1.ActivationKeyDTO;
 import org.candlepin.dto.api.client.v1.ActivationKeyProductDTO;
@@ -33,16 +35,19 @@ import org.candlepin.dto.api.client.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.client.v1.AttributeDTO;
 import org.candlepin.dto.api.client.v1.BrandingDTO;
 import org.candlepin.dto.api.client.v1.ContentDTO;
+import org.candlepin.dto.api.client.v1.NestedOwnerDTO;
 import org.candlepin.dto.api.client.v1.OwnerDTO;
 import org.candlepin.dto.api.client.v1.PoolDTO;
 import org.candlepin.dto.api.client.v1.ProductDTO;
 import org.candlepin.dto.api.client.v1.ProvidedProductDTO;
+import org.candlepin.dto.api.client.v1.SubscriptionDTO;
 import org.candlepin.dto.api.client.v1.UserDTO;
 import org.candlepin.resource.HostedTestApi;
 import org.candlepin.resource.client.v1.ActivationKeyApi;
 import org.candlepin.resource.client.v1.OwnerContentApi;
 import org.candlepin.resource.client.v1.OwnerProductApi;
 import org.candlepin.resource.client.v1.ProductsApi;
+import org.candlepin.spec.bootstrap.assertions.CandlepinMode;
 import org.candlepin.spec.bootstrap.assertions.OnlyInHosted;
 import org.candlepin.spec.bootstrap.client.ApiClient;
 import org.candlepin.spec.bootstrap.client.ApiClients;
@@ -55,6 +60,7 @@ import org.candlepin.spec.bootstrap.client.request.Response;
 import org.candlepin.spec.bootstrap.data.builder.ActivationKeys;
 import org.candlepin.spec.bootstrap.data.builder.Branding;
 import org.candlepin.spec.bootstrap.data.builder.Contents;
+import org.candlepin.spec.bootstrap.data.builder.ExportGenerator;
 import org.candlepin.spec.bootstrap.data.builder.Owners;
 import org.candlepin.spec.bootstrap.data.builder.Pools;
 import org.candlepin.spec.bootstrap.data.builder.ProductAttributes;
@@ -71,20 +77,40 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.File;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+
+
 @SpecTest
 public class OwnerProductResourceSpecTest {
-    private static final String OWNER_PRODUCTS_PATH = "/owners/{owner_key}/products";
 
     private static ApiClient client;
     private static ActivationKeyApi activationKeyApi;
@@ -286,42 +312,6 @@ public class OwnerProductResourceSpecTest {
     }
 
     @Test
-    public void shouldListAllProductsInBulkFetch() {
-        OwnerDTO owner = ownerApi.createOwner(Owners.random());
-        String ownerKey = owner.getKey();
-
-        ProductDTO prod1 = ownerProductApi.createProduct(ownerKey, Products.random());
-        ProductDTO prod2 = ownerProductApi.createProduct(ownerKey, Products.random());
-        ProductDTO prod3 = ownerProductApi.createProduct(ownerKey, Products.random());
-
-        // Note: We must account for other globals that may have been created as well
-        List<ProductDTO> products = ownerProductApi.getProductsByOwner(ownerKey, List.of(), false);
-        assertThat(products)
-            .isNotNull()
-            .hasSizeGreaterThanOrEqualTo(3)
-            .contains(prod1, prod2, prod3);
-    }
-
-    @Test
-    public void shouldListsAllSpecifiedProductsInBulkFetch() {
-        OwnerDTO owner = ownerApi.createOwner(Owners.random());
-        String ownerKey = owner.getKey();
-
-        ProductDTO prod1 = ownerProductApi.createProduct(ownerKey, Products.random());
-        ProductDTO prod2 = ownerProductApi.createProduct(ownerKey, Products.random());
-        ProductDTO prod3 = ownerProductApi.createProduct(ownerKey, Products.random());
-
-        // Pick two products to use in a bulk get
-        List<ProductDTO> products = ownerProductApi
-            .getProductsByOwner(ownerKey, List.of(prod1.getId(), prod3.getId()), false);
-
-        assertThat(products)
-            .isNotNull()
-            .hasSize(2)
-            .containsOnly(prod1, prod3);
-    }
-
-    @Test
     public void shouldNotAllowUpdatingIDFields() throws Exception {
         ApiClient adminClient = ApiClients.admin();
         OwnerDTO owner = ownerApi.createOwner(Owners.random());
@@ -349,155 +339,6 @@ public class OwnerProductResourceSpecTest {
         // Same here; should still be identical
         assertEquals(created, fetched);
         assertEquals(updated, fetched);
-    }
-
-    @Test
-    public void shouldListsProductsInPages() throws Exception {
-        OwnerDTO owner = ownerApi.createOwner(Owners.random());
-        String ownerKey = owner.getKey();
-
-        // The creation order here is important. By default, Candlepin sorts in descending order of
-        // the entity's creation time, so we need to create them backward to let the default sorting
-        // order let us page through them in ascending order.
-        ProductDTO prod3 = ownerProductApi.createProduct(ownerKey, Products.random());
-        sleep(1150);
-        ProductDTO prod2 = ownerProductApi.createProduct(ownerKey, Products.random());
-        sleep(1150);
-        ProductDTO prod1 = ownerProductApi.createProduct(ownerKey, Products.random());
-
-        Response response = Request.from(client)
-            .setPath(OWNER_PRODUCTS_PATH)
-            .setPathParam("owner_key", ownerKey)
-            .addQueryParam("page", "1")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("omit_global", "true")
-            .execute();
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-        assertThat(response.deserialize(new TypeReference<List<ProductDTO>>() {}))
-            .isNotNull()
-            .hasSize(1)
-            .containsOnly(prod1);
-
-        response = Request.from(client)
-            .setPath(OWNER_PRODUCTS_PATH)
-            .setPathParam("owner_key", ownerKey)
-            .addQueryParam("page", "2")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("omit_global", "true")
-            .execute();
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-        assertThat(response.deserialize(new TypeReference<List<ProductDTO>>() {}))
-            .isNotNull()
-            .hasSize(1)
-            .containsOnly(prod2);
-
-        response = Request.from(client)
-            .setPath(OWNER_PRODUCTS_PATH)
-            .setPathParam("owner_key", ownerKey)
-            .addQueryParam("page", "3")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("omit_global", "true")
-            .execute();
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-        assertThat(response.deserialize(new TypeReference<List<ProductDTO>>() {}))
-            .isNotNull()
-            .hasSize(1)
-            .containsOnly(prod3);
-
-        response = Request.from(client)
-            .setPath(OWNER_PRODUCTS_PATH)
-            .setPathParam("owner_key", ownerKey)
-            .addQueryParam("page", "4")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("omit_global", "true")
-            .execute();
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-        assertThat(response.deserialize(new TypeReference<List<ProductDTO>>() {}))
-            .isNotNull()
-            .hasSize(0);
-    }
-
-    @Test
-    public void shouldListProductsInSortedPages() throws Exception {
-        OwnerDTO owner = ownerApi.createOwner(Owners.random());
-        String ownerKey = owner.getKey();
-        // The creation order here is important so we don't accidentally setup the correct ordering by
-        // default.
-        ProductDTO prod2 = ownerProductApi.createProduct(ownerKey, Products.random()
-            .id("test_product-2"));
-        sleep(1000);
-        ProductDTO prod1 = ownerProductApi.createProduct(ownerKey, Products.random()
-            .id("test_product-1"));
-        sleep(1000);
-        ProductDTO prod3 = ownerProductApi.createProduct(ownerKey, Products.random()
-            .id("test_product-3"));
-
-        Response response = Request.from(client)
-            .setPath(OWNER_PRODUCTS_PATH)
-            .setPathParam("owner_key", ownerKey)
-            .addQueryParam("page", "1")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("sort_by", "id")
-            .addQueryParam("sort_order", "asc")
-            .addQueryParam("omit_global", "true")
-            .execute();
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-        assertThat(response.deserialize(new TypeReference<List<ProductDTO>>() {}))
-            .isNotNull()
-            .hasSize(1)
-            .containsOnly(prod3);
-
-        response = Request.from(client)
-            .setPath(OWNER_PRODUCTS_PATH)
-            .setPathParam("owner_key", ownerKey)
-            .addQueryParam("page", "2")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("sort_by", "id")
-            .addQueryParam("sort_order", "asc")
-            .addQueryParam("omit_global", "true")
-            .execute();
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-        assertThat(response.deserialize(new TypeReference<List<ProductDTO>>() {}))
-            .isNotNull()
-            .hasSize(1)
-            .containsOnly(prod2);
-
-        response = Request.from(client)
-            .setPath(OWNER_PRODUCTS_PATH)
-            .setPathParam("owner_key", ownerKey)
-            .addQueryParam("page", "3")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("sort_by", "id")
-            .addQueryParam("sort_order", "asc")
-            .addQueryParam("omit_global", "true")
-            .execute();
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-        assertThat(response.deserialize(new TypeReference<List<ProductDTO>>() {}))
-            .isNotNull()
-            .hasSize(1)
-            .containsOnly(prod1);
-
-        response = Request.from(client)
-            .setPath(OWNER_PRODUCTS_PATH)
-            .setPathParam("owner_key", ownerKey)
-            .addQueryParam("page", "4")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("sort_by", "id")
-            .addQueryParam("sort_order", "asc")
-            .addQueryParam("omit_global", "true")
-            .execute();
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-        assertThat(response.deserialize(new TypeReference<List<ProductDTO>>() {}))
-            .isNotNull()
-            .hasSize(0);
     }
 
     @Test
@@ -781,17 +622,895 @@ public class OwnerProductResourceSpecTest {
         return product;
     }
 
-    private void compareBranding(BrandingDTO expected, BrandingDTO actual) {
-        assertEquals(expected.getProductId(), actual.getProductId());
-        assertEquals(expected.getName(), actual.getName());
-        assertEquals(expected.getType(), actual.getType());
-    }
-
     private void verifyRefreshPoolJob(String ownerKey, String productId, boolean lazyRegen) {
         AsyncJobStatusDTO job = ownerProductApi.refreshPoolsForProduct(ownerKey, productId, lazyRegen);
         assertNotNull(job);
         AsyncJobStatusDTO status = jobsApi.waitForJob(job.getId());
         assertEquals("RefreshPoolsForProductJob", status.getKey());
         assertEquals("FINISHED", status.getState());
+    }
+
+    @Nested
+    @Isolated
+    @TestInstance(Lifecycle.PER_CLASS)
+    @Execution(ExecutionMode.SAME_THREAD)
+    public class ProductQueryTests {
+
+        private static final String QUERY_PATH = "/owners/{owner_key}/products";
+
+        private static final String INCLUSION_INCLUDE = "include";
+        private static final String INCLUSION_EXCLUDE = "exclude";
+        private static final String INCLUSION_EXCLUSIVE = "exclusive";
+
+        private static record ProductInfo(ProductDTO dto, OwnerDTO owner, Set<String> activeOwners) {
+            public String id() {
+                return this.dto() != null ? this.dto().getId() : null;
+            }
+
+            public boolean active() {
+                return !this.activeOwners().isEmpty();
+            }
+
+            public boolean custom() {
+                return this.owner() != null;
+            }
+        };
+
+        private ApiClient adminClient;
+
+        private List<OwnerDTO> owners;
+        private Map<String, ProductInfo> productMap;
+
+        /**
+         * Verifies either the manifest generator extension or the hosted test extension is present as
+         * required by the current operating mode.
+         */
+        private void checkRequiredExtensions() {
+            if (CandlepinMode.isStandalone()) {
+                assumeTrue(CandlepinMode::hasManifestGenTestExtension);
+            }
+            else {
+                assumeTrue(CandlepinMode::hasHostedTestExtension);
+            }
+        }
+
+        private OwnerDTO createOwner(String keyPrefix) {
+            OwnerDTO owner = Owners.random()
+                .key(StringUtil.random(keyPrefix + "-"));
+
+            return this.adminClient.owners()
+                .createOwner(owner);
+        }
+
+        private SubscriptionDTO createSubscription(OwnerDTO owner, ProductDTO product, boolean active) {
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            // Impl note:
+            // We create active subscriptions in the future to work around a limitation on manifests
+            // disallowing and ignoring expired pools
+            return Subscriptions.random(owner, product)
+                .startDate(active ? now.minus(7, ChronoUnit.DAYS) : now.plus(7, ChronoUnit.DAYS))
+                .endDate(now.plus(30, ChronoUnit.DAYS));
+        }
+
+        private PoolDTO createPool(OwnerDTO owner, ProductDTO product, boolean active) {
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            PoolDTO pool = Pools.random(product)
+                .startDate(now.minus(7, ChronoUnit.DAYS))
+                .endDate(active ? now.plus(7, ChronoUnit.DAYS) : now.minus(3, ChronoUnit.DAYS));
+
+            return this.adminClient.owners()
+                .createPool(owner.getKey(), pool);
+        }
+
+        private void mapProductInfo(ProductDTO product, OwnerDTO owner, OwnerDTO activeOwner) {
+            Set<String> activeOwnerKeys = new HashSet<>();
+            if (activeOwner != null) {
+                activeOwnerKeys.add(activeOwner.getKey());
+            }
+
+            ProductInfo existing = this.productMap.get(product.getId());
+            if (existing != null) {
+                activeOwnerKeys.addAll(existing.activeOwners());
+            }
+
+            ProductInfo pinfo = new ProductInfo(product, owner, activeOwnerKeys);
+            this.productMap.put(product.getId(), pinfo);
+
+        }
+
+        private void commitGlobalSubscriptions(Collection<SubscriptionDTO> subscriptions) throws Exception {
+            Map<String, List<SubscriptionDTO>> subscriptionMap = new HashMap<>();
+
+            for (SubscriptionDTO subscription : subscriptions) {
+                NestedOwnerDTO owner = subscription.getOwner();
+
+                subscriptionMap.computeIfAbsent(owner.getKey(), key -> new ArrayList<>())
+                    .add(subscription);
+            }
+
+            for (Map.Entry<String, List<SubscriptionDTO>> entry : subscriptionMap.entrySet()) {
+                String ownerKey = entry.getKey();
+                List<SubscriptionDTO> ownerSubs = entry.getValue();
+
+                AsyncJobStatusDTO job;
+                if (CandlepinMode.isStandalone()) {
+                    File manifest = new ExportGenerator()
+                        .addSubscriptions(ownerSubs)
+                        .export();
+
+                    job = this.adminClient.owners()
+                        .importManifestAsync(ownerKey, List.of(), manifest);
+                }
+                else {
+                    ownerSubs.forEach(subscription -> this.adminClient.hosted()
+                        .createSubscription(subscription, true));
+
+                    job = this.adminClient.owners()
+                        .refreshPools(ownerKey, false);
+                }
+
+                assertThatJob(job)
+                    .isNotNull()
+                    .terminates(this.adminClient)
+                    .isFinished();
+            }
+        }
+
+        @BeforeAll
+        public void setup() throws Exception {
+            // Ensure we have our required test extensions or we'll be very broken...
+            this.checkRequiredExtensions();
+
+            this.adminClient = ApiClients.admin();
+
+            this.owners = List.of(
+                this.createOwner("owner1"),
+                this.createOwner("owner2"),
+                this.createOwner("owner3"));
+
+            this.productMap = new HashMap<>();
+
+            List<SubscriptionDTO> subscriptions = new ArrayList<>();
+
+            // Dummy org we use for creating a bunch of future pools for our global products. We'll also
+            // create per-org subscriptions for these products later. Also note that these will never be
+            // fully resolved.
+            OwnerDTO globalOwner = this.createOwner("global");
+
+            List<ProductDTO> globalProducts = new ArrayList<>();
+            for (int i = 1; i <= 3; ++i) {
+                ProductDTO gprod = new ProductDTO()
+                    .id("g-prod-" + i)
+                    .name("global product " + i);
+
+                subscriptions.add(this.createSubscription(globalOwner, gprod, false));
+                globalProducts.add(gprod);
+                this.mapProductInfo(gprod, null, null);
+            }
+
+            for (int oidx = 1; oidx <= owners.size(); ++oidx) {
+                OwnerDTO owner = owners.get(oidx - 1);
+
+                List<ProductDTO> ownerProducts = new ArrayList<>();
+                for (int i = 1; i <= 2; ++i) {
+                    ProductDTO cprod = new ProductDTO()
+                        .id(String.format("o%d-prod-%d", oidx, i))
+                        .name(String.format("%s product %d", owner.getKey(), i));
+
+                    cprod = this.adminClient.ownerProducts()
+                        .createProduct(owner.getKey(), cprod);
+
+                    ownerProducts.add(cprod);
+                    this.mapProductInfo(cprod, owner, null);
+                }
+
+                // Create an active and inactive global subscription for this org
+                subscriptions.add(this.createSubscription(owner, globalProducts.get(0), true));
+                subscriptions.add(this.createSubscription(owner, globalProducts.get(1), false));
+                this.mapProductInfo(globalProducts.get(0), null, owner);
+
+                // Create an active and inactive custom subscription
+                this.createPool(owner, ownerProducts.get(0), true);
+                this.createPool(owner, ownerProducts.get(1), false);
+                this.mapProductInfo(ownerProducts.get(0), owner, owner);
+            }
+
+            this.commitGlobalSubscriptions(subscriptions);
+        }
+
+        // Impl note:
+        // Since we cannot depend on the global state being prestine from run to run (or even test to
+        // test), we cannot use exact matching on our output as extraneous products from previous test
+        // runs or otherwise pre-existing data may show up in the result set. Instead, these tests will
+        // verify our expected products are present, and unexpected products from the test data are not.
+
+        private List<String> getUnexpectedIds(List<String> expectedIds) {
+            return this.productMap.values()
+                .stream()
+                .map(ProductInfo::dto)
+                .map(ProductDTO::getId)
+                .filter(Predicate.not(expectedIds::contains))
+                .toList();
+        }
+
+        private Predicate<ProductInfo> buildOwnerProductPredicate(OwnerDTO owner) {
+            return pinfo -> pinfo.owner() == null || owner.getKey().equals(pinfo.owner().getKey());
+        }
+
+        @Test
+        public void shouldAllowQueryingWithoutAnyFilters() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldDefaultToActiveExclusiveCustomInclusive() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(ProductInfo::active)
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, null, null);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldFailWithInvalidOwners() {
+            assertNotFound(() -> this.adminClient.ownerProducts()
+                .getProductsByOwner("invalid_owner", null, null, null, null));
+        }
+
+        @Test
+        public void shouldAllowFilteringOnIDs() {
+            // Randomly seeded for consistency; seed itself chosen randomly
+            Random rand = new Random(58258);
+
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> pids = this.productMap.values()
+                .stream()
+                .filter(elem -> rand.nextBoolean())
+                .map(ProductInfo::id)
+                .toList();
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .map(ProductInfo::id)
+                .filter(pids::contains)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), pids, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "invalid_id" })
+        @NullAndEmptySource
+        public void shouldAllowFilteringOnInvalidIds(String pid) {
+            // This test verifies that invalid IDs are "allowed", but they won't match on anything
+
+            OwnerDTO owner = this.owners.get(1);
+
+            ProductDTO expected = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .findAny()
+                .map(ProductInfo::dto)
+                .get();
+
+            List<String> expectedPids = List.of(expected.getId());
+
+            List<String> pids = Arrays.asList(expected.getId(), pid);
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), pids, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldAllowFilteringOnName() {
+            Random rand = new Random(55851);
+
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> names = this.productMap.values()
+                .stream()
+                .filter(elem -> rand.nextBoolean())
+                .map(pinfo -> pinfo.dto().getName())
+                .toList();
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(pinfo -> names.contains(pinfo.dto().getName()))
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, names, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "invalid_name" })
+        @NullAndEmptySource
+        public void shouldAllowFilteringOnInvalidNames(String name) {
+            // This test verifies that invalid IDs are "allowed", but they won't match on anything
+
+            OwnerDTO owner = this.owners.get(1);
+
+            ProductDTO expected = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .findAny()
+                .map(ProductInfo::dto)
+                .get();
+
+            List<String> expectedPids = List.of(expected.getId());
+
+            List<String> names = Arrays.asList(expected.getName(), name);
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, names, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveIncluded() {
+            // This is effectively the same as no filter -- we expect everything within the org back
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids);
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveExcluded() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(pinfo -> !pinfo.active())
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_EXCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveExclusive() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(ProductInfo::active)
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_EXCLUSIVE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldErrorWithInvalidActiveInclusion() {
+            OwnerDTO owner = this.owners.get(1);
+
+            assertBadRequest(() -> this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, "invalid_type", INCLUSION_INCLUDE));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomIncluded() {
+            // This is effectively the same as no filter -- we expect everything in the org back
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids);
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomExcluded() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(pinfo -> !pinfo.custom())
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomExclusive() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::custom)
+                .filter(pinfo -> pinfo.owner().getKey().equals(owner.getKey()))
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldErrorWithInvalidCustomInclusion() {
+            OwnerDTO owner = this.owners.get(1);
+
+            assertBadRequest(() -> this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, "invalid_type"));
+        }
+
+        @Test
+        public void shouldAllowQueryingWithMultipleFilters() {
+            Random rand = new Random(14023);
+
+            OwnerDTO owner = this.owners.get(1);
+
+            // Hand pick a product to ensure that we have *something* that comes out of the filter, should
+            // our random selection process not have any intersection.
+            ProductInfo selected = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(ProductInfo::active)
+                .filter(ProductInfo::custom)
+                .findAny()
+                .get();
+
+            List<String> pids = this.productMap.values()
+                .stream()
+                .filter(elem -> rand.nextBoolean())
+                .map(ProductInfo::id)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            List<String> names = this.productMap.values()
+                .stream()
+                .filter(elem -> rand.nextBoolean())
+                .map(pinfo -> pinfo.dto().getName())
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            pids.add(selected.dto().getId());
+            names.add(selected.dto().getName());
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::active)
+                .filter(ProductInfo::custom)
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(pinfo -> pids.contains(pinfo.dto().getId()))
+                .filter(pinfo -> names.contains(pinfo.dto().getName()))
+                .map(ProductInfo::id)
+                .toList();
+
+            assertThat(expectedPids)
+                .isNotEmpty();
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), pids, names, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+        public void shouldAllowQueryingInPages(int pageSize) {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(ProductInfo::custom)
+                .map(ProductInfo::id)
+                .toList();
+
+            List<String> received = new ArrayList<>();
+
+            int page = 0;
+            while (true) {
+                Response response = Request.from(this.adminClient)
+                    .setPath(QUERY_PATH)
+                    .setPathParam("owner_key", owner.getKey())
+                    .addQueryParam("page", String.valueOf(++page))
+                    .addQueryParam("per_page", String.valueOf(pageSize))
+                    .addQueryParam("active", "include")
+                    .addQueryParam("custom", "exclusive")
+                    .execute();
+
+                assertEquals(200, response.getCode());
+
+                List<ProductDTO> output = response.deserialize(new TypeReference<List<ProductDTO>>() {});
+                assertNotNull(output);
+
+                if (output.isEmpty()) {
+                    break;
+                }
+
+                output.stream()
+                    .map(ProductDTO::getId)
+                    .sequential()
+                    .forEach(received::add);
+            }
+
+            assertThat(received)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, -1, -100 })
+        public void shouldFailWithInvalidPage(int page) {
+            OwnerDTO owner = this.owners.get(1);
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("page", String.valueOf(page))
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, -1, -100 })
+        public void shouldFailWithInvalidPageSize(int pageSize) {
+            OwnerDTO owner = this.owners.get(1);
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("per_page", String.valueOf(pageSize))
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "id", "name", "uuid" })
+        public void shouldAllowQueryingWithAscendingOrderedOutput(String field) {
+            OwnerDTO owner = this.owners.get(1);
+
+            Map<String, Comparator<ProductDTO>> comparatorMap = Map.of(
+                "id", Comparator.comparing(ProductDTO::getId),
+                "name", Comparator.comparing(ProductDTO::getName),
+                "uuid", Comparator.comparing(ProductDTO::getUuid));
+
+            List<ProductDTO> products = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            List<String> expectedPids = products.stream()
+                .sorted(comparatorMap.get(field))
+                .map(ProductDTO::getId)
+                .toList();
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("sort_by", field)
+                .addQueryParam("order", "asc")
+                .addQueryParam("active", INCLUSION_INCLUDE)
+                .addQueryParam("custom", INCLUSION_INCLUDE)
+                .execute();
+
+            assertEquals(200, response.getCode());
+
+            List<ProductDTO> output = response.deserialize(new TypeReference<List<ProductDTO>>() {});
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsExactlyElementsOf(expectedPids); // this must be an ordered check
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "id", "name", "uuid" })
+        public void shouldAllowQueryingWithDescendingOrderedOutput(String field) {
+            OwnerDTO owner = this.owners.get(1);
+
+            Map<String, Comparator<ProductDTO>> comparatorMap = Map.of(
+                "id", Comparator.comparing(ProductDTO::getId),
+                "name", Comparator.comparing(ProductDTO::getName),
+                "uuid", Comparator.comparing(ProductDTO::getUuid));
+
+            List<ProductDTO> products = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            List<String> expectedPids = products.stream()
+                .sorted(comparatorMap.get(field).reversed())
+                .map(ProductDTO::getId)
+                .toList();
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("sort_by", field)
+                .addQueryParam("order", "desc")
+                .addQueryParam("active", INCLUSION_INCLUDE)
+                .addQueryParam("custom", INCLUSION_INCLUDE)
+                .execute();
+
+            assertEquals(200, response.getCode());
+
+            List<ProductDTO> output = response.deserialize(new TypeReference<List<ProductDTO>>() {});
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsExactlyElementsOf(expectedPids); // this must be an ordered check
+        }
+
+        @Test
+        public void shouldFailWithInvalidOrderField() {
+            OwnerDTO owner = this.owners.get(1);
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("sort_by", "invalid field")
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @Test
+        public void shouldFailWithInvalidOrderDirection() {
+            OwnerDTO owner = this.owners.get(1);
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("order", "invalid order")
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        // These tests verify the definition of "active" is properly implemented, ensuring "active" is
+        // defined as a product which is attached to a pool which has started and has not expired, or
+        // attached to another active product (recursively).
+        //
+        // This definition is recursive in nature, so the effect is that it should consider any product
+        // that is a descendant of a product attached to a non-future pool that hasn't yet expired.
+
+        @Test
+        public void shouldOnlySelectActiveProductsFromActivePools() {
+            // "active" only considers pools which have started but have not yet expired -- that is:
+            // (start time < now() < end time)
+            OwnerDTO owner = this.createOwner("test_org");
+
+            ProductDTO prod1 = this.adminClient.ownerProducts()
+                .createProduct(owner.getKey(), Products.random());
+            ProductDTO prod2 = this.adminClient.ownerProducts()
+                .createProduct(owner.getKey(), Products.random());
+            ProductDTO prod3 = this.adminClient.ownerProducts()
+                .createProduct(owner.getKey(), Products.random());
+
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            // Create three pools: expired, current (active), future
+            PoolDTO pool1 = Pools.random(prod1)
+                .startDate(now.minus(7, ChronoUnit.DAYS))
+                .endDate(now.minus(3, ChronoUnit.DAYS));
+            PoolDTO pool2 = Pools.random(prod2)
+                .startDate(now.minus(3, ChronoUnit.DAYS))
+                .endDate(now.plus(3, ChronoUnit.DAYS));
+            PoolDTO pool3 = Pools.random(prod3)
+                .startDate(now.plus(3, ChronoUnit.DAYS))
+                .endDate(now.plus(7, ChronoUnit.DAYS));
+
+            this.adminClient.owners().createPool(owner.getKey(), pool1);
+            this.adminClient.owners().createPool(owner.getKey(), pool2);
+            this.adminClient.owners().createPool(owner.getKey(), pool3);
+
+            // Active = exclusive should only find the active pool; future and expired pools should be omitted
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .singleElement()
+                .isEqualTo(prod2.getId());
+        }
+
+        @Test
+        public void shouldAlsoIncludeDescendantProductsOfActiveProducts() {
+            // "active" includes descendants of products attached to an active pool
+            OwnerDTO owner = this.createOwner("test_org");
+
+            List<ProductDTO> products = new ArrayList<>();
+            for (int i = 0; i < 20; ++i) {
+                ProductDTO product = new ProductDTO()
+                    .id("p" + i)
+                    .name("product " + i);
+
+                products.add(product);
+            }
+
+            /*
+            pool -> prod - p0
+                        derived - p1
+                            provided - p2
+                            provided - p3
+                                provided - p4
+                        provided - p5
+                        provided - p6
+
+            pool -> prod - p7
+                        derived - p8*
+                        provided - p9
+
+            pool -> prod - p8*
+                        provided - p10
+                            provided - p11
+                        provided - p12
+                            provided - p13
+
+                    prod - p14
+                        derived - p15
+                            provided - p16
+
+                    prod - p17
+                        provided - p18
+
+            pool -> prod - p19
+                    prod - p20
+            */
+
+            products.get(0).setDerivedProduct(products.get(1));
+            products.get(0).addProvidedProductsItem(products.get(5));
+            products.get(0).addProvidedProductsItem(products.get(6));
+
+            products.get(1).addProvidedProductsItem(products.get(2));
+            products.get(1).addProvidedProductsItem(products.get(3));
+
+            products.get(3).addProvidedProductsItem(products.get(4));
+
+            products.get(7).setDerivedProduct(products.get(8));
+            products.get(7).addProvidedProductsItem(products.get(9));
+
+            products.get(8).addProvidedProductsItem(products.get(10));
+            products.get(8).addProvidedProductsItem(products.get(12));
+
+            products.get(10).addProvidedProductsItem(products.get(11));
+
+            products.get(12).addProvidedProductsItem(products.get(13));
+
+            products.get(14).setDerivedProduct(products.get(15));
+
+            products.get(15).setDerivedProduct(products.get(16));
+
+            products.get(17).setDerivedProduct(products.get(18));
+
+            // persist the products in reverse order so we don't hit any linkage errors
+            for (int i = products.size() - 1; i >= 0; --i) {
+                this.adminClient.ownerProducts().createProduct(owner.getKey(), products.get(i));
+            }
+
+            // create some pools to link to our product tree
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(0)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(7)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(8)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(19)));
+
+            List<String> expectedPids = List.of("p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9",
+                "p10", "p11", "p12", "p13", "p19");
+
+            List<ProductDTO> output = this.adminClient.ownerProducts()
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsExactlyInAnyOrderElementsOf(expectedPids);
+        }
     }
 }

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/RefreshPoolsSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/RefreshPoolsSpecTest.java
@@ -633,7 +633,7 @@ public class RefreshPoolsSpecTest {
             .toList();
 
         List<ProductDTO> actualProducts = adminClient.ownerProducts()
-            .getProductsByOwner(ownerKey, pids, false);
+            .getProductsByOwner(ownerKey, pids, null, null, "include");
         assertThat(actualProducts)
             .map(ProductDTO::getId)
             .containsAll(pids);

--- a/spec-tests/src/test/java/org/candlepin/spec/products/ProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/products/ProductResourceSpecTest.java
@@ -14,238 +14,1099 @@
  */
 package org.candlepin.spec.products;
 
-import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.candlepin.spec.bootstrap.assertions.JobStatusAssert.assertThatJob;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertBadRequest;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertNotFound;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.candlepin.dto.api.client.v1.AsyncJobStatusDTO;
+import org.candlepin.dto.api.client.v1.NestedOwnerDTO;
 import org.candlepin.dto.api.client.v1.OwnerDTO;
 import org.candlepin.dto.api.client.v1.PoolDTO;
 import org.candlepin.dto.api.client.v1.ProductDTO;
-import org.candlepin.resource.client.v1.OwnerApi;
-import org.candlepin.resource.client.v1.OwnerProductApi;
-import org.candlepin.resource.client.v1.ProductsApi;
+import org.candlepin.dto.api.client.v1.SubscriptionDTO;
+import org.candlepin.spec.bootstrap.assertions.CandlepinMode;
 import org.candlepin.spec.bootstrap.assertions.OnlyInHosted;
 import org.candlepin.spec.bootstrap.client.ApiClient;
 import org.candlepin.spec.bootstrap.client.ApiClients;
 import org.candlepin.spec.bootstrap.client.SpecTest;
-import org.candlepin.spec.bootstrap.client.api.JobsClient;
+import org.candlepin.spec.bootstrap.client.request.Request;
+import org.candlepin.spec.bootstrap.client.request.Response;
+import org.candlepin.spec.bootstrap.data.builder.ExportGenerator;
 import org.candlepin.spec.bootstrap.data.builder.Owners;
+import org.candlepin.spec.bootstrap.data.builder.Pools;
+import org.candlepin.spec.bootstrap.data.builder.Products;
+import org.candlepin.spec.bootstrap.data.builder.Subscriptions;
 import org.candlepin.spec.bootstrap.data.util.StringUtil;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.File;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.stream.IntStream;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+
 
 @SpecTest
 public class ProductResourceSpecTest {
-    private static ProductsApi productsApi;
-    private static OwnerApi ownerApi;
-    private static OwnerProductApi ownerProductApi;
-    private static JobsClient jobsClient;
 
-    private String p1ProductId;
-    private String p2ProductId;
-    private String p3ProductId;
-    private String p4dProductId;
-    private String p4ProductId;
-    private String p5dProductId;
-    private String p5ProductId;
-    private String p6dProductId;
-    private String p6ProductId;
+    private ProductDTO createProduct(ApiClient client, String productId, String ownerKey,
+        ProductDTO derivedProduct, Collection<ProductDTO> providedProducts) {
 
-    @BeforeAll
-    public static void beforeAll() {
-        ApiClient client = ApiClients.admin();
-        productsApi = client.products();
-        ownerApi = client.owners();
-        ownerProductApi = client.ownerProducts();
-        jobsClient = client.jobs();
+        ProductDTO product = new ProductDTO()
+            .id(productId)
+            .name(productId)
+            .derivedProduct(derivedProduct);
+
+        if (providedProducts != null && !providedProducts.isEmpty()) {
+            product.setProvidedProducts(new HashSet<>(providedProducts));
+        }
+
+        return client.ownerProducts()
+            .createProduct(ownerKey, product);
+    }
+
+    private PoolDTO createPool(ApiClient client, String ownerKey, ProductDTO product) {
+        OffsetDateTime now = Instant.now()
+            .atOffset(ZoneOffset.UTC);
+
+        PoolDTO pool = new PoolDTO()
+            .productId(product.getId())
+            .productName(product.getName())
+            .quantity(10L)
+            .startDate(now.minus(1, ChronoUnit.DAYS))
+            .endDate(now.plus(10, ChronoUnit.DAYS));
+
+        return client.owners()
+            .createPool(ownerKey, pool);
+    }
+
+    /**
+     * Creates test data for the refresh pools by products tests. Do not use this data for other tests
+     *
+     * @param client
+     *  the API client to use for creating test data
+     *
+     * @return
+     *  a map of product IDs, to owner keys, to product instances
+     */
+    private Map<String, Map<String, ProductDTO>> setupDataForRefreshProductPoolsTests(ApiClient client) {
+        OwnerDTO owner1 = client.owners().createOwner(Owners.random());
+        OwnerDTO owner2 = client.owners().createOwner(Owners.random());
+        OwnerDTO owner3 = client.owners().createOwner(Owners.random());
+
+        String p1ProductId = StringUtil.random("p1");
+        String p2ProductId = StringUtil.random("p2");
+        String p3ProductId = StringUtil.random("p3");
+        String p4dProductId = StringUtil.random("p4d");
+        String p4ProductId = StringUtil.random("p4");
+        String p5dProductId = StringUtil.random("p5d");
+        String p5ProductId = StringUtil.random("p5");
+        String p6dProductId = StringUtil.random("p6d");
+        String p6ProductId = StringUtil.random("p6");
+
+        ProductDTO prod1o1 = this.createProduct(client, p1ProductId, owner1.getKey(), null, null);
+        ProductDTO prod1o2 = this.createProduct(client, p1ProductId, owner2.getKey(), null, null);
+        ProductDTO prod1o3 = this.createProduct(client, p1ProductId, owner3.getKey(), null, null);
+
+        ProductDTO prod2o1 = this.createProduct(client, p2ProductId, owner1.getKey(), null, null);
+        ProductDTO prod2o2 = this.createProduct(client, p2ProductId, owner2.getKey(), null, null);
+
+        ProductDTO prod3o2 = this.createProduct(client, p3ProductId, owner2.getKey(), null, null);
+        ProductDTO prod3o3 = this.createProduct(client, p3ProductId, owner3.getKey(), null, null);
+
+        ProductDTO prod4d = this.createProduct(client, p4dProductId, owner1.getKey(), null, List.of(prod2o1));
+        ProductDTO prod4 = this.createProduct(client, p4ProductId, owner1.getKey(), prod4d, List.of(prod1o1));
+
+        ProductDTO prod5d = this.createProduct(client, p5dProductId, owner2.getKey(), null, List.of(prod3o2));
+        ProductDTO prod5 = this.createProduct(client, p5ProductId, owner2.getKey(), prod5d,
+            List.of(prod1o2, prod2o2));
+
+        ProductDTO prod6d = this.createProduct(client, p6dProductId, owner3.getKey(), null, List.of(prod3o3));
+        ProductDTO prod6 = this.createProduct(client, p6ProductId, owner3.getKey(), prod6d, List.of(prod1o3));
+
+        this.createPool(client, owner1.getKey(), prod4);
+        this.createPool(client, owner2.getKey(), prod5);
+        this.createPool(client, owner3.getKey(), prod6);
+
+        Map<String, ProductDTO> p1map = Map.of(
+            owner1.getKey(), prod1o1,
+            owner2.getKey(), prod1o2,
+            owner3.getKey(), prod1o3);
+
+        Map<String, ProductDTO> p2map = Map.of(
+            owner1.getKey(), prod2o1,
+            owner2.getKey(), prod2o2);
+
+        Map<String, ProductDTO> p3map = Map.of(
+            owner2.getKey(), prod3o2,
+            owner3.getKey(), prod3o3);
+
+        return Map.of(
+            p1ProductId, p1map,
+            p2ProductId, p2map,
+            p3ProductId, p3map,
+            p4dProductId, Map.of(owner1.getKey(), prod4d),
+            p4ProductId, Map.of(owner1.getKey(), prod4),
+            p5dProductId, Map.of(owner2.getKey(), prod5d),
+            p5ProductId, Map.of(owner2.getKey(), prod5),
+            p6dProductId, Map.of(owner3.getKey(), prod6d),
+            p6ProductId, Map.of(owner3.getKey(), prod6));
     }
 
     @Test
     @OnlyInHosted
     public void shouldRefreshPoolsForOrgsOwningProducts() throws Exception {
-        setupOrgProductsAndPools();
+        ApiClient client = ApiClients.admin();
+        Map<String, Map<String, ProductDTO>> data = this.setupDataForRefreshProductPoolsTests(client);
 
-        List<AsyncJobStatusDTO> jobs = productsApi.refreshPoolsForProducts(Arrays.asList(p4ProductId), true);
-        assertEquals(1, jobs.size());
-        verifyRefreshPoolsForProducts(jobs.get(0));
+        for (Map.Entry<String, Map<String, ProductDTO>> entry : data.entrySet()) {
+            String pid = entry.getKey();
+            Map<String, ProductDTO> orgProductMap = entry.getValue();
 
-        jobs = productsApi.refreshPoolsForProducts(Arrays.asList(p5dProductId), true);
-        assertEquals(1, jobs.size());
-        verifyRefreshPoolsForProducts(jobs.get(0));
+            List<AsyncJobStatusDTO> jobs = client.products()
+                .refreshPoolsForProducts(List.of(pid), true);
 
-        jobs = productsApi.refreshPoolsForProducts(Arrays.asList(p1ProductId), true);
-        assertEquals(3, jobs.size());
-        verifyRefreshPoolsForProducts(jobs.get(0));
-        verifyRefreshPoolsForProducts(jobs.get(1));
-        verifyRefreshPoolsForProducts(jobs.get(2));
+            assertThat(jobs)
+                .isNotNull()
+                .hasSize(orgProductMap.size())
+                .allSatisfy(job -> assertThatJob(job)
+                    .isNotNull()
+                    .isType("RefreshPoolsJob")
+                    .terminates(client)
+                    .isFinished());
+        }
+    }
 
-        jobs = productsApi.refreshPoolsForProducts(Arrays.asList(p3ProductId), true);
-        assertEquals(2, jobs.size());
-        verifyRefreshPoolsForProducts(jobs.get(0));
-        verifyRefreshPoolsForProducts(jobs.get(1));
+    @Test
+    @OnlyInHosted
+    public void shouldRefreshPoolsForAllOrgsOwningMultipleProducts() throws Exception {
+        ApiClient client = ApiClients.admin();
+        Map<String, Map<String, ProductDTO>> data = this.setupDataForRefreshProductPoolsTests(client);
 
-        jobs = productsApi.refreshPoolsForProducts(Arrays.asList(p4ProductId, p6ProductId), true);
-        assertEquals(2, jobs.size());
-        verifyRefreshPoolsForProducts(jobs.get(0));
-        verifyRefreshPoolsForProducts(jobs.get(1));
+        // API generation fail here. We can't pass in arbitrary collections, so we have convert it to
+        // a list first
+        List<String> pids = new ArrayList<>(data.keySet());
 
-        // Unknown product
-        assertEquals(0, productsApi.refreshPoolsForProducts(Arrays.asList("unknown"), true).size());
+        // We expect one job for every org that is found in the data set. At the time of writing, that
+        // should be three.
+        int expectedJobCount = (int) data.values()
+            .stream()
+            .flatMap(map -> map.keySet().stream())
+            .distinct()
+            .count();
+
+        List<AsyncJobStatusDTO> jobs = client.products()
+            .refreshPoolsForProducts(pids, true);
+
+        assertThat(jobs)
+            .isNotNull()
+            .hasSize(expectedJobCount)
+            .allSatisfy(job -> assertThatJob(job)
+                .isNotNull()
+                .isType("RefreshPoolsJob")
+                .terminates(client)
+                .isFinished());
+    }
+
+    @Test
+    @OnlyInHosted
+    public void shouldNotCreateRefreshPoolsJobForUnknownProducts() throws Exception {
+        ApiClient client = ApiClients.admin();
+        Map<String, Map<String, ProductDTO>> data = this.setupDataForRefreshProductPoolsTests(client);
+
+        List<AsyncJobStatusDTO> jobs = client.products()
+            .refreshPoolsForProducts(List.of("unknown_pid"), true);
+
+        assertThat(jobs)
+            .isNotNull()
+            .isEmpty();
     }
 
     @Test
     public void shouldRaiseBadRequestOnRefreshWithNoProducts() {
-        assertBadRequest(() -> productsApi.refreshPoolsForProducts(new ArrayList<>(), false));
+        ApiClient client = ApiClients.admin();
+
+        assertBadRequest(() -> client.products().refreshPoolsForProducts(List.of(), false));
     }
 
     @Test
     public void shouldRaiseNotFoundForNonExistingProducts() {
-        assertNotFound(() -> productsApi.getProductByUuid("unknown-product-id"));
-    }
+        ApiClient client = ApiClients.admin();
 
-    private List<OwnerDTO> setupOrgProductsAndPools() {
-        OwnerDTO owner1 = ownerApi.createOwner(Owners.random());
-        OwnerDTO owner2 = ownerApi.createOwner(Owners.random());
-        OwnerDTO owner3 = ownerApi.createOwner(Owners.random());
-
-        p1ProductId = StringUtil.random("p1");
-        p2ProductId = StringUtil.random("p2");
-        p3ProductId = StringUtil.random("p3");
-        p4dProductId = StringUtil.random("p4d");
-        p4ProductId = StringUtil.random("p4");
-        p5dProductId = StringUtil.random("p5d");
-        p5ProductId = StringUtil.random("p5");
-        p6dProductId = StringUtil.random("p6d");
-        p6ProductId = StringUtil.random("p6");
-
-        ProductDTO prod1o1 = createProduct(p1ProductId, owner1.getKey(), null, null);
-        ProductDTO prod1o2 = createProduct(p1ProductId, owner2.getKey(), null, null);
-        ProductDTO prod1o3 = createProduct(p1ProductId, owner3.getKey(), null, null);
-
-        ProductDTO prod2o1 = createProduct(p2ProductId, owner1.getKey(), null, null);
-        ProductDTO prod2o2 = createProduct(p2ProductId, owner2.getKey(), null, null);
-
-        ProductDTO prod3o2 = createProduct(p3ProductId, owner2.getKey(), null, null);
-        ProductDTO prod3o3 = createProduct(p3ProductId, owner3.getKey(), null, null);
-
-        ProductDTO prod4d = createProduct(p4dProductId, owner1.getKey(), null, Arrays.asList(prod2o1));
-        ProductDTO prod4 = createProduct(p4ProductId, owner1.getKey(), prod4d, Arrays.asList(prod1o1));
-
-        ProductDTO prod5d = createProduct(p5dProductId, owner2.getKey(), null, Arrays.asList(prod3o2));
-        ProductDTO prod5
-            = createProduct(p5ProductId, owner2.getKey(), prod5d, Arrays.asList(prod1o2, prod2o2));
-
-        ProductDTO prod6d = createProduct(p6dProductId, owner3.getKey(), null, Arrays.asList(prod3o3));
-        ProductDTO prod6 = createProduct(p6ProductId, owner3.getKey(), prod6d, Arrays.asList(prod1o3));
-
-        createPool(owner1.getKey(), prod4);
-        createPool(owner2.getKey(), prod5);
-        createPool(owner3.getKey(), prod6);
-
-        return Arrays.asList(owner1, owner2, owner3);
-    }
-
-    private ProductDTO createProduct(String productId, String ownerKey, ProductDTO derivedProduct,
-        Collection<ProductDTO> providedProducts) {
-        ProductDTO newProduct = new ProductDTO();
-        newProduct.setId(productId);
-        newProduct.setName(productId);
-        if (derivedProduct != null) {
-            newProduct.setDerivedProduct(derivedProduct);
-        }
-
-        if (providedProducts != null && !providedProducts.isEmpty()) {
-            newProduct.setProvidedProducts(new HashSet<>(providedProducts));
-        }
-
-        return ownerProductApi.createProduct(ownerKey, newProduct);
-    }
-
-    private PoolDTO createPool(String ownerKey, ProductDTO product) {
-        PoolDTO pool = new PoolDTO();
-        pool.setProductId(product.getId());
-        pool.setProductName(product.getName());
-        pool.setQuantity(10L);
-        pool.setStartDate(Instant.now().atOffset(ZoneOffset.UTC));
-        pool.setEndDate(Instant.now().plus(10, ChronoUnit.DAYS).atOffset(ZoneOffset.UTC));
-
-        return ownerApi.createPool(ownerKey, pool);
-    }
-
-    private void verifyRefreshPoolsForProducts(AsyncJobStatusDTO job) {
-        assertEquals("Refresh Pools", job.getName());
-
-        AsyncJobStatusDTO finishedJobStatus = jobsClient.waitForJob(job);
-        assertEquals("FINISHED", finishedJobStatus.getState());
+        assertNotFound(() -> client.products().getProductByUuid("unknown-product-id"));
     }
 
     @Nested
     @Isolated
+    @TestInstance(Lifecycle.PER_CLASS)
     @Execution(ExecutionMode.SAME_THREAD)
-    class GetPages {
-        @Test
-        public void shouldListProductsPagedAndSorted() {
-            ApiClient adminClient = ApiClients.admin();
-            OwnerDTO owner = ownerApi.createOwner(Owners.random());
+    public class ProductQueryTests {
 
-            // Ensure that there is data for this test.
-            // Most likely, there will already be data left from other test runs that will show up
-            IntStream.range(0, 5).forEach(entry -> {
-                createProduct("test_product-" + entry, owner.getKey(), null, null);
+        private static final String QUERY_PATH = "/products";
 
-                // for timestamp separation
-                try {
-                    sleep(1000);
-                }
-                catch (InterruptedException ie) {
-                    throw new RuntimeException("Unable to sleep as expected");
-                }
-            });
+        private static final String INCLUSION_INCLUDE = "include";
+        private static final String INCLUSION_EXCLUDE = "exclude";
+        private static final String INCLUSION_EXCLUSIVE = "exclusive";
 
-            List<ProductDTO> products = adminClient.products().getProducts(1, 4, "asc", "created");
-            assertThat(products)
-                .isNotNull()
-                .hasSize(4);
-            assertThat(products.get(0).getCreated().compareTo(products.get(1).getCreated()))
-                .isNotPositive();
-            assertThat(products.get(1).getCreated().compareTo(products.get(2).getCreated()))
-                .isNotPositive();
-            assertThat(products.get(2).getCreated().compareTo(products.get(3).getCreated()))
-                .isNotPositive();
+        private static record ProductInfo(ProductDTO dto, OwnerDTO owner, Set<String> activeOwners) {
+            public String id() {
+                return this.dto() != null ? this.dto().getId() : null;
+            }
+
+            public boolean active() {
+                return !this.activeOwners().isEmpty();
+            }
+
+            public boolean custom() {
+                return this.owner() != null;
+            }
+        };
+
+        private ApiClient adminClient;
+
+        private List<OwnerDTO> owners;
+        private Map<String, ProductInfo> productMap;
+
+        /**
+         * Verifies either the manifest generator extension or the hosted test extension is present as
+         * required by the current operating mode.
+         */
+        private void checkRequiredExtensions() {
+            if (CandlepinMode.isStandalone()) {
+                assumeTrue(CandlepinMode::hasManifestGenTestExtension);
+            }
+            else {
+                assumeTrue(CandlepinMode::hasHostedTestExtension);
+            }
         }
-    }
 
-    private void compareOwner(OwnerDTO expected, OwnerDTO actual) {
-        assertEquals(expected.getCreated(), actual.getCreated());
-        assertEquals(expected.getId(), actual.getId());
-        assertEquals(expected.getDisplayName(), actual.getDisplayName());
-        assertEquals(expected.getKey(), actual.getKey());
-        assertEquals(expected.getContentPrefix(), actual.getContentPrefix());
-        assertEquals(expected.getDefaultServiceLevel(), actual.getDefaultServiceLevel());
-        assertEquals(expected.getLogLevel(), actual.getLogLevel());
-        assertEquals(expected.getContentAccessMode(), actual.getContentAccessMode());
-        assertEquals(expected.getContentAccessModeList(), actual.getContentAccessModeList());
-        assertEquals(expected.getAutobindDisabled(), actual.getAutobindDisabled());
-        assertEquals(expected.getLastRefreshed(), actual.getLastRefreshed());
-        assertEquals(expected.getParentOwner(), actual.getParentOwner());
-        assertEquals(expected.getUpstreamConsumer(), actual.getUpstreamConsumer());
+        private OwnerDTO createOwner(String keyPrefix) {
+            OwnerDTO owner = Owners.random()
+                .key(StringUtil.random(keyPrefix + "-"));
+
+            return this.adminClient.owners()
+                .createOwner(owner);
+        }
+
+        private SubscriptionDTO createSubscription(OwnerDTO owner, ProductDTO product, boolean active) {
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            // Impl note:
+            // We create active subscriptions in the future to work around a limitation on manifests
+            // disallowing and ignoring expired pools
+            return Subscriptions.random(owner, product)
+                .startDate(active ? now.minus(7, ChronoUnit.DAYS) : now.plus(7, ChronoUnit.DAYS))
+                .endDate(now.plus(30, ChronoUnit.DAYS));
+        }
+
+        private PoolDTO createPool(OwnerDTO owner, ProductDTO product, boolean active) {
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            PoolDTO pool = Pools.random(product)
+                .startDate(now.minus(7, ChronoUnit.DAYS))
+                .endDate(active ? now.plus(7, ChronoUnit.DAYS) : now.minus(3, ChronoUnit.DAYS));
+
+            return this.adminClient.owners()
+                .createPool(owner.getKey(), pool);
+        }
+
+        private void mapProductInfo(ProductDTO product, OwnerDTO owner, OwnerDTO activeOwner) {
+            Set<String> activeOwnerKeys = new HashSet<>();
+            if (activeOwner != null) {
+                activeOwnerKeys.add(activeOwner.getKey());
+            }
+
+            ProductInfo existing = this.productMap.get(product.getId());
+            if (existing != null) {
+                activeOwnerKeys.addAll(existing.activeOwners());
+            }
+
+            ProductInfo pinfo = new ProductInfo(product, owner, activeOwnerKeys);
+            this.productMap.put(product.getId(), pinfo);
+
+        }
+
+        private void commitGlobalSubscriptions(Collection<SubscriptionDTO> subscriptions) throws Exception {
+            Map<String, List<SubscriptionDTO>> subscriptionMap = new HashMap<>();
+
+            for (SubscriptionDTO subscription : subscriptions) {
+                NestedOwnerDTO owner = subscription.getOwner();
+
+                subscriptionMap.computeIfAbsent(owner.getKey(), key -> new ArrayList<>())
+                    .add(subscription);
+            }
+
+            for (Map.Entry<String, List<SubscriptionDTO>> entry : subscriptionMap.entrySet()) {
+                String ownerKey = entry.getKey();
+                List<SubscriptionDTO> ownerSubs = entry.getValue();
+
+                AsyncJobStatusDTO job;
+                if (CandlepinMode.isStandalone()) {
+                    File manifest = new ExportGenerator()
+                        .addSubscriptions(ownerSubs)
+                        .export();
+
+                    job = this.adminClient.owners()
+                        .importManifestAsync(ownerKey, List.of(), manifest);
+                }
+                else {
+                    ownerSubs.forEach(subscription -> this.adminClient.hosted()
+                        .createSubscription(subscription, true));
+
+                    job = this.adminClient.owners()
+                        .refreshPools(ownerKey, false);
+                }
+
+                assertThatJob(job)
+                    .isNotNull()
+                    .terminates(this.adminClient)
+                    .isFinished();
+            }
+        }
+
+        @BeforeAll
+        public void setup() throws Exception {
+            // Ensure we have our required test extensions or we'll be very broken...
+            this.checkRequiredExtensions();
+
+            this.adminClient = ApiClients.admin();
+
+            this.owners = List.of(
+                this.createOwner("owner1"),
+                this.createOwner("owner2"),
+                this.createOwner("owner3"));
+
+            this.productMap = new HashMap<>();
+
+            List<SubscriptionDTO> subscriptions = new ArrayList<>();
+
+            // Dummy org we use for creating a bunch of future pools for our global products. We'll also
+            // create per-org subscriptions for these products later. Also note that these will never
+            // be fully resolved.
+            OwnerDTO globalOwner = this.createOwner("global");
+
+            List<ProductDTO> globalProducts = new ArrayList<>();
+            for (int i = 1; i <= 3; ++i) {
+                ProductDTO gprod = new ProductDTO()
+                    .id("g-prod-" + i)
+                    .name("global product " + i);
+
+                subscriptions.add(this.createSubscription(globalOwner, gprod, false));
+                globalProducts.add(gprod);
+                this.mapProductInfo(gprod, null, null);
+            }
+
+            for (int oidx = 1; oidx <= owners.size(); ++oidx) {
+                OwnerDTO owner = owners.get(oidx - 1);
+
+                List<ProductDTO> ownerProducts = new ArrayList<>();
+                for (int i = 1; i <= 2; ++i) {
+                    ProductDTO cprod = new ProductDTO()
+                        .id(String.format("o%d-prod-%d", oidx, i))
+                        .name(String.format("%s product %d", owner.getKey(), i));
+
+                    cprod = this.adminClient.ownerProducts()
+                        .createProduct(owner.getKey(), cprod);
+
+                    ownerProducts.add(cprod);
+                    this.mapProductInfo(cprod, owner, null);
+                }
+
+                // Create an active and inactive global subscription for this org
+                subscriptions.add(this.createSubscription(owner, globalProducts.get(0), true));
+                subscriptions.add(this.createSubscription(owner, globalProducts.get(1), false));
+                this.mapProductInfo(globalProducts.get(0), null, owner);
+
+                // Create an active and inactive custom subscription
+                this.createPool(owner, ownerProducts.get(0), true);
+                this.createPool(owner, ownerProducts.get(1), false);
+                this.mapProductInfo(ownerProducts.get(0), owner, owner);
+            }
+
+            this.commitGlobalSubscriptions(subscriptions);
+        }
+
+        // Impl note:
+        // Since we cannot depend on the global state being prestine from run to run (or even test to
+        // test), we cannot use exact matching on our output as extraneous products from previous test
+        // runs or otherwise pre-existing data may show up in the result set. Instead, these tests will
+        // verify our expected products are present, and unexpected products from the test data are not.
+
+        private List<String> getUnexpectedIds(List<String> expectedIds) {
+            return this.productMap.values()
+                .stream()
+                .map(ProductInfo::dto)
+                .map(ProductDTO::getId)
+                .filter(Predicate.not(expectedIds::contains))
+                .toList();
+        }
+
+        @Test
+        public void shouldAllowQueryingWithoutAnyFilters() {
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(this.productMap.keySet());
+        }
+
+        @Test
+        public void shouldDefaultToActiveExclusiveCustomInclusive() {
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::active)
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, null, null, null, null);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldAllowFilteringOnOwnerKeys() {
+            List<String> ownerKeys = List.of(
+                this.owners.get(0).getKey(),
+                this.owners.get(1).getKey());
+
+            Predicate<ProductInfo> ownerMatchPredicate = pinfo -> pinfo.owner() == null ||
+                ownerKeys.contains(pinfo.owner().getKey());
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(ownerMatchPredicate)
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(ownerKeys, null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "invalid_owner" })
+        @NullAndEmptySource
+        public void shouldFailWithInvalidOwners(String ownerKey) {
+            List<String> ownerKeys = Arrays.asList(ownerKey);
+
+            assertNotFound(() -> this.adminClient.products().getProducts(ownerKeys, null, null, null, null));
+        }
+
+        @Test
+        public void shouldAllowFilteringOnIDs() {
+            // Randomly seeded for consistency; seed itself chosen randomly
+            Random rand = new Random(58258);
+
+            List<String> pids = this.productMap.values()
+                .stream()
+                .filter(elem -> rand.nextBoolean())
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, pids, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(pids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(pids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "invalid_id" })
+        @NullAndEmptySource
+        public void shouldAllowFilteringOnInvalidIds(String pid) {
+            // This test verifies that invalid IDs are "allowed", but they won't match on anything
+
+            ProductDTO expected = this.productMap.values()
+                .stream()
+                .findAny()
+                .map(ProductInfo::dto)
+                .get();
+
+            List<String> expectedPids = List.of(expected.getId());
+
+            List<String> pids = Arrays.asList(expected.getId(), pid);
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, pids, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldAllowFilteringOnName() {
+            Random rand = new Random(55851);
+
+            List<String> names = this.productMap.values()
+                .stream()
+                .filter(elem -> rand.nextBoolean())
+                .map(pinfo -> pinfo.dto().getName())
+                .toList();
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(pinfo -> names.contains(pinfo.dto().getName()))
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, null, names, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "invalid_name" })
+        @NullAndEmptySource
+        public void shouldAllowFilteringOnInvalidNames(String name) {
+            // This test verifies that invalid IDs are "allowed", but they won't match on anything
+
+            ProductDTO expected = this.productMap.values()
+                .stream()
+                .findAny()
+                .map(ProductInfo::dto)
+                .get();
+
+            List<String> expectedPids = List.of(expected.getId());
+
+            List<String> names = Arrays.asList(expected.getName(), name);
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, null, names, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveIncluded() {
+            // This is effectively the same as no filter -- we expect everything back
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(this.productMap.keySet());
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveExcluded() {
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(pinfo -> !pinfo.active())
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, null, null, INCLUSION_EXCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveExclusive() {
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::active)
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, null, null, INCLUSION_EXCLUSIVE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldErrorWithInvalidActiveInclusion() {
+            assertBadRequest(() -> this.adminClient.products()
+                .getProducts(null, null, null, "invalid_type", INCLUSION_INCLUDE));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomIncluded() {
+            // This is effectively the same as no filter -- we expect everything back
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(this.productMap.keySet());
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomExcluded() {
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(pinfo -> !pinfo.custom())
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomExclusive() {
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::custom)
+                .map(ProductInfo::id)
+                .toList();
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(null, null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @Test
+        public void shouldErrorWithInvalidCustomInclusion() {
+            assertBadRequest(() -> this.adminClient.products()
+                .getProducts(null, null, null, INCLUSION_INCLUDE, "invalid_type"));
+        }
+
+        @Test
+        public void shouldAllowQueryingWithMultipleFilters() {
+            Random rand = new Random(14023);
+
+            // Hand pick a product to ensure that we have *something* that comes out of the filter, should
+            // our random selection process not have any intersection.
+            ProductInfo selected = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::active)
+                .filter(ProductInfo::custom)
+                .findAny()
+                .get();
+
+            List<String> ownerKeys = this.owners.stream()
+                .filter(elem -> rand.nextBoolean())
+                .map(OwnerDTO::getKey)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            List<String> pids = this.productMap.values()
+                .stream()
+                .filter(elem -> rand.nextBoolean())
+                .map(ProductInfo::id)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            List<String> names = this.productMap.values()
+                .stream()
+                .filter(elem -> rand.nextBoolean())
+                .map(pinfo -> pinfo.dto().getName())
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            ownerKeys.add(selected.owner().getKey());
+            pids.add(selected.dto().getId());
+            names.add(selected.dto().getName());
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::active)
+                .filter(ProductInfo::custom)
+                .filter(pinfo -> pinfo.activeOwners().stream().anyMatch(ownerKeys::contains))
+                .filter(pinfo -> pids.contains(pinfo.dto().getId()))
+                .filter(pinfo -> names.contains(pinfo.dto().getName()))
+                .map(ProductInfo::id)
+                .toList();
+
+            assertThat(expectedPids)
+                .isNotEmpty();
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(ownerKeys, pids, names, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+        public void shouldAllowQueryingInPages(int pageSize) {
+            List<String> ownerKeys = this.owners.stream()
+                .map(OwnerDTO::getKey)
+                .toList();
+
+            List<String> expectedPids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::custom)
+                .map(ProductInfo::id)
+                .toList();
+
+            List<String> received = new ArrayList<>();
+
+            int page = 0;
+            while (true) {
+                Response response = Request.from(this.adminClient)
+                    .setPath(QUERY_PATH)
+                    .addQueryParam("owner", ownerKeys)
+                    .addQueryParam("page", String.valueOf(++page))
+                    .addQueryParam("per_page", String.valueOf(pageSize))
+                    .addQueryParam("active", "include")
+                    .addQueryParam("custom", "exclusive")
+                    .execute();
+
+                assertEquals(200, response.getCode());
+
+                List<ProductDTO> output = response.deserialize(new TypeReference<List<ProductDTO>>() {});
+                assertNotNull(output);
+
+                if (output.isEmpty()) {
+                    break;
+                }
+
+                output.stream()
+                    .map(ProductDTO::getId)
+                    .sequential()
+                    .forEach(received::add);
+            }
+
+            assertThat(received)
+                .containsAll(expectedPids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedPids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, -1, -100 })
+        public void shouldFailWithInvalidPage(int page) {
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("page", String.valueOf(page))
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, -1, -100 })
+        public void shouldFailWithInvalidPageSize(int pageSize) {
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("per_page", String.valueOf(pageSize))
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "id", "name", "uuid" })
+        public void shouldAllowQueryingWithAscendingOrderedOutput(String field) {
+            List<String> ownerKeys = this.owners.stream()
+                .map(OwnerDTO::getKey)
+                .toList();
+
+            Map<String, Comparator<ProductDTO>> comparatorMap = Map.of(
+                "id", Comparator.comparing(ProductDTO::getId),
+                "name", Comparator.comparing(ProductDTO::getName),
+                "uuid", Comparator.comparing(ProductDTO::getUuid));
+
+            List<ProductDTO> products = this.adminClient.products()
+                .getProducts(ownerKeys, null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
+
+            List<String> expectedPids = products.stream()
+                .sorted(comparatorMap.get(field))
+                .map(ProductDTO::getId)
+                .toList();
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("owner", ownerKeys)
+                .addQueryParam("sort_by", field)
+                .addQueryParam("order", "asc")
+                .addQueryParam("active", INCLUSION_INCLUDE)
+                .addQueryParam("custom", INCLUSION_EXCLUSIVE)
+                .execute();
+
+            assertEquals(200, response.getCode());
+
+            List<ProductDTO> output = response.deserialize(new TypeReference<List<ProductDTO>>() {});
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsExactlyElementsOf(expectedPids); // this must be an ordered check
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "id", "name", "uuid" })
+        public void shouldAllowQueryingWithDescendingOrderedOutput(String field) {
+            List<String> ownerKeys = this.owners.stream()
+                .map(OwnerDTO::getKey)
+                .toList();
+
+            Map<String, Comparator<ProductDTO>> comparatorMap = Map.of(
+                "id", Comparator.comparing(ProductDTO::getId),
+                "name", Comparator.comparing(ProductDTO::getName),
+                "uuid", Comparator.comparing(ProductDTO::getUuid));
+
+            List<ProductDTO> products = this.adminClient.products()
+                .getProducts(ownerKeys, null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
+
+            List<String> expectedPids = products.stream()
+                .sorted(comparatorMap.get(field).reversed())
+                .map(ProductDTO::getId)
+                .toList();
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("owner", ownerKeys)
+                .addQueryParam("sort_by", field)
+                .addQueryParam("order", "desc")
+                .addQueryParam("active", INCLUSION_INCLUDE)
+                .addQueryParam("custom", INCLUSION_EXCLUSIVE)
+                .execute();
+
+            assertEquals(200, response.getCode());
+
+            List<ProductDTO> output = response.deserialize(new TypeReference<List<ProductDTO>>() {});
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsExactlyElementsOf(expectedPids); // this must be an ordered check
+        }
+
+        @Test
+        public void shouldFailWithInvalidOrderField() {
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("sort_by", "invalid field")
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @Test
+        public void shouldFailWithInvalidOrderDirection() {
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("order", "invalid order")
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        // These tests verify the definition of "active" is properly implemented, ensuring "active" is
+        // defined as a product which is attached to a pool which has started and has not expired, or
+        // attached to another active product (recursively).
+        //
+        // This definition is recursive in nature, so the effect is that it should consider any product
+        // that is a descendant of a product attached to a non-future pool that hasn't yet expired.
+
+        @Test
+        public void shouldOnlySelectActiveProductsFromActivePools() {
+            // "active" only considers pools which have started but have not yet expired -- that is:
+            // (start time < now() < end time)
+            OwnerDTO owner = this.createOwner("test_org");
+
+            ProductDTO prod1 = this.adminClient.ownerProducts()
+                .createProduct(owner.getKey(), Products.random());
+            ProductDTO prod2 = this.adminClient.ownerProducts()
+                .createProduct(owner.getKey(), Products.random());
+            ProductDTO prod3 = this.adminClient.ownerProducts()
+                .createProduct(owner.getKey(), Products.random());
+
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            // Create three pools: expired, current (active), future
+            PoolDTO pool1 = Pools.random(prod1)
+                .startDate(now.minus(7, ChronoUnit.DAYS))
+                .endDate(now.minus(3, ChronoUnit.DAYS));
+            PoolDTO pool2 = Pools.random(prod2)
+                .startDate(now.minus(3, ChronoUnit.DAYS))
+                .endDate(now.plus(3, ChronoUnit.DAYS));
+            PoolDTO pool3 = Pools.random(prod3)
+                .startDate(now.plus(3, ChronoUnit.DAYS))
+                .endDate(now.plus(7, ChronoUnit.DAYS));
+
+            this.adminClient.owners().createPool(owner.getKey(), pool1);
+            this.adminClient.owners().createPool(owner.getKey(), pool2);
+            this.adminClient.owners().createPool(owner.getKey(), pool3);
+
+            // Active = exclusive should only find the active pool; future and expired pools should be omitted
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(List.of(owner.getKey()), null, null, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .singleElement()
+                .isEqualTo(prod2.getId());
+        }
+
+        @Test
+        public void shouldAlsoIncludeDescendantProductsOfActiveProducts() {
+            // "active" includes descendants of products attached to an active pool
+            OwnerDTO owner = this.createOwner("test_org");
+
+            List<ProductDTO> products = new ArrayList<>();
+            for (int i = 0; i < 20; ++i) {
+                ProductDTO product = new ProductDTO()
+                    .id("p" + i)
+                    .name("product " + i);
+
+                products.add(product);
+            }
+
+            /*
+            pool -> prod - p0
+                        derived - p1
+                            provided - p2
+                            provided - p3
+                                provided - p4
+                        provided - p5
+                        provided - p6
+
+            pool -> prod - p7
+                        derived - p8*
+                        provided - p9
+
+            pool -> prod - p8*
+                        provided - p10
+                            provided - p11
+                        provided - p12
+                            provided - p13
+
+                    prod - p14
+                        derived - p15
+                            provided - p16
+
+                    prod - p17
+                        provided - p18
+
+            pool -> prod - p19
+                    prod - p20
+            */
+
+            products.get(0).setDerivedProduct(products.get(1));
+            products.get(0).addProvidedProductsItem(products.get(5));
+            products.get(0).addProvidedProductsItem(products.get(6));
+
+            products.get(1).addProvidedProductsItem(products.get(2));
+            products.get(1).addProvidedProductsItem(products.get(3));
+
+            products.get(3).addProvidedProductsItem(products.get(4));
+
+            products.get(7).setDerivedProduct(products.get(8));
+            products.get(7).addProvidedProductsItem(products.get(9));
+
+            products.get(8).addProvidedProductsItem(products.get(10));
+            products.get(8).addProvidedProductsItem(products.get(12));
+
+            products.get(10).addProvidedProductsItem(products.get(11));
+
+            products.get(12).addProvidedProductsItem(products.get(13));
+
+            products.get(14).setDerivedProduct(products.get(15));
+
+            products.get(15).setDerivedProduct(products.get(16));
+
+            products.get(17).setDerivedProduct(products.get(18));
+
+            // persist the products in reverse order so we don't hit any linkage errors
+            for (int i = products.size() - 1; i >= 0; --i) {
+                this.adminClient.ownerProducts().createProduct(owner.getKey(), products.get(i));
+            }
+
+            // create some pools to link to our product tree
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(0)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(7)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(8)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(19)));
+
+            List<String> expectedPids = List.of("p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9",
+                "p10", "p11", "p12", "p13", "p19");
+
+            List<ProductDTO> output = this.adminClient.products()
+                .getProducts(List.of(owner.getKey()), null, null, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ProductDTO::getId)
+                .containsExactlyInAnyOrderElementsOf(expectedPids);
+        }
     }
 }

--- a/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -1210,7 +1210,7 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
                 }
                 catch (IllegalArgumentException e) {
                     String errmsg = String.format("Invalid attribute key: %s", order.column());
-                    throw new InvalidOrderKeyException(errmsg, e);
+                    throw new InvalidOrderKeyException(errmsg, root.getModel());
                 }
             }
         }

--- a/src/main/java/org/candlepin/model/InvalidOrderKeyException.java
+++ b/src/main/java/org/candlepin/model/InvalidOrderKeyException.java
@@ -14,6 +14,10 @@
  */
 package org.candlepin.model;
 
+import java.util.Optional;
+
+import javax.persistence.metamodel.ManagedType;
+
 
 
 /**
@@ -22,55 +26,70 @@ package org.candlepin.model;
  */
 public class InvalidOrderKeyException extends IllegalArgumentException {
 
-    /**
-     * Constructs a new exception with null as its detail message. The cause is not initialized,
-     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
-     */
-    public InvalidOrderKeyException() {
-        super();
-    }
+    private final String column;
+    private final Optional<ManagedType<?>> type;
 
     /**
-     * Constructs a new exception with the specified detail message. The cause is not initialized,
-     * and may subsequently be initialized by a call to initCause(java.lang.Throwable).
+     * Constructs a new exception indicating the specified ordering column could not be applied.
      *
-     * @param message
-     *  the detail message. The detail message is saved for later retrieval by the getMessage()
-     *  method.
+     * @param column
+     *  the name of the column triggering this exception; also used as the exception message
+     *
+     * @param type
+     *  the metamodel type for the root to which the column was applied, if available
      */
-    public InvalidOrderKeyException(String message) {
-        super(message);
+    public InvalidOrderKeyException(String column, ManagedType<?> type) {
+        super(column);
+
+        if (column == null || column.isBlank()) {
+            throw new IllegalArgumentException("column is null or empty");
+        }
+
+        this.column = column;
+        this.type = Optional.ofNullable(type);
     }
 
     /**
-     * Constructs a new exception with the specified cause and a detail message of
-     * <tt>(cause == null ? null : cause.toString())</tt> (which typically contains the and
-     * detail message of cause). This constructor is useful for exceptions that are little more
-     * than wrappers for other throwables (for example, PrivilegedActionException).
+     * Constructs a new exception indicating the specified ordering column could not be applied.
+     *
+     * @param column
+     *  the name of the column triggering this exception; also used as the exception message
+     *
+     * @param type
+     *  the metamodel type for the root to which the column was applied, if available
      *
      * @param cause
      *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
-     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     *  value is permitted, and indicates that the cause is nonexistent or unknown
      */
-    public InvalidOrderKeyException(Throwable cause) {
-        super(cause);
+    public InvalidOrderKeyException(String column, ManagedType<?> type, Throwable cause) {
+        super(column, cause);
+
+        if (column == null || column.isBlank()) {
+            throw new IllegalArgumentException("column is null or empty");
+        }
+
+        this.column = column;
+        this.type = Optional.ofNullable(type);
     }
 
     /**
-     * Constructs a new exception with the specified detail message and cause.
-     * <p></p>
-     * Note that the detail message associated with cause is not automatically incorporated in this
-     * exception's detail message.
+     * Fetches the column name that triggered this exception.
      *
-     * @param message
-     *  the detail message. The detail message is saved for later retrieval by the getMessage()
-     *  method.
-     *
-     * @param cause
-     *  the cause (which is saved for later retrieval by the Throwable.getCause() method). A null
-     *  value is permitted, and indicates that the cause is nonexistent or unknown.
+     * @return
+     *  the name of the column that triggered this exception
      */
-    public InvalidOrderKeyException(String message, Throwable cause) {
-        super(message, cause);
+    public String getColumn() {
+        return this.column;
+    }
+
+    /**
+     * Fetches the type of the root on which the order column was attempted to be applied.
+     *
+     * @return
+     *  the metamodel of the entity type, if available
+     */
+    public Optional<ManagedType<?>> getManagedType() {
+        return this.type;
     }
 }

--- a/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/src/main/java/org/candlepin/model/ProductCurator.java
@@ -39,10 +39,7 @@ import javax.persistence.LockModeType;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Order;
-import javax.persistence.criteria.Root;
+
 
 
 /**
@@ -55,18 +52,22 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
     private final AttributeValidator attributeValidator;
 
     /**
-     * Container object for providing various arguments to the owner lookup method(s).
-     */
-    public static class ProductQueryArguments extends QueryArguments<ProductQueryArguments> {
-    }
-
-    /**
      * default ctor
      */
     @Inject
     public ProductCurator(AttributeValidator attributeValidator) {
         super(Product.class);
         this.attributeValidator = Objects.requireNonNull(attributeValidator);
+    }
+
+    /**
+     * Fetches a query builder to use for fetching products by various criteria.
+     *
+     * @return
+     *  a new ProductQueryBuilder instance backed by this curator's data provider
+     */
+    public ProductQueryBuilder getProductQueryBuilder() {
+        return new ProductQueryBuilder(this.entityManager);
     }
 
     /**
@@ -767,63 +768,6 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
             .createQuery(jpql, Product.class)
             .setParameter("content_uuid", contentUuid)
             .getResultList();
-    }
-
-    /**
-     * Fetches a collection of products based on the data in the query request. If the
-     * query builder is null or contains no arguments, the query will not limit or sort the result.
-     *
-     * @param arguments
-     *     a ProductQueryArguments instance containing the various arguments to use to
-     *     select owners
-     *
-     * @return a list of products. It will be paged and sorted if specified
-     */
-    public List<Product> listAll(ProductQueryArguments arguments) {
-        CriteriaBuilder criteriaBuilder = this.getEntityManager().getCriteriaBuilder();
-        CriteriaQuery<Product> criteriaQuery = criteriaBuilder.createQuery(Product.class);
-        Root<Product> root = criteriaQuery.from(Product.class);
-        criteriaQuery.select(root);
-
-        List<Order> order = this.buildJPAQueryOrder(criteriaBuilder, root, arguments);
-        if (order != null && order.size() > 0) {
-            criteriaQuery.orderBy(order);
-        }
-
-        TypedQuery query = this.getEntityManager().createQuery(criteriaQuery);
-
-        if (arguments != null) {
-            Integer offset = arguments.getOffset();
-            if (offset != null && offset > 0) {
-                query.setFirstResult(offset);
-            }
-
-            Integer limit = arguments.getLimit();
-            if (limit != null && limit > 0) {
-                query.setMaxResults(limit);
-            }
-        }
-        return query.getResultList();
-    }
-
-    /**
-     * Fetches a count of products based on the data in the query request.
-     *
-     * @param arguments
-     *     a OwnerQueryArguments instance containing the various arguments to use to
-     *     select products
-     *
-     * @return a count of products
-     */
-    public long getProductCount(ProductQueryArguments arguments) {
-        CriteriaBuilder criteriaBuilder = this.getEntityManager().getCriteriaBuilder();
-        CriteriaQuery<Long> criteriaQuery = criteriaBuilder.createQuery(Long.class);
-        Root<Product> root = criteriaQuery.from(Product.class);
-        criteriaQuery.select(criteriaBuilder.countDistinct(root));
-
-        return this.getEntityManager()
-            .createQuery(criteriaQuery)
-            .getSingleResult();
     }
 
 }

--- a/src/main/java/org/candlepin/model/ProductQueryBuilder.java
+++ b/src/main/java/org/candlepin/model/ProductQueryBuilder.java
@@ -1,0 +1,659 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.inject.Provider;
+import javax.persistence.Column;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.metamodel.EntityType;
+
+
+
+/**
+ * The ProductQueryBuilder is a utility class which provides a fluent-style interface for performing
+ * arbitrary product lookups with a number of parameters.
+ * <p></p>
+ * This class is a loose wrapper around the JPA interface and one or more native queries to fetch results
+ * as efficiently as possible, without the caller needing to jump back and forth between the curators
+ * to get both the count and results.
+ */
+public class ProductQueryBuilder extends QueryBuilder<ProductQueryBuilder, Product> {
+    private static final Logger log = LoggerFactory.getLogger(ProductQueryBuilder.class);
+
+    private final Set<String> productIds;
+    private final Set<String> productNames;
+    private final Map<String, Owner> owners;
+    private Inclusion active;
+    private Inclusion custom;
+
+    /**
+     * Creates a new query builder backed by the specified entity manager provider.
+     * <p></p>
+     * <strong>Note:</strong> Query builder instances should not be constructed directly and should be
+     * fetched from their corresponding curators.
+     *
+     * @param entityManagerProvider
+     *  the provider to use for fetching an entity manager when building queries
+     */
+    protected ProductQueryBuilder(Provider<EntityManager> entityManagerProvider) {
+        super(entityManagerProvider);
+
+        this.productIds = new HashSet<>();
+        this.productNames = new HashSet<>();
+        this.owners = new HashMap<>();
+        this.active = Inclusion.INCLUDE;
+        this.custom = Inclusion.INCLUDE;
+    }
+
+    /**
+     * Adds one or more product IDs to use for filtering query output.
+     *
+     * @param productIds
+     *  a collection of product IDs to use to filter query output, or null to clear any previously
+     *  set product IDs
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ProductQueryBuilder addProductIds(Collection<String> productIds) {
+        if (productIds == null) {
+            return this;
+        }
+
+        productIds.stream()
+            .filter(pid -> pid != null && !pid.isBlank())
+            .sequential()
+            .forEach(this.productIds::add);
+
+        if (this.productIds.size() > QueryBuilder.COLLECTION_SIZE_LIMIT) {
+            throw new IllegalStateException("query builder collection size limit exceeded for product IDs");
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds one or more product IDs to use for filtering query output.
+     *
+     * @param productIds
+     *  a collection of product IDs to use to filter query output
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ProductQueryBuilder addProductIds(String... productIds) {
+        return this.addProductIds(productIds != null ? Arrays.asList(productIds) : null);
+    }
+
+    /**
+     * Adds one or more product names to use for filtering query output.
+     *
+     * @param productNames
+     *  a collection of product names to use to filter query output
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ProductQueryBuilder addProductNames(Collection<String> productNames) {
+        if (productNames == null) {
+            return this;
+        }
+
+        productNames.stream()
+            .filter(name -> name != null && !name.isBlank())
+            .map(String::toLowerCase)
+            .sequential()
+            .forEach(this.productNames::add);
+
+        if (this.productNames.size() > QueryBuilder.COLLECTION_SIZE_LIMIT) {
+            throw new IllegalStateException("query builder collection size limit exceeded for product names");
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds one or more product names to use for filtering query output.
+     *
+     * @param productNames
+     *  a collection of product names to use to filter query output
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ProductQueryBuilder addProductNames(String... productNames) {
+        return this.addProductNames(productNames != null ? Arrays.asList(productNames) : null);
+    }
+
+    /**
+     * Adds one or more owners to use for filtering query output.
+     *
+     * @param owners
+     *  a collection of owners to use to filter query output
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ProductQueryBuilder addOwners(Collection<Owner> owners) {
+        if (owners == null) {
+            return this;
+        }
+
+        owners.stream()
+            .filter(Objects::nonNull)
+            .filter(owner -> owner.getId() != null)
+            .sequential()
+            .forEach(owner -> this.owners.put(owner.getId(), owner));
+
+        if (this.owners.size() > QueryBuilder.COLLECTION_SIZE_LIMIT) {
+            throw new IllegalStateException("query builder collection size limit exceeded for owners");
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds one or more owners to use for filtering query output.
+     *
+     * @param owners
+     *  a collection of owners to use to filter query output
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ProductQueryBuilder addOwners(Owner... owners) {
+        return this.addOwners(owners != null ? Arrays.asList(owners) : null);
+    }
+
+    /**
+     * Sets the inclusion filter to use for filtering queries by active products, where "active" is defined
+     * as a product that is currently in use by a subscription that has started and not yet expired, or
+     * is linked to such a product. If the provided inclusion filter is null, the value "INCLUDE" will
+     * be used instead.
+     *
+     * @param active
+     *  an inclusion filter to set for active products
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ProductQueryBuilder setActive(Inclusion active) {
+        this.active = active != null ? active : Inclusion.INCLUDE;
+        return this;
+    }
+
+    /**
+     * Sets the inclusion filter to use for filtering queries by custom products, where "custom" is defined
+     * as a product that originates from a source other than manifest import or pool refresh. If the provided
+     * inclusion filter is null, the value "INCLUDE" will be used instead.
+     *
+     * @param custom
+     *  an inclusion filter to set for custom products
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ProductQueryBuilder setCustom(Inclusion custom) {
+        this.custom = custom != null ? custom : Inclusion.INCLUDE;
+        return this;
+    }
+
+    // Impl note:
+    // Everything about this query is awful due to JPA limitations both in terms of what it can do
+    // and what its API allows you to do.
+    // It'd be really nice to *not* build this with string concatenation, but since we can't join against
+    // a native query from a criteria query, criteria queries can't join against a temporary table, no
+    // part of JPA is ready for CTEs, and paging support makes partitioning large result sets clunky and
+    // error prone (or a waste due to throwing everything in memory), we aren't left with many options
+    // other than string concatenation.
+
+    /**
+     * Assembles the components of the query that make up the active products filter.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for filtering on active products
+     *
+     * @param criteriaChunks
+     *  the list of criteria chunks to receive the predicates for filtering on active products
+     *
+     * @param parameters
+     *  the map of parameters to receive the specific query arguments provided to the builder
+     */
+    private void buildActiveProductsComponents(List<String> queryChunks, List<String> criteriaChunks,
+        Map<String, Object> queryArgs) {
+
+        // The "active" flag has a massive impact on how this query is constructed. If it's any value
+        // other than "include", we start with the CTE. Otherwise we're a boring ol' select and we do
+        // nothing in this method.
+        if (this.active == Inclusion.INCLUDE) {
+            return;
+        }
+
+        // Impl notes:
+        // These CTEs are a bit of a mess, and are driven by three different DBs imposing their own goofy
+        // limitations or quirks (mostly only two goofy DBs, but whatever):
+        //  - HSQLDB requires that recursive CTEs define their parameters as part of the declaration of
+        //    the CTE itself, which is the driver behind the rather redundant definitions.
+        //  - HSQLDB also disallows more than one UNION operation in a recursive CTE, which means the
+        //    anchor members *also* can't have more than one union without being wrapped in another query
+        //    or CTE, leading to the clunky declaration of the "pcmap_anchor" CTE.
+        //  - MySQL/MariaDB cannot self-reference more than once in the recursive step of a recursive
+        //    CTE, which really hamstrings how these queries are built and is why the parent-child mapping
+        //    does what it does.
+        //  - PostgreSQL, as per usual, laughs at these queries and beasts through them like I'm fetching
+        //    the count of an almost-empty table.
+        //
+        // As far as how this is all intended to work:
+        //  - We start with pools since in production this gives us our smallest working product set.
+        //  - Next we need to figure out every parent-child product relationship that will be significant
+        //    to us. In other areas it may make sense for us to just grab the union of all derived and
+        //    provided product refs, but doing so in the prod database takes 5-10s on its own. Instead,
+        //    we step through from the pool products down into derived products and then recursively into
+        //    provided products based on those we know we'll have.
+        //  - Finally, we go back to the pool products and use our parent-child map to walk down the graph
+        //    to discover all of our nested/descendant products, since our parent-child map has extraneous
+        //    pools from getting the full set of derived products
+        //
+        // Note that this query is written primarily as a function of what works best for MySQL and the
+        // shape of the data in production. It may make sense to periodically update it as the shape of
+        // prod's data changes. Or if/when we update the model to not have two N-tier paths that have
+        // to be traversed to fully/correctly build the product graph. :/
+        String poolProductsQuery = "SELECT DISTINCT pool.product_uuid " +
+            "  FROM cp_pool pool " +
+            "  WHERE now() BETWEEN pool.startdate AND pool.enddate ";
+
+        if (!this.owners.isEmpty()) {
+            poolProductsQuery += "AND pool.owner_id IN (:owner_ids)";
+            queryArgs.put("owner_ids", this.owners.keySet());
+        }
+
+        String ctes = "WITH RECURSIVE pool_products (product_uuid) AS (" + poolProductsQuery + "), " +
+            """
+            pcmap_anchor (product_uuid, child_uuid) AS (
+                SELECT uuid AS product_uuid, derived_product_uuid AS child_uuid
+                    FROM cp_products
+                    WHERE derived_product_uuid IS NOT NULL
+                UNION
+                SELECT ppp.product_uuid, ppp.provided_product_uuid AS child_uuid
+                    FROM cp_product_provided_products ppp
+                    JOIN pool_products pp ON pp.product_uuid = ppp.product_uuid
+            ),
+            parent_child_map (product_uuid, child_uuid, depth) AS (
+                SELECT product_uuid, child_uuid, 1 AS depth FROM pcmap_anchor
+                UNION ALL
+                SELECT ppp.product_uuid, ppp.provided_product_uuid AS child_uuid, pcmap.depth + 1 AS depth
+                    FROM parent_child_map pcmap
+                    JOIN cp_product_provided_products ppp ON ppp.product_uuid = pcmap.child_uuid
+            ),
+            active_products (uuid) AS (
+                SELECT product_uuid AS uuid FROM pool_products
+                UNION
+                SELECT pcmap.child_uuid AS uuid
+                    FROM active_products ap
+                    JOIN parent_child_map pcmap ON pcmap.product_uuid = ap.uuid
+            )
+            """;
+
+        // This *must* go at the beginning of the query or we break
+        queryChunks.add(0, ctes);
+
+        if (this.active == Inclusion.EXCLUSIVE) {
+            queryChunks.add("JOIN active_products active ON active.uuid = prod.uuid");
+        }
+        else if (this.active == Inclusion.EXCLUDE) {
+            queryChunks.add("LEFT JOIN active_products active ON active.uuid = prod.uuid");
+            criteriaChunks.add("active.uuid IS NULL");
+        }
+    }
+
+    /**
+     * Assembles the components of the query that make up the custom products filter.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for filtering on custom products
+     *
+     * @param criteriaChunks
+     *  the list of criteria chunks to receive the predicates for filtering on custom products
+     *
+     * @param parameters
+     *  the map of parameters to receive the specific query arguments provided to the builder
+     */
+    private void buildCustomProductsComponents(List<String> queryChunks, List<String> criteriaChunks,
+        Map<String, Object> queryArgs) {
+
+        List<String> namespaces = this.owners.values()
+            .stream()
+            .map(Owner::getKey)
+            .toList();
+
+        switch (this.custom) {
+            case EXCLUSIVE:
+                if (!namespaces.isEmpty()) {
+                    criteriaChunks.add("prod.namespace IN (:org_namespaces)");
+                    queryArgs.put("org_namespaces", namespaces);
+                }
+                else {
+                    criteriaChunks.add("prod.namespace != ''");
+                }
+                break;
+
+            case EXCLUDE:
+                criteriaChunks.add("prod.namespace = ''");
+                break;
+
+            default:
+            case INCLUDE:
+                if (!namespaces.isEmpty()) {
+                    criteriaChunks.add("(prod.namespace = '' OR prod.namespace IN (:org_namespaces))");
+                    queryArgs.put("org_namespaces", namespaces);
+                }
+        }
+    }
+
+    /**
+     * Builds the components of the query that make up the product ID filter.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for filtering on product IDs
+     *
+     * @param criteriaChunks
+     *  the list of criteria chunks to receive the predicates for filtering on product IDs
+     *
+     * @param parameters
+     *  the map of parameters to receive the specific query arguments provided to the builder
+     */
+    private void buildProductIdFilterComponents(List<String> queryChunks, List<String> criteriaChunks,
+        Map<String, Object> queryArgs) {
+
+        if (!this.productIds.isEmpty()) {
+            criteriaChunks.add("prod.product_id IN (:product_ids)");
+            queryArgs.put("product_ids", this.productIds);
+        }
+    }
+
+    /**
+     * Builds the components of the query that make up the product name filter.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for filtering on product names
+     *
+     * @param criteriaChunks
+     *  the list of criteria chunks to receive the predicates for filtering on product names
+     *
+     * @param parameters
+     *  the map of parameters to receive the specific query arguments provided to the builder
+     */
+    private void buildProductNameFilterComponents(List<String> queryChunks, List<String> criteriaChunks,
+        Map<String, Object> queryArgs) {
+
+        if (!this.productNames.isEmpty()) {
+            // Impl note: This may end up being slow without an index to go along with it
+            criteriaChunks.add("LOWER(prod.name) IN (:product_names)");
+            queryArgs.put("product_names", this.productNames);
+        }
+    }
+
+    /**
+     * Assembles the WHERE clause from the various chunks built from the criteria provided to this builder.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for filtering on product names
+     *
+     * @param criteriaChunks
+     *  the list of criteria chunks to assemble
+     */
+    private void assembleWhereClause(List<String> queryChunks, List<String> criteriaChunks) {
+        if (criteriaChunks.isEmpty()) {
+            return;
+        }
+
+        String whereClause = criteriaChunks.stream()
+            .collect(Collectors.joining(" AND ", "WHERE ", ""));
+
+        queryChunks.add(whereClause);
+    }
+
+    /**
+     * Fetches the field object for a given field name, first checking on the immediate type, and then
+     * checking any supertypes as necessary.
+     *
+     * @param type
+     *  the base type to check for a field with the given name
+     *
+     * @param fieldName
+     *  the name of the field to fetch
+     *
+     * @throws NoSuchFieldException
+     *  if the field cannot be found within the type or its superclasses
+     *
+     * @return
+     *  the field with the matching name on the nearest type defined in the hierarchy
+     */
+    private Field getAttributeField(Class<?> type, String fieldName) throws NoSuchFieldException {
+        if (type == null) {
+            throw new NoSuchFieldException(fieldName);
+        }
+
+        try {
+            return type.getDeclaredField(fieldName);
+        }
+        catch (NoSuchFieldException e) {
+            return this.getAttributeField(type.getSuperclass(), fieldName);
+        }
+    }
+
+    /**
+     * Assembles the ORDER BY clause from the query ordering provided to this builder.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for ordering the query
+     *
+     * @param metamodel
+     *  the metamodel to use to validate the ordering columns
+     *
+     * @param prefix
+     *  a prefix to prepend to all ordering attributes
+     *
+     * @throws InvalidOrderKeyException
+     *  if an order is provided referencing an attribute name (key) that does not exist
+     */
+    private void assembleOrderByClause(List<String> queryChunks, EntityType<?> metamodel, String prefix) {
+        List<Order> ordering = this.getQueryOrdering();
+        if (ordering.isEmpty()) {
+            return;
+        }
+
+        Function<QueryBuilder.Order, String> orderMapper = order -> {
+            try {
+                // Impl note:
+                // We should probably just have a known DTO field name to internal DB column/field mapper.
+                // Even with this reflection magic, we're still going to eventually hit some desync in
+                // terms of naming conventions between the DB model and our DTOs.
+                //
+                // However, things get a little spicy with the fact the DTOs are procedurally generated
+                // from the API spec file with a quirky generator; so we can still desync even with some
+                // semi-hardcoded mappings. There is no winning here. Perhaps it's best left to the resource
+                // level anyway...?
+                //
+                // Regardless of the solution picked, we absolutely need to validate this input here because
+                // the field name is going into the query raw otherwise. THE RISK OF SQL INJECTION IS
+                // VERY REAL HERE.
+                String validated = metamodel.getSingularAttribute(order.column())
+                    .getName();
+
+                Column annotation = this.getAttributeField(metamodel.getJavaType(), validated)
+                    .getAnnotation(Column.class);
+
+                // If we have a column annotation, use that; otherwise default to the validated field name
+                String column = Optional.ofNullable(annotation)
+                    .map(Column::name)
+                    .filter(name -> !name.isBlank())
+                    .orElse(validated);
+
+                return new StringBuilder(prefix)
+                    .append(column)
+                    .append(' ')
+                    .append(order.reverse() ? "DESC" : "ASC")
+                    .toString();
+            }
+            catch (IllegalArgumentException | NoSuchFieldException e) {
+                throw new InvalidOrderKeyException(order.column(), metamodel, e);
+            }
+        };
+
+        String orderClause = ordering.stream()
+            .map(orderMapper)
+            .collect(Collectors.joining(", ", "ORDER BY ", ""));
+
+        queryChunks.add(orderClause);
+    }
+
+    /**
+     * Builds a query for counting the number of products matching the criteria provided to this query
+     * builder.
+     *
+     * @return
+     *  a query for counting products matching the criteria provided to this query builder
+     */
+    private Query buildProductCountQuery() {
+        EntityManager entityManager = this.getEntityManager();
+
+        List<String> queryChunks = new ArrayList<>();
+        List<String> criteriaChunks = new ArrayList<>();
+        Map<String, Object> queryArgs = new HashMap<>();
+
+        // Prime the query with our basic select...
+        queryChunks.add("SELECT COUNT(*) FROM cp_products prod");
+
+        // Add the various components...
+        this.buildActiveProductsComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildCustomProductsComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildProductIdFilterComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildProductNameFilterComponents(queryChunks, criteriaChunks, queryArgs);
+
+        // Assemble the where clause
+        this.assembleWhereClause(queryChunks, criteriaChunks);
+        String sql = String.join(" ", queryChunks);
+
+        log.trace("BUILT QUERY: {}", sql);
+        log.trace("USING QUERY ARGUMENTS: {}", queryArgs);
+
+        Query query = entityManager.createNativeQuery(sql);
+        queryArgs.forEach(query::setParameter);
+
+        return query;
+    }
+
+    /**
+     * Builds a query for fetching products matching the criteria provided to this query builder.
+     *
+     * @return
+     *  a query for fetching products matching the criteria provided to this query builder
+     */
+    private Query buildProductQuery() {
+        EntityManager entityManager = this.getEntityManager();
+        EntityType<Product> metamodel = entityManager.getMetamodel()
+            .entity(Product.class);
+
+        List<String> queryChunks = new ArrayList<>();
+        List<String> criteriaChunks = new ArrayList<>();
+        Map<String, Object> queryArgs = new HashMap<>();
+
+        // Impl note:
+        // According to Hibernate docs, native queries can be turned into entities using the native mapper
+        // so long as all of the columns are properly defined with @Column annotations in the entity itself
+        // and the column names are returned with the query. Joins are also possible with some janky looking,
+        // JPA/Hibernate-specific syntax, and lazy-loading proxies will be built as normal. In either
+        // case, the docs actually recommend using the wildcard operator for entity retrevial.
+        queryChunks.add("SELECT prod.* FROM cp_products prod");
+
+        // Add the various components...
+        this.buildActiveProductsComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildCustomProductsComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildProductIdFilterComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildProductNameFilterComponents(queryChunks, criteriaChunks, queryArgs);
+
+        // Assemble the where clause and order statements
+        this.assembleWhereClause(queryChunks, criteriaChunks);
+        this.assembleOrderByClause(queryChunks, metamodel, "prod.");
+
+        String sql = String.join(" ", queryChunks);
+
+        log.trace("BUILT QUERY: {}", sql);
+        log.trace("USING QUERY ARGUMENTS: {}", queryArgs);
+
+        Query query = entityManager.createNativeQuery(sql, Product.class);
+        queryArgs.forEach(query::setParameter);
+
+        return query;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getResultCount() {
+        Number count = (Number) this.buildProductCountQuery()
+            .getSingleResult();
+
+        return count.longValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Product> getResultList() {
+        Query query = this.buildProductQuery();
+
+        this.applyQueryOffset(query)
+            .applyQueryLimit(query);
+
+        return (List<Product>) query.getResultList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<Product> getResultStream() {
+        Query query = this.buildProductQuery();
+
+        this.applyQueryOffset(query)
+            .applyQueryLimit(query);
+
+        return (Stream<Product>) query.getResultStream();
+    }
+
+}

--- a/src/main/java/org/candlepin/model/QueryArguments.java
+++ b/src/main/java/org/candlepin/model/QueryArguments.java
@@ -23,7 +23,7 @@ import java.util.LinkedList;
 
 
 /**
- * Container object for providing various arguments to the consumerlookup method(s).
+ * Container object for providing various arguments to the consumer lookup method(s).
  *
  * @param <T>
  *  The type of the QueryArguments subclass; used for method chaining

--- a/src/main/java/org/candlepin/model/QueryBuilder.java
+++ b/src/main/java/org/candlepin/model/QueryBuilder.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import javax.inject.Provider;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+
+
+/**
+ * The QueryBuilder class wraps the construction a database query behind an entity-focused abstraction,
+ * allowing for specifying queryable entity properties with a fluent-style interface.
+ * <p></p>
+ * Subclasses are expected to provide additional properties relevant to the entity or data set being fetched
+ * by the builder.
+ *
+ * @param <Q>
+ *  the type of the query builder; used for fluent-style method declarations
+ *
+ * @param <T>
+ *  the type of the rows or entities returned by this query builder
+ */
+public abstract class QueryBuilder<Q extends QueryBuilder, T> {
+
+    /** The number of elements a given collection in the query builder may have */
+    public static final int COLLECTION_SIZE_LIMIT = 512;
+
+    /**
+     * Generic container for storing result ordering information
+     *
+     * @param column
+     *  the name of a column by which to order the query results; cannot be null or empty
+     *
+     * @param reverse
+     *  whether or not to fetch the results in reverse (descending) order
+     */
+    public static record Order(String column, boolean reverse) {
+        /**
+         * Creates a new Order instance on the specified column.
+         *
+         * @param column
+         *  the name of a column by which to order the query results; cannot be null or empty
+         *
+         * @param reverse
+         *  whether or not to fetch the results in reverse (descending) order
+         *
+         * @throws IllegalArgumentException
+         *  if column is null or empty
+         */
+        public Order(String column, boolean reverse) {
+            if (column == null || column.isBlank()) {
+                throw new IllegalArgumentException("column is null or empty");
+            }
+
+            this.column = column;
+            this.reverse = reverse;
+        }
+    }
+
+    /**
+     * The inclusion type defines how some binary properties should be treated with respect
+     * to their inclusion in the query output
+     */
+    public enum Inclusion {
+        /**
+         * INCLUDE indicates that products in the property-defined state should be included in the
+         * results without any impact on other products with a different state. This is logically
+         * equivalent to not filtering on the property at all.
+         */
+        INCLUDE,
+
+        /**
+         * EXCLUDE indicates that products with the matching property-defined state should be excluded
+         * from the query results.
+         */
+        EXCLUDE,
+
+        /**
+         * EXCLUSIVE indicates that only products with the matching property-defined state should
+         * be returned
+         */
+        EXCLUSIVE;
+
+        /**
+         * Attempts to find a matching inclusion type from the given name, ignoring case. If the specified
+         * name is null, empty, or blank, this method returns the provided empty value, if present. If
+         * the specified name is not null, empty, or blank, and cannot be resolved to a known inclusion
+         * type, this method returns an empty optional.
+         *
+         * @param name
+         *  the name of the inclusion type to match, case-insensitive
+         *
+         * @param emptyValue
+         *  the inclusion type to use if the provided name is null, empty, or blank
+         *
+         * @return
+         *  the inclusion type mapped to the given name, the empty value if the given name is null, empty
+         *  or blank, or an empty optional otherwise
+         */
+        public static Optional<Inclusion> fromName(String name, Inclusion emptyValue) {
+            if (name == null || name.isBlank()) {
+                return Optional.ofNullable(emptyValue);
+            }
+
+            for (Inclusion inclusion : Inclusion.values()) {
+                if (inclusion.name().equalsIgnoreCase(name)) {
+                    return Optional.of(inclusion);
+                }
+            }
+
+            return Optional.empty();
+        }
+
+        /**
+         * Attempts to find a matching inclusion type from the given name, ignoring case. If the specified
+         * name does not map to a known inclusion type, or is null, empty, or blank, this function returns
+         * an empty optional.
+         *
+         * @param name
+         *  the name of the inclusion type to match
+         *
+         * @return
+         *  the inclusion type mapped to the given name, or an empty optional if no matching inclusion
+         *  was found
+         */
+        public static Optional<Inclusion> fromName(String name) {
+            return Inclusion.fromName(name, null);
+        }
+    }
+
+    private final Provider<EntityManager> entityManagerProvider;
+
+    private Optional<Integer> offset;
+    private Optional<Integer> limit;
+    private final List<Order> order;
+
+    /**
+     * Creates a new QueryBuilder using the specified entity manager provider instance.
+     * <p></p>
+     * <strong>Note:</strong> Query builder instances should not be constructed directly and should be
+     * fetched from their corresponding curators.
+     *
+     * @param entityManagerProvider
+     *  the provider to use for fetching an entity manager when building queries
+     */
+    protected QueryBuilder(Provider<EntityManager> entityManagerProvider) {
+        this.entityManagerProvider = Objects.requireNonNull(entityManagerProvider);
+
+        this.offset = Optional.empty();
+        this.limit = Optional.empty();
+        this.order = new ArrayList<>();
+    }
+
+    /**
+     * Sets or clears the offset at which to begin fetching results. If null, any previously set
+     * offset will be cleared.
+     *
+     * @param offset
+     *  the row offset at which to begin fetching results, or null to clear the offset
+     *
+     * @throws IllegalArgumentException
+     *  if the provided offset is a negative integer
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public Q setOffset(Integer offset) {
+        if (offset != null && offset < 0) {
+            throw new IllegalArgumentException("offset is a negative integer");
+        }
+
+        this.offset = Optional.ofNullable(offset);
+        return (Q) this;
+    }
+
+    /**
+     * Clears the query offset. If the query offset has not yet been set, this method does nothing.
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public Q clearOffset() {
+        this.offset = Optional.empty();
+        return (Q) this;
+    }
+
+    /**
+     * Sets or clears the limit defining the number of results to fetch. If null, any previously set
+     * limit will be cleared.
+     *
+     * @param limit
+     *  the maximum number of results to fetch, or null to clear the limit
+     *
+     * @throws IllegalArgumentException
+     *  if the provided limit is zero or a negative integer
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public Q setLimit(Integer limit) {
+        if (limit != null && limit < 1) {
+            throw new IllegalArgumentException("limit is zero or a negative integer");
+        }
+
+        this.limit = Optional.ofNullable(limit);
+        return (Q) this;
+    }
+
+    /**
+     * Clears the query limit. If the query limit has not yet been set, this method does nothing.
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public Q clearLimit() {
+        this.limit = Optional.empty();
+        return (Q) this;
+    }
+
+    /**
+     * Sets the query offset and limit for this query according to the page and page sizes provided.
+     *
+     * @param page
+     *  the one-indexed page at which to set the query offset; must be a positive value
+     *
+     * @param pageSize
+     *  the size of each page; must be a positive value
+     *
+     * @throws IllegalArgumentException
+     *  if either page or pageSize are zero or negative values
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public Q setPage(int page, int pageSize) {
+        if (page < 1) {
+            throw new IllegalArgumentException("page is not a positive integer");
+        }
+
+        if (pageSize < 1) {
+            throw new IllegalArgumentException("pageSize is not a positive integer");
+        }
+
+        this.setOffset((page - 1) * pageSize)
+            .setLimit(pageSize);
+
+        return (Q) this;
+    }
+
+    /**
+     * Adds the specified result ordering to this query builder. If any query ordering has already been
+     * provided, the new ordering will be added after any existing ordering and will be applied in the
+     * order in which each was provided.
+     *
+     * @param column
+     *  the name of a column by which to order the query results; cannot be null or empty
+     *
+     * @param reverse
+     *  whether or not to fetch the results in reverse (descending) order
+     *
+     * @throws IllegalArgumentException
+     *  if column is null or empty
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public Q addOrder(String column, boolean reverse) {
+        this.order.add(new Order(column, reverse));
+        return (Q) this;
+    }
+
+    /**
+     * Adds the specified result ordering to this query builder. If any query ordering has already been
+     * provided, the new ordering will be added after any existing ordering and will be applied in the
+     * order in which each was provided.
+     *
+     * @param order
+     *  a collection of ordering columns to apply to this query
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public Q addOrder(Order... order) {
+        if (order == null) {
+            return (Q) this;
+        }
+
+        Stream.of(order)
+            .filter(Objects::nonNull)
+            .sequential() // critical since we care about insertion order
+            .forEach(this.order::add);
+
+        return (Q) this;
+    }
+
+    /**
+     * Clears any query ordering set. If the query order has not yet been set, this method does nothing.
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public Q clearOrder() {
+        this.order.clear();
+        return (Q) this;
+    }
+
+    // TODO: We're not going to move off JPA any time soon, but if we really want to generalize this
+    // interface, we could move these protected methods to a JPAQueryBuilder and leave them undefined
+    // here; possibly even converting this class into an interface.
+
+    /**
+     * Fetches an entity manager to use to build the queries necessary for this build. While this method
+     * should not ever return null, there's no guarantee that the entity manager returned will be the
+     * same instance between two invocations.
+     *
+     * @return
+     *  an entity manager to use to build queries
+     */
+    protected EntityManager getEntityManager() {
+        return this.entityManagerProvider.get();
+    }
+
+    /**
+     * Applies query ordering to the specified criteria query and root. If no builder, query, or root
+     * are provided, or no query ordering was defined, this method silently returns.
+     *
+     * @param cquery
+     *  The criteria query to which to apply the query ordering
+     *
+     * @param root
+     *  the query root from which the order columns are derived
+     *
+     * @throws InvalidOrderKeyException
+     *  if an order is provided referencing an attribute name (key) that does not exist
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    protected <T> Q applyQueryOrdering(CriteriaBuilder builder, CriteriaQuery<T> cquery, Root<T> root) {
+        if (builder == null || cquery == null || root == null || this.order.isEmpty()) {
+            return (Q) this;
+        }
+
+        Function<Order, javax.persistence.criteria.Order> orderMapper = order -> {
+            try {
+                return order.reverse() ?
+                    builder.desc(root.get(order.column())) :
+                    builder.asc(root.get(order.column()));
+            }
+            catch (IllegalArgumentException e) {
+                throw new InvalidOrderKeyException(order.column(), root.getModel(), e);
+            }
+        };
+
+        List<javax.persistence.criteria.Order> ordering = this.order.stream()
+            .map(orderMapper)
+            .toList();
+
+        cquery.orderBy(ordering);
+        return (Q) this;
+    }
+
+    /**
+     * Fetches an unmodifiable list consisting of the query ordering arguments provided to this builder
+     * in the order they were provided. If no ordering has been provided, this method returns an empty
+     * list.
+     * <p></p>
+     * Note: This method is intended for query builders which cannot use the apply method.
+     *
+     * @return
+     *  an unmodifiable list of ordering arguments to apply to the results of this query builder
+     */
+    protected List<Order> getQueryOrdering() {
+        return Collections.unmodifiableList(this.order);
+    }
+
+    /**
+     * Applies the query offset to the specified typed query. If no query is provided, or no query offset
+     * was defined, this method silently returns.
+     *
+     * @param query
+     *  the query to which to apply the query offset
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    protected Q applyQueryOffset(Query query) {
+        if (query == null) {
+            return (Q) this;
+        }
+
+        this.offset.ifPresent(query::setFirstResult);
+        return (Q) this;
+    }
+
+    /**
+     * Applies the query limit to the specified typed query. If no query is provided, or no query limit
+     * was defined, this method silently returns.
+     *
+     * @param query
+     *  the query to which to apply the query limit
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    protected Q applyQueryLimit(Query query) {
+        if (query == null) {
+            return (Q) this;
+        }
+
+        this.limit.ifPresent(query::setMaxResults);
+        return (Q) this;
+    }
+
+    /**
+     * Fetches the number of entities matching the current query criteria, without respect to any query
+     * offsets, result limits, or ordering.
+     *
+     * @return
+     *  the number of entities matching the current criteria, ignoring any specified query offsets or
+     *  limits
+     */
+    public abstract long getResultCount();
+
+    /**
+     * Builds and executes the query with the specified query criteria and fetches a list containing
+     * all matching entities found. If no entities were found matching the given query criteria, this
+     * method returns an empty list.
+     *
+     * @return
+     *  a list of entities matching the current query critieria
+     */
+    public abstract List<T> getResultList();
+
+    /**
+     * Builds and executes the query with the specified query criteria and fetches a stream containing
+     * all matching entities found. If no entities were found matching the given query criteria, this
+     * method returns an empty stream.
+     * <p></p>
+     * <strong>Warning</strong>: In some environments, this method may return a stream which is backed
+     * by a database cursor. In such an environment, attempting to resolve a lazily loaded field will
+     * close the cursor even if the stream contains more elements. Further processing of the stream in
+     * this state will result in an SQL exception. If this is a potential concern, callers which need
+     * stream processing may want to consider using <tt>.getResultList().stream()</tt> instead.
+     *
+     * @return
+     *  a stream of entities matching the current query critieria
+     */
+    public abstract Stream<T> getResultStream();
+
+    // add any additional operations here (delete? probably not)
+}

--- a/src/main/java/org/candlepin/paging/PagingUtilFactory.java
+++ b/src/main/java/org/candlepin/paging/PagingUtilFactory.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.paging;
 
+import org.candlepin.config.Configuration;
+
 import org.xnap.commons.i18n.I18n;
 
 import java.util.Objects;
@@ -29,10 +31,12 @@ import javax.inject.Provider;
  */
 public class PagingUtilFactory {
 
+    private final Configuration config;
     private final Provider<I18n> i18nProvider;
 
     @Inject
-    public PagingUtilFactory(Provider<I18n> i18nProvider) {
+    public PagingUtilFactory(Configuration config, Provider<I18n> i18nProvider) {
+        this.config = Objects.requireNonNull(config);
         this.i18nProvider = Objects.requireNonNull(i18nProvider);
     }
 
@@ -51,7 +55,7 @@ public class PagingUtilFactory {
             throw new IllegalArgumentException("comparatorFactory is null");
         }
 
-        return new PagingUtil<>(this.i18nProvider.get(), comparatorFactory);
+        return new PagingUtil<>(this.config, this.i18nProvider.get(), comparatorFactory);
     }
 
     /**

--- a/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -41,6 +41,8 @@ import org.candlepin.model.Product;
 import org.candlepin.model.ProductCertificate;
 import org.candlepin.model.ProductContent;
 import org.candlepin.model.ProductCurator;
+import org.candlepin.model.ProductQueryBuilder;
+import org.candlepin.model.QueryBuilder.Inclusion;
 import org.candlepin.paging.PagingUtilFactory;
 import org.candlepin.pki.certs.ProductCertificateGenerator;
 import org.candlepin.resource.server.v1.OwnerProductApi;
@@ -553,30 +555,30 @@ public class OwnerProductResource implements OwnerProductApi {
 
     @Override
     @Transactional
+    // GET /owners/{key}/products
     public Stream<ProductDTO> getProductsByOwner(@Verify(Owner.class) String ownerKey,
-        List<String> productIds, Boolean omitGlobalEntities) {
+        List<String> productIds, List<String> productNames, String active, String custom) {
 
         Owner owner = this.getOwnerByKey(ownerKey);
-        String namespace = owner.getKey();
 
-        Collection<Product> products;
+        Inclusion activeInc = Inclusion.fromName(active, Inclusion.EXCLUSIVE)
+            .orElseThrow(() ->
+                new BadRequestException(i18n.tr("Invalid active inclusion type: {0}", active)));
 
-        if (omitGlobalEntities == null || !omitGlobalEntities) {
-            products = productIds != null && !productIds.isEmpty() ?
-                this.productCurator.resolveProductIds(namespace, productIds).values() :
-                this.productCurator.resolveProductsByNamespace(namespace);
-        }
-        else {
-            products = productIds != null && !productIds.isEmpty() ?
-                this.productCurator.getProductsByIds(namespace, productIds).values() :
-                this.productCurator.getProductsByNamespace(namespace);
-        }
+        Inclusion customInc = Inclusion.fromName(custom, Inclusion.INCLUDE)
+            .orElseThrow(() ->
+                new BadRequestException(i18n.tr("Invalid custom inclusion type: {0}", custom)));
 
-        Stream<ProductDTO> stream = products.stream()
+        ProductQueryBuilder queryBuilder = this.productCurator.getProductQueryBuilder()
+            .addOwners(owner)
+            .addProductIds(productIds)
+            .addProductNames(productNames)
+            .setActive(activeInc)
+            .setCustom(customInc);
+
+        return this.pagingUtilFactory.forClass(Product.class)
+            .applyPaging(queryBuilder)
             .map(this.translator.getStreamMapper(Product.class, ProductDTO.class));
-
-        return this.pagingUtilFactory.forClass(ProductDTO.class)
-            .applyPaging(stream, products.size());
     }
 
     @Override

--- a/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.config.ConfigProperties;
-import org.candlepin.model.ProductCurator.ProductQueryArguments;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.AttributeValidator;
@@ -55,7 +54,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import javax.persistence.LockModeType;
@@ -110,6 +108,18 @@ public class ProductCuratorTest extends DatabaseTestFixture {
             Arguments.of(LockModeType.PESSIMISTIC_WRITE),
             Arguments.of(LockModeType.READ),
             Arguments.of(LockModeType.WRITE));
+    }
+
+    @Test
+    public void testGetProductQueryBuilder() {
+        ProductQueryBuilder builder = this.productCurator.getProductQueryBuilder();
+
+        // Verify it is not null
+        assertNotNull(builder);
+
+        // Verify it can be used for simple queries
+        List<Product> products = builder.getResultList();
+        assertNotNull(products);
     }
 
     @Test
@@ -1356,40 +1366,4 @@ public class ProductCuratorTest extends DatabaseTestFixture {
         assertEquals(attributes, refreshed.getAttributes());
     }
 
-    @Test
-    public void testListAll() {
-        IntStream.range(0, 3).forEach(element -> {
-            createProduct("test_product-" + element);
-        });
-
-        ProductQueryArguments args = new ProductQueryArguments()
-            .setOffset(0);
-        assertEquals(3, productCurator.listAll(args).size());
-    }
-
-    @Test
-    public void testListAllPaged() {
-        IntStream.range(0, 10).forEach(element -> {
-            createProduct("test_product-" + element);
-        });
-
-        ProductQueryArguments args = new ProductQueryArguments()
-            .setOffset(3)
-            .setLimit(4);
-        List<Product> page = productCurator.listAll(args);
-        assertEquals(4, page.size());
-        assertEquals("test_product-3", page.get(0).getId());
-        assertEquals("test_product-6", page.get(3).getId());
-    }
-
-    @Test
-    public void testGetOwnerCount() {
-        IntStream.range(0, 10).forEach(element -> {
-            createProduct("test_product-" + element);
-        });
-
-        ProductQueryArguments args = new ProductQueryArguments();
-        Long result = productCurator.getProductCount(args);
-        assertEquals(10L, result);
-    }
 }

--- a/src/test/java/org/candlepin/model/ProductQueryBuilderTest.java
+++ b/src/test/java/org/candlepin/model/ProductQueryBuilderTest.java
@@ -1,0 +1,816 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.candlepin.model.QueryBuilder.Inclusion;
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+
+
+/**
+ * ProductQueryBuilderTest
+ */
+public class ProductQueryBuilderTest extends DatabaseTestFixture {
+
+    private ProductQueryBuilder buildQueryBuilder() {
+        return new ProductQueryBuilder(this.getEntityManagerProvider());
+    }
+
+    /**
+     * Creates a set of products for use with the "testQueryBuilder..." family of tests below. Do not make
+     * changes to these products unless you are updating the testing for the ProductQueryBuilder class
+     * and do not use this method to set up data for any other test!
+     *
+     * Note that this test data does not create full product graphs for products. Testing the definition
+     * of "active" is left to a set of explicit tests which validates it in full.
+     */
+    private void createDataForQueryBuilderTesting() {
+        List<Owner> owners = List.of(
+            this.createOwner("owner1"),
+            this.createOwner("owner2"),
+            this.createOwner("owner3"));
+
+        List<Product> globalProducts = new ArrayList<>();
+        for (int i = 1; i <= 3; ++i) {
+            Product gprod = new Product()
+                .setId("g-prod-" + i)
+                .setName("global product " + i);
+
+            globalProducts.add(this.productCurator.create(gprod));
+        }
+
+        for (int oidx = 1; oidx <= owners.size(); ++oidx) {
+            Owner owner = owners.get(oidx - 1);
+
+            List<Product> ownerProducts = new ArrayList<>();
+
+            // create two custom products
+            for (int i = 1; i <= 2; ++i) {
+                Product cprod = new Product()
+                    .setId(String.format("o%d-prod-%d", oidx, i))
+                    .setName(String.format("%s product %d", owner.getKey(), i))
+                    .setNamespace(owner.getKey());
+
+                ownerProducts.add(this.productCurator.create(cprod));
+            }
+
+            // create some pools:
+            // - one which references a global product
+            // - one which references a custom product
+            Pool globalPool = this.createPool(owner, globalProducts.get(0));
+            Pool customPool = this.createPool(owner, ownerProducts.get(0));
+        }
+    }
+
+    private void verifyQueryBuilderOutput(ProductQueryBuilder queryBuilder, List<String> expectedPids) {
+        int count = (int) queryBuilder.getResultCount();
+        List<Product> outputList = queryBuilder.getResultList();
+        Stream<Product> outputStream = queryBuilder.getResultStream();
+
+        assertThat(outputList)
+            .isNotNull()
+            .hasSize(count)
+            .map(Product::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+
+        assertThat(outputStream)
+            .isNotNull()
+            .hasSize(count)
+            .map(Product::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+
+    @Test
+    public void testQueryBuilderFetchesEverythingWithNoFiltering() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByOwnersAsArray() {
+        this.createDataForQueryBuilderTesting();
+
+        List<Owner> owners = Stream.of("owner2", "owner3")
+            .map(this.ownerCurator::getByKey)
+            .toList();
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o2-prod-1", "o2-prod-2",
+            "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOwners(owners.toArray(new Owner[0]));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByOwnersAsCollection() {
+        this.createDataForQueryBuilderTesting();
+
+        List<Owner> owners = Stream.of("owner2", "owner3")
+            .map(this.ownerCurator::getByKey)
+            .toList();
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o2-prod-1", "o2-prod-2",
+            "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOwners(owners);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderSilentlyIgnoresNullOwnersInArray() {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOwners(null, null, null);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderSilentlyIgnoresNullOwnersInCollection() {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOwners(Arrays.asList(null, null, null));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByProductIdAsArray() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("g-prod-2", "o1-prod-1", "o3-prod-1");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductIds("g-prod-2", "o1-prod-1", "o3-prod-1");
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByProductIdAsCollection() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("g-prod-2", "o1-prod-1", "o3-prod-1");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductIds(List.of("g-prod-2", "o1-prod-1", "o3-prod-1"));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { " ",  "\t", "  \t  ", "\t  \t" })
+    @NullAndEmptySource
+    public void testQueryBuilderSilentlyIgnoresNullAndBlankProductIdsInArray(String pid) {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductIds(pid);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { " ",  "\t", "  \t  ", "\t  \t" })
+    @NullAndEmptySource
+    public void testQueryBuilderSilentlyIgnoresNullAndBlankProductIdsInCollection(String pid) {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductIds(Arrays.asList(pid));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersOnInvalidProductIdsInArray() {
+        this.createDataForQueryBuilderTesting();
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductIds("invalid_product_id");
+
+        this.verifyQueryBuilderOutput(queryBuilder, List.of());
+    }
+
+    @Test
+    public void testQueryBuilderFiltersOnInvalidProductIdsInCollection() {
+        this.createDataForQueryBuilderTesting();
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductIds(List.of("invalid_product_id"));
+
+        this.verifyQueryBuilderOutput(queryBuilder, List.of());
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByProductNamesAsArray() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("g-prod-3", "o1-prod-2", "o3-prod-1");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductNames("owner1 product 2", "global product 3", "owner3 product 1");
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByProductNamesAsCollection() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("g-prod-3", "o1-prod-2", "o3-prod-1");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductNames(Arrays.asList("owner1 product 2", "global product 3", "owner3 product 1"));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { " ",  "\t", "  \t  ", "\t  \t" })
+    @NullAndEmptySource
+    public void testQueryBuilderSilentlyIgnoresNullAndBlankProductNamesInArray(String productName) {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductNames(productName);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { " ",  "\t", "  \t  ", "\t  \t" })
+    @NullAndEmptySource
+    public void testQueryBuilderSilentlyIgnoresNullAndBlankProductNamesInCollection(String productName) {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductNames(Arrays.asList(productName));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersOnInvalidProductNamesInArray() {
+        this.createDataForQueryBuilderTesting();
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addProductNames("invalid_product_name");
+
+        this.verifyQueryBuilderOutput(queryBuilder, List.of());
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithExcludeActiveFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("g-prod-2", "g-prod-3", "o1-prod-2", "o2-prod-2", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setActive(Inclusion.EXCLUDE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithExclusiveActiveFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("g-prod-1", "o1-prod-1", "o2-prod-1", "o3-prod-1");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setActive(Inclusion.EXCLUSIVE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithIncludeActiveFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        // active = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setActive(Inclusion.INCLUDE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithExcludeCustomFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setCustom(Inclusion.EXCLUDE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithExclusiveCustomFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("o1-prod-1", "o1-prod-2", "o2-prod-1", "o2-prod-2",
+            "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setCustom(Inclusion.EXCLUSIVE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithIncludeCustomFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        // custom = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setCustom(Inclusion.INCLUDE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByMultipleFilters() {
+        this.createDataForQueryBuilderTesting();
+
+        // This test configures a bunch of filters which loosely resolve to the following:
+        // - active global products: not custom, not inactive (active = only, custom = omit)
+        // - in orgs 2 or 3
+        // - matching the given list of product IDs (gp1, gp2, o1p1, o2p1, o3p2)
+        // - matching the given list of product names (gp1, gp2, gp3, o2p1, o2p2)
+        //
+        // These filters should be applied as an intersection, resulting in a singular match on gp1
+
+        List<Owner> owners = Stream.of("owner2", "owner3")
+            .map(this.ownerCurator::getByKey)
+            .toList();
+        List<String> productIds = List.of("g-prod-1", "g-prod-2", "o1-prod-1", "o2-prod-1", "o3-prod-2");
+        List<String> productNames = List.of("global product 1", "global product 2", "global product 3",
+            "owner2 product 1", "owner2 product 2");
+        Inclusion activeInclusion = Inclusion.EXCLUSIVE;
+        Inclusion customInclusion = Inclusion.EXCLUDE;
+
+        List<String> expectedPids = List.of("g-prod-1");
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOwners(owners)
+            .addProductIds(productIds)
+            .addProductNames(productNames)
+            .setActive(activeInclusion)
+            .setCustom(customInclusion);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+    public void testQueryBuilderPagesResultsByPage(int pageSize) {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        int expectedPages = pageSize < expectedPids.size() ?
+            (expectedPids.size() / pageSize) + (expectedPids.size() % pageSize != 0 ? 1 : 0) :
+            1;
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        List<String> found = new ArrayList<>();
+        int pages = 0;
+        while (pages < expectedPages) {
+            queryBuilder.setPage(++pages, pageSize);
+
+            List<String> receivedPids = queryBuilder.getResultStream()
+                .map(Product::getId)
+                .toList();
+
+            if (receivedPids.isEmpty()) {
+                break;
+            }
+
+            found.addAll(receivedPids);
+        }
+
+        assertEquals(expectedPages, pages);
+        assertThat(found)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+    public void testQueryBuilderPagesResultsByOffsetAndLimit(int pageSize) {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        int expectedPages = pageSize < expectedPids.size() ?
+            (expectedPids.size() / pageSize) + (expectedPids.size() % pageSize != 0 ? 1 : 0) :
+            1;
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        List<String> found = new ArrayList<>();
+        int pages = 0;
+        while (pages < expectedPages) {
+            queryBuilder.setOffset(pages++ * pageSize)
+                .setLimit(pageSize);
+
+            List<String> receivedPids = queryBuilder.getResultStream()
+                .map(Product::getId)
+                .toList();
+
+            if (receivedPids.isEmpty()) {
+                break;
+            }
+
+            found.addAll(receivedPids);
+        }
+
+        assertEquals(expectedPages, pages);
+        assertThat(found)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -1, -100, -10000 })
+    public void testQueryBuilderErrorsWithInvalidOffset(int offset) {
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        assertThrows(IllegalArgumentException.class, () -> queryBuilder.setOffset(offset));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, -1, -100, -10000 })
+    public void testQueryBuilderErrorsWithInvalidLimit(int limit) {
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        assertThrows(IllegalArgumentException.class, () -> queryBuilder.setLimit(limit));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, -1, -100, -10000 })
+    public void testQueryBuilderErrorsWithInvalidPage(int page) {
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        assertThrows(IllegalArgumentException.class, () -> queryBuilder.setPage(page, 10));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, -1, -100, -10000 })
+    public void testQueryBuilderErrorsWithInvalidPageSize(int pageSize) {
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        assertThrows(IllegalArgumentException.class, () -> queryBuilder.setPage(1, pageSize));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testQueryBuilderOrdersResultsByNameAscending(String field) {
+        this.createDataForQueryBuilderTesting();
+
+        Map<String, Comparator<Product>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Product::getId),
+            "name", Comparator.comparing(Product::getName),
+            "uuid", Comparator.comparing(Product::getUuid));
+
+        List<String> expectedPids = this.productCurator.listAll()
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Product::getId)
+            .toList();
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(field, false);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testQueryBuilderOrdersResultsByNameDescending(String field) {
+        this.createDataForQueryBuilderTesting();
+
+        Map<String, Comparator<Product>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Product::getId),
+            "name", Comparator.comparing(Product::getName),
+            "uuid", Comparator.comparing(Product::getUuid));
+
+        List<String> expectedPids = this.productCurator.listAll()
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Product::getId)
+            .toList();
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(field, true);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testQueryBuilderOrdersResultsByOrderAscending(String field) {
+        this.createDataForQueryBuilderTesting();
+
+        Map<String, Comparator<Product>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Product::getId),
+            "name", Comparator.comparing(Product::getName),
+            "uuid", Comparator.comparing(Product::getUuid));
+
+        List<String> expectedPids = this.productCurator.listAll()
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Product::getId)
+            .toList();
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(new QueryBuilder.Order(field, false));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testQueryBuilderOrdersResultsByOrderDescending(String field) {
+        this.createDataForQueryBuilderTesting();
+
+        Map<String, Comparator<Product>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Product::getId),
+            "name", Comparator.comparing(Product::getName),
+            "uuid", Comparator.comparing(Product::getUuid));
+
+        List<String> expectedPids = this.productCurator.listAll()
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Product::getId)
+            .toList();
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(new QueryBuilder.Order(field, true));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @Test
+    public void testQueryBuilderOrdersResultsByMultipleFields() {
+        this.createDataForQueryBuilderTesting();
+
+        Comparator<Product> updateComparator = Comparator.comparing(Product::getUpdated);
+        Comparator<Product> nameComparator = Comparator.comparing(Product::getName);
+        Comparator<Product> idComparator = Comparator.comparing(Product::getId);
+        Comparator<Product> uuidComparator = Comparator.comparing(Product::getUuid);
+
+        Comparator<Product> combined = updateComparator.reversed()
+            .thenComparing(nameComparator)
+            .thenComparing(idComparator)
+            .thenComparing(uuidComparator.reversed());
+
+        List<String> expectedPids = this.productCurator.listAll()
+            .stream()
+            .sorted(combined)
+            .map(Product::getId)
+            .toList();
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(new QueryBuilder.Order("updated", true))
+            .addOrder("name", false)
+            .addOrder(new QueryBuilder.Order("id", false))
+            .addOrder("uuid", true);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testQueryBuilderErrorsWithInvalidOrderingByField(boolean reverse) {
+        this.createDataForQueryBuilderTesting();
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder("invalid_field_name", reverse);
+
+        // At the time of writing, invalid keys don't trigger a failure until the query itself runs,
+        // so we have to attempt to fetch values to see the error.
+        assertThrows(InvalidOrderKeyException.class, () -> queryBuilder.getResultList());
+        assertThrows(InvalidOrderKeyException.class, () -> queryBuilder.getResultStream());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testQueryBuilderErrorsWithInvalidOrderingByOrder(boolean reverse) {
+        this.createDataForQueryBuilderTesting();
+
+        ProductQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(new QueryBuilder.Order("invalid_field_name", reverse));
+
+        // At the time of writing, invalid keys don't trigger a failure until the query itself runs,
+        // so we have to attempt to fetch values to see the error.
+        assertThrows(InvalidOrderKeyException.class, () -> queryBuilder.getResultList());
+        assertThrows(InvalidOrderKeyException.class, () -> queryBuilder.getResultStream());
+    }
+
+    // These tests verify the definition of "active" is properly implemented, ensuring "active" is defined
+    // as a product which is attached to a pool which has started and has not expired, or attached to
+    // another active product (recursively).
+    //
+    // This definition is recursive in nature, so the effect is that it should consider any product that
+    // is a descendant of a product attached to a non-future pool that hasn't yet expired.
+
+    @Test
+    public void testQueryBuilderActiveFilterOnlyConsidersActivePools() {
+        // - "active" only considers pools which have started but not expired (start time < now() < end time)
+        Owner owner = this.createOwner("test_org");
+
+        Product prod1 = this.createProduct("prod1");
+        Product prod2 = this.createProduct("prod2");
+        Product prod3 = this.createProduct("prod3");
+
+        Function<Integer, Date> days = (offset) -> TestUtil.createDateOffset(0, 0, offset);
+
+        // Create three pools: expired, current (active), future
+        Pool pool1 = this.createPool(owner, prod1, 1L, days.apply(-3), days.apply(-1));
+        Pool pool2 = this.createPool(owner, prod2, 1L, days.apply(-1), days.apply(1));
+        Pool pool3 = this.createPool(owner, prod3, 1L, days.apply(1), days.apply(3));
+
+        // Active = exclusive should only find the active pool; future and expired pools should be omitted
+        Stream<Product> output = this.buildQueryBuilder()
+            .setActive(Inclusion.EXCLUSIVE)
+            .getResultStream();
+
+        assertThat(output)
+            .isNotNull()
+            .map(Product::getId)
+            .singleElement()
+            .isEqualTo(prod2.getId());
+    }
+
+    @Test
+    public void testGetActiveProductsAlsoConsidersDescendantsOfActivePoolProducts() {
+        // - "active" includes descendants of products attached to a pool
+        Owner owner = this.createOwner("test_org");
+
+        List<Product> products = new ArrayList<>();
+        for (int i = 0; i < 20; ++i) {
+            Product product = new Product()
+                .setId("p" + i)
+                .setName("product " + i);
+
+            products.add(product);
+        }
+
+        /*
+        pool -> prod - p0
+                    derived - p1
+                        provided - p2
+                        provided - p3
+                            provided - p4
+                    provided - p5
+                    provided - p6
+
+        pool -> prod - p7
+                    derived - p8*
+                    provided - p9
+
+        pool -> prod - p8*
+                    provided - p10
+                        provided - p11
+                    provided - p12
+                        provided - p13
+
+                prod - p14
+                    derived - p15
+                        provided - p16
+
+                prod - p17
+                    provided - p18
+
+        pool -> prod - p19
+                prod - p20
+        */
+
+        products.get(0).setDerivedProduct(products.get(1));
+        products.get(0).addProvidedProduct(products.get(5));
+        products.get(0).addProvidedProduct(products.get(6));
+
+        products.get(1).addProvidedProduct(products.get(2));
+        products.get(1).addProvidedProduct(products.get(3));
+
+        products.get(3).addProvidedProduct(products.get(4));
+
+        products.get(7).setDerivedProduct(products.get(8));
+        products.get(7).addProvidedProduct(products.get(9));
+
+        products.get(8).addProvidedProduct(products.get(10));
+        products.get(8).addProvidedProduct(products.get(12));
+
+        products.get(10).addProvidedProduct(products.get(11));
+
+        products.get(12).addProvidedProduct(products.get(13));
+
+        products.get(14).setDerivedProduct(products.get(15));
+
+        products.get(15).setDerivedProduct(products.get(16));
+
+        products.get(17).setDerivedProduct(products.get(18));
+
+        // persist the products in reverse order so we don't hit any hibernate errors
+        for (int i = products.size() - 1; i >= 0; --i) {
+            this.productCurator.create(products.get(i));
+        }
+
+        Pool pool1 = this.createPool(owner, products.get(0));
+        Pool pool2 = this.createPool(owner, products.get(7));
+        Pool pool3 = this.createPool(owner, products.get(8));
+        Pool pool4 = this.createPool(owner, products.get(19));
+
+        List<String> expectedPids = List.of("p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9",
+            "p10", "p11", "p12", "p13", "p19");
+
+        Stream<Product> output = this.buildQueryBuilder()
+            .setActive(Inclusion.EXCLUSIVE)
+            .getResultStream();
+
+        assertThat(output)
+            .isNotNull()
+            .map(Product::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+}

--- a/src/test/java/org/candlepin/paging/PagingUtilFactoryTest.java
+++ b/src/test/java/org/candlepin/paging/PagingUtilFactoryTest.java
@@ -22,6 +22,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import org.candlepin.config.Configuration;
+import org.candlepin.config.TestConfig;
+
 import org.jboss.resteasy.core.ResteasyContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,12 +43,14 @@ import javax.inject.Provider;
 
 public class PagingUtilFactoryTest {
 
+    private Configuration config;
     private Provider<I18n> i18nProvider;
 
     @BeforeEach
     public void beforeEach() {
         ResteasyContext.clearContextData();
 
+        this.config = TestConfig.defaults();
         this.i18nProvider = () -> I18nFactory.getI18n(this.getClass(), Locale.US, I18nFactory.FALLBACK);
     }
 
@@ -55,7 +60,7 @@ public class PagingUtilFactoryTest {
     }
 
     private PagingUtilFactory buildPagingUtilFactory() {
-        return new PagingUtilFactory(this.i18nProvider);
+        return new PagingUtilFactory(this.config, this.i18nProvider);
     }
 
     private void setSortingPageRequestContext(String sortBy, PageRequest.Order order) {

--- a/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
+++ b/src/test/java/org/candlepin/resource/GuestIdResourceTest.java
@@ -113,7 +113,7 @@ public class GuestIdResourceTest {
 
         this.modelTranslator = new StandardTranslator(this.consumerTypeCurator, this.environmentCurator,
             this.ownerCurator);
-        this.pagingUtilFactory = new PagingUtilFactory(i18nProvider);
+        this.pagingUtilFactory = new PagingUtilFactory(this.config, i18nProvider);
 
         this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
         this.owner = TestUtil.createOwner();

--- a/src/test/java/org/candlepin/resource/JobResourceTest.java
+++ b/src/test/java/org/candlepin/resource/JobResourceTest.java
@@ -878,7 +878,7 @@ public class JobResourceTest extends DatabaseTestFixture {
 
         ResteasyContext.pushContext(PageRequest.class, pageRequest);
 
-        doThrow(new InvalidOrderKeyException()).when(this.jobManager).findJobs(any());
+        doThrow(new InvalidOrderKeyException("bad key", null)).when(this.jobManager).findJobs(any());
 
         JobResource resource = this.buildJobResource();
         assertThrows(BadRequestException.class,

--- a/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerProductResourceTest.java
@@ -22,9 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
-import org.candlepin.async.JobManager;
 import org.candlepin.dto.api.server.v1.AttributeDTO;
 import org.candlepin.dto.api.server.v1.ContentDTO;
 import org.candlepin.dto.api.server.v1.ProductCertificateDTO;
@@ -39,18 +37,28 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCertificate;
 import org.candlepin.model.ProductContent;
+import org.candlepin.model.QueryBuilder.Inclusion;
+import org.candlepin.paging.PageRequest;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
+import org.jboss.resteasy.core.ResteasyContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -59,12 +67,25 @@ import java.util.stream.Stream;
 public class OwnerProductResourceTest extends DatabaseTestFixture {
 
     private OwnerProductResource ownerProductResource;
-    private JobManager jobManager;
 
     @BeforeEach
     public void setUp() {
         ownerProductResource = this.injector.getInstance(OwnerProductResource.class);
-        this.jobManager = mock(JobManager.class);
+
+        // Make sure we don't have any latent page requests in the context
+        ResteasyContext.clearContextData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        // Also cleanup after ourselves for other tests
+        ResteasyContext.clearContextData();
+    }
+
+    private OwnerProductResource buildResource() {
+        // TODO: We could probably move the actual invocation/creation here and removing it from the class
+        // scope, but for now, just prime our new tests to be ready for such a refactor.
+        return this.ownerProductResource;
     }
 
     private ProductDTO buildTestProductDTO() {
@@ -95,159 +116,6 @@ public class OwnerProductResourceTest extends DatabaseTestFixture {
         content.setEnabled(true);
 
         product.getProductContent().add(content);
-    }
-
-    @Test
-    public void testGetProductsByOwnerFetchesAllVisibleEntities() {
-        Owner owner1 = this.createOwner("test_owner-1");
-        Owner owner2 = this.createOwner("test_owner-2");
-
-        Product product1 = TestUtil.createProduct("test_product-1", "test_product-1")
-            .setNamespace((Owner) null);
-        Product product2 = TestUtil.createProduct("test_product-2", "test_product-2")
-            .setNamespace(owner1.getKey());
-        Product product3 = TestUtil.createProduct("test_product-3", "test_product-3")
-            .setNamespace(owner2.getKey());
-
-        this.createProduct(product1);
-        this.createProduct(product2);
-        this.createProduct(product3);
-
-        ProductDTO cdto1 = this.modelTranslator.translate(product1, ProductDTO.class);
-        ProductDTO cdto2 = this.modelTranslator.translate(product2, ProductDTO.class);
-
-        Stream<ProductDTO> response = this.ownerProductResource
-            .getProductsByOwner(owner1.getKey(), List.of(), false);
-
-        assertNotNull(response);
-        assertThat(response.toList())
-            .hasSize(2)
-            .containsOnly(cdto1, cdto2);
-    }
-
-    @Test
-    public void testGetProductsByOwnerOmitsGlobalsWhenOmitFlagIsSet() {
-        Owner owner1 = this.createOwner("test_owner-1");
-        Owner owner2 = this.createOwner("test_owner-2");
-
-        Product product1 = TestUtil.createProduct("test_product-1", "test_product-1")
-            .setNamespace((Owner) null);
-        Product product2 = TestUtil.createProduct("test_product-2", "test_product-2")
-            .setNamespace(owner1.getKey());
-        Product product3 = TestUtil.createProduct("test_product-3", "test_product-3")
-            .setNamespace(owner2.getKey());
-
-        this.createProduct(product1);
-        this.createProduct(product2);
-        this.createProduct(product3);
-
-        ProductDTO cdto2 = this.modelTranslator.translate(product2, ProductDTO.class);
-
-        Stream<ProductDTO> response = this.ownerProductResource
-            .getProductsByOwner(owner1.getKey(), List.of(), true);
-
-        assertNotNull(response);
-        assertThat(response.toList())
-            .hasSize(1)
-            .containsOnly(cdto2);
-    }
-
-    @Test
-    public void testGetProductsByOwnerWithEntityIDFiltering() {
-        Owner owner1 = this.createOwner("test_owner-1");
-        Owner owner2 = this.createOwner("test_owner-2");
-
-        Product product1 = TestUtil.createProduct("test_product-1", "test_product-1")
-            .setNamespace((Owner) null);
-        Product product2 = TestUtil.createProduct("test_product-2", "test_product-2")
-            .setNamespace(owner1.getKey());
-        Product product3 = TestUtil.createProduct("test_product-3", "test_product-3")
-            .setNamespace((Owner) null);
-        Product product4 = TestUtil.createProduct("test_product-4", "test_product-4")
-            .setNamespace(owner1.getKey());
-        Product product5 = TestUtil.createProduct("test_product-5", "test_product-5")
-            .setNamespace(owner2.getKey());
-
-        this.createProduct(product1);
-        this.createProduct(product2);
-        this.createProduct(product3);
-        this.createProduct(product4);
-        this.createProduct(product5);
-
-        List<String> ids = Stream.of(product3, product4, product5)
-            .map(Product::getId)
-            .toList();
-
-        Stream<ProductDTO> response = this.ownerProductResource
-            .getProductsByOwner(owner1.getKey(), ids, false);
-
-        List<ProductDTO> expected = Stream.of(product3, product4)
-            .map(this.modelTranslator.getStreamMapper(Product.class, ProductDTO.class))
-            .toList();
-
-        assertNotNull(response);
-        assertThat(response.toList())
-            .hasSize(expected.size())
-            .containsAll(expected);
-    }
-
-    @Test
-    public void testGetProductsByOwnerWithEntityIDFilteringAndOmitGlobalsSet() {
-        Owner owner1 = this.createOwner("test_owner-1");
-        Owner owner2 = this.createOwner("test_owner-2");
-
-        Product product1 = TestUtil.createProduct("test_product-1", "test_product-1")
-            .setNamespace((Owner) null);
-        Product product2 = TestUtil.createProduct("test_product-2", "test_product-2")
-            .setNamespace(owner1.getKey());
-        Product product3 = TestUtil.createProduct("test_product-3", "test_product-3")
-            .setNamespace((Owner) null);
-        Product product4 = TestUtil.createProduct("test_product-4", "test_product-4")
-            .setNamespace(owner1.getKey());
-        Product product5 = TestUtil.createProduct("test_product-5", "test_product-5")
-            .setNamespace(owner2.getKey());
-
-        this.createProduct(product1);
-        this.createProduct(product2);
-        this.createProduct(product3);
-        this.createProduct(product4);
-        this.createProduct(product5);
-
-        List<String> ids = Stream.of(product3, product4, product5)
-            .map(Product::getId)
-            .toList();
-
-        Stream<ProductDTO> response = this.ownerProductResource
-            .getProductsByOwner(owner1.getKey(), ids, true);
-
-        List<ProductDTO> expected = Stream.of(product4)
-            .map(this.modelTranslator.getStreamMapper(Product.class, ProductDTO.class))
-            .toList();
-
-        assertNotNull(response);
-        assertThat(response.toList())
-            .hasSize(expected.size())
-            .containsAll(expected);
-    }
-
-    @Test
-    public void testGetProductsByOwnerWithNoProduct() throws Exception {
-        Owner owner = this.createOwner("test_owner");
-
-        Stream<ProductDTO> response = this.ownerProductResource
-            .getProductsByOwner(owner.getKey(), List.of(), false);
-        assertNotNull(response);
-
-        List<ProductDTO> received = response.toList();
-        assertEquals(0, received.size());
-    }
-
-    @Test
-    public void testGetProductsByOwnerBadOwner() throws Exception {
-        Owner owner = this.createOwner("test_owner");
-
-        assertThrows(NotFoundException.class,
-            () -> this.ownerProductResource.getProductsByOwner("bad owner", List.of(), false));
     }
 
     @Test
@@ -961,4 +829,546 @@ public class OwnerProductResourceTest extends DatabaseTestFixture {
         assertThrows(BadRequestException.class,
             () -> ownerProductResource.getProductCertificateById(owner.getKey(), entity.getId()));
     }
+
+
+    /**
+     * Creates a set of products for use with the "testGetProductsByOwner..." family of tests below. Do
+     * not make changes to these products unless you are updating the testing for the
+     * OwnerProductResource.getProductsByOwner method, and do not use this method to set up data for any
+     * other test!
+     *
+     * Note that this test data does not create full product graphs for products. Testing the definition
+     * of "active" is left to a set of explicit tests which validates it in full.
+     */
+    private void createDataForEndpointQueryTesting() {
+        List<Owner> owners = List.of(
+            this.createOwner("owner1"),
+            this.createOwner("owner2"),
+            this.createOwner("owner3"));
+
+        List<Product> globalProducts = new ArrayList<>();
+        for (int i = 1; i <= 3; ++i) {
+            Product gprod = new Product()
+                .setId("g-prod-" + i)
+                .setName("global product " + i);
+
+            globalProducts.add(this.productCurator.create(gprod));
+        }
+
+        for (int oidx = 1; oidx <= owners.size(); ++oidx) {
+            Owner owner = owners.get(oidx - 1);
+
+            List<Product> ownerProducts = new ArrayList<>();
+
+            // create two custom products
+            for (int i = 1; i <= 3; ++i) {
+                Product cprod = new Product()
+                    .setId(String.format("o%d-prod-%d", oidx, i))
+                    .setName(String.format("%s product %d", owner.getKey(), i))
+                    .setNamespace(owner.getKey());
+
+                ownerProducts.add(this.productCurator.create(cprod));
+            }
+
+            // create some pools:
+            // - two which references a global product
+            // - two which references a custom product
+            Pool globalPool1 = this.createPool(owner, globalProducts.get(0));
+            Pool globalPool2 = this.createPool(owner, globalProducts.get(1));
+
+            Pool customPool1 = this.createPool(owner, ownerProducts.get(0));
+            Pool customPool2 = this.createPool(owner, ownerProducts.get(1));
+        }
+    }
+
+    @Test
+    public void testGetProductsByOwnerFetchesWithNoFiltering() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o2-prod-1", "o2-prod-2",
+            "o2-prod-3");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsByOwnerDefaultsToActiveOnly() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "o2-prod-1", "o2-prod-2");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, null, null, null);
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_owner" })
+    @NullAndEmptySource
+    public void testGetProductsByOwnerErrorsWithInvalidOwners(String ownerKey) {
+        this.createDataForEndpointQueryTesting();
+
+        OwnerProductResource resource = this.buildResource();
+
+        assertThrows(NotFoundException.class, () -> resource.getProductsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name()));
+    }
+
+    @Test
+    public void testGetProductsByOwnerFetchesWithIDFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> productIds = List.of("g-prod-2", "o1-prod-1", "o2-prod-2", "o3-prod-3");
+        List<String> expectedPids = List.of("g-prod-2", "o2-prod-2");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, productIds, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_prod_id" })
+    @NullAndEmptySource
+    public void testGetProductsByOwnerFetchesWithInvalidIDs(String invalidProductId) {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> productIds = Arrays.asList("o2-prod-1", invalidProductId);
+        List<String> expectedPids = List.of("o2-prod-1");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, productIds, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsByOwnerFetchesWithNameFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> productNames = Arrays.asList("global product 2", "owner1 product 1", "owner2 product 2",
+            "owner3 product 3");
+        List<String> expectedPids = List.of("g-prod-2", "o2-prod-2");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, productNames,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_prod_name" })
+    @NullAndEmptySource
+    public void testGetProductsByOwnerFetchesWithInvalidNames(String invalidProductName) {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> productNames = Arrays.asList("global product 2", invalidProductName);
+        List<String> expectedPids = List.of("g-prod-2");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, productNames,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsByOwnerFetchesWithOmitActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedPids = List.of("g-prod-3", "o2-prod-3");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, null,
+            Inclusion.EXCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsByOwnerFetchesWithOnlyActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "o2-prod-1", "o2-prod-2");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, null,
+            Inclusion.EXCLUSIVE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsByOwnerFetchesWithIncludeActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        // active = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o2-prod-1", "o2-prod-2",
+            "o2-prod-3");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsByOwnerErrorsWithInvalidActiveFilter() {
+        Owner owner = this.createOwner("test_org");
+
+        OwnerProductResource resource = this.buildResource();
+        assertThrows(BadRequestException.class, () -> resource.getProductsByOwner(owner.getKey(), null, null,
+            "invalid_type", Inclusion.INCLUDE.name()));
+    }
+
+    @Test
+    public void testGetProductsByOwnerFetchesWithOmitCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.EXCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsByOwnerFetchesWithOnlyCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedPids = List.of("o2-prod-1", "o2-prod-2", "o2-prod-3");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.EXCLUSIVE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsByOwnerFetchesWithIncludeCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        // custom = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o2-prod-1", "o2-prod-2",
+            "o2-prod-3");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsByOwnerErrorsWithInvalidCustomFilter() {
+        Owner owner = this.createOwner("test_org");
+
+        OwnerProductResource resource = this.buildResource();
+        assertThrows(BadRequestException.class, () -> resource.getProductsByOwner(owner.getKey(), null, null,
+            Inclusion.INCLUDE.name(), "invalid_type"));
+    }
+
+    @Test
+    public void testGetProductsByOwnerFetchesWithMultipleFilters() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        // This test configures a bunch of filters which loosely resolve to the following:
+        // - active global products: not custom, not inactive (active = only, custom = omit)
+        // - in orgs 2 or 3
+        // - matching the given list of product IDs (gp1, gp2, o1p1, o2p1, o3p2)
+        // - matching the given list of product names (gp1, gp2, gp3, o2p1, o2p2)
+        //
+        // These filters should be applied as an intersection, resulting in a singular match on gp1
+
+        List<String> productIds = List.of("g-prod-1", "g-prod-2", "o1-prod-1", "o2-prod-1", "o3-prod-2");
+        List<String> productNames = List.of("global product 1", "global product 3", "owner2 product 1",
+            "owner2 product 2");
+        String activeInclusion = Inclusion.EXCLUSIVE.name();
+        String customInclusion = Inclusion.EXCLUDE.name();
+
+        List<String> expectedPids = List.of("g-prod-1");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, productIds, productNames,
+            activeInclusion, customInclusion);
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+    public void testGetProductsByOwnerFetchesPagedResults(int pageSize) {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o2-prod-1", "o2-prod-2",
+            "o2-prod-3");
+
+        int expectedPages = pageSize < expectedPids.size() ?
+            (expectedPids.size() / pageSize) + (expectedPids.size() % pageSize != 0 ? 1 : 0) :
+            1;
+
+        OwnerProductResource resource = this.buildResource();
+
+        List<String> found = new ArrayList<>();
+        int pages = 0;
+        while (pages < expectedPages) {
+            // Set the context page request
+            ResteasyContext.popContextData(PageRequest.class);
+            ResteasyContext.pushContext(PageRequest.class, new PageRequest()
+                .setPage(++pages)
+                .setPerPage(pageSize));
+
+            Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, null,
+                Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+            assertNotNull(output);
+            List<String> receivedPids = output.map(ProductDTO::getId)
+                .toList();
+
+            if (receivedPids.isEmpty()) {
+                break;
+            }
+
+            found.addAll(receivedPids);
+        }
+
+        assertEquals(expectedPages, pages);
+        assertThat(found)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testGetProductsByOwnerFetchesOrderedResults(String field) {
+        this.createDataForEndpointQueryTesting();
+
+        String ownerKey = "owner2";
+
+        Map<String, Comparator<Product>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Product::getId),
+            "name", Comparator.comparing(Product::getName),
+            "uuid", Comparator.comparing(Product::getUuid));
+
+        List<String> expectedPids = this.productCurator.resolveProductsByNamespace(ownerKey)
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Product::getId)
+            .toList();
+
+        ResteasyContext.pushContext(PageRequest.class, new PageRequest().setSortBy(field));
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        // Note that this output needs to be ordered according to our expected ordering!
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsByOwnerErrorsWithInvalidOrderingRequest() {
+        Owner owner = this.createOwner("test_org");
+
+        ResteasyContext.pushContext(PageRequest.class, new PageRequest().setSortBy("invalid_field_name"));
+
+        OwnerProductResource resource = this.buildResource();
+        assertThrows(BadRequestException.class, () -> resource.getProductsByOwner(owner.getKey(), null, null,
+            null, null));
+    }
+
+    // These tests verify the definition of "active" is properly implemented, ensuring "active" is defined
+    // as a product which is attached to a pool which has started and has not expired, or attached to
+    // another active product (recursively).
+    //
+    // This definition is recursive in nature, so the effect is that it should consider any product that
+    // is a descendant of a product attached to a non-future pool that hasn't yet expired.
+
+    @Test
+    public void testGetActiveProductsOnlyConsidersActivePools() {
+        // - "active" only considers pools which have started but not expired (start time < now() < end time)
+        Owner owner = this.createOwner("test_org");
+
+        Product prod1 = this.createProduct("prod1");
+        Product prod2 = this.createProduct("prod2");
+        Product prod3 = this.createProduct("prod3");
+
+        Function<Integer, Date> days = (offset) -> TestUtil.createDateOffset(0, 0, offset);
+
+        // Create three pools: expired, current (active), future
+        Pool pool1 = this.createPool(owner, prod1, 1L, days.apply(-3), days.apply(-1));
+        Pool pool2 = this.createPool(owner, prod2, 1L, days.apply(-1), days.apply(1));
+        Pool pool3 = this.createPool(owner, prod3, 1L, days.apply(1), days.apply(3));
+
+        // Active = exclusive should only find the active pool; future and expired pools should be omitted
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(owner.getKey(), null, null,
+            Inclusion.EXCLUSIVE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .singleElement()
+            .isEqualTo(prod2.getId());
+    }
+
+    @Test
+    public void testGetActiveProductsAlsoConsidersDescendantsOfActivePoolProducts() {
+        // - "active" includes descendants of products attached to a pool
+        Owner owner = this.createOwner("test_org");
+
+        List<Product> products = new ArrayList<>();
+        for (int i = 0; i < 20; ++i) {
+            Product product = new Product()
+                .setId("p" + i)
+                .setName("product " + i);
+
+            products.add(product);
+        }
+
+        /*
+        pool -> prod - p0
+                    derived - p1
+                        provided - p2
+                        provided - p3
+                            provided - p4
+                    provided - p5
+                    provided - p6
+
+        pool -> prod - p7
+                    derived - p8*
+                    provided - p9
+
+        pool -> prod - p8*
+                    provided - p10
+                        provided - p11
+                    provided - p12
+                        provided - p13
+
+                prod - p14
+                    derived - p15
+                        provided - p16
+
+                prod - p17
+                    provided - p18
+
+        pool -> prod - p19
+                prod - p20
+        */
+
+        products.get(0).setDerivedProduct(products.get(1));
+        products.get(0).addProvidedProduct(products.get(5));
+        products.get(0).addProvidedProduct(products.get(6));
+
+        products.get(1).addProvidedProduct(products.get(2));
+        products.get(1).addProvidedProduct(products.get(3));
+
+        products.get(3).addProvidedProduct(products.get(4));
+
+        products.get(7).setDerivedProduct(products.get(8));
+        products.get(7).addProvidedProduct(products.get(9));
+
+        products.get(8).addProvidedProduct(products.get(10));
+        products.get(8).addProvidedProduct(products.get(12));
+
+        products.get(10).addProvidedProduct(products.get(11));
+
+        products.get(12).addProvidedProduct(products.get(13));
+
+        products.get(14).setDerivedProduct(products.get(15));
+
+        products.get(15).setDerivedProduct(products.get(16));
+
+        products.get(17).setDerivedProduct(products.get(18));
+
+        // persist the products in reverse order so we don't hit any hibernate errors
+        for (int i = products.size() - 1; i >= 0; --i) {
+            this.productCurator.create(products.get(i));
+        }
+
+        Pool pool1 = this.createPool(owner, products.get(0));
+        Pool pool2 = this.createPool(owner, products.get(7));
+        Pool pool3 = this.createPool(owner, products.get(8));
+        Pool pool4 = this.createPool(owner, products.get(19));
+
+        List<String> expectedPids = List.of("p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9",
+            "p10", "p11", "p12", "p13", "p19");
+
+        OwnerProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProductsByOwner(owner.getKey(), null, null,
+            Inclusion.EXCLUSIVE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
 }

--- a/src/test/java/org/candlepin/resource/ProductResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ProductResourceTest.java
@@ -14,15 +14,14 @@
  */
 package org.candlepin.resource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.candlepin.async.JobConfig;
@@ -34,25 +33,34 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.dto.api.server.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.server.v1.ProductDTO;
 import org.candlepin.exceptions.BadRequestException;
+import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.AsyncJobStatus;
 import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
-import org.candlepin.model.ProductCurator;
-import org.candlepin.model.ProductCurator.ProductQueryArguments;
+import org.candlepin.model.QueryBuilder.Inclusion;
 import org.candlepin.paging.PageRequest;
+import org.candlepin.paging.PagingUtilFactory;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
 import org.jboss.resteasy.core.ResteasyContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.stubbing.Answer;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedList;
+import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 
 
@@ -60,25 +68,50 @@ import java.util.stream.Collectors;
  * ProductResourceTest
  */
 public class ProductResourceTest extends DatabaseTestFixture {
-    private ProductResource productResource;
-    private JobManager jobManager;
 
     @BeforeEach
     public void init() throws Exception {
         super.init();
-        productResource = this.injector.getInstance(ProductResource.class);
-        this.jobManager = mock(JobManager.class);
 
-        doAnswer((Answer<AsyncJobStatus>) invocation -> {
-            Object[] args = invocation.getArguments();
-            JobConfig<?> jobConfig = (JobConfig<?>) args[0];
+        // Make sure we don't have any latent page requests in the context
+        ResteasyContext.clearContextData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        // Also cleanup after ourselves for other tests
+        ResteasyContext.clearContextData();
+    }
+
+    private JobManager mockJobManager() throws JobException {
+        JobManager manager = mock(JobManager.class);
+
+        Answer<AsyncJobStatus> queueJobAnswer = invocation -> {
+            JobConfig<?> jobConfig = invocation.getArgument(0);
 
             return new AsyncJobStatus()
                 .setState(AsyncJobStatus.JobState.QUEUED)
                 .setJobKey(jobConfig.getJobKey())
                 .setName(jobConfig.getJobName())
                 .setJobArguments(jobConfig.getJobArguments());
-        }).when(this.jobManager).queueJob(any(JobConfig.class));
+        };
+
+        doAnswer(queueJobAnswer)
+            .when(manager)
+            .queueJob(any(JobConfig.class));
+
+        return manager;
+    }
+
+    private ProductResource buildResource(JobManager jobManager) {
+        PagingUtilFactory pagingUtilFactory = new PagingUtilFactory(config, this.i18nProvider);
+
+        return new ProductResource(this.config, this.i18n, this.productCurator, this.ownerCurator,
+            this.productCertificateCurator, pagingUtilFactory, this.modelTranslator, jobManager);
+    }
+
+    private ProductResource buildResource() {
+        return this.injector.getInstance(ProductResource.class);
     }
 
     @Test
@@ -88,7 +121,9 @@ public class ProductResourceTest extends DatabaseTestFixture {
         ProductDTO expected = this.modelTranslator.translate(entity, ProductDTO.class);
 
         securityInterceptor.enable();
-        ProductDTO result = productResource.getProductByUuid(entity.getUuid());
+
+        ProductResource resource = this.buildResource();
+        ProductDTO result = resource.getProductByUuid(entity.getUuid());
 
         assertNotNull(result);
         assertEquals(result, expected);
@@ -136,16 +171,16 @@ public class ProductResourceTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testRefreshPoolsByProduct() {
-        config.setProperty(ConfigProperties.STANDALONE, "false");
+    public void testRefreshPoolsByProduct() throws JobException {
+        this.config.setProperty(ConfigProperties.STANDALONE, "false");
 
-        ProductResource productResource = new ProductResource(this.productCurator, this.ownerCurator,
-            this.productCertificateCurator, config, this.i18n, this.modelTranslator, this.jobManager);
+        JobManager mockJobManager = this.mockJobManager();
+        ProductResource resource = this.buildResource(mockJobManager);
+
         this.setupDBForOwnerProdTests();
 
-        List<AsyncJobStatusDTO> jobs = productResource
-            .refreshPoolsForProducts(Collections.singletonList("p1"), true)
-            .collect(Collectors.toList());
+        List<AsyncJobStatusDTO> jobs = resource.refreshPoolsForProducts(List.of("p1"), true)
+            .toList();
 
         assertNotNull(jobs);
         assertEquals(2, jobs.size());
@@ -153,16 +188,16 @@ public class ProductResourceTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testRefreshPoolsByProductForMultipleProducts() {
-        config.setProperty(ConfigProperties.STANDALONE, "false");
+    public void testRefreshPoolsByProductForMultipleProducts() throws JobException {
+        this.config.setProperty(ConfigProperties.STANDALONE, "false");
 
-        ProductResource productResource = new ProductResource(this.productCurator, this.ownerCurator,
-            this.productCertificateCurator, config, this.i18n, this.modelTranslator, this.jobManager);
+        JobManager mockJobManager = this.mockJobManager();
+        ProductResource resource = this.buildResource(mockJobManager);
+
         this.setupDBForOwnerProdTests();
 
-        List<AsyncJobStatusDTO> jobs = productResource
-            .refreshPoolsForProducts(Arrays.asList("p1", "p2"), false)
-            .collect(Collectors.toList());
+        List<AsyncJobStatusDTO> jobs = resource.refreshPoolsForProducts(List.of("p1", "p2"), false)
+            .toList();
 
         assertNotNull(jobs);
         assertEquals(3, jobs.size());
@@ -170,16 +205,16 @@ public class ProductResourceTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testRefreshPoolsByProductWithoutLazyOffload() {
-        config.setProperty(ConfigProperties.STANDALONE, "false");
+    public void testRefreshPoolsByProductWithoutLazyOffload() throws JobException {
+        this.config.setProperty(ConfigProperties.STANDALONE, "false");
 
-        ProductResource productResource = new ProductResource(this.productCurator, this.ownerCurator,
-            this.productCertificateCurator, config, this.i18n, this.modelTranslator, this.jobManager);
+        JobManager mockJobManager = this.mockJobManager();
+        ProductResource resource = this.buildResource(mockJobManager);
+
         this.setupDBForOwnerProdTests();
 
-        List<AsyncJobStatusDTO> jobs = productResource
-            .refreshPoolsForProducts(Collections.singletonList("p3"), false)
-            .collect(Collectors.toList());
+        List<AsyncJobStatusDTO> jobs = resource.refreshPoolsForProducts(List.of("p3"), false)
+            .toList();
 
         assertNotNull(jobs);
         assertEquals(1, jobs.size());
@@ -187,16 +222,16 @@ public class ProductResourceTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testRefreshPoolsByProductWithBadProductId() {
-        config.setProperty(ConfigProperties.STANDALONE, "false");
+    public void testRefreshPoolsByProductWithBadProductId() throws JobException {
+        this.config.setProperty(ConfigProperties.STANDALONE, "false");
 
-        ProductResource productResource = new ProductResource(this.productCurator, this.ownerCurator,
-            this.productCertificateCurator, config, this.i18n, this.modelTranslator, this.jobManager);
+        JobManager mockJobManager = this.mockJobManager();
+        ProductResource resource = this.buildResource(mockJobManager);
+
         this.setupDBForOwnerProdTests();
 
-        List<AsyncJobStatusDTO> jobs = productResource
-            .refreshPoolsForProducts(Collections.singletonList("nope"), false)
-            .collect(Collectors.toList());
+        List<AsyncJobStatusDTO> jobs = resource.refreshPoolsForProducts(List.of("nope"), false)
+            .toList();
 
         assertNotNull(jobs);
         assertEquals(0, jobs.size());
@@ -204,38 +239,40 @@ public class ProductResourceTest extends DatabaseTestFixture {
 
     @Test
     public void testRefreshPoolsByProductInputValidation() {
-        assertThrows(BadRequestException.class,
-            () -> productResource.refreshPoolsForProducts(new LinkedList<>(), true));
+        ProductResource resource = this.buildResource();
+        assertThrows(BadRequestException.class, () -> resource.refreshPoolsForProducts(List.of(), true));
     }
 
     @Test
     public void testRefreshPoolsByProductJobQueueingErrorsShouldBeHandled() throws JobException {
-        config.setProperty(ConfigProperties.STANDALONE, "false");
+        this.config.setProperty(ConfigProperties.STANDALONE, "false");
+
+        AsyncJobStatus status1 = new AsyncJobStatus()
+            .setName(RefreshPoolsJob.JOB_NAME)
+            .setState(AsyncJobStatus.JobState.CREATED) // need to prime the previous state field
+            .setState(AsyncJobStatus.JobState.QUEUED);
 
         // We want to simulate the first queueJob call succeeds, and the second throws a validation
         // exception
         JobManager jobManager = mock(JobManager.class);
-        AsyncJobStatus status1 = new AsyncJobStatus();
-        status1.setName(RefreshPoolsJob.JOB_NAME);
-        status1.setState(AsyncJobStatus.JobState.CREATED); // need to prime the previous state field
-        status1.setState(AsyncJobStatus.JobState.QUEUED);
         when(jobManager.queueJob(any(JobConfig.class)))
             .thenReturn(status1)
             .thenThrow(new JobConfigValidationException("a job config validation error happened!"));
 
-        ProductResource productResource = new ProductResource(this.productCurator, this.ownerCurator,
-            this.productCertificateCurator, config, this.i18n, this.modelTranslator, jobManager);
+        ProductResource resource = this.buildResource(jobManager);
+
         this.setupDBForOwnerProdTests();
 
         List<AsyncJobStatusDTO> jobs = null;
         try {
-            jobs = productResource.refreshPoolsForProducts(Collections.singletonList("p1"), true)
-                .collect(Collectors.toList());
+            jobs = resource.refreshPoolsForProducts(List.of("p1"), true)
+                .toList();
         }
         catch (Exception e) {
             fail("A validation exception when trying to queue a job should be handled " +
                 "by the endpoint, not thrown!");
         }
+
         assertNotNull(jobs);
         assertEquals(2, jobs.size());
 
@@ -256,46 +293,542 @@ public class ProductResourceTest extends DatabaseTestFixture {
         assertEquals(Integer.valueOf(1), statusDTO2.getMaxAttempts());
     }
 
-    @Test
-    public void testGetProducts() {
-        ProductCurator mockProductCurator = mock(ProductCurator.class);
-        ProductResource productResource = new ProductResource(mockProductCurator, this.ownerCurator,
-            this.productCertificateCurator, config, this.i18n, this.modelTranslator, this.jobManager);
-        when(mockProductCurator.listAll(any(ProductQueryArguments.class)))
-            .thenReturn(new LinkedList<>());
-        ResteasyContext.pushContext(PageRequest.class,
-            new PageRequest()
-                .setPage(1)
-                .setPerPage(10)
-                .setSortBy("created"));
-        productResource.getProducts(1, 10, "asc", "created");
-        verify(mockProductCurator, atLeastOnce()).listAll(any(ProductQueryArguments.class));
-        ResteasyContext.popContextData(PageRequest.class);
+    /**
+     * Creates a set of products for use with the "testGetProducts..." family of tests below. Do not make
+     * changes to these products unless you are updating the testing for the ProductResource.getProducts
+     * method, and do not use this method to set up data for any other test!
+     *
+     * Note that this test data does not create full product graphs for products. Testing the definition
+     * of "active" is left to a set of explicit tests which validates it in full.
+     */
+    private void createDataForEndpointQueryTesting() {
+        List<Owner> owners = List.of(
+            this.createOwner("owner1"),
+            this.createOwner("owner2"),
+            this.createOwner("owner3"));
+
+        List<Product> globalProducts = new ArrayList<>();
+        for (int i = 1; i <= 3; ++i) {
+            Product gprod = new Product()
+                .setId("g-prod-" + i)
+                .setName("global product " + i);
+
+            globalProducts.add(this.productCurator.create(gprod));
+        }
+
+        for (int oidx = 1; oidx <= owners.size(); ++oidx) {
+            Owner owner = owners.get(oidx - 1);
+
+            List<Product> ownerProducts = new ArrayList<>();
+
+            // create two custom products
+            for (int i = 1; i <= 2; ++i) {
+                Product cprod = new Product()
+                    .setId(String.format("o%d-prod-%d", oidx, i))
+                    .setName(String.format("%s product %d", owner.getKey(), i))
+                    .setNamespace(owner.getKey());
+
+                ownerProducts.add(this.productCurator.create(cprod));
+            }
+
+            // create some pools:
+            // - one which references a global product
+            // - one which references a custom product
+            Pool globalPool = this.createPool(owner, globalProducts.get(0));
+            Pool customPool = this.createPool(owner, ownerProducts.get(0));
+        }
     }
 
     @Test
-    public void testGetProductsOverMaxNoPaging() {
-        ResteasyContext.popContextData(PageRequest.class);
-        ProductCurator mockProductCurator = mock(ProductCurator.class);
-        ProductResource productResource = new ProductResource(mockProductCurator, this.ownerCurator,
-            this.productCertificateCurator, config, this.i18n, this.modelTranslator, this.jobManager);
-        config.setProperty(ConfigProperties.PAGING_MAX_PAGE_SIZE, "7");
-        when(mockProductCurator.getProductCount(any(ProductQueryArguments.class)))
-            .thenReturn(10L);
-        assertThrows(BadRequestException.class, () -> productResource.getProducts(
-            null, null, null, null));
+    public void testGetProductsFetchesWithNoFiltering() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
     }
 
     @Test
-    public void testGetProductsNoPaging() {
-        ResteasyContext.popContextData(PageRequest.class);
-        ProductCurator mockProductCurator = mock(ProductCurator.class);
-        ProductResource productResource = new ProductResource(mockProductCurator, this.ownerCurator,
-            this.productCertificateCurator, config, this.i18n, this.modelTranslator, this.jobManager);
-        when(mockProductCurator.getProductCount(any(ProductQueryArguments.class)))
-            .thenReturn(1L);
-        when(mockProductCurator.listAll(any(ProductQueryArguments.class)))
-            .thenReturn(List.of(new Product()));
-        assertEquals(1, productResource.getProducts(null, null, null, null).toList().size());
+    public void testGetProductsDefaultsToActiveOnly() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedPids = List.of("g-prod-1", "o1-prod-1", "o2-prod-1", "o3-prod-1");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null, null, null);
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
     }
+
+    @Test
+    public void testGetProductsFetchesWithOwnerFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> ownerKeys = List.of("owner2", "owner3");
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o2-prod-1", "o2-prod-2",
+            "o3-prod-1", "o3-prod-2");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(ownerKeys, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_owner" })
+    @NullAndEmptySource
+    public void testGetProductsErrorsWithInvalidOwners(String invalidOwnerKey) {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> ownerKeys = Arrays.asList("owner1", invalidOwnerKey);
+
+        ProductResource resource = this.buildResource();
+
+        assertThrows(NotFoundException.class, () -> resource.getProducts(ownerKeys, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name()));
+    }
+
+    @Test
+    public void testGetProductsFetchesWithIDFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> productIds = List.of("g-prod-2", "o1-prod-1", "o3-prod-1");
+        List<String> expectedPids = List.of("g-prod-2", "o1-prod-1", "o3-prod-1");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, productIds, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_prod_id" })
+    @NullAndEmptySource
+    public void testGetProductsFetchesWithInvalidIDs(String invalidProductId) {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> productIds = Arrays.asList("o1-prod-1", invalidProductId);
+        List<String> expectedPids = List.of("o1-prod-1");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, productIds, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsFetchesWithNameFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> productNames = Arrays.asList("owner1 product 2", "global product 3", "owner3 product 1");
+        List<String> expectedPids = List.of("g-prod-3", "o1-prod-2", "o3-prod-1");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, productNames,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_prod_name" })
+    @NullAndEmptySource
+    public void testGetProductsFetchesWithInvalidNames(String invalidProductName) {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> productNames = Arrays.asList("owner1 product 2", invalidProductName);
+        List<String> expectedPids = List.of("o1-prod-2");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, productNames,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsFetchesWithOmitActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedPids = List.of("g-prod-2", "g-prod-3", "o1-prod-2", "o2-prod-2", "o3-prod-2");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null,
+            Inclusion.EXCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsFetchesWithOnlyActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedPids = List.of("g-prod-1", "o1-prod-1", "o2-prod-1", "o3-prod-1");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null,
+            Inclusion.EXCLUSIVE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsFetchesWithIncludeActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        // active = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsErrorsWithInvalidActiveFilter() {
+        ProductResource resource = this.buildResource();
+
+        assertThrows(BadRequestException.class, () -> resource.getProducts(null, null, null,
+            "invalid_type", Inclusion.INCLUDE.name()));
+    }
+
+    @Test
+    public void testGetProductsFetchesWithOmitCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.EXCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsFetchesWithOnlyCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedPids = List.of("o1-prod-1", "o1-prod-2", "o2-prod-1", "o2-prod-2",
+            "o3-prod-1", "o3-prod-2");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.EXCLUSIVE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsFetchesWithIncludeCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        // custom = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsErrorsWithInvalidCustomFilter() {
+        ProductResource resource = this.buildResource();
+
+        assertThrows(BadRequestException.class, () -> resource.getProducts(null, null, null,
+            Inclusion.INCLUDE.name(), "invalid_type"));
+    }
+
+    @Test
+    public void testGetProductsFetchesWithMultipleFilters() {
+        this.createDataForEndpointQueryTesting();
+
+        // This test configures a bunch of filters which loosely resolve to the following:
+        // - active global products: not custom, not inactive (active = only, custom = omit)
+        // - in orgs 2 or 3
+        // - matching the given list of product IDs (gp1, gp2, o1p1, o2p1, o3p2)
+        // - matching the given list of product names (gp1, gp2, gp3, o2p1, o2p2)
+        //
+        // These filters should be applied as an intersection, resulting in a singular match on gp1
+
+        List<String> ownerKeys = List.of("owner2", "owner3");
+        List<String> productIds = List.of("g-prod-1", "g-prod-2", "o1-prod-1", "o2-prod-1", "o3-prod-2");
+        List<String> productNames = List.of("global product 1", "global product 2", "global product 3",
+            "owner2 product 1", "owner2 product 2");
+        String activeInclusion = Inclusion.EXCLUSIVE.name();
+        String customInclusion = Inclusion.EXCLUDE.name();
+
+        List<String> expectedPids = List.of("g-prod-1");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(ownerKeys, productIds, productNames, activeInclusion,
+            customInclusion);
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+    public void testGetProductsFetchesPagedResults(int pageSize) {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedPids = List.of("g-prod-1", "g-prod-2", "g-prod-3", "o1-prod-1", "o1-prod-2",
+            "o2-prod-1", "o2-prod-2", "o3-prod-1", "o3-prod-2");
+
+        int expectedPages = pageSize < expectedPids.size() ?
+            (expectedPids.size() / pageSize) + (expectedPids.size() % pageSize != 0 ? 1 : 0) :
+            1;
+
+        ProductResource resource = this.buildResource();
+
+        List<String> found = new ArrayList<>();
+        int pages = 0;
+        while (pages < expectedPages) {
+            // Set the context page request
+            ResteasyContext.popContextData(PageRequest.class);
+            ResteasyContext.pushContext(PageRequest.class, new PageRequest()
+                .setPage(++pages)
+                .setPerPage(pageSize));
+
+            Stream<ProductDTO> output = resource.getProducts(null, null, null, Inclusion.INCLUDE.name(),
+                Inclusion.INCLUDE.name());
+
+            assertNotNull(output);
+            List<String> receivedPids = output.map(ProductDTO::getId)
+                .toList();
+
+            if (receivedPids.isEmpty()) {
+                break;
+            }
+
+            found.addAll(receivedPids);
+        }
+
+        assertEquals(expectedPages, pages);
+        assertThat(found)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testGetProductsFetchesOrderedResults(String field) {
+        this.createDataForEndpointQueryTesting();
+
+        Map<String, Comparator<Product>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Product::getId),
+            "name", Comparator.comparing(Product::getName),
+            "uuid", Comparator.comparing(Product::getUuid));
+
+        List<String> expectedPids = this.productCurator.listAll()
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Product::getId)
+            .toList();
+
+        ResteasyContext.pushContext(PageRequest.class, new PageRequest().setSortBy(field));
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null, Inclusion.INCLUDE.name(),
+            Inclusion.INCLUDE.name());
+
+        // Note that this output needs to be ordered according to our expected ordering!
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyElementsOf(expectedPids);
+    }
+
+    @Test
+    public void testGetProductsErrorsWithInvalidOrderingRequest() {
+        this.createDataForEndpointQueryTesting();
+
+        ResteasyContext.pushContext(PageRequest.class, new PageRequest().setSortBy("invalid_field_name"));
+
+        ProductResource resource = this.buildResource();
+        assertThrows(BadRequestException.class, () -> resource.getProducts(null, null, null, null, null));
+    }
+
+    // These tests verify the definition of "active" is properly implemented, ensuring "active" is defined
+    // as a product which is attached to a pool which has started and has not expired, or attached to
+    // another active product (recursively).
+    //
+    // This definition is recursive in nature, so the effect is that it should consider any product that
+    // is a descendant of a product attached to a non-future pool that hasn't yet expired.
+
+    @Test
+    public void testGetActiveProductsOnlyConsidersActivePools() {
+        // - "active" only considers pools which have started but not expired (start time < now() < end time)
+        Owner owner = this.createOwner("test_org");
+
+        Product prod1 = this.createProduct("prod1");
+        Product prod2 = this.createProduct("prod2");
+        Product prod3 = this.createProduct("prod3");
+
+        Function<Integer, Date> days = (offset) -> TestUtil.createDateOffset(0, 0, offset);
+
+        // Create three pools: expired, current (active), future
+        Pool pool1 = this.createPool(owner, prod1, 1L, days.apply(-3), days.apply(-1));
+        Pool pool2 = this.createPool(owner, prod2, 1L, days.apply(-1), days.apply(1));
+        Pool pool3 = this.createPool(owner, prod3, 1L, days.apply(1), days.apply(3));
+
+        // Active = exclusive should only find the active pool; future and expired pools should be omitted
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null, Inclusion.EXCLUSIVE.name(),
+            Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .singleElement()
+            .isEqualTo(prod2.getId());
+    }
+
+    @Test
+    public void testGetActiveProductsAlsoConsidersDescendantsOfActivePoolProducts() {
+        // - "active" includes descendants of products attached to a pool
+        Owner owner = this.createOwner("test_org");
+
+        List<Product> products = new ArrayList<>();
+        for (int i = 0; i < 20; ++i) {
+            Product product = new Product()
+                .setId("p" + i)
+                .setName("product " + i);
+
+            products.add(product);
+        }
+
+        /*
+        pool -> prod - p0
+                    derived - p1
+                        provided - p2
+                        provided - p3
+                            provided - p4
+                    provided - p5
+                    provided - p6
+
+        pool -> prod - p7
+                    derived - p8*
+                    provided - p9
+
+        pool -> prod - p8*
+                    provided - p10
+                        provided - p11
+                    provided - p12
+                        provided - p13
+
+                prod - p14
+                    derived - p15
+                        provided - p16
+
+                prod - p17
+                    provided - p18
+
+        pool -> prod - p19
+                prod - p20
+        */
+
+        products.get(0).setDerivedProduct(products.get(1));
+        products.get(0).addProvidedProduct(products.get(5));
+        products.get(0).addProvidedProduct(products.get(6));
+
+        products.get(1).addProvidedProduct(products.get(2));
+        products.get(1).addProvidedProduct(products.get(3));
+
+        products.get(3).addProvidedProduct(products.get(4));
+
+        products.get(7).setDerivedProduct(products.get(8));
+        products.get(7).addProvidedProduct(products.get(9));
+
+        products.get(8).addProvidedProduct(products.get(10));
+        products.get(8).addProvidedProduct(products.get(12));
+
+        products.get(10).addProvidedProduct(products.get(11));
+
+        products.get(12).addProvidedProduct(products.get(13));
+
+        products.get(14).setDerivedProduct(products.get(15));
+
+        products.get(15).setDerivedProduct(products.get(16));
+
+        products.get(17).setDerivedProduct(products.get(18));
+
+        // persist the products in reverse order so we don't hit any hibernate errors
+        for (int i = products.size() - 1; i >= 0; --i) {
+            this.productCurator.create(products.get(i));
+        }
+
+        Pool pool1 = this.createPool(owner, products.get(0));
+        Pool pool2 = this.createPool(owner, products.get(7));
+        Pool pool3 = this.createPool(owner, products.get(8));
+        Pool pool4 = this.createPool(owner, products.get(19));
+
+        List<String> expectedPids = List.of("p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9",
+            "p10", "p11", "p12", "p13", "p19");
+
+        ProductResource resource = this.buildResource();
+        Stream<ProductDTO> output = resource.getProducts(null, null, null, Inclusion.EXCLUSIVE.name(),
+            Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ProductDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedPids);
+    }
+
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
     </encoder>
   </appender>
   <logger name="org.candlepin.util.filters.DumpFilter" level="INFO"/>
-  <logger name="org.candlepin" level="DEBUG"/>
+  <logger name="org.candlepin" level="TRACE"/>
   <logger name="org.hibernate.tool.hbm2ddl" level="WARN"/>
   <logger name="org.hibernate.id.UUIDHexGenerator" level="ERROR"/>
   <logger name="liquibase" level="ERROR"/>


### PR DESCRIPTION
- Added the "name", "active", and "custom" filters to the query parameters of the GET /owners/{key}/products endpoint
- Added the "owner", "name", "active", and "custom" filters to the query parameters of the GET /products endpoint
- Removed the now-redundant "omit_globals" query parameter from both GET /owners/{key}/products and GET /products endpoints
- Reworked the GET /products and GET /owner/{key}/products endpoints to support filtering on product IDs, product names, and the "active" and "custom" states
- Added a new query builder object for building dynamic product queries