### PR TITLE
[M] Optimized the ContentCurator.getActiveContentByOwner query

### DIFF
--- a/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -900,6 +900,8 @@ public class ContentCuratorTest extends DatabaseTestFixture {
 
         createProductContent(owner, true, content1, content2, content3);
 
+        this.contentCurator.flush();
+        this.contentCurator.clear();
         List<ProductContent> activeContentByOwner = contentCurator.getActiveContentByOwner(owner.getId());
 
         assertThat(activeContentByOwner).hasSize(3)
@@ -919,6 +921,8 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         createProductContent(owner, true, content);
         createProductContent(owner, false, content);
 
+        this.contentCurator.flush();
+        this.contentCurator.clear();
         List<ProductContent> activeContentByOwner = contentCurator.getActiveContentByOwner(owner.getId());
 
         assertThat(activeContentByOwner).hasSize(1)
@@ -941,7 +945,11 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         createProductContent(owner1, true, content1);
         createProductContent(owner2, false, content2, content3);
 
+        this.contentCurator.flush();
+        this.contentCurator.clear();
         List<ProductContent> activeContentByOwner1 = contentCurator.getActiveContentByOwner(owner1.getId());
+
+        this.contentCurator.clear();
         List<ProductContent> activeContentByOwner2 = contentCurator.getActiveContentByOwner(owner2.getId());
 
         assertThat(activeContentByOwner1)


### PR DESCRIPTION
- Optimized the query backing the ContentCurator.getActiveContentByOwner method based on the shape of the data in production, and MySQL's query planner. The new query should still perform well on non-MySQL and standalone, but will no longer take 5+ seconds to prime some of its CTEs with very large data sets.