### PR TITLE
[M] CANDLEPIN-940: Fixed bug in Pool.isManaged when managed flag is null

### DIFF
--- a/src/main/java/org/candlepin/model/Pool.java
+++ b/src/main/java/org/candlepin/model/Pool.java
@@ -1330,7 +1330,7 @@ public class Pool extends AbstractHibernateObject<Pool> implements Owned, Named,
      *  true if the pool is a managed pool; false otherwise
      */
     public boolean isManaged() {
-        return this.managed;
+        return this.managed != null && this.managed;
     }
 
     /**

--- a/src/test/java/org/candlepin/model/PoolTest.java
+++ b/src/test/java/org/candlepin/model/PoolTest.java
@@ -307,6 +307,28 @@ public class PoolTest {
         assertFalse(pool.isDerived());
     }
 
+    @Test
+    public void testPoolWithNullManagedFieldInDBIsNotFlaggedAsManaged() throws Exception {
+        // This test verifies that if the Pool.managed flag somehow ends up null in the DB, we don't crash
+        // out while trying to access it.
+
+        Owner owner = new Owner();
+        Product prod = new Product();
+
+        Pool pool = new Pool()
+            .setOwner(owner)
+            .setProduct(prod)
+            .setQuantity(1000L);
+
+        // Use reflection to set the field to null, since we have no normal way of doing that
+        Field managedField = Pool.class.getDeclaredField("managed");
+        managedField.setAccessible(true);
+        managedField.set(pool, null);
+
+        // Assert default value of "false" when managed ends up as a null
+        assertFalse(pool.isManaged());
+    }
+
     @Nested
     @DisplayName("Field Access Tests")
     public class FieldAccessTest extends DatabaseTestFixture {


### PR DESCRIPTION
- Fixed a bug in the Pool entity that can occur when checking the managed state if the manage flag had been changed to null in the backing database