### PR TITLE
[M] CANDLEPIN-913: Updated content endpoints to support improved querying

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -2881,10 +2881,107 @@ paths:
         isContainer: true
       security: []
       parameters:
-        - $ref: "#/components/parameters/paging_page"
-        - $ref: "#/components/parameters/paging_per_page"
-        - $ref: "#/components/parameters/paging_order"
-        - $ref: "#/components/parameters/paging_sort_by"
+        - name: owner
+          in: query
+          description: |
+            The key of an owner to use to limit the content search. If defined, the list of contents returned
+            by this endpoint will only include those available to the given owner. May be specified multiple
+            times to filter by multiple owners. If multiple owners are provided, contents available to
+            any of the provided owners will be returned.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: content
+          in: query
+          description: |
+            The ID of a content to fetch. If defined, the list of contents returned by this method
+            will only include those matching the given ID. May be specified multiple times to filter
+            on multiple content IDs.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: label
+          in: query
+          description: |
+            The labels of content to fetch. If defined, the list of content returned by this endpoint
+            will only include those matching the given labels (case-insensitive). May be specified multiple
+            times to filter on multiple labels. If multiple labels are provided, any content matching any
+            of the provided labels will be returned.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: active
+          in: query
+          description: |
+            A value indicating how 'active' content should be considered when fetching content, where
+            'active' is defined as a content that is currently in use by a subscription with a start time
+            in the past and that has not yet expired, or in use by a product which itself is considered
+            'active.' Must be one of 'include', 'exclude', or 'exclusive' indicating that active content
+            should be included along with inactive content, excluded (omitted) from the results, or
+            exclusively selected as the only content to return.
+            Defaults to 'exclusive'.
+          required: false
+          schema:
+            type: string
+            enum:
+              - include
+              - exclude
+              - exclusive
+            default: exclusive
+            example:
+              include:
+                value: include
+                description: |
+                  indicates the query should include matching active content, along with any inactive
+                  content
+              exclude:
+                value: exclude
+                description: |
+                  indicates the query should exclude, or omit, active content, returning only matching
+                  inactive content
+              exclusive:
+                value: exclusive
+                description: |
+                  indicates the query should only include matching active content, excluding any inactive
+                  content
+        - name: custom
+          in: query
+          description: |
+            A value indicating how custom content are considered when fetching content, where 'custom'
+            is defined as content that did not originate from a refresh operation nor manifest import.
+            Must be one of 'include', 'exclude', or 'exclusive' indicating that custom content should
+            be passively included, excluded or omitted from the output, or exclusively selected
+            as the only content to return.
+          required: false
+          schema:
+            type: string
+            enum:
+              - include
+              - exclude
+              - exclusive
+            default: include
+            example:
+              include:
+                value: include
+                description: |
+                  indicates the query should include matching custom content, along with any matching
+                  globally defined content
+              exclude:
+                value: exclude
+                description: |
+                  indicates the query should exclude, or omit, custom content, returning only matching
+                  globally defined content
+              exclusive:
+                value: exclusive
+                description: |
+                  indicates the query should only include matching custom content, excluding any globally
+                  defined content
       responses:
         200:
           description: Content successfully listed
@@ -4769,15 +4866,84 @@ paths:
             type: array
             items:
               type: string
-        - name: omit_global
+        - name: label
           in: query
           description: |
-            whether or not to limit the lookup to only contents defined within the organization's
-            namespace, excluding any globally defined contents
+            The labels of content to fetch. If defined, the list of content returned by this endpoint
+            will only include those matching the given labels (case-insensitive). May be specified multiple
+            times to filter on multiple labels. If multiple labels are provided, any content matching any
+            of the provided labels will be returned.
           required: false
           schema:
-            type: boolean
-            default: false
+            type: array
+            items:
+              type: string
+        - name: active
+          in: query
+          description: |
+            A value indicating how 'active' content should be considered when fetching content, where
+            'active' is defined as a content that is currently in use by a subscription with a start time
+            in the past and that has not yet expired, or in use by a product which itself is considered
+            'active.' Must be one of 'include', 'exclude', or 'exclusive' indicating that active content
+            should be included along with inactive content, excluded (omitted) from the results, or
+            exclusively selected as the only content to return.
+            Defaults to 'exclusive'.
+          required: false
+          schema:
+            type: string
+            enum:
+              - include
+              - exclude
+              - exclusive
+            default: exclusive
+            example:
+              include:
+                value: include
+                description: |
+                  indicates the query should include matching active content, along with any inactive
+                  content
+              exclude:
+                value: exclude
+                description: |
+                  indicates the query should exclude, or omit, active content, returning only matching
+                  inactive content
+              exclusive:
+                value: exclusive
+                description: |
+                  indicates the query should only include matching active content, excluding any inactive
+                  content
+        - name: custom
+          in: query
+          description: |
+            A value indicating how custom content are considered when fetching content, where 'custom'
+            is defined as content that did not originate from a refresh operation nor manifest import.
+            Must be one of 'include', 'exclude', or 'exclusive' indicating that custom content should
+            be passively included, excluded or omitted from the output, or exclusively selected
+            as the only content to return.
+          required: false
+          schema:
+            type: string
+            enum:
+              - include
+              - exclude
+              - exclusive
+            default: include
+            example:
+              include:
+                value: include
+                description: |
+                  indicates the query should include matching custom content, along with any matching
+                  globally defined content
+              exclude:
+                value: exclude
+                description: |
+                  indicates the query should exclude, or omit, custom content, returning only matching
+                  globally defined content
+              exclusive:
+                value: exclusive
+                description: |
+                  indicates the query should only include matching custom content, excluding any globally
+                  defined content
       responses:
         200:
           description: Content successfully listed

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Contents.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Contents.java
@@ -15,6 +15,7 @@
 package org.candlepin.spec.bootstrap.data.builder;
 
 import org.candlepin.dto.api.client.v1.ContentDTO;
+import org.candlepin.dto.api.client.v1.ProductContentDTO;
 import org.candlepin.spec.bootstrap.data.util.StringUtil;
 
 import java.util.Collection;
@@ -107,5 +108,23 @@ public final class Contents {
         }
 
         return content.stream().collect(Collectors.toMap(ContentDTO::getId, Function.identity()));
+    }
+
+    /**
+     * Wraps the given content in a product content DTO, for attaching to a product
+     *
+     * @param content
+     *  the content to wrap
+     *
+     * @param enabled
+     *  the initial state of the "enabled" flag in the generated wrapper
+     *
+     * @return
+     *  a new product content DTO wrapping the given content instance
+     */
+    public static ProductContentDTO toProductContent(ContentDTO content, boolean enabled) {
+        return new ProductContentDTO()
+            .content(content)
+            .enabled(enabled);
     }
 }

--- a/spec-tests/src/test/java/org/candlepin/spec/ContentResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ContentResourceSpecTest.java
@@ -14,48 +14,82 @@
  */
 package org.candlepin.spec;
 
-import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.candlepin.spec.bootstrap.assertions.JobStatusAssert.assertThatJob;
+import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertBadRequest;
+import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertNotFound;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import org.candlepin.dto.api.client.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.client.v1.AttributeDTO;
 import org.candlepin.dto.api.client.v1.ConsumerDTO;
 import org.candlepin.dto.api.client.v1.ConsumerTypeDTO;
 import org.candlepin.dto.api.client.v1.ContentDTO;
+import org.candlepin.dto.api.client.v1.NestedOwnerDTO;
 import org.candlepin.dto.api.client.v1.OwnerDTO;
 import org.candlepin.dto.api.client.v1.PoolDTO;
+import org.candlepin.dto.api.client.v1.ProductContentDTO;
 import org.candlepin.dto.api.client.v1.ProductDTO;
+import org.candlepin.dto.api.client.v1.SubscriptionDTO;
 import org.candlepin.resource.client.v1.OwnerApi;
 import org.candlepin.resource.client.v1.OwnerContentApi;
 import org.candlepin.resource.client.v1.OwnerProductApi;
 import org.candlepin.resource.client.v1.ProductsApi;
+import org.candlepin.spec.bootstrap.assertions.CandlepinMode;
 import org.candlepin.spec.bootstrap.client.ApiClient;
 import org.candlepin.spec.bootstrap.client.ApiClients;
 import org.candlepin.spec.bootstrap.client.SpecTest;
 import org.candlepin.spec.bootstrap.client.api.ConsumerClient;
+import org.candlepin.spec.bootstrap.client.request.Request;
+import org.candlepin.spec.bootstrap.client.request.Response;
 import org.candlepin.spec.bootstrap.data.builder.Consumers;
 import org.candlepin.spec.bootstrap.data.builder.Contents;
+import org.candlepin.spec.bootstrap.data.builder.ExportGenerator;
 import org.candlepin.spec.bootstrap.data.builder.Owners;
 import org.candlepin.spec.bootstrap.data.builder.Pools;
 import org.candlepin.spec.bootstrap.data.builder.ProductAttributes;
 import org.candlepin.spec.bootstrap.data.builder.Products;
+import org.candlepin.spec.bootstrap.data.builder.Subscriptions;
 import org.candlepin.spec.bootstrap.data.util.StringUtil;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.IntStream;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @SpecTest
 public class ContentResourceSpecTest {
@@ -230,44 +264,6 @@ public class ContentResourceSpecTest {
         assertEquals("ppc64", actualArch);
     }
 
-    @Nested
-    @Isolated
-    @Execution(ExecutionMode.SAME_THREAD)
-    class GetPages {
-        @Test
-        public void shouldListContentPagedAndSorted() {
-            ApiClient adminClient = ApiClients.admin();
-
-            OwnerDTO owner = adminClient.owners().createOwner(Owners.random());
-            String ownerKey = owner.getKey();
-
-            // Ensure that there is data for this test.
-            // Most likely, there will already be data left from other test runs that will show up
-            IntStream.range(0, 5).forEach(entry -> {
-                adminClient.ownerContent().createContent(ownerKey, Contents.random());
-                // for timestamp separation
-                try {
-                    sleep(1000);
-                }
-                catch (InterruptedException ie) {
-                    throw new RuntimeException("Unable to sleep as expected");
-                }
-            });
-
-            List<ContentDTO> contents = adminClient.content().getContents(1, 4, "asc", "created");
-            assertThat(contents)
-                .isNotNull()
-                .hasSize(4);
-            assertThat(contents.get(0).getCreated().compareTo(contents.get(1).getCreated()))
-                .isLessThanOrEqualTo(0);
-            assertThat(contents.get(1).getCreated().compareTo(contents.get(2).getCreated()))
-                .isLessThanOrEqualTo(0);
-            assertThat(contents.get(2).getCreated().compareTo(contents.get(3).getCreated()))
-                .isLessThanOrEqualTo(0);
-
-        }
-    }
-
     private ContentDTO createContent(String ownerKey, String contentUrl, String arches) {
         ContentDTO newContent = Contents.random();
         newContent.setContentUrl(contentUrl);
@@ -291,4 +287,937 @@ public class ContentResourceSpecTest {
         pool.setProductName(product.getName());
         return ownerApi.createPool(ownerKey, pool);
     }
+
+    @Nested
+    @Isolated
+    @TestInstance(Lifecycle.PER_CLASS)
+    @Execution(ExecutionMode.SAME_THREAD)
+    public class ContentQueryTests {
+
+        private static final String QUERY_PATH = "/content";
+
+        private static final String INCLUSION_INCLUDE = "include";
+        private static final String INCLUSION_EXCLUDE = "exclude";
+        private static final String INCLUSION_EXCLUSIVE = "exclusive";
+
+        private static record ProductInfo(ProductDTO dto, OwnerDTO owner, Set<String> activeOwners) {
+
+            public String id() {
+                return this.dto() != null ? this.dto().getId() : null;
+            }
+
+            public boolean active() {
+                return !this.activeOwners().isEmpty();
+            }
+
+            public boolean custom() {
+                return this.owner() != null;
+            }
+
+            public Stream<ContentDTO> content() {
+                return Optional.ofNullable(this.dto())
+                  .map(ProductDTO::getProductContent)
+                  .map(Collection::stream)
+                  .orElse(Stream.empty())
+                  .map(ProductContentDTO::getContent);
+            }
+        };
+
+        private ApiClient adminClient;
+
+        private List<OwnerDTO> owners;
+        private Map<String, ProductInfo> productMap;
+
+        /**
+         * Verifies either the manifest generator extension or the hosted test extension is present as
+         * required by the current operating mode.
+         */
+        private void checkRequiredExtensions() {
+            if (CandlepinMode.isStandalone()) {
+                assumeTrue(CandlepinMode::hasManifestGenTestExtension);
+            }
+            else {
+                assumeTrue(CandlepinMode::hasHostedTestExtension);
+            }
+        }
+
+        private OwnerDTO createOwner(String keyPrefix) {
+            OwnerDTO owner = Owners.random()
+                .key(StringUtil.random(keyPrefix + "-"));
+
+            return this.adminClient.owners()
+                .createOwner(owner);
+        }
+
+        private SubscriptionDTO createSubscription(OwnerDTO owner, ProductDTO product, boolean active) {
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            // Impl note:
+            // We create active subscriptions in the future to work around a limitation on manifests
+            // disallowing and ignoring expired pools
+            return Subscriptions.random(owner, product)
+                .startDate(active ? now.minus(7, ChronoUnit.DAYS) : now.plus(7, ChronoUnit.DAYS))
+                .endDate(now.plus(30, ChronoUnit.DAYS));
+        }
+
+        private PoolDTO createPool(OwnerDTO owner, ProductDTO product, boolean active) {
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            PoolDTO pool = Pools.random(product)
+                .startDate(now.minus(7, ChronoUnit.DAYS))
+                .endDate(active ? now.plus(7, ChronoUnit.DAYS) : now.minus(3, ChronoUnit.DAYS));
+
+            return this.adminClient.owners()
+                .createPool(owner.getKey(), pool);
+        }
+
+        private void mapProductInfo(ProductDTO product, OwnerDTO owner, OwnerDTO activeOwner) {
+            Set<String> activeOwnerKeys = new HashSet<>();
+            if (activeOwner != null) {
+                activeOwnerKeys.add(activeOwner.getKey());
+            }
+
+            ProductInfo existing = this.productMap.get(product.getId());
+            if (existing != null) {
+                activeOwnerKeys.addAll(existing.activeOwners());
+            }
+
+            ProductInfo pinfo = new ProductInfo(product, owner, activeOwnerKeys);
+            this.productMap.put(product.getId(), pinfo);
+
+        }
+
+        private void commitGlobalSubscriptions(Collection<SubscriptionDTO> subscriptions) throws Exception {
+            Map<String, List<SubscriptionDTO>> subscriptionMap = new HashMap<>();
+
+            for (SubscriptionDTO subscription : subscriptions) {
+                NestedOwnerDTO owner = subscription.getOwner();
+
+                subscriptionMap.computeIfAbsent(owner.getKey(), key -> new ArrayList<>())
+                    .add(subscription);
+            }
+
+            for (Map.Entry<String, List<SubscriptionDTO>> entry : subscriptionMap.entrySet()) {
+                String ownerKey = entry.getKey();
+                List<SubscriptionDTO> ownerSubs = entry.getValue();
+
+                AsyncJobStatusDTO job;
+                if (CandlepinMode.isStandalone()) {
+                    File manifest = new ExportGenerator()
+                        .addSubscriptions(ownerSubs)
+                        .export();
+
+                    job = this.adminClient.owners()
+                        .importManifestAsync(ownerKey, List.of(), manifest);
+                }
+                else {
+                    ownerSubs.forEach(subscription -> this.adminClient.hosted()
+                        .createSubscription(subscription, true));
+
+                    job = this.adminClient.owners()
+                        .refreshPools(ownerKey, false);
+                }
+
+                assertThatJob(job)
+                    .isNotNull()
+                    .terminates(this.adminClient)
+                    .isFinished();
+            }
+        }
+
+        @BeforeAll
+        public void setup() throws Exception {
+            // Ensure we have our required test extensions or we'll be very broken...
+            this.checkRequiredExtensions();
+
+            this.adminClient = ApiClients.admin();
+
+            this.owners = List.of(
+                this.createOwner("owner1"),
+                this.createOwner("owner2"),
+                this.createOwner("owner3"));
+
+            this.productMap = new HashMap<>();
+
+            List<SubscriptionDTO> subscriptions = new ArrayList<>();
+
+            // Dummy org we use for creating a bunch of future pools for our global products. We'll also
+            // create per-org subscriptions for these products later. Also note that these will never be
+            // fully resolved.
+            OwnerDTO globalOwner = this.createOwner("global");
+
+            List<ProductDTO> globalProducts = new ArrayList<>();
+            for (int i = 1; i <= 3; ++i) {
+                List<ContentDTO> contents = new ArrayList<>();
+
+                for (int c = 0; c < 2; ++c) {
+                    ContentDTO content = Contents.random()
+                        .id(String.format("g-content-%d%s", i, (char) ('a' + c)))
+                        .name(String.format("global_content_%d%s", i, (char) ('a' + c)))
+                        .label(String.format("global content %d%s", i, (char) ('a' + c)));
+
+                    contents.add(content);
+                }
+
+                ProductDTO gprod = new ProductDTO()
+                    .id("g-prod-" + i)
+                    .name("global product " + i)
+                    .addProductContentItem(Contents.toProductContent(contents.get(0), true))
+                    .addProductContentItem(Contents.toProductContent(contents.get(1), false));
+
+                subscriptions.add(this.createSubscription(globalOwner, gprod, false));
+                globalProducts.add(gprod);
+                this.mapProductInfo(gprod, null, null);
+            }
+
+            for (int oidx = 1; oidx <= owners.size(); ++oidx) {
+                OwnerDTO owner = owners.get(oidx - 1);
+
+                List<ProductDTO> ownerProducts = new ArrayList<>();
+                for (int i = 1; i <= 2; ++i) {
+                    List<ContentDTO> contents = new ArrayList<>();
+
+                    for (int c = 0; c < 2; ++c) {
+                        ContentDTO content = Contents.random()
+                            .id(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
+                            .name(String.format("%s_content_%d%s", owner.getKey(), i, (char) ('a' + c)))
+                            .label(String.format("%s content %d%s", owner.getKey(), i, (char) ('a' + c)));
+
+                        contents.add(this.adminClient.ownerContent()
+                            .createContent(owner.getKey(), content));
+                    }
+
+                    ProductDTO cprod = new ProductDTO()
+                        .id(String.format("o%d-prod-%d", oidx, i))
+                        .name(String.format("%s product %d", owner.getKey(), i))
+                        .addProductContentItem(Contents.toProductContent(contents.get(0), true))
+                        .addProductContentItem(Contents.toProductContent(contents.get(1), false));
+
+                    cprod = this.adminClient.ownerProducts()
+                        .createProduct(owner.getKey(), cprod);
+
+                    ownerProducts.add(cprod);
+                    this.mapProductInfo(cprod, owner, null);
+                }
+
+                // Create an active and inactive global subscription for this org
+                subscriptions.add(this.createSubscription(owner, globalProducts.get(0), true));
+                subscriptions.add(this.createSubscription(owner, globalProducts.get(1), false));
+                this.mapProductInfo(globalProducts.get(0), null, owner);
+
+                // Create an active and inactive custom subscription
+                this.createPool(owner, ownerProducts.get(0), true);
+                this.createPool(owner, ownerProducts.get(1), false);
+                this.mapProductInfo(ownerProducts.get(0), owner, owner);
+            }
+
+            this.commitGlobalSubscriptions(subscriptions);
+        }
+
+        // Impl note:
+        // Since we cannot depend on the global state being prestine from run to run (or even test to
+        // test), we cannot use exact matching on our output as extraneous products from previous test
+        // runs or otherwise pre-existing data may show up in the result set. Instead, these tests will
+        // verify our expected products are present, and unexpected products from the test data are not.
+
+        private List<String> getUnexpectedIds(List<String> expectedIds) {
+            return this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .filter(Predicate.not(expectedIds::contains))
+                .toList();
+        }
+
+        @Test
+        public void shouldAllowQueryingWithoutAnyFilters() {
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids);
+        }
+
+        @Test
+        public void shouldDefaultToActiveExclusiveCustomInclusive() {
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::active)
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, null, null, null, null);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldAllowFilteringOnOwnerKeys() {
+            List<String> ownerKeys = List.of(
+                this.owners.get(0).getKey(),
+                this.owners.get(1).getKey());
+
+            Predicate<ProductInfo> ownerMatchPredicate = pinfo -> pinfo.owner() == null ||
+                ownerKeys.contains(pinfo.owner().getKey());
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(ownerMatchPredicate)
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(ownerKeys, null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "invalid_owner" })
+        @NullAndEmptySource
+        public void shouldFailWithInvalidOwners(String ownerKey) {
+            List<String> ownerKeys = Arrays.asList(ownerKey);
+
+            assertNotFound(() -> this.adminClient.content().getContents(ownerKeys, null, null, null, null));
+        }
+
+        @Test
+        public void shouldAllowFilteringOnIDs() {
+            // Randomly seeded for consistency; seed itself chosen randomly
+            Random rand = new Random(99955);
+
+            List<String> cids = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .sorted()
+                .filter(elem -> rand.nextBoolean())
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, cids, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(cids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(cids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "invalid_id" })
+        @NullAndEmptySource
+        public void shouldAllowFilteringOnInvalidIds(String cid) {
+            // This test verifies that invalid IDs are "allowed", but they won't match on anything
+
+            ContentDTO content = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .findAny()
+                .get();
+
+            List<String> cids = Arrays.asList(content.getId(), cid);
+            List<String> expectedCids = List.of(content.getId());
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, cids, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldAllowFilteringOnLabel() {
+            Random rand = new Random(86243);
+
+            List<ContentDTO> contents = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .sorted(Comparator.comparing(ContentDTO::getId))
+                .filter(elem -> rand.nextBoolean())
+                .toList();
+
+            List<String> labels = contents.stream()
+                .map(ContentDTO::getLabel)
+                .toList();
+
+            List<String> expectedCids = contents.stream()
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, null, labels, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "invalid_label" })
+        @NullAndEmptySource
+        public void shouldAllowFilteringOnInvalidLabels(String label) {
+            // This test verifies that invalid IDs are "allowed", but they won't match on anything
+
+            ContentDTO content = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .findAny()
+                .get();
+
+            List<String> labels = Arrays.asList(content.getLabel(), label);
+            List<String> expectedCids = List.of(content.getId());
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, null, labels, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveIncluded() {
+            // This is effectively the same as no filter -- we expect everything back
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids);
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveExcluded() {
+            List<String> expecteCids = this.productMap.values()
+                .stream()
+                .filter(pinfo -> !pinfo.active())
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, null, null, INCLUSION_EXCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expecteCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expecteCids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveExclusive() {
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::active)
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, null, null, INCLUSION_EXCLUSIVE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldErrorWithInvalidActiveInclusion() {
+            assertBadRequest(() -> this.adminClient.content()
+                .getContents(null, null, null, "invalid_type", INCLUSION_INCLUDE));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomIncluded() {
+            // This is effectively the same as no filter -- we expect everything back
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids);
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomExcluded() {
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(pinfo -> !pinfo.custom())
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomExclusive() {
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::custom)
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(null, null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldErrorWithInvalidCustomInclusion() {
+            assertBadRequest(() -> this.adminClient.content()
+                .getContents(null, null, null, INCLUSION_INCLUDE, "invalid_type"));
+        }
+
+        @Test
+        public void shouldAllowQueryingWithMultipleFilters() {
+            Random rand = new Random(24043);
+
+            // Hand pick a content to ensure that we have *something* that comes out of the filter, should
+            // our random selection process not have any intersection.
+            ContentDTO selectedContent = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::active)
+                .filter(ProductInfo::custom)
+                .flatMap(ProductInfo::content)
+                .findAny()
+                .get();
+
+            List<String> ownerKeys = this.owners.stream()
+                .filter(elem -> rand.nextBoolean())
+                .map(OwnerDTO::getKey)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            List<String> cids = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .sorted(Comparator.comparing(ContentDTO::getId))
+                .filter(elem -> rand.nextBoolean())
+                .map(ContentDTO::getId)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            List<String> labels = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .sorted(Comparator.comparing(ContentDTO::getId))
+                .filter(elem -> rand.nextBoolean())
+                .map(ContentDTO::getLabel)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            cids.add(selectedContent.getId());
+            labels.add(selectedContent.getLabel());
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::active)
+                .filter(ProductInfo::custom)
+                .filter(pinfo -> pinfo.activeOwners().stream().anyMatch(ownerKeys::contains))
+                .flatMap(ProductInfo::content)
+                .filter(content -> cids.contains(content.getId()))
+                .filter(content -> labels.contains(content.getLabel()))
+                .map(ContentDTO::getId)
+                .toList();
+
+            assertThat(expectedCids)
+                .isNotEmpty();
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(ownerKeys, cids, labels, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+        public void shouldAllowQueryingInPages(int pageSize) {
+            List<String> ownerKeys = this.owners.stream()
+                .map(OwnerDTO::getKey)
+                .toList();
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::custom)
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<String> received = new ArrayList<>();
+
+            int page = 0;
+            while (true) {
+                Response response = Request.from(this.adminClient)
+                    .setPath(QUERY_PATH)
+                    .addQueryParam("owner", ownerKeys)
+                    .addQueryParam("page", String.valueOf(++page))
+                    .addQueryParam("per_page", String.valueOf(pageSize))
+                    .addQueryParam("active", "include")
+                    .addQueryParam("custom", "exclusive")
+                    .execute();
+
+                assertEquals(200, response.getCode());
+
+                List<ProductDTO> output = response.deserialize(new TypeReference<List<ProductDTO>>() {});
+                assertNotNull(output);
+
+                if (output.isEmpty()) {
+                    break;
+                }
+
+                output.stream()
+                    .map(ProductDTO::getId)
+                    .sequential()
+                    .forEach(received::add);
+            }
+
+            assertThat(received)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, -1, -100 })
+        public void shouldFailWithInvalidPage(int page) {
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("page", String.valueOf(page))
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, -1, -100 })
+        public void shouldFailWithInvalidPageSize(int pageSize) {
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("per_page", String.valueOf(pageSize))
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "id", "name", "uuid" })
+        public void shouldAllowQueryingWithAscendingOrderedOutput(String field) {
+            List<String> ownerKeys = this.owners.stream()
+                .map(OwnerDTO::getKey)
+                .toList();
+
+            Map<String, Comparator<ContentDTO>> comparatorMap = Map.of(
+                "id", Comparator.comparing(ContentDTO::getId),
+                "name", Comparator.comparing(ContentDTO::getName),
+                "uuid", Comparator.comparing(ContentDTO::getUuid));
+
+            List<ContentDTO> content = this.adminClient.content()
+                .getContents(ownerKeys, null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
+
+            List<String> expectedCids = content.stream()
+                .sorted(comparatorMap.get(field))
+                .map(ContentDTO::getId)
+                .toList();
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("owner", ownerKeys)
+                .addQueryParam("sort_by", field)
+                .addQueryParam("order", "asc")
+                .addQueryParam("active", INCLUSION_INCLUDE)
+                .addQueryParam("custom", INCLUSION_EXCLUSIVE)
+                .execute();
+
+            assertEquals(200, response.getCode());
+
+            List<ContentDTO> output = response.deserialize(new TypeReference<List<ContentDTO>>() {});
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsExactlyElementsOf(expectedCids); // this must be an ordered check
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "id", "name", "uuid" })
+        public void shouldAllowQueryingWithDescendingOrderedOutput(String field) {
+            List<String> ownerKeys = this.owners.stream()
+                .map(OwnerDTO::getKey)
+                .toList();
+
+            Map<String, Comparator<ContentDTO>> comparatorMap = Map.of(
+                "id", Comparator.comparing(ContentDTO::getId),
+                "name", Comparator.comparing(ContentDTO::getName),
+                "uuid", Comparator.comparing(ContentDTO::getUuid));
+
+            List<ContentDTO> contents = this.adminClient.content()
+                .getContents(ownerKeys, null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
+
+            List<String> expectedCids = contents.stream()
+                .sorted(comparatorMap.get(field).reversed())
+                .map(ContentDTO::getId)
+                .toList();
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("owner", ownerKeys)
+                .addQueryParam("sort_by", field)
+                .addQueryParam("order", "desc")
+                .addQueryParam("active", INCLUSION_INCLUDE)
+                .addQueryParam("custom", INCLUSION_EXCLUSIVE)
+                .execute();
+
+            assertEquals(200, response.getCode());
+
+            List<ContentDTO> output = response.deserialize(new TypeReference<List<ContentDTO>>() {});
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsExactlyElementsOf(expectedCids); // this must be an ordered check
+        }
+
+        @Test
+        public void shouldFailWithInvalidOrderField() {
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("sort_by", "invalid field")
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @Test
+        public void shouldFailWithInvalidOrderDirection() {
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .addQueryParam("order", "invalid order")
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        // These tests verify the definition of "active" is properly implemented, ensuring "active" is
+        // defined as a product which is attached to a pool which has started and has not expired, or
+        // attached to another active product (recursively).
+        //
+        // This definition is recursive in nature, so the effect is that it should consider any product
+        // that is a descendant of a product attached to a non-future pool that hasn't yet expired.
+
+        @Test
+        public void shouldOnlySelectActiveProductsFromActivePools() {
+            // "active" only considers pools which have started but have not yet expired -- that is:
+            // (start time < now() < end time)
+            OwnerDTO owner = this.createOwner("test_org");
+
+            List<ProductDTO> products = new ArrayList<>();
+            for (int i = 1; i <= 3; ++i) {
+                ContentDTO contentA = Contents.random().id(String.format("p%d-ca", i));
+                ContentDTO contentB = Contents.random().id(String.format("p%d-cb", i));
+
+                contentA = this.adminClient.ownerContent().createContent(owner.getKey(), contentA);
+                contentB = this.adminClient.ownerContent().createContent(owner.getKey(), contentB);
+
+                ProductDTO product = Products.random()
+                    .id("prod-" + i)
+                    .name("product " + i)
+                    .addProductContentItem(Contents.toProductContent(contentA, true))
+                    .addProductContentItem(Contents.toProductContent(contentB, false));
+
+                this.adminClient.ownerProducts().createProduct(owner.getKey(), product);
+                products.add(product);
+            }
+
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            // Create three pools: expired, current (active), future
+            PoolDTO pool1 = Pools.random(products.get(0))
+                .startDate(now.minus(7, ChronoUnit.DAYS))
+                .endDate(now.minus(3, ChronoUnit.DAYS));
+            PoolDTO pool2 = Pools.random(products.get(1))
+                .startDate(now.minus(3, ChronoUnit.DAYS))
+                .endDate(now.plus(3, ChronoUnit.DAYS));
+            PoolDTO pool3 = Pools.random(products.get(2))
+                .startDate(now.plus(3, ChronoUnit.DAYS))
+                .endDate(now.plus(7, ChronoUnit.DAYS));
+
+            this.adminClient.owners().createPool(owner.getKey(), pool1);
+            this.adminClient.owners().createPool(owner.getKey(), pool2);
+            this.adminClient.owners().createPool(owner.getKey(), pool3);
+
+            // Active = exclusive should only find the active pool; future and expired pools should be omitted
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(List.of(owner.getKey()), null, null, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsExactlyInAnyOrder("p2-ca", "p2-cb");
+        }
+
+        @Test
+        public void shouldAlsoIncludeDescendantProductsOfActiveProducts() {
+            // "active" includes descendants of products attached to an active pool
+            OwnerDTO owner = this.createOwner("test_org");
+
+            List<ProductDTO> products = new ArrayList<>();
+            for (int i = 0; i < 20; ++i) {
+                ContentDTO contentA = Contents.random().id(String.format("p%d-ca", i));
+                ContentDTO contentB = Contents.random().id(String.format("p%d-cb", i));
+
+                contentA = this.adminClient.ownerContent().createContent(owner.getKey(), contentA);
+                contentB = this.adminClient.ownerContent().createContent(owner.getKey(), contentB);
+
+                ProductDTO product = new ProductDTO()
+                    .id("p" + i)
+                    .name("product " + i)
+                    .addProductContentItem(Contents.toProductContent(contentA, true))
+                    .addProductContentItem(Contents.toProductContent(contentB, false));
+
+                // Impl note: We can't create the products quite yet
+                products.add(product);
+            }
+
+            /*
+            pool -> prod - p0
+                        derived - p1
+                            provided - p2
+                            provided - p3
+                                provided - p4
+                        provided - p5
+                        provided - p6
+
+            pool -> prod - p7
+                        derived - p8*
+                        provided - p9
+
+            pool -> prod - p8*
+                        provided - p10
+                            provided - p11
+                        provided - p12
+                            provided - p13
+
+                    prod - p14
+                        derived - p15
+                            provided - p16
+
+                    prod - p17
+                        provided - p18
+
+            pool -> prod - p19
+                    prod - p20
+            */
+
+            products.get(0).setDerivedProduct(products.get(1));
+            products.get(0).addProvidedProductsItem(products.get(5));
+            products.get(0).addProvidedProductsItem(products.get(6));
+
+            products.get(1).addProvidedProductsItem(products.get(2));
+            products.get(1).addProvidedProductsItem(products.get(3));
+
+            products.get(3).addProvidedProductsItem(products.get(4));
+
+            products.get(7).setDerivedProduct(products.get(8));
+            products.get(7).addProvidedProductsItem(products.get(9));
+
+            products.get(8).addProvidedProductsItem(products.get(10));
+            products.get(8).addProvidedProductsItem(products.get(12));
+
+            products.get(10).addProvidedProductsItem(products.get(11));
+
+            products.get(12).addProvidedProductsItem(products.get(13));
+
+            products.get(14).setDerivedProduct(products.get(15));
+
+            products.get(15).setDerivedProduct(products.get(16));
+
+            products.get(17).setDerivedProduct(products.get(18));
+
+            // persist the products in reverse order so we don't hit any linkage errors
+            for (int i = products.size() - 1; i >= 0; --i) {
+                this.adminClient.ownerProducts().createProduct(owner.getKey(), products.get(i));
+            }
+
+            // create some pools to link to our product tree
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(0)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(7)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(8)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(19)));
+
+            List<String> expectedCids = List.of("p0-ca", "p0-cb", "p1-ca", "p1-cb", "p2-ca", "p2-cb", "p3-ca",
+                "p3-cb", "p4-ca", "p4-cb", "p5-ca", "p5-cb", "p6-ca", "p6-cb", "p7-ca", "p7-cb", "p8-ca",
+                "p8-cb", "p9-ca", "p9-cb", "p10-ca", "p10-cb", "p11-ca", "p11-cb", "p12-ca", "p12-cb",
+                "p13-ca", "p13-cb", "p19-ca", "p19-cb");
+
+            List<ContentDTO> output = this.adminClient.content()
+                .getContents(List.of(owner.getKey()), null, null, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsExactlyInAnyOrderElementsOf(expectedCids);
+        }
+    }
+
 }

--- a/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
@@ -1122,8 +1122,8 @@ public class OwnerProductResourceSpecTest {
 
             List<String> expectedPids = this.productMap.values()
                 .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
                 .filter(ProductInfo::custom)
-                .filter(pinfo -> pinfo.owner().getKey().equals(owner.getKey()))
                 .map(ProductInfo::id)
                 .toList();
 
@@ -1283,7 +1283,7 @@ public class OwnerProductResourceSpecTest {
                 "uuid", Comparator.comparing(ProductDTO::getUuid));
 
             List<ProductDTO> products = this.adminClient.ownerProducts()
-                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
 
             List<String> expectedPids = products.stream()
                 .sorted(comparatorMap.get(field))
@@ -1296,7 +1296,7 @@ public class OwnerProductResourceSpecTest {
                 .addQueryParam("sort_by", field)
                 .addQueryParam("order", "asc")
                 .addQueryParam("active", INCLUSION_INCLUDE)
-                .addQueryParam("custom", INCLUSION_INCLUDE)
+                .addQueryParam("custom", INCLUSION_EXCLUSIVE)
                 .execute();
 
             assertEquals(200, response.getCode());
@@ -1320,7 +1320,7 @@ public class OwnerProductResourceSpecTest {
                 "uuid", Comparator.comparing(ProductDTO::getUuid));
 
             List<ProductDTO> products = this.adminClient.ownerProducts()
-                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+                .getProductsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
 
             List<String> expectedPids = products.stream()
                 .sorted(comparatorMap.get(field).reversed())
@@ -1333,7 +1333,7 @@ public class OwnerProductResourceSpecTest {
                 .addQueryParam("sort_by", field)
                 .addQueryParam("order", "desc")
                 .addQueryParam("active", INCLUSION_INCLUDE)
-                .addQueryParam("custom", INCLUSION_INCLUDE)
+                .addQueryParam("custom", INCLUSION_EXCLUSIVE)
                 .execute();
 
             assertEquals(200, response.getCode());

--- a/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -16,12 +16,14 @@ package org.candlepin.spec.content;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatObject;
+import static org.candlepin.spec.bootstrap.assertions.JobStatusAssert.assertThatJob;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertBadRequest;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertForbidden;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertNotFound;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.candlepin.dto.api.client.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.client.v1.CertificateSerialDTO;
@@ -30,12 +32,14 @@ import org.candlepin.dto.api.client.v1.ContentDTO;
 import org.candlepin.dto.api.client.v1.ContentToPromoteDTO;
 import org.candlepin.dto.api.client.v1.EnvironmentContentDTO;
 import org.candlepin.dto.api.client.v1.EnvironmentDTO;
+import org.candlepin.dto.api.client.v1.NestedOwnerDTO;
 import org.candlepin.dto.api.client.v1.OwnerDTO;
 import org.candlepin.dto.api.client.v1.PoolDTO;
 import org.candlepin.dto.api.client.v1.ProductContentDTO;
 import org.candlepin.dto.api.client.v1.ProductDTO;
 import org.candlepin.dto.api.client.v1.SubscriptionDTO;
 import org.candlepin.dto.api.client.v1.UserDTO;
+import org.candlepin.spec.bootstrap.assertions.CandlepinMode;
 import org.candlepin.spec.bootstrap.assertions.OnlyInHosted;
 import org.candlepin.spec.bootstrap.client.ApiClient;
 import org.candlepin.spec.bootstrap.client.ApiClients;
@@ -45,6 +49,7 @@ import org.candlepin.spec.bootstrap.client.request.Response;
 import org.candlepin.spec.bootstrap.data.builder.Consumers;
 import org.candlepin.spec.bootstrap.data.builder.Contents;
 import org.candlepin.spec.bootstrap.data.builder.Environments;
+import org.candlepin.spec.bootstrap.data.builder.ExportGenerator;
 import org.candlepin.spec.bootstrap.data.builder.Owners;
 import org.candlepin.spec.bootstrap.data.builder.Pools;
 import org.candlepin.spec.bootstrap.data.builder.Products;
@@ -60,22 +65,36 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.File;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 
 
 @SpecTest
@@ -83,11 +102,6 @@ class OwnerContentSpecTest {
 
     private OwnerDTO createOwner(ApiClient client) {
         return client.owners().createOwner(Owners.random());
-    }
-
-    private ContentDTO createContent(ApiClient client, OwnerDTO owner) {
-        return client.ownerContent()
-            .createContent(owner.getKey(), Contents.random());
     }
 
     private ApiClient createOrgAdminClient(ApiClient adminClient, OwnerDTO owner) {
@@ -391,220 +405,6 @@ class OwnerContentSpecTest {
 
         ApiClient consumerClient = this.createConsumerClient(adminClient, owner);
         assertForbidden(() -> consumerClient.ownerContent().getContentById(owner.getKey(), created.getId()));
-    }
-
-    @Test
-    public void shouldListAllContentsInBulkFetch() {
-        ApiClient adminClient = ApiClients.admin();
-
-        OwnerDTO owner = this.createOwner(adminClient);
-        String ownerKey = owner.getKey();
-
-        ContentDTO content1 = adminClient.ownerContent().createContent(ownerKey, Contents.random());
-        ContentDTO content2 = adminClient.ownerContent().createContent(ownerKey, Contents.random());
-        ContentDTO content3 = adminClient.ownerContent().createContent(ownerKey, Contents.random());
-
-        // Note: We must account for other globals that may have been created as well
-        List<ContentDTO> contents = adminClient.ownerContent().getContentsByOwner(ownerKey, List.of(), false);
-        assertThat(contents)
-            .isNotNull()
-            .hasSizeGreaterThanOrEqualTo(3)
-            .contains(content1, content2, content3);
-    }
-
-    @Test
-    public void shouldListsAllSpecifiedContentsInBulkFetch() {
-        ApiClient adminClient = ApiClients.admin();
-
-        OwnerDTO owner = this.createOwner(adminClient);
-        String ownerKey = owner.getKey();
-
-        ContentDTO content1 = adminClient.ownerContent().createContent(ownerKey, Contents.random());
-        ContentDTO content2 = adminClient.ownerContent().createContent(ownerKey, Contents.random());
-        ContentDTO content3 = adminClient.ownerContent().createContent(ownerKey, Contents.random());
-
-        // Pick two contents to use in a bulk get
-        List<ContentDTO> contents = adminClient.ownerContent()
-            .getContentsByOwner(ownerKey, List.of(content1.getId(), content3.getId()), false);
-
-        assertThat(contents)
-            .isNotNull()
-            .hasSize(2)
-            .containsOnly(content1, content3);
-    }
-
-    @Test
-    public void shouldListContentInPages() throws Exception {
-        ApiClient adminClient = ApiClients.admin();
-        OwnerDTO owner = this.createOwner(adminClient);
-
-        // The creation order here is important. By default, Candlepin sorts in descending order of the
-        // entity's creation time, so we need to create them backward to let the default sorting order
-        // let us page through them in ascending order.
-        ContentDTO content3 = this.createContent(adminClient, owner);
-        Thread.sleep(1000);
-        ContentDTO content2 = this.createContent(adminClient, owner);
-        Thread.sleep(1000);
-        ContentDTO content1 = this.createContent(adminClient, owner);
-
-        List<ContentDTO> content = List.of(content1, content2, content3);
-
-        Response response = Request.from(adminClient)
-            .setPath("/owners/{owner_key}/content")
-            .setPathParam("owner_key", owner.getKey())
-            .addQueryParam("page", "1")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("omit_global", "true")
-            .execute();
-
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-
-        List<ContentDTO> c1set = response.deserialize(new TypeReference<List<ContentDTO>>() {});
-
-        // Impl note: we aren't specifying the sort field or ID, so we can't guarantee any
-        // particular object should be here, just that each page should be different,
-        // non-duplicated, and part of our expected output.
-        assertThat(c1set)
-            .isNotNull()
-            .hasSize(1)
-            .isSubsetOf(content);
-
-        response = Request.from(adminClient)
-            .setPath("/owners/{owner_key}/content")
-            .setPathParam("owner_key", owner.getKey())
-            .addQueryParam("page", "2")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("omit_global", "true")
-            .execute();
-
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-
-        List<ContentDTO> c2set = response.deserialize(new TypeReference<List<ContentDTO>>() {});
-        assertThat(c2set)
-            .isNotNull()
-            .hasSize(1)
-            .isSubsetOf(content)
-            .doesNotContainAnyElementsOf(c1set);
-
-        response = Request.from(adminClient)
-            .setPath("/owners/{owner_key}/content")
-            .setPathParam("owner_key", owner.getKey())
-            .addQueryParam("page", "3")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("omit_global", "true")
-            .execute();
-
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-
-        List<ContentDTO> c3set = response.deserialize(new TypeReference<List<ContentDTO>>() {});
-        assertThat(c3set)
-            .isNotNull()
-            .hasSize(1)
-            .isSubsetOf(content)
-            .doesNotContainAnyElementsOf(c1set)
-            .doesNotContainAnyElementsOf(c2set);
-
-        response = Request.from(adminClient)
-            .setPath("/owners/{owner_key}/content")
-            .setPathParam("owner_key", owner.getKey())
-            .addQueryParam("page", "4")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("omit_global", "true")
-            .execute();
-
-        List<ContentDTO> c4set = response.deserialize(new TypeReference<>() {});
-        assertThat(c4set)
-            .isNotNull()
-            .isEmpty();
-    }
-
-    @Test
-    public void shouldListContentInSortedPages() throws Exception {
-        ApiClient adminClient = ApiClients.admin();
-        OwnerDTO owner = this.createOwner(adminClient);
-
-        // The creation order here is important. By default, Candlepin sorts in descending order of the
-        // entity's creation time, so we need to create them backward to let the default sorting order
-        // let us page through them in ascending order.
-        ContentDTO content3 = this.createContent(adminClient, owner);
-        Thread.sleep(1000);
-        ContentDTO content2 = this.createContent(adminClient, owner);
-        Thread.sleep(1000);
-        ContentDTO content1 = this.createContent(adminClient, owner);
-
-        Response response = Request.from(adminClient)
-            .setPath("/owners/{owner_key}/content")
-            .setPathParam("owner_key", owner.getKey())
-            .addQueryParam("page", "1")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("order_by", "id")
-            .addQueryParam("sort_order", "asc")
-            .addQueryParam("omit_global", "true")
-            .execute();
-
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-
-        assertThat(response.deserialize(new TypeReference<List<ContentDTO>>() {}))
-            .isNotNull()
-            .hasSize(1)
-            .containsOnly(content1);
-
-        response = Request.from(adminClient)
-            .setPath("/owners/{owner_key}/content")
-            .setPathParam("owner_key", owner.getKey())
-            .addQueryParam("page", "2")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("order_by", "id")
-            .addQueryParam("sort_order", "asc")
-            .addQueryParam("omit_global", "true")
-            .execute();
-
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-
-        assertThat(response.deserialize(new TypeReference<List<ContentDTO>>() {}))
-            .isNotNull()
-            .hasSize(1)
-            .containsOnly(content2);
-
-        response = Request.from(adminClient)
-            .setPath("/owners/{owner_key}/content")
-            .setPathParam("owner_key", owner.getKey())
-            .addQueryParam("page", "3")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("order_by", "id")
-            .addQueryParam("sort_order", "asc")
-            .addQueryParam("omit_global", "true")
-            .execute();
-
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-
-        assertThat(response.deserialize(new TypeReference<List<ContentDTO>>() {}))
-            .isNotNull()
-            .hasSize(1)
-            .containsOnly(content3);
-
-        response = Request.from(adminClient)
-            .setPath("/owners/{owner_key}/content")
-            .setPathParam("owner_key", owner.getKey())
-            .addQueryParam("page", "4")
-            .addQueryParam("per_page", "1")
-            .addQueryParam("order_by", "id")
-            .addQueryParam("sort_order", "asc")
-            .addQueryParam("omit_global", "true")
-            .execute();
-
-        assertNotNull(response);
-        assertEquals(200, response.getCode());
-
-        assertThat(response.deserialize(new TypeReference<List<ContentDTO>>() {}))
-            .isNotNull()
-            .isEmpty();
     }
 
     @Test
@@ -1154,6 +954,959 @@ class OwnerContentSpecTest {
                 .map(ProductContentDTO::getContent)
                 .map(ContentDTO::getId)
                 .containsExactlyInAnyOrderElementsOf(cids);
+        }
+    }
+
+    @Nested
+    @Isolated
+    @TestInstance(Lifecycle.PER_CLASS)
+    @Execution(ExecutionMode.SAME_THREAD)
+    public class ContentQueryTests {
+
+        private static final String QUERY_PATH = "/owners/{owner_key}/content";
+
+        private static final String INCLUSION_INCLUDE = "include";
+        private static final String INCLUSION_EXCLUDE = "exclude";
+        private static final String INCLUSION_EXCLUSIVE = "exclusive";
+
+        private static record ProductInfo(ProductDTO dto, OwnerDTO owner, Set<String> activeOwners) {
+
+            public String id() {
+                return this.dto() != null ? this.dto().getId() : null;
+            }
+
+            public boolean active() {
+                return !this.activeOwners().isEmpty();
+            }
+
+            public boolean custom() {
+                return this.owner() != null;
+            }
+
+            public Stream<ContentDTO> content() {
+                return Optional.ofNullable(this.dto())
+                  .map(ProductDTO::getProductContent)
+                  .map(Collection::stream)
+                  .orElse(Stream.empty())
+                  .map(ProductContentDTO::getContent);
+            }
+        };
+
+        private ApiClient adminClient;
+
+        private List<OwnerDTO> owners;
+        private Map<String, ProductInfo> productMap;
+
+        /**
+         * Verifies either the manifest generator extension or the hosted test extension is present as
+         * required by the current operating mode.
+         */
+        private void checkRequiredExtensions() {
+            if (CandlepinMode.isStandalone()) {
+                assumeTrue(CandlepinMode::hasManifestGenTestExtension);
+            }
+            else {
+                assumeTrue(CandlepinMode::hasHostedTestExtension);
+            }
+        }
+
+        private OwnerDTO createOwner(String keyPrefix) {
+            OwnerDTO owner = Owners.random()
+                .key(StringUtil.random(keyPrefix + "-"));
+
+            return this.adminClient.owners()
+                .createOwner(owner);
+        }
+
+        private SubscriptionDTO createSubscription(OwnerDTO owner, ProductDTO product, boolean active) {
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            // Impl note:
+            // We create active subscriptions in the future to work around a limitation on manifests
+            // disallowing and ignoring expired pools
+            return Subscriptions.random(owner, product)
+                .startDate(active ? now.minus(7, ChronoUnit.DAYS) : now.plus(7, ChronoUnit.DAYS))
+                .endDate(now.plus(30, ChronoUnit.DAYS));
+        }
+
+        private PoolDTO createPool(OwnerDTO owner, ProductDTO product, boolean active) {
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            PoolDTO pool = Pools.random(product)
+                .startDate(now.minus(7, ChronoUnit.DAYS))
+                .endDate(active ? now.plus(7, ChronoUnit.DAYS) : now.minus(3, ChronoUnit.DAYS));
+
+            return this.adminClient.owners()
+                .createPool(owner.getKey(), pool);
+        }
+
+        private void mapProductInfo(ProductDTO product, OwnerDTO owner, OwnerDTO activeOwner) {
+            Set<String> activeOwnerKeys = new HashSet<>();
+            if (activeOwner != null) {
+                activeOwnerKeys.add(activeOwner.getKey());
+            }
+
+            ProductInfo existing = this.productMap.get(product.getId());
+            if (existing != null) {
+                activeOwnerKeys.addAll(existing.activeOwners());
+            }
+
+            ProductInfo pinfo = new ProductInfo(product, owner, activeOwnerKeys);
+            this.productMap.put(product.getId(), pinfo);
+
+        }
+
+        private void commitGlobalSubscriptions(Collection<SubscriptionDTO> subscriptions) throws Exception {
+            Map<String, List<SubscriptionDTO>> subscriptionMap = new HashMap<>();
+
+            for (SubscriptionDTO subscription : subscriptions) {
+                NestedOwnerDTO owner = subscription.getOwner();
+
+                subscriptionMap.computeIfAbsent(owner.getKey(), key -> new ArrayList<>())
+                    .add(subscription);
+            }
+
+            for (Map.Entry<String, List<SubscriptionDTO>> entry : subscriptionMap.entrySet()) {
+                String ownerKey = entry.getKey();
+                List<SubscriptionDTO> ownerSubs = entry.getValue();
+
+                AsyncJobStatusDTO job;
+                if (CandlepinMode.isStandalone()) {
+                    File manifest = new ExportGenerator()
+                        .addSubscriptions(ownerSubs)
+                        .export();
+
+                    job = this.adminClient.owners()
+                        .importManifestAsync(ownerKey, List.of(), manifest);
+                }
+                else {
+                    ownerSubs.forEach(subscription -> this.adminClient.hosted()
+                        .createSubscription(subscription, true));
+
+                    job = this.adminClient.owners()
+                        .refreshPools(ownerKey, false);
+                }
+
+                assertThatJob(job)
+                    .isNotNull()
+                    .terminates(this.adminClient)
+                    .isFinished();
+            }
+        }
+
+        @BeforeAll
+        public void setup() throws Exception {
+            // Ensure we have our required test extensions or we'll be very broken...
+            this.checkRequiredExtensions();
+
+            this.adminClient = ApiClients.admin();
+
+            this.owners = List.of(
+                this.createOwner("owner1"),
+                this.createOwner("owner2"),
+                this.createOwner("owner3"));
+
+            this.productMap = new HashMap<>();
+
+            List<SubscriptionDTO> subscriptions = new ArrayList<>();
+
+            // Dummy org we use for creating a bunch of future pools for our global products. We'll also
+            // create per-org subscriptions for these products later. Also note that these will never be
+            // fully resolved.
+            OwnerDTO globalOwner = this.createOwner("global");
+
+            List<ProductDTO> globalProducts = new ArrayList<>();
+            for (int i = 1; i <= 3; ++i) {
+                List<ContentDTO> contents = new ArrayList<>();
+
+                for (int c = 0; c < 2; ++c) {
+                    ContentDTO content = Contents.random()
+                        .id(String.format("g-content-%d%s", i, (char) ('a' + c)))
+                        .name(String.format("global_content_%d%s", i, (char) ('a' + c)))
+                        .label(String.format("global content %d%s", i, (char) ('a' + c)));
+
+                    contents.add(content);
+                }
+
+                ProductDTO gprod = new ProductDTO()
+                    .id("g-prod-" + i)
+                    .name("global product " + i)
+                    .addProductContentItem(Contents.toProductContent(contents.get(0), true))
+                    .addProductContentItem(Contents.toProductContent(contents.get(1), false));
+
+                subscriptions.add(this.createSubscription(globalOwner, gprod, false));
+                globalProducts.add(gprod);
+                this.mapProductInfo(gprod, null, null);
+            }
+
+            for (int oidx = 1; oidx <= owners.size(); ++oidx) {
+                OwnerDTO owner = owners.get(oidx - 1);
+
+                List<ProductDTO> ownerProducts = new ArrayList<>();
+                for (int i = 1; i <= 2; ++i) {
+                    List<ContentDTO> contents = new ArrayList<>();
+
+                    for (int c = 0; c < 2; ++c) {
+                        ContentDTO content = Contents.random()
+                            .id(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
+                            .name(String.format("%s_content_%d%s", owner.getKey(), i, (char) ('a' + c)))
+                            .label(String.format("%s content %d%s", owner.getKey(), i, (char) ('a' + c)));
+
+                        contents.add(this.adminClient.ownerContent()
+                            .createContent(owner.getKey(), content));
+                    }
+
+                    ProductDTO cprod = new ProductDTO()
+                        .id(String.format("o%d-prod-%d", oidx, i))
+                        .name(String.format("%s product %d", owner.getKey(), i))
+                        .addProductContentItem(Contents.toProductContent(contents.get(0), true))
+                        .addProductContentItem(Contents.toProductContent(contents.get(1), false));
+
+                    cprod = this.adminClient.ownerProducts()
+                        .createProduct(owner.getKey(), cprod);
+
+                    ownerProducts.add(cprod);
+                    this.mapProductInfo(cprod, owner, null);
+                }
+
+                // Create an active and inactive global subscription for this org
+                subscriptions.add(this.createSubscription(owner, globalProducts.get(0), true));
+                subscriptions.add(this.createSubscription(owner, globalProducts.get(1), false));
+                this.mapProductInfo(globalProducts.get(0), null, owner);
+
+                // Create an active and inactive custom subscription
+                this.createPool(owner, ownerProducts.get(0), true);
+                this.createPool(owner, ownerProducts.get(1), false);
+                this.mapProductInfo(ownerProducts.get(0), owner, owner);
+            }
+
+            this.commitGlobalSubscriptions(subscriptions);
+        }
+
+        // Impl note:
+        // Since we cannot depend on the global state being prestine from run to run (or even test to
+        // test), we cannot use exact matching on our output as extraneous products from previous test
+        // runs or otherwise pre-existing data may show up in the result set. Instead, these tests will
+        // verify our expected products are present, and unexpected products from the test data are not.
+
+        private List<String> getUnexpectedIds(List<String> expectedIds) {
+            return this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .filter(Predicate.not(expectedIds::contains))
+                .toList();
+        }
+
+        private Predicate<ProductInfo> buildOwnerProductPredicate(OwnerDTO owner) {
+            return pinfo -> pinfo.owner() == null || owner.getKey().equals(pinfo.owner().getKey());
+        }
+
+        @Test
+        public void shouldAllowQueryingWithoutAnyFilters() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldDefaultToActiveExclusiveCustomInclusive() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(ProductInfo::active)
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, null, null);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldFailWithInvalidOwners() {
+            assertNotFound(() -> this.adminClient.ownerContent()
+                .getContentsByOwner("invalid_owner", null, null, null, null));
+        }
+
+        @Test
+        public void shouldAllowFilteringOnIDs() {
+            // Randomly seeded for consistency; seed itself chosen randomly
+            Random rand = new Random(81451);
+
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> cids = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .filter(elem -> rand.nextBoolean())
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .filter(cids::contains)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), cids, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "invalid_id" })
+        @NullAndEmptySource
+        public void shouldAllowFilteringOnInvalidIds(String cid) {
+            // This test verifies that invalid IDs are "allowed", but they won't match on anything
+
+            OwnerDTO owner = this.owners.get(1);
+
+            String expectedCid = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .findAny()
+                .get();
+
+            List<String> expectedCids = List.of(expectedCid);
+            List<String> cids = Arrays.asList(expectedCid, cid);
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), cids, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldAllowFilteringOnLabel() {
+            Random rand = new Random(54978);
+
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> labels = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .filter(elem -> rand.nextBoolean())
+                .map(ContentDTO::getLabel)
+                .toList();
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .flatMap(ProductInfo::content)
+                .filter(content -> labels.contains(content.getLabel()))
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, labels, INCLUSION_INCLUDE,
+                    INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "invalid_label" })
+        @NullAndEmptySource
+        public void shouldAllowFilteringOnInvalidLabels(String label) {
+            // This test verifies that invalid IDs are "allowed", but they won't match on anything
+            OwnerDTO owner = this.owners.get(1);
+
+            ContentDTO content = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .flatMap(ProductInfo::content)
+                .findAny()
+                .get();
+
+            List<String> labels = Arrays.asList(content.getLabel(), label);
+            List<String> expectedCids = List.of(content.getId());
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, labels, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveIncluded() {
+            // This is effectively the same as no filter -- we expect everything within the org back
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids);
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveExcluded() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(pinfo -> !pinfo.active())
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_EXCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithActiveExclusive() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(ProductInfo::active)
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_EXCLUSIVE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldErrorWithInvalidActiveInclusion() {
+            OwnerDTO owner = this.owners.get(1);
+
+            assertBadRequest(() -> this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, "invalid_type", INCLUSION_INCLUDE));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomIncluded() {
+            // This is effectively the same as no filter -- we expect everything in the org back
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids);
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomExcluded() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(pinfo -> !pinfo.custom())
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUDE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldAllowFilteringWithCustomExclusive() {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(ProductInfo::custom)
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @Test
+        public void shouldErrorWithInvalidCustomInclusion() {
+            OwnerDTO owner = this.owners.get(1);
+
+            assertBadRequest(() -> this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, "invalid_type"));
+        }
+
+        @Test
+        public void shouldAllowQueryingWithMultipleFilters() {
+            Random rand = new Random(58574);
+
+            OwnerDTO owner = this.owners.get(1);
+
+            // Hand pick a content to ensure that we have *something* that comes out of the filter, should
+            // our random selection process not have any intersection.
+            ContentDTO selectedContent = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(ProductInfo::active)
+                .filter(ProductInfo::custom)
+                .flatMap(ProductInfo::content)
+                .findAny()
+                .get();
+
+            List<String> cids = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .filter(elem -> rand.nextBoolean())
+                .map(ContentDTO::getId)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            List<String> labels = this.productMap.values()
+                .stream()
+                .flatMap(ProductInfo::content)
+                .filter(elem -> rand.nextBoolean())
+                .map(ContentDTO::getLabel)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+            cids.add(selectedContent.getId());
+            labels.add(selectedContent.getLabel());
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(ProductInfo::active)
+                .filter(ProductInfo::custom)
+                .filter(this.buildOwnerProductPredicate(owner))
+                .flatMap(ProductInfo::content)
+                .filter(content -> cids.contains(content.getId()))
+                .filter(content -> labels.contains(content.getLabel()))
+                .map(ContentDTO::getId)
+                .toList();
+
+            assertThat(expectedCids)
+                .isNotEmpty();
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), cids, labels, INCLUSION_EXCLUSIVE,
+                    INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+        public void shouldAllowQueryingInPages(int pageSize) {
+            OwnerDTO owner = this.owners.get(1);
+
+            List<String> expectedCids = this.productMap.values()
+                .stream()
+                .filter(this.buildOwnerProductPredicate(owner))
+                .filter(ProductInfo::custom)
+                .flatMap(ProductInfo::content)
+                .map(ContentDTO::getId)
+                .toList();
+
+            List<String> received = new ArrayList<>();
+
+            int page = 0;
+            while (true) {
+                Response response = Request.from(this.adminClient)
+                    .setPath(QUERY_PATH)
+                    .setPathParam("owner_key", owner.getKey())
+                    .addQueryParam("page", String.valueOf(++page))
+                    .addQueryParam("per_page", String.valueOf(pageSize))
+                    .addQueryParam("active", "include")
+                    .addQueryParam("custom", "exclusive")
+                    .execute();
+
+                assertEquals(200, response.getCode());
+
+                List<ContentDTO> output = response.deserialize(new TypeReference<List<ContentDTO>>() {});
+                assertNotNull(output);
+
+                if (output.isEmpty()) {
+                    break;
+                }
+
+                output.stream()
+                    .map(ContentDTO::getId)
+                    .sequential()
+                    .forEach(received::add);
+            }
+
+            assertThat(received)
+                .containsAll(expectedCids)
+                .doesNotContainAnyElementsOf(this.getUnexpectedIds(expectedCids));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, -1, -100 })
+        public void shouldFailWithInvalidPage(int page) {
+            OwnerDTO owner = this.owners.get(1);
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("page", String.valueOf(page))
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, -1, -100 })
+        public void shouldFailWithInvalidPageSize(int pageSize) {
+            OwnerDTO owner = this.owners.get(1);
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("per_page", String.valueOf(pageSize))
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "id", "name", "uuid" })
+        public void shouldAllowQueryingWithAscendingOrderedOutput(String field) {
+            OwnerDTO owner = this.owners.get(1);
+
+            Map<String, Comparator<ContentDTO>> comparatorMap = Map.of(
+                "id", Comparator.comparing(ContentDTO::getId),
+                "name", Comparator.comparing(ContentDTO::getName),
+                "uuid", Comparator.comparing(ContentDTO::getUuid));
+
+            List<ContentDTO> contents = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
+
+            List<String> expectedCids = contents.stream()
+                .sorted(comparatorMap.get(field))
+                .map(ContentDTO::getId)
+                .toList();
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("sort_by", field)
+                .addQueryParam("order", "asc")
+                .addQueryParam("active", INCLUSION_INCLUDE)
+                .addQueryParam("custom", INCLUSION_EXCLUSIVE)
+                .execute();
+
+            assertEquals(200, response.getCode());
+
+            List<ContentDTO> output = response.deserialize(new TypeReference<List<ContentDTO>>() {});
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsExactlyElementsOf(expectedCids); // this must be an ordered check
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "id", "name", "uuid" })
+        public void shouldAllowQueryingWithDescendingOrderedOutput(String field) {
+            OwnerDTO owner = this.owners.get(1);
+
+            Map<String, Comparator<ContentDTO>> comparatorMap = Map.of(
+                "id", Comparator.comparing(ContentDTO::getId),
+                "name", Comparator.comparing(ContentDTO::getName),
+                "uuid", Comparator.comparing(ContentDTO::getUuid));
+
+            List<ContentDTO> contents = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_INCLUDE, INCLUSION_EXCLUSIVE);
+
+            List<String> expectedCids = contents.stream()
+                .sorted(comparatorMap.get(field).reversed())
+                .map(ContentDTO::getId)
+                .toList();
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("sort_by", field)
+                .addQueryParam("order", "desc")
+                .addQueryParam("active", INCLUSION_INCLUDE)
+                .addQueryParam("custom", INCLUSION_EXCLUSIVE)
+                .execute();
+
+            assertEquals(200, response.getCode());
+
+            List<ContentDTO> output = response.deserialize(new TypeReference<List<ContentDTO>>() {});
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsExactlyElementsOf(expectedCids); // this must be an ordered check
+        }
+
+        @Test
+        public void shouldFailWithInvalidOrderField() {
+            OwnerDTO owner = this.owners.get(1);
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("sort_by", "invalid field")
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        @Test
+        public void shouldFailWithInvalidOrderDirection() {
+            OwnerDTO owner = this.owners.get(1);
+
+            Response response = Request.from(this.adminClient)
+                .setPath(QUERY_PATH)
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("order", "invalid order")
+                .execute();
+
+            assertEquals(400, response.getCode());
+        }
+
+        // These tests verify the definition of "active" is properly implemented, ensuring "active" is
+        // defined as a product which is attached to a pool which has started and has not expired, or
+        // attached to another active product (recursively).
+        //
+        // This definition is recursive in nature, so the effect is that it should consider any product
+        // that is a descendant of a product attached to a non-future pool that hasn't yet expired.
+
+        @Test
+        public void shouldOnlySelectActiveContentFromActivePools() {
+            // "active" only considers pools which have started but have not yet expired -- that is:
+            // (start time < now() < end time)
+            OwnerDTO owner = this.createOwner("test_org");
+
+            List<ProductDTO> products = new ArrayList<>();
+            for (int i = 1; i <= 3; ++i) {
+                ContentDTO contentA = Contents.random().id(String.format("p%d-ca", i));
+                ContentDTO contentB = Contents.random().id(String.format("p%d-cb", i));
+
+                contentA = this.adminClient.ownerContent().createContent(owner.getKey(), contentA);
+                contentB = this.adminClient.ownerContent().createContent(owner.getKey(), contentB);
+
+                ProductDTO product = Products.random()
+                    .id("prod-" + i)
+                    .name("product " + i)
+                    .addProductContentItem(Contents.toProductContent(contentA, true))
+                    .addProductContentItem(Contents.toProductContent(contentB, false));
+
+                this.adminClient.ownerProducts().createProduct(owner.getKey(), product);
+                products.add(product);
+            }
+
+            OffsetDateTime now = Instant.now()
+                .atOffset(ZoneOffset.UTC);
+
+            // Create three pools: expired, current (active), future
+            PoolDTO pool1 = Pools.random(products.get(0))
+                .startDate(now.minus(7, ChronoUnit.DAYS))
+                .endDate(now.minus(3, ChronoUnit.DAYS));
+            PoolDTO pool2 = Pools.random(products.get(1))
+                .startDate(now.minus(3, ChronoUnit.DAYS))
+                .endDate(now.plus(3, ChronoUnit.DAYS));
+            PoolDTO pool3 = Pools.random(products.get(2))
+                .startDate(now.plus(3, ChronoUnit.DAYS))
+                .endDate(now.plus(7, ChronoUnit.DAYS));
+
+            this.adminClient.owners().createPool(owner.getKey(), pool1);
+            this.adminClient.owners().createPool(owner.getKey(), pool2);
+            this.adminClient.owners().createPool(owner.getKey(), pool3);
+
+            // Active = exclusive should only find the active pool; future and expired pools should be omitted
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsExactlyInAnyOrder("p2-ca", "p2-cb");
+        }
+
+        @Test
+        public void shouldAlsoIncludeDescendantProductsOfActiveProducts() {
+            // "active" includes descendants of products attached to an active pool
+            OwnerDTO owner = this.createOwner("test_org");
+
+            List<ProductDTO> products = new ArrayList<>();
+            for (int i = 0; i < 20; ++i) {
+                ContentDTO contentA = Contents.random().id(String.format("p%d-ca", i));
+                ContentDTO contentB = Contents.random().id(String.format("p%d-cb", i));
+
+                contentA = this.adminClient.ownerContent().createContent(owner.getKey(), contentA);
+                contentB = this.adminClient.ownerContent().createContent(owner.getKey(), contentB);
+
+                ProductDTO product = new ProductDTO()
+                    .id("p" + i)
+                    .name("product " + i)
+                    .addProductContentItem(Contents.toProductContent(contentA, true))
+                    .addProductContentItem(Contents.toProductContent(contentB, false));
+
+                // Impl note: We can't create the products quite yet
+                products.add(product);
+            }
+
+            /*
+            pool -> prod - p0
+                        derived - p1
+                            provided - p2
+                            provided - p3
+                                provided - p4
+                        provided - p5
+                        provided - p6
+            pool -> prod - p7
+                        derived - p8*
+                        provided - p9
+            pool -> prod - p8*
+                        provided - p10
+                            provided - p11
+                        provided - p12
+                            provided - p13
+                    prod - p14
+                        derived - p15
+                            provided - p16
+                    prod - p17
+                        provided - p18
+            pool -> prod - p19
+                    prod - p20
+            */
+
+            products.get(0).setDerivedProduct(products.get(1));
+            products.get(0).addProvidedProductsItem(products.get(5));
+            products.get(0).addProvidedProductsItem(products.get(6));
+
+            products.get(1).addProvidedProductsItem(products.get(2));
+            products.get(1).addProvidedProductsItem(products.get(3));
+
+            products.get(3).addProvidedProductsItem(products.get(4));
+
+            products.get(7).setDerivedProduct(products.get(8));
+            products.get(7).addProvidedProductsItem(products.get(9));
+
+            products.get(8).addProvidedProductsItem(products.get(10));
+            products.get(8).addProvidedProductsItem(products.get(12));
+
+            products.get(10).addProvidedProductsItem(products.get(11));
+
+            products.get(12).addProvidedProductsItem(products.get(13));
+
+            products.get(14).setDerivedProduct(products.get(15));
+
+            products.get(15).setDerivedProduct(products.get(16));
+
+            products.get(17).setDerivedProduct(products.get(18));
+
+            // persist the products in reverse order so we don't hit any linkage errors
+            for (int i = products.size() - 1; i >= 0; --i) {
+                this.adminClient.ownerProducts().createProduct(owner.getKey(), products.get(i));
+            }
+
+            // create some pools to link to our product tree
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(0)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(7)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(8)));
+            this.adminClient.owners().createPool(owner.getKey(), Pools.random(products.get(19)));
+
+            List<String> expectedCids = List.of("p0-ca", "p0-cb", "p1-ca", "p1-cb", "p2-ca", "p2-cb", "p3-ca",
+                "p3-cb", "p4-ca", "p4-cb", "p5-ca", "p5-cb", "p6-ca", "p6-cb", "p7-ca", "p7-cb", "p8-ca",
+                "p8-cb", "p9-ca", "p9-cb", "p10-ca", "p10-cb", "p11-ca", "p11-cb", "p12-ca", "p12-cb",
+                "p13-ca", "p13-cb", "p19-ca", "p19-cb");
+
+            List<ContentDTO> output = this.adminClient.ownerContent()
+                .getContentsByOwner(owner.getKey(), null, null, INCLUSION_EXCLUSIVE, INCLUSION_EXCLUSIVE);
+
+            assertThat(output)
+                .isNotNull()
+                .map(ContentDTO::getId)
+                .containsExactlyInAnyOrderElementsOf(expectedCids);
         }
     }
 

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportSuccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportSuccessSpecTest.java
@@ -508,7 +508,7 @@ public class ImportSuccessSpecTest {
             .toList();
 
         List<ContentDTO> contents = adminClient.ownerContent()
-            .getContentsByOwner(owner.getKey(), cids, false);
+            .getContentsByOwner(owner.getKey(), cids, List.of(), null, null);
 
         assertThat(contents)
             .isNotNull()

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/RefreshPoolsSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/RefreshPoolsSpecTest.java
@@ -642,7 +642,8 @@ public class RefreshPoolsSpecTest {
             .map(ContentDTO::getId)
             .toList();
 
-        List<ContentDTO> actualContent = adminClient.ownerContent().getContentsByOwner(ownerKey, cids, false);
+        List<ContentDTO> actualContent = adminClient.ownerContent()
+            .getContentsByOwner(ownerKey, cids, List.of(), null, null);
         assertThat(actualContent)
             .map(ContentDTO::getId)
             .containsAll(cids);

--- a/spec-tests/src/test/java/org/candlepin/spec/products/ProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/products/ProductResourceSpecTest.java
@@ -543,8 +543,9 @@ public class ProductResourceSpecTest {
 
             List<String> pids = this.productMap.values()
                 .stream()
-                .filter(elem -> rand.nextBoolean())
                 .map(ProductInfo::id)
+                .sorted()
+                .filter(elem -> rand.nextBoolean())
                 .toList();
 
             List<ProductDTO> output = this.adminClient.products()
@@ -589,6 +590,7 @@ public class ProductResourceSpecTest {
 
             List<String> names = this.productMap.values()
                 .stream()
+                .sorted(Comparator.comparing(ProductInfo::id))
                 .filter(elem -> rand.nextBoolean())
                 .map(pinfo -> pinfo.dto().getName())
                 .toList();
@@ -693,7 +695,6 @@ public class ProductResourceSpecTest {
         @Test
         public void shouldAllowFilteringWithCustomIncluded() {
             // This is effectively the same as no filter -- we expect everything back
-
             List<ProductDTO> output = this.adminClient.products()
                 .getProducts(null, null, null, INCLUSION_INCLUDE, INCLUSION_INCLUDE);
 
@@ -765,12 +766,14 @@ public class ProductResourceSpecTest {
 
             List<String> pids = this.productMap.values()
                 .stream()
-                .filter(elem -> rand.nextBoolean())
                 .map(ProductInfo::id)
+                .sorted()
+                .filter(elem -> rand.nextBoolean())
                 .collect(Collectors.toCollection(ArrayList::new));
 
             List<String> names = this.productMap.values()
                 .stream()
+                .sorted(Comparator.comparing(ProductInfo::id))
                 .filter(elem -> rand.nextBoolean())
                 .map(pinfo -> pinfo.dto().getName())
                 .collect(Collectors.toCollection(ArrayList::new));

--- a/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/src/main/java/org/candlepin/model/ContentCurator.java
@@ -69,6 +69,16 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
     }
 
     /**
+     * Fetches a query builder to use for fetching products by various criteria.
+     *
+     * @return
+     *  a new ContentQueryBuilder instance backed by this curator's data provider
+     */
+    public ContentQueryBuilder getContentQueryBuilder() {
+        return new ContentQueryBuilder(this.entityManager);
+    }
+
+    /**
      * Fetches a list of contents with the given content UUIDs. If a given content UUID was not
      * found, it will not be included in the resultant list.If no contents could be found, this
      * method returns an empty list.

--- a/src/main/java/org/candlepin/model/ContentQueryBuilder.java
+++ b/src/main/java/org/candlepin/model/ContentQueryBuilder.java
@@ -1,0 +1,666 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.inject.Provider;
+import javax.persistence.Column;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.metamodel.EntityType;
+
+
+
+/**
+ * The ContentQueryBuilder is a utility class which provides a fluent-style interface for performing
+ * arbitrary content lookups with a number of parameters.
+ * <p></p>
+ * This class is a loose wrapper around the JPA interface and one or more native queries to fetch results
+ * as efficiently as possible, without the caller needing to jump back and forth between the curators
+ * to get both the count and results.
+ */
+public class ContentQueryBuilder extends QueryBuilder<ContentQueryBuilder, Content> {
+    private static final Logger log = LoggerFactory.getLogger(ContentQueryBuilder.class);
+
+    private final Set<String> contentIds;
+    private final Set<String> contentLabels;
+    private final Map<String, Owner> owners;
+    private Inclusion active;
+    private Inclusion custom;
+
+    /**
+     * Creates a new query builder backed by the specified entity manager provider.
+     * <p></p>
+     * <strong>Note:</strong> Query builder instances should not be constructed directly and should be
+     * fetched from their corresponding curators.
+     *
+     * @param entityManagerProvider
+     *  the provider to use for fetching an entity manager when building queries
+     */
+    protected ContentQueryBuilder(Provider<EntityManager> entityManagerProvider) {
+        super(entityManagerProvider);
+
+        this.contentIds = new HashSet<>();
+        this.contentLabels = new HashSet<>();
+        this.owners = new HashMap<>();
+        this.active = Inclusion.INCLUDE;
+        this.custom = Inclusion.INCLUDE;
+    }
+
+    /**
+     * Adds one or more content IDs to use for filtering query output.
+     *
+     * @param contentIds
+     *  a collection of content IDs to use to filter query output, or null to clear any previously
+     *  set content IDs
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ContentQueryBuilder addContentIds(Collection<String> contentIds) {
+        if (contentIds == null) {
+            return this;
+        }
+
+        contentIds.stream()
+            .filter(cid -> cid != null && !cid.isBlank())
+            .sequential()
+            .forEach(this.contentIds::add);
+
+        if (this.contentIds.size() > QueryBuilder.COLLECTION_SIZE_LIMIT) {
+            throw new IllegalStateException("query builder collection size limit exceeded for content IDs");
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds one or more content IDs to use for filtering query output.
+     *
+     * @param contentIds
+     *  a collection of content IDs to use to filter query output
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ContentQueryBuilder addContentIds(String... contentIds) {
+        return this.addContentIds(contentIds != null ? Arrays.asList(contentIds) : null);
+    }
+
+    /**
+     * Adds one or more content labels to use for filtering query output.
+     *
+     * @param contentLabels
+     *  a collection of content labels to use to filter query output
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ContentQueryBuilder addContentLabels(Collection<String> contentLabels) {
+        if (contentLabels == null) {
+            return this;
+        }
+
+        contentLabels.stream()
+            .filter(label -> label != null && !label.isBlank())
+            .map(String::toLowerCase)
+            .sequential()
+            .forEach(this.contentLabels::add);
+
+        if (this.contentLabels.size() > QueryBuilder.COLLECTION_SIZE_LIMIT) {
+            throw new IllegalStateException(
+                "query builder collection size limit exceeded for content labels");
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds one or more content labels to use for filtering query output.
+     *
+     * @param contentLabels
+     *  a collection of content labels to use to filter query output
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ContentQueryBuilder addContentLabels(String... contentLabels) {
+        return this.addContentLabels(contentLabels != null ? Arrays.asList(contentLabels) : null);
+    }
+
+    /**
+     * Adds one or more owners to use for filtering query output.
+     *
+     * @param owners
+     *  a collection of owners to use to filter query output
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ContentQueryBuilder addOwners(Collection<Owner> owners) {
+        if (owners == null) {
+            return this;
+        }
+
+        owners.stream()
+            .filter(Objects::nonNull)
+            .filter(owner -> owner.getId() != null)
+            .sequential()
+            .forEach(owner -> this.owners.put(owner.getId(), owner));
+
+        if (this.owners.size() > QueryBuilder.COLLECTION_SIZE_LIMIT) {
+            throw new IllegalStateException("query builder collection size limit exceeded for owners");
+        }
+
+        return this;
+    }
+
+    /**
+     * Adds one or more owners to use for filtering query output.
+     *
+     * @param owners
+     *  a collection of owners to use to filter query output
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ContentQueryBuilder addOwners(Owner... owners) {
+        return this.addOwners(owners != null ? Arrays.asList(owners) : null);
+    }
+
+    /**
+     * Sets the inclusion filter to use for filtering queries by active contents, where "active" is defined
+     * as a content that is currently in use by a subscription that has started and not yet expired, or
+     * is linked to such a content. If the provided inclusion filter is null, the value "INCLUDE" will
+     * be used instead.
+     *
+     * @param active
+     *  an inclusion filter to set for active contents
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ContentQueryBuilder setActive(Inclusion active) {
+        this.active = active != null ? active : Inclusion.INCLUDE;
+        return this;
+    }
+
+    /**
+     * Sets the inclusion filter to use for filtering queries by custom contents, where "custom" is defined
+     * as a content that originates from a source other than manifest import or pool refresh. If the provided
+     * inclusion filter is null, the value "INCLUDE" will be used instead.
+     *
+     * @param custom
+     *  an inclusion filter to set for custom contents
+     *
+     * @return
+     *  a reference to this query builder
+     */
+    public ContentQueryBuilder setCustom(Inclusion custom) {
+        this.custom = custom != null ? custom : Inclusion.INCLUDE;
+        return this;
+    }
+
+    // Impl note:
+    // Everything about this query is awful due to JPA limitations both in terms of what it can do
+    // and what its API allows you to do.
+    // It'd be really nice to *not* build this with string concatenation, but since we can't join against
+    // a native query from a criteria query, criteria queries can't join against a temporary table, no
+    // part of JPA is ready for CTEs, and paging support makes partitioning large result sets clunky and
+    // error prone (or a waste due to throwing everything in memory), we aren't left with many options
+    // other than string concatenation.
+
+    /**
+     * Assembles the components of the query that make up the active contents filter.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for filtering on active contents
+     *
+     * @param criteriaChunks
+     *  the list of criteria chunks to receive the predicates for filtering on active contents
+     *
+     * @param parameters
+     *  the map of parameters to receive the specific query arguments provided to the builder
+     */
+    private void buildActiveContentsComponents(List<String> queryChunks, List<String> criteriaChunks,
+        Map<String, Object> queryArgs) {
+
+        // The "active" flag has a massive impact on how this query is constructed. If it's any value
+        // other than "include", we start with the CTE. Otherwise we're a boring ol' select and we do
+        // nothing in this method.
+        if (this.active == Inclusion.INCLUDE) {
+            return;
+        }
+
+        // Impl notes:
+        // These CTEs are a bit of a mess, and are driven by three different DBs imposing their own goofy
+        // limitations or quirks (mostly only two goofy DBs, but whatever):
+        //  - HSQLDB requires that recursive CTEs define their parameters as part of the declaration of
+        //    the CTE itself, which is the driver behind the rather redundant definitions.
+        //  - HSQLDB also disallows more than one UNION operation in a recursive CTE, which means the
+        //    anchor members *also* can't have more than one union without being wrapped in another query
+        //    or CTE, leading to the clunky declaration of the "pcmap_anchor" CTE.
+        //  - MySQL/MariaDB cannot self-reference more than once in the recursive step of a recursive
+        //    CTE, which really hamstrings how these queries are built and is why the parent-child mapping
+        //    does what it does.
+        //  - PostgreSQL, as per usual, laughs at these queries and beasts through them like I'm fetching
+        //    the count of an almost-empty table.
+        //
+        // As far as how this is all intended to work:
+        //  - We start with pools since in production this gives us our smallest working product set.
+        //  - Next we need to figure out every parent-child product relationship that will be significant
+        //    to us. In other areas it may make sense for us to just grab the union of all derived and
+        //    provided product refs, but doing so in the prod database takes 5-10s on its own. Instead,
+        //    we step through from the pool products down into derived products and then recursively into
+        //    provided products based on those we know we'll have.
+        //  - Finally, we go back to the pool products and use our parent-child map to walk down the graph
+        //    to discover all of our nested/descendant products, since our parent-child map has extraneous
+        //    pools from getting the full set of derived products
+        //
+        // Note that this query is written primarily as a function of what works best for MySQL and the
+        // shape of the data in production. It may make sense to periodically update it as the shape of
+        // prod's data changes. Or if/when we update the model to not have two N-tier paths that have
+        // to be traversed to fully/correctly build the product graph. :/
+        String poolProductsQuery = "SELECT DISTINCT pool.product_uuid " +
+            "  FROM cp_pool pool " +
+            "  WHERE now() BETWEEN pool.startdate AND pool.enddate ";
+
+        if (!this.owners.isEmpty()) {
+            poolProductsQuery += "AND pool.owner_id IN (:owner_ids)";
+            queryArgs.put("owner_ids", this.owners.keySet());
+        }
+
+        String ctes = "WITH RECURSIVE pool_products (product_uuid) AS (" + poolProductsQuery + "), " +
+            """
+            pcmap_anchor (product_uuid, child_uuid) AS (
+                SELECT uuid AS product_uuid, derived_product_uuid AS child_uuid
+                    FROM cp_products
+                    WHERE derived_product_uuid IS NOT NULL
+                UNION
+                SELECT ppp.product_uuid, ppp.provided_product_uuid AS child_uuid
+                    FROM cp_product_provided_products ppp
+                    JOIN pool_products pp ON pp.product_uuid = ppp.product_uuid
+            ),
+            parent_child_map (product_uuid, child_uuid, depth) AS (
+                SELECT product_uuid, child_uuid, 1 AS depth FROM pcmap_anchor
+                UNION ALL
+                SELECT ppp.product_uuid, ppp.provided_product_uuid AS child_uuid, pcmap.depth + 1 AS depth
+                    FROM parent_child_map pcmap
+                    JOIN cp_product_provided_products ppp ON ppp.product_uuid = pcmap.child_uuid
+            ),
+            active_products (uuid) AS (
+                SELECT product_uuid AS uuid FROM pool_products
+                UNION
+                SELECT pcmap.child_uuid AS uuid
+                    FROM active_products ap
+                    JOIN parent_child_map pcmap ON pcmap.product_uuid = ap.uuid
+            )
+            """;
+
+        // This *must* go at the beginning of the query or we break
+        queryChunks.add(0, ctes);
+        queryChunks.add("JOIN cp_product_contents pc ON pc.content_uuid = content.uuid");
+
+        if (this.active == Inclusion.EXCLUSIVE) {
+            queryChunks.add("JOIN active_products active ON active.uuid = pc.product_uuid");
+        }
+        else if (this.active == Inclusion.EXCLUDE) {
+            queryChunks.add("LEFT JOIN active_products active ON active.uuid = pc.product_uuid");
+            criteriaChunks.add("active.uuid IS NULL");
+        }
+    }
+
+    /**
+     * Assembles the components of the query that make up the custom contents filter.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for filtering on custom contents
+     *
+     * @param criteriaChunks
+     *  the list of criteria chunks to receive the predicates for filtering on custom contents
+     *
+     * @param parameters
+     *  the map of parameters to receive the specific query arguments provided to the builder
+     */
+    private void buildCustomContentsComponents(List<String> queryChunks, List<String> criteriaChunks,
+        Map<String, Object> queryArgs) {
+
+        List<String> namespaces = this.owners.values()
+            .stream()
+            .map(Owner::getKey)
+            .toList();
+
+        switch (this.custom) {
+            case EXCLUSIVE:
+                if (!namespaces.isEmpty()) {
+                    criteriaChunks.add("content.namespace IN (:org_namespaces)");
+                    queryArgs.put("org_namespaces", namespaces);
+                }
+                else {
+                    criteriaChunks.add("content.namespace != ''");
+                }
+                break;
+
+            case EXCLUDE:
+                criteriaChunks.add("content.namespace = ''");
+                break;
+
+            default:
+            case INCLUDE:
+                if (!namespaces.isEmpty()) {
+                    criteriaChunks.add("(content.namespace = '' OR content.namespace IN (:org_namespaces))");
+                    queryArgs.put("org_namespaces", namespaces);
+                }
+        }
+    }
+
+    /**
+     * Builds the components of the query that make up the content ID filter.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for filtering on content IDs
+     *
+     * @param criteriaChunks
+     *  the list of criteria chunks to receive the predicates for filtering on content IDs
+     *
+     * @param parameters
+     *  the map of parameters to receive the specific query arguments provided to the builder
+     */
+    private void buildContentIdFilterComponents(List<String> queryChunks, List<String> criteriaChunks,
+        Map<String, Object> queryArgs) {
+
+        if (!this.contentIds.isEmpty()) {
+            criteriaChunks.add("content.content_id IN (:content_ids)");
+            queryArgs.put("content_ids", this.contentIds);
+        }
+    }
+
+    /**
+     * Builds the components of the query that make up the content label filter.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for filtering on content labels
+     *
+     * @param criteriaChunks
+     *  the list of criteria chunks to receive the predicates for filtering on content labels
+     *
+     * @param parameters
+     *  the map of parameters to receive the specific query arguments provided to the builder
+     */
+    private void buildContentLabelFilterComponents(List<String> queryChunks, List<String> criteriaChunks,
+        Map<String, Object> queryArgs) {
+
+        if (!this.contentLabels.isEmpty()) {
+            // Impl note: This may end up being slow without an index to go along with it
+            criteriaChunks.add("LOWER(content.label) IN (:content_labels)");
+            queryArgs.put("content_labels", this.contentLabels);
+        }
+    }
+
+    /**
+     * Assembles the WHERE clause from the various chunks built from the criteria provided to this builder.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for filtering on content labels
+     *
+     * @param criteriaChunks
+     *  the list of criteria chunks to assemble
+     */
+    private void assembleWhereClause(List<String> queryChunks, List<String> criteriaChunks) {
+        if (criteriaChunks.isEmpty()) {
+            return;
+        }
+
+        String whereClause = criteriaChunks.stream()
+            .collect(Collectors.joining(" AND ", "WHERE ", ""));
+
+        queryChunks.add(whereClause);
+    }
+
+    /**
+     * Fetches the field object for a given field name, first checking on the immediate type, and then
+     * checking any supertypes as necessary.
+     *
+     * @param type
+     *  the base type to check for a field with the given name
+     *
+     * @param fieldName
+     *  the name of the field to fetch
+     *
+     * @throws NoSuchFieldException
+     *  if the field cannot be found within the type or its superclasses
+     *
+     * @return
+     *  the field with the matching name on the nearest type defined in the hierarchy
+     */
+    private Field getAttributeField(Class<?> type, String fieldName) throws NoSuchFieldException {
+        if (type == null) {
+            throw new NoSuchFieldException(fieldName);
+        }
+
+        try {
+            return type.getDeclaredField(fieldName);
+        }
+        catch (NoSuchFieldException e) {
+            return this.getAttributeField(type.getSuperclass(), fieldName);
+        }
+    }
+
+    /**
+     * Assembles the ORDER BY clause from the query ordering provided to this builder.
+     *
+     * @param queryChunks
+     *  the list of query chunks to receive the query components for ordering the query
+     *
+     * @param metamodel
+     *  the metamodel to use to validate the ordering columns
+     *
+     * @param prefix
+     *  a prefix to prepend to all ordering attributes
+     *
+     * @throws InvalidOrderKeyException
+     *  if an order is provided referencing an attribute name (key) that does not exist
+     */
+    private void assembleOrderByClause(List<String> queryChunks, EntityType<?> metamodel, String prefix) {
+        List<Order> ordering = this.getQueryOrdering();
+        if (ordering.isEmpty()) {
+            return;
+        }
+
+        Function<QueryBuilder.Order, String> orderMapper = order -> {
+            try {
+                // Impl note:
+                // We should probably just have a known DTO field name to internal DB column/field mapper.
+                // Even with this reflection magic, we're still going to eventually hit some desync in
+                // terms of naming conventions between the DB model and our DTOs.
+                //
+                // However, things get a little spicy with the fact the DTOs are procedurally generated
+                // from the API spec file with a quirky generator; so we can still desync even with some
+                // semi-hardcoded mappings. There is no winning here. Perhaps it's best left to the resource
+                // level anyway...?
+                //
+                // Regardless of the solution picked, we absolutely need to validate this input here because
+                // the field name is going into the query raw otherwise. THE RISK OF SQL INJECTION IS
+                // VERY REAL HERE.
+                String validated = metamodel.getSingularAttribute(order.column())
+                    .getName();
+
+                Column annotation = this.getAttributeField(metamodel.getJavaType(), validated)
+                    .getAnnotation(Column.class);
+
+                // If we have a column annotation, use that; otherwise default to the validated field name
+                String column = Optional.ofNullable(annotation)
+                    .map(Column::name)
+                    .filter(name -> !name.isBlank())
+                    .orElse(validated);
+
+                return new StringBuilder(prefix)
+                    .append(column)
+                    .append(' ')
+                    .append(order.reverse() ? "DESC" : "ASC")
+                    .toString();
+            }
+            catch (IllegalArgumentException | NoSuchFieldException e) {
+                throw new InvalidOrderKeyException(order.column(), metamodel, e);
+            }
+        };
+
+        String orderClause = ordering.stream()
+            .map(orderMapper)
+            .collect(Collectors.joining(", ", "ORDER BY ", ""));
+
+        queryChunks.add(orderClause);
+    }
+
+    /**
+     * Assembles the query to use for fetching contents based on the criteria provided to this builder.
+     *
+     * @param entityManager
+     *  the entity manager to use for building the query
+     *
+     * @return
+     *  a typed query for fet
+     */
+    private Query buildContentCountQuery() {
+        EntityManager entityManager = this.getEntityManager();
+
+        List<String> queryChunks = new ArrayList<>();
+        List<String> criteriaChunks = new ArrayList<>();
+        Map<String, Object> queryArgs = new HashMap<>();
+
+        // Prime the query with our basic select...
+        queryChunks.add("SELECT COUNT(*) FROM cp_contents content");
+
+        // Add the various components...
+        this.buildActiveContentsComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildCustomContentsComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildContentIdFilterComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildContentLabelFilterComponents(queryChunks, criteriaChunks, queryArgs);
+
+        // Assemble the where clause
+        this.assembleWhereClause(queryChunks, criteriaChunks);
+        String sql = String.join(" ", queryChunks);
+
+        log.trace("BUILT QUERY: {}", sql);
+        log.trace("USING QUERY ARGUMENTS: {}", queryArgs);
+
+        Query query = entityManager.createNativeQuery(sql);
+        queryArgs.forEach((key, value) -> query.setParameter(key, value));
+
+        return query;
+    }
+
+    /**
+     * Assembles the query to use for fetching contents based on the criteria provided to this builder.
+     *
+     * @param entityManager
+     *  the entity manager to use for building the query
+     *
+     * @return
+     *  a typed query for fet
+     */
+    private Query buildContentQuery() {
+        EntityManager entityManager = this.getEntityManager();
+        EntityType<Content> metamodel = entityManager.getMetamodel()
+            .entity(Content.class);
+
+        List<String> queryChunks = new ArrayList<>();
+        List<String> criteriaChunks = new ArrayList<>();
+        Map<String, Object> queryArgs = new HashMap<>();
+
+        // Impl note:
+        // According to Hibernate docs, native queries can be turned into entities using the native mapper
+        // so long as all of the columns are properly defined with @Column annotations in the entity itself
+        // and the column names are returned with the query. Joins are also possible with some janky looking,
+        // JPA/Hibernate-specific syntax, and lazy-loading proxies will be built as normal. In either
+        // case, the docs actually recommend using the wildcard operator for entity retrevial.
+        queryChunks.add("SELECT content.* FROM cp_contents content");
+
+        // Add the various components...
+        this.buildActiveContentsComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildCustomContentsComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildContentIdFilterComponents(queryChunks, criteriaChunks, queryArgs);
+        this.buildContentLabelFilterComponents(queryChunks, criteriaChunks, queryArgs);
+
+        // Assemble the where clause and order statements
+        this.assembleWhereClause(queryChunks, criteriaChunks);
+        this.assembleOrderByClause(queryChunks, metamodel, "content.");
+
+        String sql = String.join(" ", queryChunks);
+
+        log.trace("BUILT QUERY: {}", sql);
+        log.trace("USING QUERY ARGUMENTS: {}", queryArgs);
+
+        Query query = entityManager.createNativeQuery(sql, Content.class);
+        queryArgs.forEach((key, value) -> query.setParameter(key, value));
+
+        return query;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getResultCount() {
+        Number count = (Number) this.buildContentCountQuery()
+            .getSingleResult();
+
+        return count.longValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Content> getResultList() {
+        Query query = this.buildContentQuery();
+
+        this.applyQueryOffset(query)
+            .applyQueryLimit(query);
+
+        return (List<Content>) query.getResultList();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<Content> getResultStream() {
+        Query query = this.buildContentQuery();
+
+        this.applyQueryOffset(query)
+            .applyQueryLimit(query);
+
+        return (Stream<Content>) query.getResultStream();
+    }
+
+}

--- a/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/src/main/java/org/candlepin/resource/ContentResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -14,7 +14,6 @@
  */
 package org.candlepin.resource;
 
-import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.server.v1.ContentDTO;
@@ -22,71 +21,102 @@ import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
-import org.candlepin.model.ContentCurator.ContentQueryArguments;
-import org.candlepin.paging.Page;
-import org.candlepin.paging.PageRequest;
+import org.candlepin.model.ContentQueryBuilder;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.QueryBuilder.Inclusion;
+import org.candlepin.paging.PagingUtilFactory;
 import org.candlepin.resource.server.v1.ContentApi;
 
-import org.jboss.resteasy.core.ResteasyContext;
+import com.google.inject.persist.Transactional;
+
 import org.xnap.commons.i18n.I18n;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
+
+
 public class ContentResource implements ContentApi {
 
-    private final ContentCurator contentCurator;
-    private final I18n i18n;
-    private final ModelTranslator modelTranslator;
     private final Configuration config;
+    private final I18n i18n;
+    private final OwnerCurator ownerCurator;
+    private final ContentCurator contentCurator;
+    private final ModelTranslator modelTranslator;
+    private final PagingUtilFactory pagingUtilFactory;
 
     @Inject
-    public ContentResource(ContentCurator contentCurator, I18n i18n, ModelTranslator modelTranslator,
-        Configuration config) {
+    public ContentResource(
+        Configuration config,
+        I18n i18n,
+        OwnerCurator ownerCurator,
+        ContentCurator contentCurator,
+        ModelTranslator modelTranslator,
+        PagingUtilFactory pagingUtilFactory) {
+
+        this.config = Objects.requireNonNull(config);
         this.i18n = Objects.requireNonNull(i18n);
+        this.ownerCurator = Objects.requireNonNull(ownerCurator);
         this.contentCurator = Objects.requireNonNull(contentCurator);
         this.modelTranslator = Objects.requireNonNull(modelTranslator);
-        this.config = Objects.requireNonNull(config);
+        this.pagingUtilFactory = Objects.requireNonNull(pagingUtilFactory);
+    }
+
+    /**
+     * Retrieves an Owner instance for the owner with the specified key/account. If a matching owner could
+     * not be found, this method throws an exception.
+     *
+     * @param key
+     *  The key for the owner to retrieve
+     *
+     * @throws NotFoundException
+     *  if an owner could not be found for the specified key.
+     *
+     * @return
+     *  the Owner instance for the owner with the specified key.
+     *
+     * @httpcode 200
+     * @httpcode 404
+     */
+    private Owner resolveOwner(String key) {
+        Owner owner = this.ownerCurator.getByKey(key);
+        if (owner == null) {
+            throw new NotFoundException(i18n.tr("Owner with key \"{0}\" was not found.", key));
+        }
+
+        return owner;
     }
 
     @Override
-    public Stream<ContentDTO> getContents(Integer page, Integer perPage, String order, String sortBy) {
-        PageRequest pageRequest = ResteasyContext.getContextData(PageRequest.class);
-        ContentQueryArguments queryArgs = new ContentQueryArguments();
-        long count = this.contentCurator.getContentCount();
+    @Transactional
+    // GET /contents
+    public Stream<ContentDTO> getContents(List<String> ownerKeys, List<String> contentIds,
+        List<String> contentLabels, String active, String custom) {
 
-        if (pageRequest != null) {
-            Page<Stream<ContentDTO>> pageResponse = new Page<>();
-            pageResponse.setPageRequest(pageRequest);
+        List<Owner> owners = (ownerKeys != null ? ownerKeys.stream() : Stream.<String>empty())
+            .map(this::resolveOwner)
+            .toList();
 
-            if (pageRequest.isPaging()) {
-                queryArgs.setOffset((pageRequest.getPage() - 1) * pageRequest.getPerPage())
-                    .setLimit(pageRequest.getPerPage());
-            }
+        Inclusion activeInc = Inclusion.fromName(active, Inclusion.EXCLUSIVE)
+            .orElseThrow(() ->
+                new BadRequestException(i18n.tr("Invalid active inclusion type: {0}", active)));
+        Inclusion customInc = Inclusion.fromName(custom, Inclusion.INCLUDE)
+            .orElseThrow(() ->
+                new BadRequestException(i18n.tr("Invalid custom inclusion type: {0}", custom)));
 
-            if (pageRequest.getSortBy() != null) {
-                boolean reverse = pageRequest.getOrder() == PageRequest.DEFAULT_ORDER;
-                queryArgs.addOrder(pageRequest.getSortBy(), reverse);
-            }
+        ContentQueryBuilder queryBuilder = this.contentCurator.getContentQueryBuilder()
+            .addOwners(owners)
+            .addContentIds(contentIds)
+            .addContentLabels(contentLabels)
+            .setActive(activeInc)
+            .setCustom(customInc);
 
-            pageResponse.setMaxRecords((int) count);
-
-            // Store the page for the LinkHeaderResponseFilter
-            ResteasyContext.pushContext(Page.class, pageResponse);
-        }
-        // If no paging was specified, force a limit on amount of results
-        else {
-            int maxSize = config.getInt(ConfigProperties.PAGING_MAX_PAGE_SIZE);
-            if (count > maxSize) {
-                String errmsg = this.i18n.tr("This endpoint does not support returning more than {0} " +
-                    "results at a time, please use paging.", maxSize);
-                throw new BadRequestException(errmsg);
-            }
-        }
-
-        return this.contentCurator.listAll(queryArgs).stream()
+        return this.pagingUtilFactory.forClass(Content.class)
+            .applyPaging(queryBuilder)
             .map(this.modelTranslator.getStreamMapper(Content.class, ContentDTO.class));
     }
 

--- a/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -24,8 +24,10 @@ import org.candlepin.exceptions.ForbiddenException;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.Content;
 import org.candlepin.model.ContentCurator;
+import org.candlepin.model.ContentQueryBuilder;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.QueryBuilder.Inclusion;
 import org.candlepin.paging.PagingUtilFactory;
 import org.candlepin.resource.server.v1.OwnerContentApi;
 import org.candlepin.resource.util.InfoAdapter;
@@ -39,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -268,30 +269,29 @@ public class OwnerContentResource implements OwnerContentApi {
 
     @Override
     @Transactional
+    // GET /owners/{key}/contents
     public Stream<ContentDTO> getContentsByOwner(@Verify(Owner.class) String ownerKey,
-        List<String> contentIds, Boolean omitGlobalEntities) {
+        List<String> contentIds, List<String> contentLabels, String active, String custom) {
 
         Owner owner = this.getOwnerByKey(ownerKey);
-        String namespace = owner.getKey();
 
-        Collection<Content> contents;
+        Inclusion activeInc = Inclusion.fromName(active, Inclusion.EXCLUSIVE)
+            .orElseThrow(() ->
+                new BadRequestException(i18n.tr("Invalid active inclusion type: {0}", active)));
+        Inclusion customInc = Inclusion.fromName(custom, Inclusion.INCLUDE)
+            .orElseThrow(() ->
+                new BadRequestException(i18n.tr("Invalid custom inclusion type: {0}", custom)));
 
-        if (omitGlobalEntities == null || !omitGlobalEntities) {
-            contents = contentIds != null && !contentIds.isEmpty() ?
-                this.contentCurator.resolveContentIds(namespace, contentIds).values() :
-                this.contentCurator.resolveContentsByNamespace(namespace);
-        }
-        else {
-            contents = contentIds != null && !contentIds.isEmpty() ?
-                this.contentCurator.getContentsByIds(namespace, contentIds).values() :
-                this.contentCurator.getContentsByNamespace(namespace);
-        }
+        ContentQueryBuilder queryBuilder = this.contentCurator.getContentQueryBuilder()
+            .addOwners(owner)
+            .addContentIds(contentIds)
+            .addContentLabels(contentLabels)
+            .setActive(activeInc)
+            .setCustom(customInc);
 
-        Stream<ContentDTO> stream = contents.stream()
+        return this.pagingUtilFactory.forClass(Content.class)
+            .applyPaging(queryBuilder)
             .map(this.translator.getStreamMapper(Content.class, ContentDTO.class));
-
-        return this.pagingUtilFactory.forClass(ContentDTO.class)
-            .applyPaging(stream, contents.size());
     }
 
     @Override

--- a/src/main/java/org/candlepin/testext/manifestgen/EntityMapper.java
+++ b/src/main/java/org/candlepin/testext/manifestgen/EntityMapper.java
@@ -116,13 +116,11 @@ public class EntityMapper {
                 throw new IllegalStateException("content lacks an id: " + cdto);
             }
 
-            // Impl note:
-            // We won't namespace stuff here since it'll be vanishing in a moment anyway, and at the
-            // time of writing, this best reflects how export works and is used today.
-            Content fetched = this.contentCurator.getContentById(null, cid);
+            Content fetched = this.contentCurator.getContentById(this.owner.getKey(), cid);
             if (fetched == null) {
                 fetched = new Content()
-                    .setId(cid);
+                    .setId(cid)
+                    .setNamespace(this.owner.getKey());
             }
 
             return fetched;
@@ -170,10 +168,11 @@ public class EntityMapper {
             // Impl note:
             // We won't namespace stuff here since it'll be vanishing in a moment anyway, and at the
             // time of writing, this best reflects how export works and is used today.
-            Product fetched = this.productCurator.getProductById(null, pid);
+            Product fetched = this.productCurator.getProductById(this.owner.getKey(), pid);
             if (fetched == null) {
                 fetched = new Product()
-                    .setId(pid);
+                    .setId(pid)
+                    .setNamespace(this.owner.getKey());
             }
 
             return fetched;

--- a/src/test/java/org/candlepin/model/ContentQueryBuilderTest.java
+++ b/src/test/java/org/candlepin/model/ContentQueryBuilderTest.java
@@ -1,0 +1,905 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.candlepin.model.QueryBuilder.Inclusion;
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+
+
+/**
+ * ContentQueryBuilderTest
+ */
+public class ContentQueryBuilderTest extends DatabaseTestFixture {
+
+    private ContentQueryBuilder buildQueryBuilder() {
+        return new ContentQueryBuilder(this.getEntityManagerProvider());
+    }
+
+    /**
+     * Creates a set of products for use with the "testQueryBuilder..." family of tests below. Do not make
+     * changes to these products unless you are updating the testing for the ContentQueryBuilder class
+     * and do not use this method to set up data for any other test!
+     *
+     * Note that this test data does not create full product graphs for products. Testing the definition
+     * of "active" is left to a set of explicit tests which validates it in full.
+     */
+    private void createDataForQueryBuilderTesting() {
+        List<Owner> owners = List.of(
+            this.createOwner("owner1"),
+            this.createOwner("owner2"),
+            this.createOwner("owner3"));
+
+        List<Product> globalProducts = new ArrayList<>();
+        for (int i = 1; i <= 3; ++i) {
+            List<Content> contents = new ArrayList<>();
+
+            for (int c = 0; c < 2; ++c) {
+                Content content = new Content()
+                    .setId(String.format("g-content-%d%s", i, (char) ('a' + c)))
+                    .setName(String.format("global_content_%d%s", i, (char) ('a' + c)))
+                    .setLabel(String.format("global content %d%s", i, (char) ('a' + c)))
+                    .setType("test")
+                    .setVendor("vendor");
+
+                contents.add(this.contentCurator.create(content));
+            }
+
+            Product gprod = new Product()
+                .setId("g-prod-" + i)
+                .setName("global product " + i)
+                .addContent(contents.get(0), true)
+                .addContent(contents.get(1), false);
+
+            globalProducts.add(this.productCurator.create(gprod));
+        }
+
+        for (int oidx = 1; oidx <= owners.size(); ++oidx) {
+            Owner owner = owners.get(oidx - 1);
+
+            List<Product> ownerProducts = new ArrayList<>();
+
+            // create two custom products
+            for (int i = 1; i <= 2; ++i) {
+                List<Content> contents = new ArrayList<>();
+
+                for (int c = 0; c < 2; ++c) {
+                    Content content = new Content()
+                        .setId(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
+                        .setName(String.format("%s_content_%d%s", owner.getKey(), i, (char) ('a' + c)))
+                        .setLabel(String.format("%s content %d%s", owner.getKey(), i, (char) ('a' + c)))
+                        .setType("test")
+                        .setVendor("vendor")
+                        .setNamespace(owner.getKey());
+
+                    contents.add(this.contentCurator.create(content));
+                }
+
+                Product cprod = new Product()
+                    .setId(String.format("o%d-prod-%d", oidx, i))
+                    .setName(String.format("%s product %d", owner.getKey(), i))
+                    .setNamespace(owner.getKey())
+                    .addContent(contents.get(0), true)
+                    .addContent(contents.get(1), false);
+
+                ownerProducts.add(this.productCurator.create(cprod));
+            }
+
+            // create some pools:
+            // - one which references a global product
+            // - one which references a custom product
+            Pool globalPool = this.createPool(owner, globalProducts.get(0));
+            Pool customPool = this.createPool(owner, ownerProducts.get(0));
+        }
+    }
+
+    private void verifyQueryBuilderOutput(ContentQueryBuilder queryBuilder, List<String> expectedCids) {
+        int count = (int) queryBuilder.getResultCount();
+        List<Content> outputList = queryBuilder.getResultList();
+        Stream<Content> outputStream = queryBuilder.getResultStream();
+
+        assertThat(outputList)
+            .isNotNull()
+            .hasSize(count)
+            .map(Content::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+
+        assertThat(outputStream)
+            .isNotNull()
+            .hasSize(count)
+            .map(Content::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+
+    @Test
+    public void testQueryBuilderFetchesEverythingWithNoFiltering() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByOwnersAsArray() {
+        this.createDataForQueryBuilderTesting();
+
+        List<Owner> owners = Stream.of("owner2", "owner3")
+            .map(this.ownerCurator::getByKey)
+            .toList();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o2-content-1a", "o2-content-1b", "o2-content-2a",
+            "o2-content-2b", "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOwners(owners.toArray(new Owner[0]));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByOwnersAsCollection() {
+        this.createDataForQueryBuilderTesting();
+
+        List<Owner> owners = Stream.of("owner2", "owner3")
+            .map(this.ownerCurator::getByKey)
+            .toList();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o2-content-1a", "o2-content-1b", "o2-content-2a",
+            "o2-content-2b", "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOwners(owners);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderSilentlyIgnoresNullOwnersInArray() {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOwners(null, null, null);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderSilentlyIgnoresNullOwnersInCollection() {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOwners(Arrays.asList(null, null, null));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByContentIdAsArray() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("g-content-2a", "g-content-2b", "o1-content-1a", "o1-content-1b",
+            "o3-content-1a", "o3-content-1b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentIds("g-content-2a", "g-content-2b", "o1-content-1a")
+            .addContentIds("o1-content-1b", "o3-content-1a", "o3-content-1b");
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByContentIdAsCollection() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("g-content-2a", "g-content-2b", "o1-content-1a", "o1-content-1b",
+            "o3-content-1a", "o3-content-1b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentIds(List.of("g-content-2a", "g-content-2b", "o1-content-1a"))
+            .addContentIds(List.of("o1-content-1b", "o3-content-1a", "o3-content-1b"));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { " ",  "\t", "  \t  ", "\t  \t" })
+    @NullAndEmptySource
+    public void testQueryBuilderSilentlyIgnoresNullAndBlankContentIdsInArray(String pid) {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentIds(pid);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { " ",  "\t", "  \t  ", "\t  \t" })
+    @NullAndEmptySource
+    public void testQueryBuilderSilentlyIgnoresNullAndBlankContentIdsInCollection(String pid) {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentIds(Arrays.asList(pid));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersOnInvalidContentIdsInArray() {
+        this.createDataForQueryBuilderTesting();
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentIds("invalid_content_id");
+
+        this.verifyQueryBuilderOutput(queryBuilder, List.of());
+    }
+
+    @Test
+    public void testQueryBuilderFiltersOnInvalidContentIdsInCollection() {
+        this.createDataForQueryBuilderTesting();
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentIds(List.of("invalid_content_id"));
+
+        this.verifyQueryBuilderOutput(queryBuilder, List.of());
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByContentLabelsAsArray() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("g-content-3a", "g-content-3b", "o1-content-2a", "o1-content-2b",
+            "o3-content-1a", "o3-content-1b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentLabels("global content 3a", "owner1 content 2a", "owner3 content 1a")
+            .addContentLabels("global content 3b", "owner1 content 2b", "owner3 content 1b");
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByContentLabelsAsCollection() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("g-content-3a", "g-content-3b", "o1-content-2a", "o1-content-2b",
+            "o3-content-1a", "o3-content-1b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentLabels(Arrays.asList("global content 3a", "owner1 content 2a", "owner3 content 1a"))
+            .addContentLabels(Arrays.asList("global content 3b", "owner1 content 2b", "owner3 content 1b"));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { " ",  "\t", "  \t  ", "\t  \t" })
+    @NullAndEmptySource
+    public void testQueryBuilderSilentlyIgnoresNullAndBlankContentLabelsInArray(String contentLabel) {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentLabels(contentLabel);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { " ",  "\t", "  \t  ", "\t  \t" })
+    @NullAndEmptySource
+    public void testQueryBuilderSilentlyIgnoresNullAndBlankContentLabelsInCollection(String contentLabel) {
+        this.createDataForQueryBuilderTesting();
+
+        // Ignored parameters should result in an effective "fetch everything" with no other filters present
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentLabels(Arrays.asList(contentLabel));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersOnInvalidContentLabelsInArray() {
+        this.createDataForQueryBuilderTesting();
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addContentLabels("invalid_product_name");
+
+        this.verifyQueryBuilderOutput(queryBuilder, List.of());
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithExcludeActiveFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("g-content-2a", "g-content-2b", "g-content-3a", "g-content-3b",
+            "o1-content-2a", "o1-content-2b", "o2-content-2a", "o2-content-2b", "o3-content-2a",
+            "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setActive(Inclusion.EXCLUDE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithExclusiveActiveFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "o1-content-1a", "o1-content-1b",
+            "o2-content-1a", "o2-content-1b", "o3-content-1a", "o3-content-1b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setActive(Inclusion.EXCLUSIVE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithIncludeActiveFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        // active = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setActive(Inclusion.INCLUDE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithExcludeCustomFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setCustom(Inclusion.EXCLUDE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithExclusiveCustomFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setCustom(Inclusion.EXCLUSIVE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersWithIncludeCustomFilter() {
+        this.createDataForQueryBuilderTesting();
+
+        // custom = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .setCustom(Inclusion.INCLUDE);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderFiltersByMultipleFilters() {
+        this.createDataForQueryBuilderTesting();
+
+        // This test configures a bunch of filters which loosely resolve to the following:
+        // - active global content: not custom, not inactive (active = only, custom = omit)
+        // - in orgs 2 or 3
+        // - matching the given list of content IDs (gc1a+b, gc2a+b, o1c1a+b, o2c1a+b, o3c2a+b)
+        // - matching the given list of content labels (gc1a, gc2b, gc3a, o2c1b, o2c2a)
+        //
+        // These filters should be applied as an intersection, resulting in a singular match on gc1a
+
+        List<Owner> owners = Stream.of("owner2", "owner3")
+            .map(this.ownerCurator::getByKey)
+            .toList();
+        List<String> contentIds = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "o1-content-1a", "o1-content-1b", "o2-content-1a", "o2-content-1b", "o3-content-2a",
+            "o3-content-2b");
+        List<String> contentLabels = List.of("global content 1a", "global content 2b", "global content 3a",
+            "owner2 content 1b", "owner2 content 2a");
+        Inclusion activeInclusion = Inclusion.EXCLUSIVE;
+        Inclusion customInclusion = Inclusion.EXCLUDE;
+
+        List<String> expectedCids = List.of("g-content-1a");
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOwners(owners)
+            .addContentIds(contentIds)
+            .addContentLabels(contentLabels)
+            .setActive(activeInclusion)
+            .setCustom(customInclusion);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+    public void testQueryBuilderPagesResultsByPage(int pageSize) {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        int expectedPages = pageSize < expectedCids.size() ?
+            (expectedCids.size() / pageSize) + (expectedCids.size() % pageSize != 0 ? 1 : 0) :
+            1;
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        List<String> found = new ArrayList<>();
+        int pages = 0;
+        while (pages < expectedPages) {
+            queryBuilder.setPage(++pages, pageSize);
+
+            List<String> receivedPids = queryBuilder.getResultStream()
+                .map(Content::getId)
+                .toList();
+
+            if (receivedPids.isEmpty()) {
+                break;
+            }
+
+            found.addAll(receivedPids);
+        }
+
+        assertEquals(expectedPages, pages);
+        assertThat(found)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+    public void testQueryBuilderPagesResultsByOffsetAndLimit(int pageSize) {
+        this.createDataForQueryBuilderTesting();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        int expectedPages = pageSize < expectedCids.size() ?
+            (expectedCids.size() / pageSize) + (expectedCids.size() % pageSize != 0 ? 1 : 0) :
+            1;
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        List<String> found = new ArrayList<>();
+        int pages = 0;
+        while (pages < expectedPages) {
+            queryBuilder.setOffset(pages++ * pageSize)
+                .setLimit(pageSize);
+
+            List<String> receivedPids = queryBuilder.getResultStream()
+                .map(Content::getId)
+                .toList();
+
+            if (receivedPids.isEmpty()) {
+                break;
+            }
+
+            found.addAll(receivedPids);
+        }
+
+        assertEquals(expectedPages, pages);
+        assertThat(found)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -1, -100, -10000 })
+    public void testQueryBuilderErrorsWithInvalidOffset(int offset) {
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        assertThrows(IllegalArgumentException.class, () -> queryBuilder.setOffset(offset));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, -1, -100, -10000 })
+    public void testQueryBuilderErrorsWithInvalidLimit(int limit) {
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        assertThrows(IllegalArgumentException.class, () -> queryBuilder.setLimit(limit));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, -1, -100, -10000 })
+    public void testQueryBuilderErrorsWithInvalidPage(int page) {
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        assertThrows(IllegalArgumentException.class, () -> queryBuilder.setPage(page, 10));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, -1, -100, -10000 })
+    public void testQueryBuilderErrorsWithInvalidPageSize(int pageSize) {
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder();
+
+        assertThrows(IllegalArgumentException.class, () -> queryBuilder.setPage(1, pageSize));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testQueryBuilderOrdersResultsByNameAscending(String field) {
+        this.createDataForQueryBuilderTesting();
+
+        Map<String, Comparator<Content>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Content::getId),
+            "name", Comparator.comparing(Content::getName),
+            "uuid", Comparator.comparing(Content::getUuid));
+
+        List<String> expectedCids = this.contentCurator.listAll()
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Content::getId)
+            .toList();
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(field, false);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testQueryBuilderOrdersResultsByNameDescending(String field) {
+        this.createDataForQueryBuilderTesting();
+
+        Map<String, Comparator<Content>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Content::getId),
+            "name", Comparator.comparing(Content::getName),
+            "uuid", Comparator.comparing(Content::getUuid));
+
+        List<String> expectedCids = this.contentCurator.listAll()
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Content::getId)
+            .toList();
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(field, true);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testQueryBuilderOrdersResultsByOrderAscending(String field) {
+        this.createDataForQueryBuilderTesting();
+
+        Map<String, Comparator<Content>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Content::getId),
+            "name", Comparator.comparing(Content::getName),
+            "uuid", Comparator.comparing(Content::getUuid));
+
+        List<String> expectedCids = this.contentCurator.listAll()
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Content::getId)
+            .toList();
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(new QueryBuilder.Order(field, false));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testQueryBuilderOrdersResultsByOrderDescending(String field) {
+        this.createDataForQueryBuilderTesting();
+
+        Map<String, Comparator<Content>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Content::getId),
+            "name", Comparator.comparing(Content::getName),
+            "uuid", Comparator.comparing(Content::getUuid));
+
+        List<String> expectedCids = this.contentCurator.listAll()
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Content::getId)
+            .toList();
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(new QueryBuilder.Order(field, true));
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @Test
+    public void testQueryBuilderOrdersResultsByMultipleFields() {
+        this.createDataForQueryBuilderTesting();
+
+        Comparator<Content> updateComparator = Comparator.comparing(Content::getUpdated);
+        Comparator<Content> nameComparator = Comparator.comparing(Content::getName);
+        Comparator<Content> idComparator = Comparator.comparing(Content::getId);
+        Comparator<Content> uuidComparator = Comparator.comparing(Content::getUuid);
+
+        Comparator<Content> combined = updateComparator.reversed()
+            .thenComparing(nameComparator)
+            .thenComparing(idComparator)
+            .thenComparing(uuidComparator.reversed());
+
+        List<String> expectedCids = this.contentCurator.listAll()
+            .stream()
+            .sorted(combined)
+            .map(Content::getId)
+            .toList();
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(new QueryBuilder.Order("updated", true))
+            .addOrder("name", false)
+            .addOrder(new QueryBuilder.Order("id", false))
+            .addOrder("uuid", true);
+
+        this.verifyQueryBuilderOutput(queryBuilder, expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testQueryBuilderErrorsWithInvalidOrderingByField(boolean reverse) {
+        this.createDataForQueryBuilderTesting();
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder("invalid_field_name", reverse);
+
+        // At the time of writing, invalid keys don't trigger a failure until the query itself runs,
+        // so we have to attempt to fetch values to see the error.
+        assertThrows(InvalidOrderKeyException.class, () -> queryBuilder.getResultList());
+        assertThrows(InvalidOrderKeyException.class, () -> queryBuilder.getResultStream());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testQueryBuilderErrorsWithInvalidOrderingByOrder(boolean reverse) {
+        this.createDataForQueryBuilderTesting();
+
+        ContentQueryBuilder queryBuilder = this.buildQueryBuilder()
+            .addOrder(new QueryBuilder.Order("invalid_field_name", reverse));
+
+        // At the time of writing, invalid keys don't trigger a failure until the query itself runs,
+        // so we have to attempt to fetch values to see the error.
+        assertThrows(InvalidOrderKeyException.class, () -> queryBuilder.getResultList());
+        assertThrows(InvalidOrderKeyException.class, () -> queryBuilder.getResultStream());
+    }
+
+    // These tests verify the definition of "active" is properly implemented, ensuring "active" is defined
+    // as a product which is attached to a pool which has started and has not expired, or attached to
+    // another active product (recursively).
+    //
+    // This definition is recursive in nature, so the effect is that it should consider any product that
+    // is a descendant of a product attached to a non-future pool that hasn't yet expired.
+
+    @Test
+    public void testQueryBuilderActiveFilterOnlyConsidersActivePools() {
+        // - "active" only considers pools which have started but not expired (start time < now() < end time)
+        Owner owner = this.createOwner("test_org");
+
+        List<Product> products = new ArrayList<>();
+
+        for (int idx = 1; idx <= 3; ++idx) {
+            Content content1 = this.createContent(String.format("content-%da", idx));
+            Content content2 = this.createContent(String.format("content-%db", idx));
+
+            Product product = new Product()
+                .setId("prod-" + idx)
+                .setName("product " + idx)
+                .setNamespace(owner.getKey())
+                .addContent(content1, true)
+                .addContent(content2, false);
+
+            products.add(this.productCurator.create(product));
+        }
+
+        Function<Integer, Date> days = (offset) -> TestUtil.createDateOffset(0, 0, offset);
+        Date now = new Date();
+
+        // Create three pools: expired, current (active), future
+        Pool pool1 = this.createPool(owner, products.get(0), 1L, days.apply(-3), days.apply(-1));
+        Pool pool2 = this.createPool(owner, products.get(1), 1L, days.apply(-1), days.apply(1));
+        Pool pool3 = this.createPool(owner, products.get(2), 1L, days.apply(1), days.apply(3));
+
+        // Active = exclusive should only find the active pool; future and expired pools should be omitted
+        Stream<Content> output = this.buildQueryBuilder()
+            .setActive(Inclusion.EXCLUSIVE)
+            .getResultStream();
+
+        assertThat(output)
+            .isNotNull()
+            .map(Content::getId)
+            .containsExactlyInAnyOrder("content-2a", "content-2b");
+    }
+
+    @Test
+    public void testGetActiveProductsAlsoConsidersDescendantsOfActivePoolProducts() {
+        // - "active" includes descendants of products attached to a pool
+        Owner owner = this.createOwner("test_org");
+
+        List<Product> products = new ArrayList<>();
+
+        for (int i = 0; i < 20; ++i) {
+            Content content1 = this.createContent(String.format("c%da", i));
+            Content content2 = this.createContent(String.format("c%db", i));
+
+            Product product = new Product()
+                .setId("p" + i)
+                .setName("product " + i)
+                .addContent(content1, true)
+                .addContent(content2, false);
+
+            products.add(product);
+        }
+
+        /*
+        pool -> prod - p0
+                    derived - p1
+                        provided - p2
+                        provided - p3
+                            provided - p4
+                    provided - p5
+                    provided - p6
+
+        pool -> prod - p7
+                    derived - p8*
+                    provided - p9
+
+        pool -> prod - p8*
+                    provided - p10
+                        provided - p11
+                    provided - p12
+                        provided - p13
+
+                prod - p14
+                    derived - p15
+                        provided - p16
+
+                prod - p17
+                    provided - p18
+
+        pool -> prod - p19
+                prod - p20
+        */
+
+        products.get(0).setDerivedProduct(products.get(1));
+        products.get(0).addProvidedProduct(products.get(5));
+        products.get(0).addProvidedProduct(products.get(6));
+
+        products.get(1).addProvidedProduct(products.get(2));
+        products.get(1).addProvidedProduct(products.get(3));
+
+        products.get(3).addProvidedProduct(products.get(4));
+
+        products.get(7).setDerivedProduct(products.get(8));
+        products.get(7).addProvidedProduct(products.get(9));
+
+        products.get(8).addProvidedProduct(products.get(10));
+        products.get(8).addProvidedProduct(products.get(12));
+
+        products.get(10).addProvidedProduct(products.get(11));
+
+        products.get(12).addProvidedProduct(products.get(13));
+
+        products.get(14).setDerivedProduct(products.get(15));
+
+        products.get(15).setDerivedProduct(products.get(16));
+
+        products.get(17).setDerivedProduct(products.get(18));
+
+        // persist the products in reverse order so we don't hit any hibernate errors
+        for (int i = products.size() - 1; i >= 0; --i) {
+            this.productCurator.create(products.get(i));
+        }
+
+        Pool pool1 = this.createPool(owner, products.get(0));
+        Pool pool2 = this.createPool(owner, products.get(7));
+        Pool pool3 = this.createPool(owner, products.get(8));
+        Pool pool4 = this.createPool(owner, products.get(19));
+
+        List<String> expectedCids = List.of("c0a", "c0b", "c1a", "c1b", "c2a", "c2b", "c3a", "c3b", "c4a",
+            "c4b", "c5a", "c5b", "c6a", "c6b", "c7a", "c7b", "c8a", "c8b", "c9a", "c9b", "c10a", "c10b",
+            "c11a", "c11b", "c12a", "c12b", "c13a", "c13b", "c19a", "c19b");
+
+        Stream<Content> output = this.buildQueryBuilder()
+            .setActive(Inclusion.EXCLUSIVE)
+            .getResultStream();
+
+        assertThat(output)
+            .isNotNull()
+            .map(Content::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+}

--- a/src/test/java/org/candlepin/resource/ContentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ContentResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -14,103 +14,692 @@
  */
 package org.candlepin.resource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import org.candlepin.config.DevConfig;
-import org.candlepin.config.TestConfig;
-import org.candlepin.dto.ModelTranslator;
-import org.candlepin.dto.SimpleModelTranslator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.candlepin.dto.api.server.v1.ContentDTO;
-import org.candlepin.dto.api.v1.ContentTranslator;
 import org.candlepin.exceptions.BadRequestException;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.Content;
-import org.candlepin.model.ContentCurator;
-import org.candlepin.model.ContentCurator.ContentQueryArguments;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
+import org.candlepin.model.Product;
+import org.candlepin.model.QueryBuilder.Inclusion;
 import org.candlepin.paging.PageRequest;
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
 
 import org.jboss.resteasy.core.ResteasyContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.xnap.commons.i18n.I18n;
-import org.xnap.commons.i18n.I18nFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
-import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
 
 
 /**
  * ContentResourceTest
  */
-public class ContentResourceTest {
-
-    private ContentCurator cc;
-    private ContentResource resource;
-    private I18n i18n;
-    private ModelTranslator modelTranslator;
-    private DevConfig config;
+public class ContentResourceTest extends DatabaseTestFixture {
 
     @BeforeEach
-    public void init() {
-        this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
-        this.cc = mock(ContentCurator.class);
-        this.modelTranslator = new SimpleModelTranslator();
-        this.modelTranslator.registerTranslator(new ContentTranslator(), Content.class, ContentDTO.class);
-        this.config = TestConfig.defaults();
+    @Override
+    public void init() throws Exception {
+        super.init();
 
-        this.resource = new ContentResource(this.cc, this.i18n, this.modelTranslator, this.config);
-        ResteasyContext.popContextData(PageRequest.class);
+        // Make sure we don't have any latent page requests in the context
+        ResteasyContext.clearContextData();
     }
 
-    @Test
-    public void testGetContents() {
-        when(cc.listAll(any(ContentQueryArguments.class))).thenReturn(new LinkedList<>());
-        ResteasyContext.pushContext(PageRequest.class,
-            new PageRequest()
-            .setPage(1)
-            .setPerPage(10)
-            .setSortBy("label"));
-        resource.getContents(1, 10, "asc", "label");
-        verify(cc, atLeastOnce()).listAll(any(ContentQueryArguments.class));
-        ResteasyContext.popContextData(PageRequest.class);
+    @AfterEach
+    public void cleanup() throws Exception {
+        // Also cleanup after ourselves for other tests
+        ResteasyContext.clearContextData();
     }
 
-    @Test
-    public void testGetContentsOverMaxNoPaging() {
-        when(cc.getContentCount()).thenReturn(10001L);
-        assertThrows(BadRequestException.class, () -> resource.getContents(null, null, null, null));
-    }
-
-    @Test
-    public void testGetContentsNoPaging() {
-        when(cc.getContentCount()).thenReturn(1L);
-        when(cc.listAll(any(ContentQueryArguments.class))).thenReturn(List.of(new Content()));
-        assertEquals(1, resource.getContents(null, null, null, null).toList().size());
+    private ContentResource buildResource() {
+        return this.injector.getInstance(ContentResource.class);
     }
 
     @Test
     public void getContentNull() {
-        when(cc.get(anyLong())).thenReturn(null);
+        ContentResource resource = this.buildResource();
+
         assertThrows(NotFoundException.class, () -> resource.getContentByUuid("10"));
     }
 
     @Test
     public void getContent() {
-        Content content = mock(Content.class);
-        ContentDTO expected = this.modelTranslator.translate(content, ContentDTO.class);
-        when(cc.getByUuid(eq("10"))).thenReturn(content);
+        Content content = this.createContent("test_content");
 
-        ContentDTO output = resource.getContentByUuid("10");
+        ContentResource resource = this.buildResource();
 
-        assertEquals(expected, output);
+        ContentDTO output = resource.getContentByUuid(content.getUuid());
+
+        assertThat(output)
+            .isNotNull()
+            .returns(content.getUuid(), ContentDTO::getUuid);
+    }
+
+    /**
+     * Creates a set of products for use with the "testGetContents..." family of tests below. Do not make
+     * changes to these products unless you are updating the testing for the ContentResource.getContents
+     * method, and do not use this method to set up data for any other test!
+     *
+     * Note that this test data does not create full product graphs for products. Testing the definition
+     * of "active" is left to a set of explicit tests which validates it in full.
+     */
+    private void createDataForEndpointQueryTesting() {
+        List<Owner> owners = List.of(
+            this.createOwner("owner1"),
+            this.createOwner("owner2"),
+            this.createOwner("owner3"));
+
+        List<Product> globalProducts = new ArrayList<>();
+        for (int i = 1; i <= 3; ++i) {
+            List<Content> contents = new ArrayList<>();
+
+            for (int c = 0; c < 2; ++c) {
+                Content content = new Content()
+                    .setId(String.format("g-content-%d%s", i, (char) ('a' + c)))
+                    .setName(String.format("global_content_%d%s", i, (char) ('a' + c)))
+                    .setLabel(String.format("global content %d%s", i, (char) ('a' + c)))
+                    .setType("test")
+                    .setVendor("vendor");
+
+                contents.add(this.contentCurator.create(content));
+            }
+
+            Product gprod = new Product()
+                .setId("g-prod-" + i)
+                .setName("global product " + i)
+                .addContent(contents.get(0), true)
+                .addContent(contents.get(1), false);
+
+            globalProducts.add(this.productCurator.create(gprod));
+        }
+
+        for (int oidx = 1; oidx <= owners.size(); ++oidx) {
+            Owner owner = owners.get(oidx - 1);
+
+            List<Product> ownerProducts = new ArrayList<>();
+
+            // create two custom products
+            for (int i = 1; i <= 2; ++i) {
+                List<Content> contents = new ArrayList<>();
+
+                for (int c = 0; c < 2; ++c) {
+                    Content content = new Content()
+                        .setId(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
+                        .setName(String.format("%s_content_%d%s", owner.getKey(), i, (char) ('a' + c)))
+                        .setLabel(String.format("%s content %d%s", owner.getKey(), i, (char) ('a' + c)))
+                        .setType("test")
+                        .setVendor("vendor")
+                        .setNamespace(owner.getKey());
+
+                    contents.add(this.contentCurator.create(content));
+                }
+
+                Product cprod = new Product()
+                    .setId(String.format("o%d-prod-%d", oidx, i))
+                    .setName(String.format("%s product %d", owner.getKey(), i))
+                    .setNamespace(owner.getKey())
+                    .addContent(contents.get(0), true)
+                    .addContent(contents.get(1), false);
+
+                ownerProducts.add(this.productCurator.create(cprod));
+            }
+
+            // create some pools:
+            // - one which references a global product
+            // - one which references a custom product
+            Pool globalPool = this.createPool(owner, globalProducts.get(0));
+            Pool customPool = this.createPool(owner, ownerProducts.get(0));
+        }
+    }
+
+    @Test
+    public void testGetContentsFetchesWithNoFiltering() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsDefaultsToActiveOnly() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "o1-content-1a", "o1-content-1b",
+            "o2-content-1a", "o2-content-1b", "o3-content-1a", "o3-content-1b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null, null, null);
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsFetchesWithOwnerFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> ownerKeys = List.of("owner2", "owner3");
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o2-content-1a", "o2-content-1b", "o2-content-2a",
+            "o2-content-2b", "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(ownerKeys, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_owner" })
+    @NullAndEmptySource
+    public void testGetContentsErrorsWithInvalidOwners(String invalidOwnerKey) {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> ownerKeys = Arrays.asList("owner1", invalidOwnerKey);
+
+        ContentResource resource = this.buildResource();
+
+        assertThrows(NotFoundException.class, () -> resource.getContents(ownerKeys, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name()));
+    }
+
+    @Test
+    public void testGetContentsFetchesWithIDFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> contentIds = List.of("g-content-2a", "g-content-2b", "o1-content-1a", "o1-content-1b",
+            "o3-content-1a", "o3-content-1b");
+        List<String> expectedCids = List.of("g-content-2a", "g-content-2b", "o1-content-1a", "o1-content-1b",
+            "o3-content-1a", "o3-content-1b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, contentIds, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_id" })
+    @NullAndEmptySource
+    public void testGetContentsFetchesWithInvalidIDs(String contentId) {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> contentIds = Arrays.asList("o1-content-1a", "o1-content-1b", contentId);
+        List<String> expectedCids = List.of("o1-content-1a", "o1-content-1b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, contentIds, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsFetchesWithLabelFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> contentLabels = List.of("global content 3a", "owner1 content 2b", "owner3 content 1a");
+        List<String> expectedCids = List.of("g-content-3a", "o1-content-2b", "o3-content-1a");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, contentLabels,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_label" })
+    @NullAndEmptySource
+    public void testGetContentsFetchesWithInvalidLabels(String contentLabel) {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> contentLabels = Arrays.asList("owner1 content 2a", contentLabel);
+        List<String> expectedCids = List.of("o1-content-2a");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, contentLabels,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsFetchesWithOmitActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedCids = List.of("g-content-2a", "g-content-2b", "g-content-3a", "g-content-3b",
+            "o1-content-2a", "o1-content-2b", "o2-content-2a", "o2-content-2b", "o3-content-2a",
+            "o3-content-2b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null,
+            Inclusion.EXCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsFetchesWithOnlyActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "o1-content-1a", "o1-content-1b",
+            "o2-content-1a", "o2-content-1b", "o3-content-1a", "o3-content-1b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null,
+            Inclusion.EXCLUSIVE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsFetchesWithIncludeActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        // active = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsErrorsWithInvalidActiveFilter() {
+        ContentResource resource = this.buildResource();
+
+        assertThrows(BadRequestException.class, () -> resource.getContents(null, null, null,
+            "invalid_type", Inclusion.INCLUDE.name()));
+    }
+
+    @Test
+    public void testGetContentsFetchesWithOmitCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.EXCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsFetchesWithOnlyCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedCids = List.of("o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.EXCLUSIVE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsFetchesWithIncludeCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+
+        // custom = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsErrorsWithInvalidCustomFilter() {
+        ContentResource resource = this.buildResource();
+
+        assertThrows(BadRequestException.class, () -> resource.getContents(null, null, null,
+            Inclusion.INCLUDE.name(), "invalid_type"));
+    }
+
+    @Test
+    public void testGetContentsFetchesWithMultipleFilters() {
+        this.createDataForEndpointQueryTesting();
+
+        // This test configures a bunch of filters which loosely resolve to the following:
+        // - active global content: not custom, not inactive (active = only, custom = omit)
+        // - in orgs 2 or 3
+        // - matching the given list of content IDs (gc1a+b, gc2a+b, o1c1a+b, o2c1a+b, o3c2a+b)
+        // - matching the given list of content labels (gc1a, gc2b, gc3a, o2c1b, o2c2a)
+        //
+        // These filters should be applied as an intersection, resulting in a singular match on gc1a
+
+        List<String> ownerKeys = List.of("owner2", "owner3");
+        List<String> contentIds = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "o1-content-1a", "o1-content-1b", "o2-content-1a", "o2-content-1b", "o3-content-2a",
+            "o3-content-2b");
+        List<String> contentlabels = List.of("global content 1a", "global content 2b", "global content 3a",
+            "owner2 content 1b", "owner2 content 2a");
+        String activeInclusion = Inclusion.EXCLUSIVE.name();
+        String customInclusion = Inclusion.EXCLUDE.name();
+
+        List<String> expectedCids = List.of("g-content-1a");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(ownerKeys, contentIds, contentlabels,
+            activeInclusion, customInclusion);
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+    public void testGetContentsFetchesPagedResults(int pageSize) {
+        this.createDataForEndpointQueryTesting();
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o1-content-1a", "o1-content-1b", "o1-content-2a",
+            "o1-content-2b", "o2-content-1a", "o2-content-1b", "o2-content-2a", "o2-content-2b",
+            "o3-content-1a", "o3-content-1b", "o3-content-2a", "o3-content-2b");
+
+        int expectedPages = pageSize < expectedCids.size() ?
+            (expectedCids.size() / pageSize) + (expectedCids.size() % pageSize != 0 ? 1 : 0) :
+            1;
+
+        ContentResource resource = this.buildResource();
+
+        List<String> found = new ArrayList<>();
+        int pages = 0;
+        while (pages < expectedPages) {
+            // Set the context page request
+            ResteasyContext.popContextData(PageRequest.class);
+            ResteasyContext.pushContext(PageRequest.class, new PageRequest()
+                .setPage(++pages)
+                .setPerPage(pageSize));
+
+            Stream<ContentDTO> output = resource.getContents(null, null, null, Inclusion.INCLUDE.name(),
+                Inclusion.INCLUDE.name());
+
+            assertNotNull(output);
+            List<String> receivedPids = output.map(ContentDTO::getId)
+                .toList();
+
+            if (receivedPids.isEmpty()) {
+                break;
+            }
+
+            found.addAll(receivedPids);
+        }
+
+        assertEquals(expectedPages, pages);
+        assertThat(found)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testGetContentsFetchesOrderedResults(String field) {
+        this.createDataForEndpointQueryTesting();
+
+        Map<String, Comparator<Content>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Content::getId),
+            "name", Comparator.comparing(Content::getName),
+            "uuid", Comparator.comparing(Content::getUuid));
+
+        List<String> expectedCids = this.contentCurator.listAll()
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Content::getId)
+            .toList();
+
+        ResteasyContext.pushContext(PageRequest.class, new PageRequest().setSortBy(field));
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null, Inclusion.INCLUDE.name(),
+            Inclusion.INCLUDE.name());
+
+        // Note that this output needs to be ordered according to our expected ordering!
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsErrorsWithInvalidOrderingRequest() {
+        this.createDataForEndpointQueryTesting();
+
+        ResteasyContext.pushContext(PageRequest.class, new PageRequest().setSortBy("invalid_field_name"));
+
+        ContentResource resource = this.buildResource();
+        assertThrows(BadRequestException.class, () -> resource.getContents(null, null, null, null, null));
+    }
+
+    /**
+     * These tests verifies the definition of "active" is properly implemented, ensuring "active" is defined
+     * as a product which is attached to a pool which has started and has not expired, or attached to
+     * another active product (recursively).
+     *
+     * This definition is recursive in nature, so the effect is that it should consider any product that
+     * is a descendant of a product attached to a non-future pool that hasn't yet expired.
+     */
+    @Test
+    public void testGetActiveProductsOnlyConsidersActivePools() {
+        // - "active" only considers pools which have started but not expired (start time < now() < end time)
+        Owner owner = this.createOwner("test_org");
+
+        List<Product> products = new ArrayList<>();
+
+        for (int idx = 1; idx <= 3; ++idx) {
+            Content content1 = this.createContent(String.format("content-%da", idx));
+            Content content2 = this.createContent(String.format("content-%db", idx));
+
+            Product product = new Product()
+                .setId("prod-" + idx)
+                .setName("product " + idx)
+                .setNamespace(owner.getKey())
+                .addContent(content1, true)
+                .addContent(content2, false);
+
+            products.add(this.productCurator.create(product));
+        }
+
+        Function<Integer, Date> days = (offset) -> TestUtil.createDateOffset(0, 0, offset);
+        Date now = new Date();
+
+        // Create three pools: expired, current (active), future
+        Pool pool1 = this.createPool(owner, products.get(0), 1L, days.apply(-3), days.apply(-1));
+        Pool pool2 = this.createPool(owner, products.get(1), 1L, days.apply(-1), days.apply(1));
+        Pool pool3 = this.createPool(owner, products.get(2), 1L, days.apply(1), days.apply(3));
+
+        // Active = exclusive should only find the active pool; future and expired pools should be omitted
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null, Inclusion.EXCLUSIVE.name(),
+            Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrder("content-2a", "content-2b");
+    }
+
+    @Test
+    public void testGetActiveProductsAlsoConsidersDescendantsOfActivePoolProducts() {
+        // - "active" includes descendants of products attached to a pool
+        Owner owner = this.createOwner("test_org");
+
+        List<Product> products = new ArrayList<>();
+
+        for (int i = 0; i < 20; ++i) {
+            Content content1 = this.createContent(String.format("c%da", i));
+            Content content2 = this.createContent(String.format("c%db", i));
+
+            Product product = new Product()
+                .setId("p" + i)
+                .setName("product " + i)
+                .addContent(content1, true)
+                .addContent(content2, false);
+
+            products.add(product);
+        }
+
+        /*
+        pool -> prod - p0
+                    derived - p1
+                        provided - p2
+                        provided - p3
+                            provided - p4
+                    provided - p5
+                    provided - p6
+
+        pool -> prod - p7
+                    derived - p8*
+                    provided - p9
+
+        pool -> prod - p8*
+                    provided - p10
+                        provided - p11
+                    provided - p12
+                        provided - p13
+
+                prod - p14
+                    derived - p15
+                        provided - p16
+
+                prod - p17
+                    provided - p18
+
+        pool -> prod - p19
+                prod - p20
+        */
+
+        products.get(0).setDerivedProduct(products.get(1));
+        products.get(0).addProvidedProduct(products.get(5));
+        products.get(0).addProvidedProduct(products.get(6));
+
+        products.get(1).addProvidedProduct(products.get(2));
+        products.get(1).addProvidedProduct(products.get(3));
+
+        products.get(3).addProvidedProduct(products.get(4));
+
+        products.get(7).setDerivedProduct(products.get(8));
+        products.get(7).addProvidedProduct(products.get(9));
+
+        products.get(8).addProvidedProduct(products.get(10));
+        products.get(8).addProvidedProduct(products.get(12));
+
+        products.get(10).addProvidedProduct(products.get(11));
+
+        products.get(12).addProvidedProduct(products.get(13));
+
+        products.get(14).setDerivedProduct(products.get(15));
+
+        products.get(15).setDerivedProduct(products.get(16));
+
+        products.get(17).setDerivedProduct(products.get(18));
+
+        // persist the products in reverse order so we don't hit any hibernate errors
+        for (int i = products.size() - 1; i >= 0; --i) {
+            this.productCurator.create(products.get(i));
+        }
+
+        Pool pool1 = this.createPool(owner, products.get(0));
+        Pool pool2 = this.createPool(owner, products.get(7));
+        Pool pool3 = this.createPool(owner, products.get(8));
+        Pool pool4 = this.createPool(owner, products.get(19));
+
+        List<String> expectedCids = List.of("c0a", "c0b", "c1a", "c1b", "c2a", "c2b", "c3a", "c3b", "c4a",
+            "c4b", "c5a", "c5b", "c6a", "c6b", "c7a", "c7b", "c8a", "c8b", "c9a", "c9b", "c10a", "c10b",
+            "c11a", "c11b", "c12a", "c12b", "c13a", "c13b", "c19a", "c19b");
+
+        ContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContents(null, null, null, Inclusion.EXCLUSIVE.name(),
+            Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
     }
 }

--- a/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -26,186 +26,61 @@ import org.candlepin.exceptions.ForbiddenException;
 import org.candlepin.exceptions.NotFoundException;
 import org.candlepin.model.Content;
 import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
+import org.candlepin.model.Product;
+import org.candlepin.model.QueryBuilder.Inclusion;
+import org.candlepin.paging.PageRequest;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
 
+import org.jboss.resteasy.core.ResteasyContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Stream;
+
 
 
 
 public class OwnerContentResourceTest extends DatabaseTestFixture {
 
-    private OwnerContentResource ownerContentResource;
-
     @BeforeEach
     @Override
     public void init() throws Exception {
         super.init();
-        ownerContentResource = injector.getInstance(OwnerContentResource.class);
+
+        // Make sure we don't have any latent page requests in the context
+        ResteasyContext.clearContextData();
     }
 
-    @Test
-    public void testGetContentsByOwnerFetchesAllVisibleEntities() {
-        Owner owner1 = this.createOwner("test_owner-1");
-        Owner owner2 = this.createOwner("test_owner-2");
-
-        Content content1 = TestUtil.createContent("test_content-1", "test_content-1")
-            .setNamespace((Owner) null);
-        Content content2 = TestUtil.createContent("test_content-2", "test_content-2")
-            .setNamespace(owner1.getKey());
-        Content content3 = TestUtil.createContent("test_content-3", "test_content-3")
-            .setNamespace(owner2.getKey());
-
-        this.createContent(content1);
-        this.createContent(content2);
-        this.createContent(content3);
-
-        ContentDTO cdto1 = this.modelTranslator.translate(content1, ContentDTO.class);
-        ContentDTO cdto2 = this.modelTranslator.translate(content2, ContentDTO.class);
-
-        Stream<ContentDTO> response = this.ownerContentResource
-            .getContentsByOwner(owner1.getKey(), List.of(), false);
-
-        assertNotNull(response);
-        assertThat(response.toList())
-            .hasSize(2)
-            .containsOnly(cdto1, cdto2);
+    @AfterEach
+    public void cleanup() throws Exception {
+        // Also cleanup after ourselves for other tests
+        ResteasyContext.clearContextData();
     }
 
-    @Test
-    public void testGetContentsByOwnerOmitsGlobalsWhenOmitFlagIsSet() {
-        Owner owner1 = this.createOwner("test_owner-1");
-        Owner owner2 = this.createOwner("test_owner-2");
-
-        Content content1 = TestUtil.createContent("test_content-1", "test_content-1")
-            .setNamespace((Owner) null);
-        Content content2 = TestUtil.createContent("test_content-2", "test_content-2")
-            .setNamespace(owner1.getKey());
-        Content content3 = TestUtil.createContent("test_content-3", "test_content-3")
-            .setNamespace(owner2.getKey());
-
-        this.createContent(content1);
-        this.createContent(content2);
-        this.createContent(content3);
-
-        ContentDTO cdto2 = this.modelTranslator.translate(content2, ContentDTO.class);
-
-        Stream<ContentDTO> response = this.ownerContentResource
-            .getContentsByOwner(owner1.getKey(), List.of(), true);
-
-        assertNotNull(response);
-        assertThat(response.toList())
-            .hasSize(1)
-            .containsOnly(cdto2);
-    }
-
-    @Test
-    public void testGetContentsByOwnerWithEntityIDFiltering() {
-        Owner owner1 = this.createOwner("test_owner-1");
-        Owner owner2 = this.createOwner("test_owner-2");
-
-        Content content1 = TestUtil.createContent("test_content-1", "test_content-1")
-            .setNamespace((Owner) null);
-        Content content2 = TestUtil.createContent("test_content-2", "test_content-2")
-            .setNamespace(owner1.getKey());
-        Content content3 = TestUtil.createContent("test_content-3", "test_content-3")
-            .setNamespace((Owner) null);
-        Content content4 = TestUtil.createContent("test_content-4", "test_content-4")
-            .setNamespace(owner1.getKey());
-        Content content5 = TestUtil.createContent("test_content-5", "test_content-5")
-            .setNamespace(owner2.getKey());
-
-        this.createContent(content1);
-        this.createContent(content2);
-        this.createContent(content3);
-        this.createContent(content4);
-        this.createContent(content5);
-
-        List<String> ids = Stream.of(content3, content4, content5)
-            .map(Content::getId)
-            .toList();
-
-        Stream<ContentDTO> response = this.ownerContentResource
-            .getContentsByOwner(owner1.getKey(), ids, false);
-
-        List<ContentDTO> expected = Stream.of(content3, content4)
-            .map(this.modelTranslator.getStreamMapper(Content.class, ContentDTO.class))
-            .toList();
-
-        assertNotNull(response);
-        assertThat(response.toList())
-            .hasSize(expected.size())
-            .containsAll(expected);
-    }
-
-    @Test
-    public void testGetContentsByOwnerWithEntityIDFilteringAndOmitGlobalsSet() {
-        Owner owner1 = this.createOwner("test_owner-1");
-        Owner owner2 = this.createOwner("test_owner-2");
-
-        Content content1 = TestUtil.createContent("test_content-1", "test_content-1")
-            .setNamespace((Owner) null);
-        Content content2 = TestUtil.createContent("test_content-2", "test_content-2")
-            .setNamespace(owner1.getKey());
-        Content content3 = TestUtil.createContent("test_content-3", "test_content-3")
-            .setNamespace((Owner) null);
-        Content content4 = TestUtil.createContent("test_content-4", "test_content-4")
-            .setNamespace(owner1.getKey());
-        Content content5 = TestUtil.createContent("test_content-5", "test_content-5")
-            .setNamespace(owner2.getKey());
-
-        this.createContent(content1);
-        this.createContent(content2);
-        this.createContent(content3);
-        this.createContent(content4);
-        this.createContent(content5);
-
-        List<String> ids = Stream.of(content3, content4, content5)
-            .map(Content::getId)
-            .toList();
-
-        Stream<ContentDTO> response = this.ownerContentResource
-            .getContentsByOwner(owner1.getKey(), ids, true);
-
-        List<ContentDTO> expected = Stream.of(content4)
-            .map(this.modelTranslator.getStreamMapper(Content.class, ContentDTO.class))
-            .toList();
-
-        assertNotNull(response);
-        assertThat(response.toList())
-            .hasSize(expected.size())
-            .containsAll(expected);
-    }
-
-    @Test
-    public void testGetContentsByOwnerWithNoContent() throws Exception {
-        Owner owner = this.createOwner("test_owner");
-
-        Stream<ContentDTO> response = this.ownerContentResource
-            .getContentsByOwner(owner.getKey(), List.of(), false);
-        assertNotNull(response);
-
-        List<ContentDTO> received = response.toList();
-        assertEquals(0, received.size());
-    }
-
-    @Test
-    public void testGetContentsByOwnerBadOwner() throws Exception {
-        Owner owner = this.createOwner("test_owner");
-
-        assertThrows(NotFoundException.class,
-            () -> this.ownerContentResource.getContentsByOwner("bad owner", List.of(), false));
+    public OwnerContentResource buildResource() {
+        return this.injector.getInstance(OwnerContentResource.class);
     }
 
     @Test
     public void testGetContentById() {
         Owner owner = this.createOwner("test_owner");
         Content content = this.createContent("test_content", "test_content");
-        ContentDTO output = this.ownerContentResource.getContentById(owner.getKey(), content.getId());
+
+        ContentDTO output = this.buildResource()
+            .getContentById(owner.getKey(), content.getId());
 
         assertNotNull(output);
         assertEquals(content.getId(), output.getId());
@@ -215,8 +90,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
     public void testGetContentByIdNotFound() {
         Owner owner = this.createOwner("test_owner");
 
-        assertThrows(NotFoundException.class,
-            () -> this.ownerContentResource.getContentById(owner.getKey(), "test_content"));
+        assertThrows(NotFoundException.class, () -> this.buildResource()
+            .getContentById(owner.getKey(), "test_content"));
     }
 
     @Test
@@ -229,7 +104,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
 
         assertNull(this.contentCurator.getContentById(owner.getKey(), cdto.getId()));
 
-        ContentDTO output = this.ownerContentResource.createContent(owner.getKey(), cdto);
+        ContentDTO output = this.buildResource()
+            .createContent(owner.getKey(), cdto);
 
         assertNotNull(output);
         assertEquals(cdto.getId(), output.getId());
@@ -256,7 +132,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
 
         assertNotNull(this.contentCurator.getContentById(owner.getKey(), update.getId()));
 
-        ContentDTO output = this.ownerContentResource.createContent(owner.getKey(), update);
+        ContentDTO output = this.buildResource()
+            .createContent(owner.getKey(), update);
 
         assertNotNull(output);
         assertEquals(update.getId(), output.getId());
@@ -282,8 +159,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
         assertNotNull(this.contentCurator.getContentById(null, update.getId()));
         assertNull(this.contentCurator.getContentById(owner.getKey(), update.getId()));
 
-        assertThrows(BadRequestException.class,
-            () -> this.ownerContentResource.createContent(owner.getKey(), update));
+        assertThrows(BadRequestException.class, () -> this.buildResource()
+            .createContent(owner.getKey(), update));
     }
 
     @Test
@@ -296,7 +173,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
 
         assertNull(this.contentCurator.getContentById(owner.getKey(), cdto.getId()));
 
-        ContentDTO output = this.ownerContentResource.createContent(owner.getKey(), cdto);
+        ContentDTO output = this.buildResource()
+            .createContent(owner.getKey(), cdto);
 
         assertNotNull(output);
         assertEquals(cdto.getId(), output.getId());
@@ -319,7 +197,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
         ContentDTO update = TestUtil.createContentDTO("test_content", "updated_name");
         assertNotNull(this.contentCurator.getContentById(owner.getKey(), update.getId()));
 
-        ContentDTO output = this.ownerContentResource.updateContent(owner.getKey(), update.getId(), update);
+        ContentDTO output = this.buildResource()
+            .updateContent(owner.getKey(), update.getId(), update);
 
         assertNotNull(output);
         assertEquals(update.getId(), output.getId());
@@ -338,8 +217,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
 
         assertNull(this.contentCurator.resolveContentId(owner.getKey(), update.getId()));
 
-        assertThrows(NotFoundException.class,
-            () -> this.ownerContentResource.updateContent(owner.getKey(), update.getId(), update));
+        assertThrows(NotFoundException.class, () -> this.buildResource()
+            .updateContent(owner.getKey(), update.getId(), update));
 
         assertNull(this.contentCurator.resolveContentId(owner.getKey(), update.getId()));
     }
@@ -354,8 +233,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
 
         ContentDTO update = TestUtil.createContentDTO(content.getId(), "updated_name");
 
-        assertThrows(ForbiddenException.class,
-            () -> this.ownerContentResource.updateContent(owner.getKey(), update.getId(), update));
+        assertThrows(ForbiddenException.class, () -> this.buildResource()
+            .updateContent(owner.getKey(), update.getId(), update));
     }
 
     @Test
@@ -369,8 +248,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
 
         ContentDTO update = TestUtil.createContentDTO(content.getId(), "updated_name");
 
-        assertThrows(NotFoundException.class,
-            () -> this.ownerContentResource.updateContent(owner1.getKey(), update.getId(), update));
+        assertThrows(NotFoundException.class, () -> this.buildResource()
+            .updateContent(owner1.getKey(), update.getId(), update));
     }
 
     @Test
@@ -382,7 +261,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
 
         assertNotNull(this.contentCurator.getContentById(owner.getKey(), content.getId()));
 
-        this.ownerContentResource.removeContent(owner.getKey(), content.getId());
+        this.buildResource()
+            .removeContent(owner.getKey(), content.getId());
 
         assertNull(this.contentCurator.getContentById(owner.getKey(), content.getId()));
         assertNull(this.contentCurator.get(content.getUuid()));
@@ -396,8 +276,8 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
             .setNamespace((Owner) null);
         Content content = this.contentCurator.create(template);
 
-        assertThrows(ForbiddenException.class,
-            () -> this.ownerContentResource.removeContent(owner.getKey(), content.getId()));
+        assertThrows(ForbiddenException.class, () -> this.buildResource()
+            .removeContent(owner.getKey(), content.getId()));
     }
 
     @Test
@@ -409,23 +289,622 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
             .setNamespace(owner2.getKey());
         Content content = this.contentCurator.create(template);
 
-        assertThrows(NotFoundException.class,
-            () -> this.ownerContentResource.removeContent(owner1.getKey(), content.getId()));
+        assertThrows(NotFoundException.class, () -> this.buildResource()
+            .removeContent(owner1.getKey(), content.getId()));
     }
 
     @Test
     public void deleteContentWithNonExistentContent() {
         Owner owner = this.createOwner("test_owner");
 
-        assertThrows(NotFoundException.class,
-            () -> this.ownerContentResource.removeContent(owner.getKey(), "test_content"));
+        assertThrows(NotFoundException.class, () -> this.buildResource()
+            .removeContent(owner.getKey(), "test_content"));
     }
 
     @Test
     public void testUpdateContentThrowsExceptionWhenOwnerDoesNotExist() {
         ContentDTO cdto = TestUtil.createContentDTO("test_content");
 
-        assertThrows(NotFoundException.class,
-            () -> this.ownerContentResource.updateContent("fake_owner_key", cdto.getId(), cdto));
+        assertThrows(NotFoundException.class, () -> this.buildResource()
+            .updateContent("fake_owner_key", cdto.getId(), cdto));
+    }
+
+    /**
+     * Creates a set of products for use with the "testGetContentsByOwner..." family of tests below. Do
+     * not make changes to these products unless you are updating the testing for the
+     * OwnerContentResource.getContentsByOwner method, and do not use this method to set up data for any
+     * other test!
+     *
+     * Note that this test data does not create full product graphs for products. Testing the definition
+     * of "active" is left to a set of explicit tests which validates it in full.
+     */
+    private void createDataForEndpointQueryTesting() {
+        List<Owner> owners = List.of(
+            this.createOwner("owner1"),
+            this.createOwner("owner2"),
+            this.createOwner("owner3"));
+
+        List<Product> globalProducts = new ArrayList<>();
+        for (int i = 1; i <= 3; ++i) {
+            List<Content> contents = new ArrayList<>();
+
+            for (int c = 0; c < 2; ++c) {
+                Content content = new Content()
+                    .setId(String.format("g-content-%d%s", i, (char) ('a' + c)))
+                    .setName(String.format("global_content_%d%s", i, (char) ('a' + c)))
+                    .setLabel(String.format("global content %d%s", i, (char) ('a' + c)))
+                    .setType("test")
+                    .setVendor("vendor");
+
+                contents.add(this.contentCurator.create(content));
+            }
+
+            Product gprod = new Product()
+                .setId("g-prod-" + i)
+                .setName("global product " + i)
+                .addContent(contents.get(0), true)
+                .addContent(contents.get(1), false);
+
+            globalProducts.add(this.productCurator.create(gprod));
+        }
+
+        for (int oidx = 1; oidx <= owners.size(); ++oidx) {
+            Owner owner = owners.get(oidx - 1);
+
+            List<Product> ownerProducts = new ArrayList<>();
+
+            // create two custom products
+            for (int i = 1; i <= 2; ++i) {
+                List<Content> contents = new ArrayList<>();
+
+                for (int c = 0; c < 2; ++c) {
+                    Content content = new Content()
+                        .setId(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
+                        .setName(String.format("%s_content_%d%s", owner.getKey(), i, (char) ('a' + c)))
+                        .setLabel(String.format("%s content %d%s", owner.getKey(), i, (char) ('a' + c)))
+                        .setType("test")
+                        .setVendor("vendor")
+                        .setNamespace(owner.getKey());
+
+                    contents.add(this.contentCurator.create(content));
+                }
+
+                Product cprod = new Product()
+                    .setId(String.format("o%d-prod-%d", oidx, i))
+                    .setName(String.format("%s product %d", owner.getKey(), i))
+                    .setNamespace(owner.getKey())
+                    .addContent(contents.get(0), true)
+                    .addContent(contents.get(1), false);
+
+                ownerProducts.add(this.productCurator.create(cprod));
+            }
+
+            // create some pools:
+            // - one which references a global product
+            // - one which references a custom product
+            Pool globalPool = this.createPool(owner, globalProducts.get(0));
+            Pool customPool = this.createPool(owner, ownerProducts.get(0));
+        }
+    }
+
+    @Test
+    public void testGetContentsByOwnerFetchesWithNoFiltering() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o2-content-1a", "o2-content-1b", "o2-content-2a",
+            "o2-content-2b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsByOwnerDefaultsToActiveOnly() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "o2-content-1a", "o2-content-1b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, null, null, null);
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_owner" })
+    @NullAndEmptySource
+    public void testGetContentsByOwnerErrorsWithInvalidOwners(String ownerKey) {
+        this.createDataForEndpointQueryTesting();
+
+        OwnerContentResource resource = this.buildResource();
+
+        assertThrows(NotFoundException.class, () -> resource.getContentsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name()));
+    }
+
+    @Test
+    public void testGetContentsByOwnerFetchesWithIDFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> contentIds = List.of("g-content-2a", "g-content-2b", "o1-content-1a", "o2-content-1b",
+            "o3-content-1a");
+        List<String> expectedCids = List.of("g-content-2a", "g-content-2b", "o2-content-1b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, contentIds, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_id" })
+    @NullAndEmptySource
+    public void testGetContentsByOwnerFetchesWithInvalidIDs(String contentId) {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> contentIds = Arrays.asList("o2-content-1a", "o2-content-1b", contentId);
+        List<String> expectedCids = List.of("o2-content-1a", "o2-content-1b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, contentIds, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsByOwnerFetchesWithLabelFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> contentLabels = List.of("global content 3a", "owner2 content 2b", "owner3 content 1a");
+        List<String> expectedCids = List.of("g-content-3a", "o2-content-2b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, contentLabels,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid_label" })
+    @NullAndEmptySource
+    public void testGetContentsByOwnerFetchesWithInvalidLabels(String contentLabel) {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> contentLabels = Arrays.asList("owner2 content 1a", contentLabel);
+        List<String> expectedCids = List.of("o2-content-1a");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, contentLabels,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsByOwnerFetchesWithOmitActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedCids = List.of("g-content-2a", "g-content-2b", "g-content-3a", "g-content-3b",
+            "o2-content-2a", "o2-content-2b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, null,
+            Inclusion.EXCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsByOwnerFetchesWithOnlyActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "o2-content-1a", "o2-content-1b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, null,
+            Inclusion.EXCLUSIVE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsByOwnerFetchesWithIncludeActiveFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        // active = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o2-content-1a", "o2-content-1b", "o2-content-2a",
+            "o2-content-2b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsByOwnerErrorsWithInvalidActiveFilter() {
+        Owner owner = this.createOwner("test_org");
+
+        OwnerContentResource resource = this.buildResource();
+
+        assertThrows(BadRequestException.class, () -> resource.getContentsByOwner(owner.getKey(), null, null,
+            "invalid_type", Inclusion.INCLUDE.name()));
+    }
+
+    @Test
+    public void testGetContentsByOwnerFetchesWithOmitCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.EXCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsByOwnerFetchesWithOnlyCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedCids = List.of("o2-content-1a", "o2-content-1b", "o2-content-2a",
+            "o2-content-2b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.EXCLUSIVE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsByOwnerFetchesWithIncludeCustomFilter() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        // custom = "include" with no other filters is effectively a "fetch the world" kind of option.
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o2-content-1a", "o2-content-1b", "o2-content-2a",
+            "o2-content-2b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsByOwnerErrorsWithInvalidCustomFilter() {
+        Owner owner = this.createOwner("test_org");
+
+        OwnerContentResource resource = this.buildResource();
+
+        assertThrows(BadRequestException.class, () -> resource.getContentsByOwner(owner.getKey(), null, null,
+            Inclusion.INCLUDE.name(), "invalid_type"));
+    }
+
+    @Test
+    public void testGetContentsByOwnerFetchesWithMultipleFilters() {
+        this.createDataForEndpointQueryTesting();
+
+        // This test configures a bunch of filters which loosely resolve to the following:
+        // - active global content: not custom, not inactive (active = only, custom = omit)
+        // - in orgs 2 or 3
+        // - matching the given list of content IDs (gc1a+b, gc2a+b, o1c1a+b, o2c1a+b, o3c2a+b)
+        // - matching the given list of content labels (gc1a, gc2b, gc3a, o2c1b, o2c2a)
+        //
+        // These filters should be applied as an intersection, resulting in a singular match on gc1a
+
+        String ownerKey = "owner2";
+        List<String> contentIds = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "o1-content-1a", "o1-content-1b", "o2-content-1a", "o2-content-1b", "o3-content-2a",
+            "o3-content-2b");
+        List<String> contentlabels = List.of("global content 1a", "global content 2b", "global content 3a",
+            "owner2 content 1b", "owner2 content 2a");
+        String activeInclusion = Inclusion.EXCLUSIVE.name();
+        String customInclusion = Inclusion.EXCLUDE.name();
+
+        List<String> expectedCids = List.of("g-content-1a");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, contentIds, contentlabels,
+            activeInclusion, customInclusion);
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 2, 3, 6, 10, 1000 })
+    public void testGetContentsByOwnerFetchesPagedResults(int pageSize) {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        List<String> expectedCids = List.of("g-content-1a", "g-content-1b", "g-content-2a", "g-content-2b",
+            "g-content-3a", "g-content-3b", "o2-content-1a", "o2-content-1b", "o2-content-2a",
+            "o2-content-2b");
+
+        int expectedPages = pageSize < expectedCids.size() ?
+            (expectedCids.size() / pageSize) + (expectedCids.size() % pageSize != 0 ? 1 : 0) :
+            1;
+
+        OwnerContentResource resource = this.buildResource();
+
+        List<String> found = new ArrayList<>();
+        int pages = 0;
+        while (pages < expectedPages) {
+            // Set the context page request
+            ResteasyContext.popContextData(PageRequest.class);
+            ResteasyContext.pushContext(PageRequest.class, new PageRequest()
+                .setPage(++pages)
+                .setPerPage(pageSize));
+
+            Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, null,
+                Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+            assertNotNull(output);
+            List<String> receivedPids = output.map(ContentDTO::getId)
+                .toList();
+
+            if (receivedPids.isEmpty()) {
+                break;
+            }
+
+            found.addAll(receivedPids);
+        }
+
+        assertEquals(expectedPages, pages);
+        assertThat(found)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "id", "name", "uuid" })
+    public void testGetContentsByOwnerFetchesOrderedResults(String field) {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        Map<String, Comparator<Content>> comparatorMap = Map.of(
+            "id", Comparator.comparing(Content::getId),
+            "name", Comparator.comparing(Content::getName),
+            "uuid", Comparator.comparing(Content::getUuid));
+
+        List<String> expectedCids = this.contentCurator.resolveContentsByNamespace(ownerKey)
+            .stream()
+            .sorted(comparatorMap.get(field))
+            .map(Content::getId)
+            .toList();
+
+        ResteasyContext.pushContext(PageRequest.class, new PageRequest().setSortBy(field));
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(ownerKey, null, null,
+            Inclusion.INCLUDE.name(), Inclusion.INCLUDE.name());
+
+        // Note that this output needs to be ordered according to our expected ordering!
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyElementsOf(expectedCids);
+    }
+
+    @Test
+    public void testGetContentsByOwnerErrorsWithInvalidOrderingRequest() {
+        this.createDataForEndpointQueryTesting();
+        String ownerKey = "owner2";
+
+        ResteasyContext.pushContext(PageRequest.class, new PageRequest().setSortBy("invalid_field_name"));
+
+        OwnerContentResource resource = this.buildResource();
+        assertThrows(BadRequestException.class,
+            () -> resource.getContentsByOwner(ownerKey, null, null, null, null));
+    }
+
+    /**
+     * These tests verifies the definition of "active" is properly implemented, ensuring "active" is defined
+     * as a product which is attached to a pool which has started and has not expired, or attached to
+     * another active product (recursively).
+     *
+     * This definition is recursive in nature, so the effect is that it should consider any product that
+     * is a descendant of a product attached to a non-future pool that hasn't yet expired.
+     */
+    @Test
+    public void testGetActiveProductsOnlyConsidersActivePools() {
+        // - "active" only considers pools which have started but not expired (start time < now() < end time)
+        Owner owner = this.createOwner("test_org");
+
+        List<Product> products = new ArrayList<>();
+
+        for (int idx = 1; idx <= 3; ++idx) {
+            Content content1 = this.createContent(String.format("content-%da", idx));
+            Content content2 = this.createContent(String.format("content-%db", idx));
+
+            Product product = new Product()
+                .setId("prod-" + idx)
+                .setName("product " + idx)
+                .setNamespace(owner.getKey())
+                .addContent(content1, true)
+                .addContent(content2, false);
+
+            products.add(this.productCurator.create(product));
+        }
+
+        Function<Integer, Date> days = (offset) -> TestUtil.createDateOffset(0, 0, offset);
+        Date now = new Date();
+
+        // Create three pools: expired, current (active), future
+        Pool pool1 = this.createPool(owner, products.get(0), 1L, days.apply(-3), days.apply(-1));
+        Pool pool2 = this.createPool(owner, products.get(1), 1L, days.apply(-1), days.apply(1));
+        Pool pool3 = this.createPool(owner, products.get(2), 1L, days.apply(1), days.apply(3));
+
+        // Active = exclusive should only find the active pool; future and expired pools should be omitted
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(owner.getKey(), null, null,
+            Inclusion.EXCLUSIVE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrder("content-2a", "content-2b");
+    }
+
+    @Test
+    public void testGetActiveProductsAlsoConsidersDescendantsOfActivePoolProducts() {
+        // - "active" includes descendants of products attached to a pool
+        Owner owner = this.createOwner("test_org");
+
+        List<Product> products = new ArrayList<>();
+
+        for (int i = 0; i < 20; ++i) {
+            Content content1 = this.createContent(String.format("c%da", i));
+            Content content2 = this.createContent(String.format("c%db", i));
+
+            Product product = new Product()
+                .setId("p" + i)
+                .setName("product " + i)
+                .addContent(content1, true)
+                .addContent(content2, false);
+
+            products.add(product);
+        }
+
+        /*
+        pool -> prod - p0
+                    derived - p1
+                        provided - p2
+                        provided - p3
+                            provided - p4
+                    provided - p5
+                    provided - p6
+
+        pool -> prod - p7
+                    derived - p8*
+                    provided - p9
+
+        pool -> prod - p8*
+                    provided - p10
+                        provided - p11
+                    provided - p12
+                        provided - p13
+
+                prod - p14
+                    derived - p15
+                        provided - p16
+
+                prod - p17
+                    provided - p18
+
+        pool -> prod - p19
+                prod - p20
+        */
+
+        products.get(0).setDerivedProduct(products.get(1));
+        products.get(0).addProvidedProduct(products.get(5));
+        products.get(0).addProvidedProduct(products.get(6));
+
+        products.get(1).addProvidedProduct(products.get(2));
+        products.get(1).addProvidedProduct(products.get(3));
+
+        products.get(3).addProvidedProduct(products.get(4));
+
+        products.get(7).setDerivedProduct(products.get(8));
+        products.get(7).addProvidedProduct(products.get(9));
+
+        products.get(8).addProvidedProduct(products.get(10));
+        products.get(8).addProvidedProduct(products.get(12));
+
+        products.get(10).addProvidedProduct(products.get(11));
+
+        products.get(12).addProvidedProduct(products.get(13));
+
+        products.get(14).setDerivedProduct(products.get(15));
+
+        products.get(15).setDerivedProduct(products.get(16));
+
+        products.get(17).setDerivedProduct(products.get(18));
+
+        // persist the products in reverse order so we don't hit any hibernate errors
+        for (int i = products.size() - 1; i >= 0; --i) {
+            this.productCurator.create(products.get(i));
+        }
+
+        Pool pool1 = this.createPool(owner, products.get(0));
+        Pool pool2 = this.createPool(owner, products.get(7));
+        Pool pool3 = this.createPool(owner, products.get(8));
+        Pool pool4 = this.createPool(owner, products.get(19));
+
+        List<String> expectedCids = List.of("c0a", "c0b", "c1a", "c1b", "c2a", "c2b", "c3a", "c3b", "c4a",
+            "c4b", "c5a", "c5b", "c6a", "c6b", "c7a", "c7b", "c8a", "c8b", "c9a", "c9b", "c10a", "c10b",
+            "c11a", "c11b", "c12a", "c12b", "c13a", "c13b", "c19a", "c19b");
+
+        OwnerContentResource resource = this.buildResource();
+        Stream<ContentDTO> output = resource.getContentsByOwner(owner.getKey(), null, null,
+            Inclusion.EXCLUSIVE.name(), Inclusion.INCLUDE.name());
+
+        assertThat(output)
+            .isNotNull()
+            .map(ContentDTO::getId)
+            .containsExactlyInAnyOrderElementsOf(expectedCids);
     }
 }


### PR DESCRIPTION
- Added the "label", "active", and "custom" filters to the query parameters of the GET /owners/{key}/content endpoint
- Added the "owner", "label", "active", and "custom" filters to the query parameters of the GET /content endpoint
- Removed the now-redundant "omit_globals" query parameter from both GET /owners/{key}/content and GET /content endpoints
- Reworked the GET /contents and GET /owner/{key}/contens endpoints to support filtering on content IDs, content labels, and the "active" and "custom" states
- Added a new query builder object for building dynamic content queries
- Updated the manifest generator test extension to create entities in a namespace rather than global to fix multiple issues with manifest generation