### PR TITLE
[M] CANDLEPIN-914: Optimized the update content overrides endpoints

### DIFF
--- a/src/main/java/org/candlepin/model/ContentOverrideCurator.java
+++ b/src/main/java/org/candlepin/model/ContentOverrideCurator.java
@@ -16,7 +16,11 @@ package org.candlepin.model;
 
 import com.google.inject.persist.Transactional;
 
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
@@ -25,6 +29,8 @@ import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+
+
 
 /**
  * ContentOverrideCurator
@@ -129,6 +135,67 @@ public abstract class ContentOverrideCurator<T extends ContentOverride<T, Parent
     }
 
     /**
+     * Fetches a map of maps of content overrides matching the input list of entries. The outer map is
+     * a mapping of the content label to inner maps, where the inner maps are a mapping of override names
+     * to values. If a given label-name pairing does not exist for the given parent, it will not be
+     * represented in the output map. If no matching overrides were found, this method returns an empty
+     * map.
+     * <p></p>
+     * While the input content overrides may be populated with a value, it will be ignored for the purposes
+     * of matching against existing overrides. Additionally, override entries which are null, or do not
+     * define a content label or name will also be silently ignored.
+     *
+     * @param parent
+     *  the parent object for which to fetch content overrides
+     *
+     * @param overrides
+     *  a collection of overrides to fetch
+     *
+     * @return
+     *  a mapping of matched content overrides for the given parent entity
+     */
+    public Map<String, Map<String, T>> retrieveAll(Parent parent,
+        Collection<? extends ContentOverride> overrides) {
+
+        Map<String, Map<String, T>> output = new HashMap<>();
+
+        if (parent == null) {
+            return output;
+        }
+
+        EntityManager manager = this.getEntityManager();
+        CriteriaBuilder builder = manager.getCriteriaBuilder();
+        CriteriaQuery<T> cquery = builder.createQuery(this.entityType());
+
+        Root<T> root = cquery.from(this.entityType());
+        cquery.select(root);
+
+        Predicate parentPredicate = builder.equal(root.get(this.parentAttr), parent);
+
+        int blockSize = Math.min(this.getInBlockSize(), this.getQueryParameterLimit() / 2 - 1);
+        for (List<? extends ContentOverride> block : this.partition(overrides, blockSize)) {
+            Predicate[] predicates = block.stream()
+                .filter(Objects::nonNull)
+                .filter(override -> override.getContentLabel() != null && override.getName() != null)
+                .map(override -> builder.and(
+                    builder.equal(root.get("contentLabel"), override.getContentLabel()),
+                    builder.equal(root.get("name"), override.getName())))
+                .toArray(Predicate[]::new);
+
+            Predicate blockPredicate = builder.or(predicates);
+
+            cquery.where(parentPredicate, blockPredicate);
+
+            manager.createQuery(cquery)
+                .getResultList()
+                .forEach(entity -> output.computeIfAbsent(entity.getContentLabel(), key -> new HashMap<>())
+                    .put(entity.getName(), entity));
+        }
+
+        return output;
+    }
+
+     /**
      * Creates an empty/default override, to be completed by the caller.
      *
      * @return

--- a/src/main/java/org/candlepin/util/ContentOverrideValidator.java
+++ b/src/main/java/org/candlepin/util/ContentOverrideValidator.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -121,43 +122,31 @@ public class ContentOverrideValidator {
 
             if (!invalidLabels.isEmpty() || !invalidProps.isEmpty() || !invalidValues.isEmpty() ||
                 !invalidLengthValues.isEmpty()) {
-                StringBuilder builder = new StringBuilder();
+                StringJoiner joiner = new StringJoiner("\n");
 
                 if (!invalidLabels.isEmpty()) {
-                    builder.append(i18n.tr("The following content labels are invalid: {0}",
+                    joiner.add(i18n.tr("The following content labels are invalid: {0}",
                         String.join(", ", invalidLabels)));
                 }
 
                 if (!invalidProps.isEmpty()) {
-                    if (builder.length() > 0) {
-                        builder.append('\n');
-                    }
-
-                    builder.append(i18n.tr("The following content properties cannot be overridden: {0}",
+                    joiner.add(i18n.tr("The following content properties cannot be overridden: {0}",
                         String.join(", ", invalidProps)));
                 }
 
                 if (!invalidValues.isEmpty()) {
-                    if (builder.length() > 0) {
-                        builder.append('\n');
-                    }
-
-                    builder.append(i18n.tr("The following override values are invalid: {0}",
+                    joiner.add(i18n.tr("The following override values are invalid: {0}",
                         String.join(", ", invalidValues)));
                 }
 
                 if (!invalidLengthValues.isEmpty()) {
-                    if (builder.length() > 0) {
-                        builder.append('\n');
-                    }
-
-                    builder.append(i18n.tr("The following overrides have values longer than the " +
+                    joiner.add(i18n.tr("The following overrides have values longer than the " +
                         "maximum length of {0}: {1}",
                         ContentOverride.MAX_VALUE_LENGTH,
                         String.join(", ", invalidLengthValues)));
                 }
 
-                throw new BadRequestException(builder.toString());
+                throw new BadRequestException(joiner.toString());
             }
         }
     }

--- a/src/test/java/org/candlepin/model/ConsumerContentOverrideCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerContentOverrideCuratorTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 
 
@@ -618,5 +619,69 @@ public class ConsumerContentOverrideCuratorTest extends DatabaseTestFixture {
             .hasSize(3)
             .usingRecursiveFieldByFieldElementComparatorOnFields("contentLabel", "name", "value")
             .containsExactlyInAnyOrder(consumerOverride1, envOverride2, consumerOverride2);
+    }
+
+    @Test
+    public void testRetrieveAllWithNullConsumer() {
+        ConsumerContentOverride override = new ConsumerContentOverride()
+            .setContentLabel(TestUtil.randomString())
+            .setName(TestUtil.randomString())
+            .setValue(TestUtil.randomString());
+
+        Map<String, Map<String, ConsumerContentOverride>> actual = consumerContentOverrideCurator
+            .retrieveAll(null, List.of(override));
+
+        assertThat(actual)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    public void testRetrieveAll() {
+        Owner owner = this.createOwner();
+        Consumer c1 = this.createConsumer(owner);
+        Consumer c2 = this.createConsumer(owner);
+
+        ConsumerContentOverride c1Override1 = new ConsumerContentOverride()
+            .setConsumer(c1)
+            .setContentLabel("c1-repo1")
+            .setName(TestUtil.randomString())
+            .setValue(TestUtil.randomString());
+
+        ConsumerContentOverride c2Override1 = new ConsumerContentOverride()
+            .setConsumer(c2)
+            .setContentLabel("c2-repo1")
+            .setName(TestUtil.randomString())
+            .setValue(TestUtil.randomString());
+
+        ConsumerContentOverride c2Override2 = new ConsumerContentOverride()
+            .setConsumer(c2)
+            .setContentLabel("c2-repo2")
+            .setName(TestUtil.randomString())
+            .setValue(TestUtil.randomString());
+
+        ConsumerContentOverride c2Override3 = new ConsumerContentOverride()
+            .setConsumer(c2)
+            .setContentLabel("c2-repo3")
+            .setName(TestUtil.randomString())
+            .setValue(TestUtil.randomString());
+
+        c1Override1 = consumerContentOverrideCurator.create(c1Override1);
+        c2Override1 = consumerContentOverrideCurator.create(c2Override1);
+        c2Override2 = consumerContentOverrideCurator.create(c2Override2);
+        c2Override3 = consumerContentOverrideCurator.create(c2Override3);
+
+        Map<String, Map<String, ConsumerContentOverride>> actual = consumerContentOverrideCurator
+            .retrieveAll(c2, List.of(c2Override1, c2Override2));
+
+        Map<String, ConsumerContentOverride> expected1 = Map.of(c2Override1.getName(), c2Override1);
+        Map<String, ConsumerContentOverride> expected2 = Map.of(c2Override2.getName(), c2Override2);
+
+        assertThat(actual)
+            .isNotNull()
+            .hasSize(2)
+            .containsOnlyKeys(List.of(c2Override1.getContentLabel(), c2Override2.getContentLabel()))
+            .extractingByKeys(c2Override1.getContentLabel(), c2Override2.getContentLabel())
+            .containsExactly(expected1, expected2);
     }
 }

--- a/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -438,7 +438,7 @@ public class DatabaseTestFixture {
         ActivationKey key = new ActivationKey();
 
         key.setOwner(owner);
-        key.setName("A Test Key");
+        key.setName(TestUtil.randomString("key-"));
         key.setServiceLevel("TestLevel");
         key.setDescription("A test description for the test key.");
 


### PR DESCRIPTION
- Refactored and optimized the endpoints PUT /consumers/{uuid}/content_overrides, PUT /activation_keys/{id}/content_overrides, and PUT /environments/{id}/content_overrides such that they pull all overrides in bulk instead of each individually for update.
