### PR TITLE
[M] CANDLEPIN-928: Updated updateLastCheckIn to refresh updated consumer

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Consumers.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Consumers.java
@@ -20,6 +20,9 @@ import org.candlepin.dto.api.client.v1.OwnerDTO;
 import org.candlepin.dto.api.client.v1.ReleaseVerDTO;
 import org.candlepin.spec.bootstrap.data.util.StringUtil;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Class meant to provide fully randomized instances of consumer.
  *
@@ -42,6 +45,26 @@ public final class Consumers {
     public static ConsumerDTO random(OwnerDTO owner, ConsumerTypes type) {
         return random(owner)
             .type(type.value());
+    }
+
+    /**
+     * Creates a randomly generated cloud consumer with AWS facts.
+     *
+     * @param owner
+     *  the owner of the randomly generated consumer
+     *
+     * @return a randomly generated AWS cloud consumer
+     */
+    public static ConsumerDTO randomAWS(OwnerDTO owner) {
+        ConsumerDTO consumer  = random(owner != null ? Owners.toNested(owner) : null);
+
+        Map<String, String> cloudFacts = new HashMap<>();
+        cloudFacts.put("aws_instance_id", StringUtil.random("instance-"));
+        cloudFacts.put("aws_account_id", StringUtil.random("cloud-account-"));
+
+        consumer.facts(cloudFacts);
+
+        return consumer;
     }
 
     private static ConsumerDTO random(NestedOwnerDTO owner) {

--- a/src/main/java/org/candlepin/controller/ConsumerManager.java
+++ b/src/main/java/org/candlepin/controller/ConsumerManager.java
@@ -21,7 +21,9 @@ import org.candlepin.service.EventAdapter;
 import org.candlepin.service.model.CloudCheckInEvent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.persist.Transactional;
 
+import java.util.Date;
 import java.util.Objects;
 
 import javax.inject.Inject;
@@ -52,12 +54,14 @@ public class ConsumerManager {
      *
      * @param consumer The Consumer object to be updated.
      */
+    @Transactional
     public void updateLastCheckIn(Consumer consumer) {
         if (consumer == null) {
             throw new IllegalArgumentException("Consumer cannot be null");
         }
 
-        consumerCurator.updateLastCheckin(consumer);
+        consumer.setLastCheckin(new Date());
+        consumer = consumerCurator.merge(consumer);
 
         if (consumer.getConsumerCloudData() != null) {
             CloudCheckInEvent cloudCheckInEvent =

--- a/src/main/java/org/candlepin/service/model/CloudCheckInEvent.java
+++ b/src/main/java/org/candlepin/service/model/CloudCheckInEvent.java
@@ -57,9 +57,11 @@ public class CloudCheckInEvent implements AdapterEvent {
      *  the object mapper used to serialize the event body
      *
      * @throws IllegalArgumentException
-     *  if the provided consumer cloud data or object mapper is null or if the consumer cloud data has no
-     *  cloud provider shortname, cloud account ID, consumer, or has a consumer that does not have a UUID, or
-     *  last check in date
+     *  if the provided object mapper, consumer cloud data, or consumer in the consumer cloud data is null
+     *
+     * @throws IllegalStateException
+     *  if the consumer cloud data has no cloud provider shortname, cloud account ID, consumer, or has a
+     *  consumer that does not have a UUID, or last check in date
      *
      * @throws RuntimeException
      *  if unable to serialize the body of the event
@@ -80,22 +82,22 @@ public class CloudCheckInEvent implements AdapterEvent {
 
         String consumerUuid = consumer.getUuid();
         if (consumerUuid == null || consumerUuid.isBlank()) {
-            throw new IllegalArgumentException("consumer UUID is null or blank");
+            throw new IllegalStateException("consumer UUID is null or blank");
         }
 
         Date checkIn = consumer.getLastCheckin();
         if (checkIn == null) {
-            throw new IllegalArgumentException("last check-in is null");
+            throw new IllegalStateException("last check-in is null");
         }
 
         String cloudProviderId = cloudData.getCloudProviderShortName();
         if (cloudProviderId == null || cloudProviderId.isBlank()) {
-            throw new IllegalArgumentException("cloud provider shortname is null or blank");
+            throw new IllegalStateException("cloud provider shortname is null or blank");
         }
 
         String cloudAccountId = cloudData.getCloudAccountId();
         if (cloudAccountId == null || cloudAccountId.isBlank()) {
-            throw new IllegalArgumentException("cloud account ID is null or blank");
+            throw new IllegalStateException("cloud account ID is null or blank");
         }
 
         this.consumerUuid = consumerUuid;

--- a/src/test/java/org/candlepin/controller/ConsumerManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ConsumerManagerTest.java
@@ -18,6 +18,7 @@ package org.candlepin.controller;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -65,10 +66,11 @@ public class ConsumerManagerTest {
     public void testUpdateLastCheckInWithoutCloudData() {
         ConsumerManager consumerManager = buildConsumerManager();
         Consumer consumer = new Consumer();
+        doReturn(consumer).when(consumerCurator).merge(any(Consumer.class));
 
         consumerManager.updateLastCheckIn(consumer);
 
-        verify(consumerCurator).updateLastCheckin(consumer);
+        verify(consumerCurator).merge(consumer);
         verify(eventAdapter, never()).publish(any());
     }
 
@@ -80,9 +82,11 @@ public class ConsumerManagerTest {
         consumerCloudData.setConsumer(consumer);
         consumer.setConsumerCloudData(consumerCloudData);
 
+        doReturn(consumer).when(consumerCurator).merge(any(Consumer.class));
+
         consumerManager.updateLastCheckIn(consumer);
 
-        verify(consumerCurator).updateLastCheckin(consumer);
+        verify(consumerCurator).merge(consumer);
         verify(eventAdapter).publish(any(CloudCheckInEvent.class));
     }
 
@@ -94,9 +98,11 @@ public class ConsumerManagerTest {
         consumerCloudData.setConsumer(consumer);
         consumer.setConsumerCloudData(consumerCloudData);
 
+        doReturn(consumer).when(consumerCurator).merge(any(Consumer.class));
+
         consumerManager.updateLastCheckIn(consumer);
 
-        verify(consumerCurator).updateLastCheckin(consumer);
+        verify(consumerCurator).merge(consumer);
         verify(eventAdapter).publish(argThat(event ->
             event instanceof CloudCheckInEvent &&
                 ((CloudCheckInEvent) event).getConsumerUuid()

--- a/src/test/java/org/candlepin/resteasy/filter/ConsumerCheckInFilterTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/ConsumerCheckInFilterTest.java
@@ -23,6 +23,7 @@ import org.candlepin.auth.Principal;
 import org.candlepin.auth.UpdateConsumerCheckIn;
 import org.candlepin.controller.ConsumerManager;
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.resteasy.AnnotationLocator;
 import org.candlepin.resteasy.MethodLocator;
@@ -125,8 +126,6 @@ public class ConsumerCheckInFilterTest extends DatabaseTestFixture {
 
         ConsumerPrincipal p = (ConsumerPrincipal) ResteasyContext.getContextData(Principal.class);
 
-        this.consumerCurator.refresh(this.consumer);
-
         Date updatedLastCheckin = p.getConsumer().getLastCheckin();
         assertNotEquals(lastCheckin, updatedLastCheckin);
     }
@@ -151,8 +150,6 @@ public class ConsumerCheckInFilterTest extends DatabaseTestFixture {
         interceptor.filter(getContext());
 
         ConsumerPrincipal p = (ConsumerPrincipal) ResteasyContext.getContextData(Principal.class);
-
-        this.consumerCurator.refresh(this.consumer);
 
         Date updatedLastCheckin = p.getConsumer().getLastCheckin();
         assertEquals(lastCheckin, updatedLastCheckin);
@@ -203,6 +200,7 @@ public class ConsumerCheckInFilterTest extends DatabaseTestFixture {
         protected void configure() {
             bind(FakeApiImpl.class);
             bind(FakeResource.class);
+            bind(ConsumerCurator.class);
         }
     }
 }

--- a/src/test/java/org/candlepin/service/model/CloudCheckInEventTest.java
+++ b/src/test/java/org/candlepin/service/model/CloudCheckInEventTest.java
@@ -87,7 +87,7 @@ public class CloudCheckInEventTest {
         ConsumerCloudData cloudData = createCloudData()
             .setConsumer(consumer);
 
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalStateException.class, () -> {
             new CloudCheckInEvent(cloudData, mapper);
         });
     }
@@ -101,7 +101,7 @@ public class CloudCheckInEventTest {
         ConsumerCloudData cloudData = createCloudData()
             .setConsumer(consumer);
 
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalStateException.class, () -> {
             new CloudCheckInEvent(cloudData, mapper);
         });
     }
@@ -117,7 +117,7 @@ public class CloudCheckInEventTest {
             .setConsumer(createConsumer())
             .setCreated(new Date());
 
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalStateException.class, () -> {
             new CloudCheckInEvent(cloudData, mapper);
         });
     }
@@ -128,7 +128,7 @@ public class CloudCheckInEventTest {
         ConsumerCloudData cloudData = createCloudData()
             .setCloudAccountId(accountId);
 
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalStateException.class, () -> {
             new CloudCheckInEvent(cloudData, mapper);
         });
     }


### PR DESCRIPTION
- Updated ConsumerManager.updateLastCheckIn to merge the updated
  entity so that the new check-in date is populated. An IAE exception
  would be thrown while creating a CloudCheckInEvent if the consumer
  was not refreshed with the new last check-in date and the consumer
  had a null last check-in date before the update.
- Updated CloudCheckInEvent constructor validation checks to throw
  IllegalStateException instead of IllegalArgumentException for invalid
  consumer state.