### PR TITLE
[M] CANDLEPIN-917: Updated anon consumer cloud_offering_id column size

### DIFF
--- a/src/main/resources/db/changelog/20240920000000-update-cloud-offering-id-column-size.xml
+++ b/src/main/resources/db/changelog/20240920000000-update-cloud-offering-id-column-size.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+    <changeSet id="20240920000000-1" author="jalbrech" >
+        <modifyDataType tableName="cp_anonymous_cloud_consumers"
+            columnName="cloud_offering_id"
+            newDataType="varchar(255)" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -200,4 +200,5 @@
     <include file="db/changelog/20240329143555-add_environment_content_override_schema.xml"/>
     <include file="db/changelog/20240802101300-update-anon-cert-table-cert-column.xml"/>
     <include file="db/changelog/202408010000000-create-consumer-cloud-data.xml"/>
+    <include file="db/changelog/20240920000000-update-cloud-offering-id-column-size.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- Updated the cp_anonymous_cloud_consumers.cloud_offering_id column size from 170 to 255.