### PR TITLE
[M] CANDLEPIN-918: Fixed bug preventing removal of consumer environments

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceEnvironmentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceEnvironmentSpecTest.java
@@ -198,6 +198,29 @@ public class ConsumerResourceEnvironmentSpecTest {
             .environments(List.of(env1, env2, env1))));
     }
 
+    @Test
+    public void shouldAllowRemovingAllEnvironmentsFromConsumer() {
+        ApiClient userClient = ApiClients.basic(UserUtil.createUser(adminClient, owner));
+        EnvironmentDTO env1 = adminClient.owners().createEnvironment(owner.getKey(), Environments.random());
+        EnvironmentDTO env2 = adminClient.owners().createEnvironment(owner.getKey(), Environments.random());
+
+        ConsumerDTO consumer = userClient.consumers().createConsumer(Consumers.random(owner)
+            .environments(List.of(env1, env2)));
+
+        ConsumerDTO update = new ConsumerDTO()
+            .uuid(consumer.getUuid())
+            .environments(List.of());
+
+        ApiClient consumerClient = ApiClients.ssl(consumer);
+        consumerClient.consumers().updateConsumer(consumer.getUuid(), update);
+
+        ConsumerDTO result = consumerClient.consumers().getConsumer(consumer.getUuid());
+
+        assertThat(result)
+            .isNotNull()
+            .returns(null, ConsumerDTO::getEnvironments);
+    }
+
     private UserDTO createUserTypeAllAccess(ApiClient client, OwnerDTO owner) {
         return UserUtil.createWith(client,
             Permissions.USERNAME_CONSUMERS.all(owner),

--- a/src/main/java/org/candlepin/dto/api/v1/ConsumerTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/ConsumerTranslator.java
@@ -115,6 +115,7 @@ public class ConsumerTranslator implements ObjectTranslator<Consumer, ConsumerDT
         if (dest == null) {
             throw new IllegalArgumentException("dest is null");
         }
+
         dest.id(source.getId())
             .uuid(source.getUuid())
             .name(source.getName())
@@ -151,6 +152,9 @@ public class ConsumerTranslator implements ObjectTranslator<Consumer, ConsumerDT
                 dest.setOwner(owner != null ? translator.translate(owner, NestedOwnerDTO.class) : null);
             }
 
+            // TODO: FIXME: WHY DOES THIS PROPERTY VIOLATE EXISTING CONVENTIONS WITH RESPECT TO NULLABILITY
+            // ON DTO COLLECTIONS? WE ADDED A NEW PROPERTY AND THEN STILL VIOLATED THOSE CONVENTIONS!
+            // WHY WHY WHY WHY WHY!?
             if (source.getEnvironmentIds() != null && !source.getEnvironmentIds().isEmpty()) {
                 List<EnvironmentDTO> environments = this.environmentCurator.getConsumerEnvironments(source)
                     .stream()
@@ -164,6 +168,7 @@ public class ConsumerTranslator implements ObjectTranslator<Consumer, ConsumerDT
             }
             else {
                 dest.setEnvironments(null);
+                dest.setEnvironment(null);
             }
 
             Set<ConsumerInstalledProduct> installedProducts = source.getInstalledProducts();
@@ -239,14 +244,15 @@ public class ConsumerTranslator implements ObjectTranslator<Consumer, ConsumerDT
             dest.setIdCert(translator.translate(source.getIdCert(), CertificateDTO.class));
         }
         else {
-            dest.setReleaseVer(null);
-            dest.setOwner(null);
-            dest.setEnvironments(null);
-            dest.setInstalledProducts(null);
-            dest.setCapabilities(null);
-            dest.setHypervisorId(null);
-            dest.setType(null);
-            dest.setIdCert(null);
+            dest.releaseVer(null)
+                .owner(null)
+                .environments(null)
+                .environment(null)
+                .installedProducts(null)
+                .capabilities(null)
+                .hypervisorId(null)
+                .type(null)
+                .idCert(null);
         }
 
         return dest;

--- a/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -1601,6 +1601,7 @@ public class ConsumerResourceTest {
             consumerResource.searchConsumers(null, null, null, null, null, null, null, "env", null, null,
                 null, null));
     }
+
     @Test
     public void testSearchConsumersRequiresOwnerAndEnvironmentToBeEmpty() {
         assertThrows(BadRequestException.class, () ->


### PR DESCRIPTION
- Fixed a bug that prevented the removal of all environments from a consumer via the consumer update endpoint (PUT /consumers/{uuid})