### PR TITLE
Fix Huffman content path compression regression

### DIFF
--- a/src/main/java/org/candlepin/pki/huffman/PathNode.java
+++ b/src/main/java/org/candlepin/pki/huffman/PathNode.java
@@ -61,6 +61,20 @@ public class PathNode {
         }
     }
 
+    /**
+     * Determine if the nodes are equivalent. This node is equivalent to the other node if each
+     * point is true:
+     *
+     * <ul>
+     *   <li>Every child in this node has a matching child in the other node with the same name.
+     *   <li>The matching child-pairs' connections are equivalent.
+     * </ul>
+     *
+     * Alternatively, if the two nodes are actually the same node, then they are equivalent.
+     *
+     * @param that the comparing node
+     * @return true if this node is equivalent to that node.
+     */
     boolean isEquivalentTo(PathNode that) {
         if (this.getId() == that.getId()) {
             return true;
@@ -72,24 +86,27 @@ public class PathNode {
         for (NodePair thisNodePair : this.getChildren()) {
             boolean found = false;
             for (NodePair thatNodePair : that.getChildren()) {
-                if (areNodesEquivalent(thisNodePair, thatNodePair)) {
-                    found = true;
-                    break;
-                }
-                else {
-                    return false;
+                // Does "this" node have a child node that "that" node has?
+                if (thisNodePair.getName().equals(thatNodePair.getName())) {
+                    // Yes. Are the child nodes' connections equivalent?
+                    if (thisNodePair.getConnection().isEquivalentTo(thatNodePair.getConnection())) {
+                        // Yes. Look for the next child compare.
+                        found = true;
+                        break;
+                    }
+                    else {
+                        // No, the child nodes' connections aren't equivalent.
+                        // So, "this" and "that" are not equivalent.
+                        return false;
+                    }
                 }
             }
+            // If "this" has a child node not found in "that", then the nodes are not equivalent.
             if (!found) {
                 return false;
             }
         }
         return true;
-    }
-
-    private boolean areNodesEquivalent(NodePair thisNodePair, NodePair thatNodePair) {
-        return thisNodePair.getName().equals(thatNodePair.getName()) &&
-            thisNodePair.getConnection().isEquivalentTo(thatNodePair.getConnection());
     }
 
     @Override

--- a/src/test/java/org/candlepin/pki/huffman/PathNodeTest.java
+++ b/src/test/java/org/candlepin/pki/huffman/PathNodeTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.pki.huffman;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class PathNodeTest {
+    private static NodePair addChild(PathNode target, int id, String name) {
+        PathNode childConn = new PathNode(id);
+        NodePair child = new NodePair(name, childConn);
+        target.addChild(child);
+        return child;
+    }
+
+    @Test
+    public void isEquivalentTo() {
+        // Two nodes with different ids, but have children with identical names
+        // and connections, regardless of child ordering, are equivalent.
+        int id = 0;
+        PathNode a = new PathNode(++id);
+        addChild(a, ++id, "rhel8");
+        addChild(a, ++id, "rhel9");
+
+        PathNode b = new PathNode(++id);
+        addChild(b, ++id, "rhel9");
+        addChild(b, ++id, "rhel8");
+
+        assertTrue(a.isEquivalentTo(b));
+    }
+
+    @Test
+    public void isEquivalentToNoChildren() {
+        // Two nodes with different ids and no children are equivalent.
+        int id = 0;
+        PathNode a = new PathNode(++id);
+        PathNode b = new PathNode(++id);
+        assertTrue(a.isEquivalentTo(b));
+    }
+
+    @Test
+    public void isEquivalentToSelf() {
+        // A node is equivalent to itself.
+        int id = 0;
+        PathNode a = new PathNode(++id);
+        addChild(a, ++id, "rhel8");
+        addChild(a, ++id, "rhel9");
+        assertTrue(a.isEquivalentTo(a));
+    }
+
+    @Test
+    public void isEquivalentToDifferentAmountOfChildren() {
+        // If the nodes have different child amounts, they aren't equivalent
+        int id = 0;
+        PathNode a = new PathNode(++id);
+        addChild(a, ++id, "rhel8");
+        addChild(a, ++id, "rhel9");
+
+        PathNode b = new PathNode(++id);
+        addChild(b, ++id, "rhel8");
+        addChild(b, ++id, "rhel9");
+        addChild(b, ++id, "rhel10");
+
+        assertFalse(a.isEquivalentTo(b));
+        // (specially check the inverse holds as well)
+        assertFalse(b.isEquivalentTo(a));
+    }
+
+    @Test
+    public void isEquivalentToUnmatchedChild() {
+        // If the nodes have same amount of children, but one child has no
+        // match, then the nodes aren't equivalent.
+        int id = 0;
+        PathNode a = new PathNode(++id);
+        addChild(a, ++id, "rhel8");
+        addChild(a, ++id, "rhel9");
+
+        PathNode b = new PathNode(++id);
+        addChild(b, ++id, "rhel8");
+        addChild(b, ++id, "tandy basic");
+
+        assertFalse(a.isEquivalentTo(b));
+    }
+
+    @Test
+    public void isEquivalentToUnequivalentConnection() {
+        // If the nodes have matching-by-name children, but at least one child
+        // does not have an equivalent connection to its matches' connection,
+        // then the nodes aren't equivalent.
+        int id = 0;
+        PathNode a = new PathNode(++id);
+        addChild(a, ++id, "rhel8");
+        NodePair aChild = addChild(a, ++id, "rhel9");
+        addChild(aChild.getConnection(), ++id, "iso");
+
+        PathNode b = new PathNode(++id);
+        addChild(b, ++id, "rhel8");
+        NodePair bChild = addChild(b, ++id, "rhel9");
+        addChild(bChild.getConnection(), ++id, "different");
+
+        assertFalse(a.isEquivalentTo(b));
+    }
+
+}


### PR DESCRIPTION
A regression in how content paths are compressed in certs made the cert size bigger than it used to be.