### PR TITLE
[M] CANDLEPIN-938: Fixed multiple bugs in ContentManager.isChangedBy

### DIFF
--- a/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/src/main/java/org/candlepin/controller/ContentManager.java
@@ -289,10 +289,6 @@ public class ContentManager {
         }
 
         // Field checks
-        if (hasValueChanged(entity.getId(), update.getId(), false)) {
-            return true;
-        }
-
         if (hasValueChanged(entity.getType(), update.getType(), false)) {
             return true;
         }
@@ -306,10 +302,6 @@ public class ContentManager {
         }
 
         if (hasValueChanged(entity.getVendor(), update.getVendor(), false)) {
-            return true;
-        }
-
-        if (hasValueChanged(entity.getGpgUrl(), update.getGpgUrl(), false)) {
             return true;
         }
 


### PR DESCRIPTION
- Removed the ability for ContentManager.isChangedBy to acknowledge or flag a content as changed if the ID changed; as IDs are immutable fields
- Removed an extraneous check on the gpgUrl field that did not consider nulls and empty as equal, causing content to be considered changed when it had not actually changed
- Updated the testing in content manager to avoid using content objects as update objects, to avoid passing tests that are broken due to checks in the content object rather than isChangedBy