### PR TITLE
[M] Added candlepin.hidden_resources configuration to the dev image

### DIFF
--- a/containers/release.Containerfile
+++ b/containers/release.Containerfile
@@ -103,7 +103,8 @@ RUN echo "jpa.config.hibernate.dialect=org.hibernate.dialect.PostgreSQL92Dialect
     echo "candlepin.auth.oauth.enable=true" >> /etc/candlepin/candlepin.conf; \
     echo "candlepin.auth.oauth.consumer.rspec.secret=rspec-oauth-secret" >> /etc/candlepin/candlepin.conf; \
     echo "candlepin.db.database_manage_on_startup=Manage" >> /etc/candlepin/candlepin.conf; \
-    echo "candlepin.standalone=true" >> /etc/candlepin/candlepin.conf;
+    echo "candlepin.standalone=true" >> /etc/candlepin/candlepin.conf; \
+    echo "candlepin.hidden_resources=" >> /etc/candlepin/candlepin.conf;
 
 # Setup development certificate and key
 WORKDIR /etc/candlepin/certs


### PR DESCRIPTION
- Set the candlepin.hidden_resources configuration as an empty string in the development container Candlepin configurations.

# Testing

1. Create the war file using `./gradlew war -Ptest_extensions=hostedtest,manifestgen`
2. Build the dev container image using the following command:

```
sudo docker build --target development -f ./containers/release.Containerfile -t testing:test . \
	--build-arg WAR_FILE=./build/libs/candlepin-4.4.17.war \
	--no-cache
```

3. Modify the `./dev-container/docker-compose.yml` file to use the newly created container image
4. Run `docker-compose up -d` to create the Candlepin container and the db container
5. Validate that the environment resource exists by running `curl -k https://localhost:8443/candlepin/`