### PR TITLE
[M] Use guestIdLower column instead of LOWER SQL function

### DIFF
--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -765,7 +765,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         String jpql = """
             SELECT g.consumer FROM GuestId g
             WHERE g.consumer.owner.id = :ownerId
-                AND LOWER(g.guestId) IN :possibleIds
+                AND g.guestIdLower IN :possibleIds
             ORDER BY g.updated DESC
             """;
 
@@ -773,7 +773,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         try {
             host = getEntityManager().createQuery(jpql, Consumer.class)
                 .setParameter("ownerId", ownerId)
-                .setParameter("possibleIds", Util.getPossibleUuids(guestId))
+                .setParameter("possibleIds", Util.getPossibleUuids(guestLower))
                 .setMaxResults(1)
                 .getSingleResult();
         }

--- a/src/main/java/org/candlepin/model/GuestIdCurator.java
+++ b/src/main/java/org/candlepin/model/GuestIdCurator.java
@@ -64,7 +64,7 @@ public class GuestIdCurator extends AbstractHibernateCurator<GuestId> {
         String jpql = """
                 SELECT g FROM GuestId g
                 WHERE g.consumer = :consumer
-                    AND LOWER(g.guestIdLower) = :guestId
+                    AND g.guestIdLower = :guestId
                 """;
 
         try {
@@ -83,7 +83,7 @@ public class GuestIdCurator extends AbstractHibernateCurator<GuestId> {
         String jpql = """
                 SELECT g FROM GuestId g
                 JOIN g.consumer c
-                WHERE LOWER(g.guestIdLower) = :guestUuid
+                WHERE g.guestIdLower = :guestUuid
                     AND c.ownerId = :ownerId
                 """;
 


### PR DESCRIPTION
- Queries for GuestId entities used to use an optimization where a specific guestIdLower field/column was used instead of using the LOWER SQL function. That optimization got accidentally lost during the refactor and this change brings it back.