### PR TITLE
[M] CANDLEPIN-921: Improved listAvailableEntitlementPools performance

### DIFF
--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -708,7 +708,6 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         Root<Pool> root, String attribute, Function<Expression<String>, Predicate> valuePredicateFunc) {
 
         Subquery<Pool> subquery = query.subquery(Pool.class);
-        Root<Pool> correlation = subquery.correlate(root);
 
         Root<Pool> subqueryRoot = subquery.from(Pool.class);
         Join<Pool, Product> prodJoin = subqueryRoot.join(Pool_.product);
@@ -718,8 +717,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         prodAttr.on(builder.equal(prodAttr.key(), attribute));
 
         subquery.select(subqueryRoot)
-            .where(builder.equal(subqueryRoot, correlation),
-                builder.or(builder.isNotNull(poolAttr.value()), builder.isNotNull(prodAttr.value())),
+            .where(builder.or(builder.isNotNull(poolAttr.value()), builder.isNotNull(prodAttr.value())),
                 valuePredicateFunc.apply(builder.coalesce(poolAttr.value(), prodAttr.value())));
 
         return builder.exists(subquery);

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1315,7 +1315,8 @@ public class OwnerResource implements OwnerApi {
             .setActiveOn(afterDate == null ? activeOnDate : null)
             .setAddFuture(addFuture)
             .setOnlyFuture(onlyFuture)
-            .setAfter(afterDate);
+            .setAfter(afterDate)
+            .setIncludeWarnings(listAll);
 
         if (pageRequest != null) {
             qualifier.setOffset(pageRequest.getPage())


### PR DESCRIPTION
- Improved the PoolCurator.listAvailableEntitlementPools by removing a correlation on the pool attribute subquery. This was generating a cross join that caused performance issues.
- Updated OwnerResource.listOwnerPools to include the listAll query parameter on the pool qualifier.

The following is the new query that is produced when replicating the request that the issue was discovered. The consumer in this case needs to be a manifest consumer type. 

Endpoint:
GET candlepin/owners/<Owner Key>/pools?consumer=<Consumer UUID>?attribute=key:value 
