### PR TITLE
[M] CANDLEPIN-933: Updated AHC.lockAndLoad to not return null elements in collections

### DIFF
--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -443,12 +443,11 @@ public class PoolManagerTest {
 
     @Test
     public void deletePoolsTest() {
-        Set<Pool> pools = new HashSet<>();
-
         Product prod = TestUtil.createProduct();
         Pool pool = TestUtil.createPool(prod);
         pool.setId("test-id");
-        pools.add(pool);
+
+        List<Pool> pools = List.of(pool);
 
         when(poolCurator.lockAndLoad(anyIterable())).thenReturn(pools);
 


### PR DESCRIPTION
- Updated AbstractHibernateCurator.lockAndLoad to no longer include null elements in its output if one or more input IDs could not be found
- Updated the output type on AHC.lockAndLoad to be a List, rather than the more generic Collection
- Updated the documentation on the two list-outputting lockAndLoad implementations to be clear and consistent regarding the inclusion of nulls when a provided ID was not found
- Replaced use of Hamcrest.assertThat in the AbstractHibernateCurator test suite with AssertJ.assertThat