### PR TITLE
[M] CANDLEPIN-921: Improved listAvailableEntitlementPools performance

### DIFF
--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -622,7 +622,7 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
             Subquery<String> subQuery = query.subquery(String.class);
             Root<Pool> subQueryRoot = subQuery.from(Pool.class);
             Predicate idPredicate = builder
-                .equal(subQueryRoot.get(Pool_.id), query.from(Pool.class).get(Pool_.id));
+                .equal(subQueryRoot.get(Pool_.id), root.get(Pool_.id));
 
             MapJoin<Pool, String, String> attributes = subQueryRoot.join(Pool_.attributes);
             Predicate attributePredicate = builder.equal(attributes.key(), Pool.Attributes.REQUIRES_HOST);

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1315,7 +1315,8 @@ public class OwnerResource implements OwnerApi {
             .setActiveOn(afterDate == null ? activeOnDate : null)
             .setAddFuture(addFuture)
             .setOnlyFuture(onlyFuture)
-            .setAfter(afterDate);
+            .setAfter(afterDate)
+            .setIncludeWarnings(listAll);
 
         if (pageRequest != null) {
             qualifier.setOffset(pageRequest.getPage())


### PR DESCRIPTION
- Improved the PoolCurator.listAvailableEntitlementPools by preventing a cross join from being generated and causing performance issues.
- Updated OwnerResource.listOwnerPools to include the listAll query parameter on the pool qualifier.

The following is the new query that is produced when replicating the request that the issue was discovered.

Endpoint:
GET candlepin/owners/<Owner Key>/pools?consumer=<Consumer UUID>?attribute=key:value

```sql
select distinct <Columns> 
from cp_pool pool0_ 
inner join cp_products product1_ on pool0_.product_uuid=product1_.uuid 
where  not (exists (
	select pool2_.id from cp_pool pool2_ 
	inner join cp_pool_attribute attributes3_ on pool2_.id=attributes3_.pool_id 
	where pool2_.id=pool0_.id and attributes3_.name=?)) 
and pool0_.owner_id=? and pool0_.startDate<=? and pool0_.endDate>=? and (exists (
	select pool4_.id from cp_pool pool4_ 
	inner join cp_products product5_ on pool4_.product_uuid=product5_.uuid 
	left outer join cp_product_attributes attributes6_ on product5_.uuid=attributes6_.product_uuid and (attributes6_.name=?) 
	left outer join cp_pool_attribute attributes7_ on pool4_.id=attributes7_.pool_id and (attributes7_.name=?) 
	where pool4_.id=pool0_.id and (attributes7_.value is not null or attributes6_.value is not null) and (lower(coalesce(attributes7_.value, attributes6_.value)) like lower(?) escape ?)))
```