### PR TITLE
Added a missing space to the "paging required" error message

### DIFF
--- a/src/main/java/org/candlepin/paging/PagingUtil.java
+++ b/src/main/java/org/candlepin/paging/PagingUtil.java
@@ -81,7 +81,7 @@ public class PagingUtil<T> {
             return pageSize;
         }
 
-        String errmsg = this.i18n.tr("This endpoint does not support returning {0} elements in a single" +
+        String errmsg = this.i18n.tr("This endpoint does not support returning {0} elements in a single " +
             "request; please apply paging with a page size no larger than {1}",
             pageSize, this.maxPageSize);
 


### PR DESCRIPTION
- Added a missing space to the error message returned when an endpoint either requires paging and no paging was specified, or the requested page size is too large