### PR TITLE
[M] CANDLEPIN-922: Updated Owner claim to create owner if it exists upstream

### DIFF
--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1748,9 +1748,28 @@ public class OwnerResource implements OwnerApi {
         if (Util.isFalse(originOwner.getAnonymous())) {
             throw new BadRequestException(this.i18n.tr("Origin owner has to be anonymous!"));
         }
-        Owner destinationOwner = findOwnerByKey(claimantOwner.getClaimantOwnerKey());
-        if (Boolean.TRUE.equals(destinationOwner.getAnonymous())) {
-            throw new BadRequestException(this.i18n.tr("Claimant owner cannot be anonymous!"));
+        Owner destinationOwner = this.ownerCurator.getByKey(claimantOwner.getClaimantOwnerKey());
+        if (destinationOwner == null) {
+            // If the owner does not exist in CP, check if they exist upstream.
+            // If they do, create a copy in CP
+            if (ownerService.isOwnerKeyValidForCreation(claimantOwner.getClaimantOwnerKey())) {
+                Owner ownerToCreate = new Owner()
+                    .setKey(claimantOwner.getClaimantOwnerKey())
+                    .setDisplayName(claimantOwner.getClaimantOwnerKey())
+                    .setContentAccessModeList(ContentAccessManager.defaultContentAccessModeList())
+                    .setContentAccessMode(ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
+
+                this.ownerCurator.create(ownerToCreate);
+            }
+            else {
+                throw new BadRequestException(
+                    this.i18n.tr("Claimant owner does not exist in Candlepin or upstream!"));
+            }
+        }
+        else {
+            if (Boolean.TRUE.equals(destinationOwner.getAnonymous())) {
+                throw new BadRequestException(this.i18n.tr("Claimant owner cannot be anonymous!"));
+            }
         }
 
         boolean claimantOwnerMatches = StringUtils.equals(

--- a/src/test/java/org/candlepin/resource/OwnerResourceOwnerClaimingTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceOwnerClaimingTest.java
@@ -17,6 +17,7 @@ package org.candlepin.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -206,6 +207,31 @@ public class OwnerResourceOwnerClaimingTest {
         Owner claimantOwner = createAnonOwner(CLAIMANT_KEY);
         when(this.ownerCurator.getByKey(ORIGIN_KEY)).thenReturn(originOwner);
         when(this.ownerCurator.getByKey(CLAIMANT_KEY)).thenReturn(claimantOwner);
+        OwnerResource resource = buildOwnerResource();
+
+        assertThatThrownBy(() -> resource.claim(ORIGIN_KEY, createClaimant()))
+            .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    public void testClaimWhenClaimantOwnerExistOnlyUpstream() {
+        Owner originOwner = createAnonOwner(ORIGIN_KEY);
+        when(this.ownerCurator.getByKey(ORIGIN_KEY)).thenReturn(originOwner);
+        when(this.ownerCurator.getByKey(CLAIMANT_KEY)).thenReturn(null);
+        when(this.ownerServiceAdapter.isOwnerKeyValidForCreation(CLAIMANT_KEY)).thenReturn(true);
+        OwnerResource resource = buildOwnerResource();
+
+        resource.claim(ORIGIN_KEY, createClaimant());
+
+        verify(ownerCurator, times(1)).create(any(Owner.class));
+    }
+
+    @Test
+    public void testClaimWhenClaimantOwnerDoesNotExistUpstreamOrCandlepin() {
+        Owner originOwner = createAnonOwner(ORIGIN_KEY);
+        when(this.ownerCurator.getByKey(ORIGIN_KEY)).thenReturn(originOwner);
+        when(this.ownerCurator.getByKey(CLAIMANT_KEY)).thenReturn(null);
+        when(this.ownerServiceAdapter.isOwnerKeyValidForCreation(CLAIMANT_KEY)).thenReturn(false);
         OwnerResource resource = buildOwnerResource();
 
         assertThatThrownBy(() -> resource.claim(ORIGIN_KEY, createClaimant()))


### PR DESCRIPTION
- Modified `OwnerResource.claim` to check if the claimant owner exists upstream. If the claimant owner does not exist in Candlepin but exists upstream, it is now created in Candlepin before proceeding with the claim operation. This ensures that Red Hat customers can claim an anonymous organization even if the claimant organization hasn't been synced to Candlepin yet.