### PR TITLE
[M] Updated logic for offering id in ConsumerCloudData

### DIFF
--- a/src/main/java/org/candlepin/model/ConsumerCloudData.java
+++ b/src/main/java/org/candlepin/model/ConsumerCloudData.java
@@ -44,8 +44,6 @@ public class ConsumerCloudData extends AbstractHibernateObject<ConsumerCloudData
 
     /** Max length for a value in the ID field */
     public static final int ID_MAX_LENGTH = 32;
-    /** Max length for a value in the UUID field */
-    public static final int UUID_MAX_LENGTH = 36;
     /** Max length for a value in the cloud account ID field */
     public static final int CLOUD_ACCOUNT_ID_MAX_LENGTH = 255;
     /** Max length for a value in the cloud instance ID field */
@@ -177,7 +175,21 @@ public class ConsumerCloudData extends AbstractHibernateObject<ConsumerCloudData
     }
 
     /**
-     * @return the list of cloud offering IDs for this cloud consumer
+     * Retrieves the list of cloud offering IDs associated with this cloud consumer.
+     *
+     * <p>This method parses the internal comma-separated string of cloud offering IDs
+     * and returns them as a list of individual IDs. It handles redundant whitespace,
+     * repeated commas, and ensures that the returned list does not contain empty strings.</p>
+     *
+     * <p>If there are no cloud offering IDs set (i.e., the internal string is {@code null} or blank),
+     * this method returns an empty list.</p>
+     *
+     * <p><strong>Note:</strong> The returned list is a fixed-size list backed by an array.
+     * Modifications to the list (such as adding or removing elements) are not supported and
+     * will result in an {@code UnsupportedOperationException}. However, you can modify the elements
+     * within the list if needed.</p>
+     *
+     * @return a list of cloud offering IDs; never {@code null}, possibly empty
      */
     public List<String> getCloudOfferingIds() {
         if (this.cloudOfferingIds == null) {
@@ -187,23 +199,63 @@ public class ConsumerCloudData extends AbstractHibernateObject<ConsumerCloudData
     }
 
     /**
-     * @param cloudOfferingIds
-     *  the cloud offering IDs to set
+     * Adds the specified cloud offering IDs to the current list of offering IDs.
      *
-     * @return a reference to this ConsumerCloudData instance
+     * <p>This method accepts a variable number of cloud offering ID strings, which are appended
+     * to the existing list of cloud offering IDs in this {@code ConsumerCloudData} instance.
+     * The IDs are stored internally as a comma-separated string.</p>
+     *
+     * @param cloudOfferingIds
+     *         the cloud offering IDs to be added; must not be {@code null} or contain {@code null} elements;
+     *         if there is empty list the attribute remains unchanged
+     *
+     * @return a reference to this {@code ConsumerCloudData} instance
+     *
+     * @throws IllegalArgumentException
+     *         if {@code cloudOfferingIds} is {@code null} or contains {@code null} elements,
+     *         or if the combined cloud offering IDs exceed the maximum allowed length of 255 characters
      */
-    public ConsumerCloudData setCloudOfferingIds(String... cloudOfferingIds) {
-        this.setCloudOfferingIds(Arrays.asList(cloudOfferingIds));
+    public ConsumerCloudData addCloudOfferingIds(String... cloudOfferingIds) {
+        if (cloudOfferingIds == null) {
+            throw new IllegalArgumentException("cloudOfferingIds is null");
+        }
+
+        this.addCloudOfferingIds(Arrays.asList(cloudOfferingIds));
         return this;
     }
 
     /**
-     * @param cloudOfferingIds
-     *  collection of the cloud offering IDs to set
+     * Adds the specified collection of cloud offering IDs to the current list of offering IDs.
      *
-     * @return a reference to this ConsumerCloudData instance
+     * <p>This method accepts a collection of cloud offering ID strings, which are appended
+     * to the existing list of cloud offering IDs in this {@code ConsumerCloudData} instance.
+     * The IDs are stored internally as a comma-separated string.</p>
+     *
+     * @param cloudOfferingIds
+     *         the cloud offering IDs to be added; must not be {@code null},
+     *         or contain {@code null} elements; if there is empty list the attribute remains unchanged
+     *
+     * @return a reference to this {@code ConsumerCloudData} instance
+     *
+     * @throws IllegalArgumentException
+     *         if {@code cloudOfferingIds} is {@code null}, contains {@code null} elements,
+     *         or if the combined cloud offering IDs exceed the maximum allowed length of 255 characters
      */
-    public ConsumerCloudData setCloudOfferingIds(Collection<String> cloudOfferingIds) {
+    public ConsumerCloudData addCloudOfferingIds(Collection<String> cloudOfferingIds) {
+        if (cloudOfferingIds == null) {
+            throw new IllegalArgumentException("cloudOfferingIds is null or empty");
+        }
+
+        if (cloudOfferingIds.isEmpty()) {
+            return this;
+        }
+
+        for (String cloudOfferingId : cloudOfferingIds) {
+            if (cloudOfferingId == null) {
+                throw new IllegalArgumentException("cloudOfferingIds contains null element");
+            }
+        }
+
         String joinedCloudOfferingIds = String.join(",", cloudOfferingIds);
 
         String combinedCloudOfferingIds;
@@ -215,10 +267,79 @@ public class ConsumerCloudData extends AbstractHibernateObject<ConsumerCloudData
         }
 
         if (combinedCloudOfferingIds.length() > CLOUD_OFFERING_ID_MAX_LENGTH) {
-            throw new IllegalArgumentException("cloudOfferingId exceeds the max length");
+            throw new IllegalArgumentException(
+                "Combined cloudOfferingIds exceed the max length of 255 characters");
         }
 
         this.cloudOfferingIds = combinedCloudOfferingIds;
+        return this;
+    }
+
+    /**
+     * Sets the cloud offering IDs to the specified IDs, replacing any existing IDs.
+     *
+     * <p>This method replaces the current list of cloud offering IDs with the provided IDs.
+     * The IDs are stored internally as a comma-separated string.</p>
+     *
+     * @param cloudOfferingIds
+     *         the cloud offering IDs to be set; must not be {@code null} or contain {@code null} elements;
+     *         if there is empty list it will store {@code null}
+     *
+     * @return a reference to this {@code ConsumerCloudData} instance
+     *
+     * @throws IllegalArgumentException
+     *         if {@code cloudOfferingIds} is {@code null} or contains {@code null} elements,
+     *         or if the combined cloud offering IDs exceed the maximum allowed length of 255 characters
+     */
+    public ConsumerCloudData setCloudOfferingIds(String... cloudOfferingIds) {
+        if (cloudOfferingIds == null) {
+            throw new IllegalArgumentException("cloudOfferingIds is null");
+        }
+
+        this.setCloudOfferingIds(Arrays.asList(cloudOfferingIds));
+        return this;
+    }
+
+    /**
+     * Sets the cloud offering IDs to the specified collection of IDs, replacing any existing IDs.
+     *
+     * <p>This method replaces the current list of cloud offering IDs with the provided collection.
+     * The IDs are stored internally as a comma-separated string.</p>
+     *
+     * @param cloudOfferingIds
+     *         the cloud offering IDs to be set; must not be {@code null},
+     *         or contain {@code null} elements; if there is empty list it will store {@code null}
+     *
+     * @return a reference to this {@code ConsumerCloudData} instance
+     *
+     * @throws IllegalArgumentException
+     *         if {@code cloudOfferingIds} is {@code null}, contains {@code null} elements,
+     *         or if the combined cloud offering IDs exceed the maximum allowed length of 255 characters
+     */
+    public ConsumerCloudData setCloudOfferingIds(Collection<String> cloudOfferingIds) {
+        if (cloudOfferingIds == null) {
+            throw new IllegalArgumentException("cloudOfferingIds is null");
+        }
+
+        if (cloudOfferingIds.isEmpty()) {
+            this.cloudOfferingIds = null;
+            return this;
+        }
+
+        for (String cloudOfferingId : cloudOfferingIds) {
+            if (cloudOfferingId == null) {
+                throw new IllegalArgumentException("cloudOfferingIds contains null element");
+            }
+        }
+
+        String joinedCloudOfferingIds = String.join(",", cloudOfferingIds);
+
+        if (joinedCloudOfferingIds.length() > CLOUD_OFFERING_ID_MAX_LENGTH) {
+            throw new IllegalArgumentException(
+                "Combined cloudOfferingIds exceed the max length of 255 characters");
+        }
+
+        this.cloudOfferingIds = joinedCloudOfferingIds;
         return this;
     }
 

--- a/src/test/java/org/candlepin/model/ConsumerCloudDataTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerCloudDataTest.java
@@ -15,12 +15,18 @@
 
 package org.candlepin.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.candlepin.test.TestUtil;
+
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class ConsumerCloudDataTest {
@@ -94,23 +100,255 @@ public class ConsumerCloudDataTest {
     }
 
     @Test
-    public void testSetCloudOfferingIds() {
+    public void testAddCloudOfferingIdsSingleIdArrayInput() {
         ConsumerCloudData consumerCloudData = new ConsumerCloudData();
-        String validId = "offering123";
+        String validId = TestUtil.randomString("offering");
+        consumerCloudData.addCloudOfferingIds(validId);
+
+        assertEquals(List.of(validId), consumerCloudData.getCloudOfferingIds());
+    }
+
+    @Test
+    public void testAddCloudOfferingIdsMultipleIdsArrayInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId1 = TestUtil.randomString("offering");
+        String validId2 = TestUtil.randomString("offering");
+        consumerCloudData.addCloudOfferingIds(validId1, validId2);
+
+        assertEquals(List.of(validId1, validId2), consumerCloudData.getCloudOfferingIds());
+    }
+
+    @Test
+    public void testAddCloudOfferingIdsNullArrayInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.addCloudOfferingIds((String[]) null);
+        });
+        assertEquals("cloudOfferingIds is null", exception.getMessage());
+    }
+
+    @Test
+    public void testAddCloudOfferingIdsArrayWithNullElement() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId = TestUtil.randomString("offering");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.addCloudOfferingIds(validId, null);
+        });
+        assertEquals("cloudOfferingIds contains null element", exception.getMessage());
+    }
+
+    @Test
+    public void testAddCloudOfferingIdsExceedMaxLengthArrayInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId = TestUtil.randomString("offering");
+        consumerCloudData.addCloudOfferingIds(validId);
+
+        // Generate a string that exceeds the maximum allowed length
+        String longId = TestUtil.randomString(256, "a");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.addCloudOfferingIds(longId);
+        });
+        assertEquals(
+            "Combined cloudOfferingIds exceed the max length of 255 characters", exception.getMessage());
+    }
+
+    @Test
+    public void testAddCloudOfferingIdsSingleIdCollectionInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId = TestUtil.randomString("offering");
+        consumerCloudData.addCloudOfferingIds(Collections.singletonList(validId));
+
+        assertEquals(List.of(validId), consumerCloudData.getCloudOfferingIds());
+    }
+
+    @Test
+    public void testAddCloudOfferingIdsMultipleIdsCollectionInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId1 = TestUtil.randomString("offering");
+        String validId2 = TestUtil.randomString("offering");
+        consumerCloudData.addCloudOfferingIds(Arrays.asList(validId1, validId2));
+
+        assertEquals(List.of(validId1, validId2), consumerCloudData.getCloudOfferingIds());
+    }
+
+    @Test
+    public void testAddCloudOfferingIdsNullCollectionInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.addCloudOfferingIds((Collection<String>) null);
+        });
+        assertEquals("cloudOfferingIds is null or empty", exception.getMessage());
+    }
+
+    @Test
+    public void testAddCloudOfferingIdsEmptyCollectionInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId1 = TestUtil.randomString("offering");
+
+        consumerCloudData.addCloudOfferingIds(validId1);
+        consumerCloudData.addCloudOfferingIds(Collections.emptyList());
+
+        assertThat(consumerCloudData.getCloudOfferingIds())
+            .containsExactly(validId1);
+    }
+
+    @Test
+    public void testAddCloudOfferingIdsCollectionWithNullElement() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId = TestUtil.randomString("offering");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.addCloudOfferingIds(Arrays.asList(validId, null));
+        });
+        assertEquals("cloudOfferingIds contains null element", exception.getMessage());
+    }
+
+    @Test
+    public void testAddCloudOfferingIdsExceedMaxLengthCollectionInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId = TestUtil.randomString("offering");
+        consumerCloudData.addCloudOfferingIds(validId);
+
+        // Generate a string that exceeds the maximum allowed length
+        String longId = TestUtil.randomString(256, "a");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.addCloudOfferingIds(Arrays.asList(longId));
+        });
+        assertEquals(
+            "Combined cloudOfferingIds exceed the max length of 255 characters", exception.getMessage());
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsSingleIdArrayInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId = TestUtil.randomString("offering");
         consumerCloudData.setCloudOfferingIds(validId);
 
         assertEquals(List.of(validId), consumerCloudData.getCloudOfferingIds());
+    }
 
-        String validId1 = "offering1231";
-        consumerCloudData.setCloudOfferingIds(validId1);
+    @Test
+    public void testSetCloudOfferingIdsMultipleIdsArrayInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId1 = TestUtil.randomString("offering");
+        String validId2 = TestUtil.randomString("offering");
+        consumerCloudData.setCloudOfferingIds(validId1, validId2);
 
-        assertEquals(List.of(validId, validId1), consumerCloudData.getCloudOfferingIds());
+        assertEquals(List.of(validId1, validId2), consumerCloudData.getCloudOfferingIds());
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsNullArrayInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            consumerCloudData.setCloudOfferingIds(
-                new String(new char[255]).replace('\0', 'a'));
+            consumerCloudData.setCloudOfferingIds((String[]) null);
         });
-        assertEquals("cloudOfferingId exceeds the max length", exception.getMessage());
+        assertEquals("cloudOfferingIds is null", exception.getMessage());
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsEmptyArrayInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+
+        consumerCloudData.setCloudOfferingIds();
+
+        assertThat(consumerCloudData.getCloudOfferingIds())
+            .isEmpty();
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsArrayWithNullElement() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId = TestUtil.randomString("offering");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.setCloudOfferingIds(validId, null);
+        });
+        assertEquals("cloudOfferingIds contains null element", exception.getMessage());
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsExceedMaxLengthArrayInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+
+        // Generate a string that exceeds the maximum allowed length
+        String longId = TestUtil.randomString(256, "a");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.setCloudOfferingIds(longId);
+        });
+        assertEquals(
+            "Combined cloudOfferingIds exceed the max length of 255 characters", exception.getMessage());
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsSingleIdCollectionInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId = TestUtil.randomString("offering");
+        consumerCloudData.setCloudOfferingIds(Collections.singletonList(validId));
+
+        assertEquals(List.of(validId), consumerCloudData.getCloudOfferingIds());
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsMultipleIdsCollectionInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId1 = TestUtil.randomString("offering");
+        String validId2 = TestUtil.randomString("offering");
+        consumerCloudData.setCloudOfferingIds(Arrays.asList(validId1, validId2));
+
+        assertEquals(List.of(validId1, validId2), consumerCloudData.getCloudOfferingIds());
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsNullCollectionInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.setCloudOfferingIds((Collection<String>) null);
+        });
+        assertEquals("cloudOfferingIds is null", exception.getMessage());
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsEmptyCollectionInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+
+        consumerCloudData.setCloudOfferingIds(Collections.emptyList());
+
+        assertThat(consumerCloudData.getCloudOfferingIds())
+            .isEmpty();
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsCollectionWithNullElement() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+        String validId = TestUtil.randomString("offering");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.setCloudOfferingIds(Arrays.asList(validId, null));
+        });
+        assertEquals("cloudOfferingIds contains null element", exception.getMessage());
+    }
+
+    @Test
+    public void testSetCloudOfferingIdsExceedMaxLengthCollectionInput() {
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
+
+        // Generate a string that exceeds the maximum allowed length
+        String longId = TestUtil.randomString(256, "a");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            consumerCloudData.setCloudOfferingIds(Collections.singletonList(longId));
+        });
+        assertEquals(
+            "Combined cloudOfferingIds exceed the max length of 255 characters", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
- Refactored the ConsumerCloudData class to include a `setCloudOfferingIds` method, enabling direct replacement of cloud offering IDs instead of only appending them via `addCloudOfferingIds`. This allows for flexible management of cloud offering IDs, with validation ensuring that the maximum length is not exceeded.