### PR TITLE
[M] CANDLEPIN-938: Fixed column name format in dirty_product precondition

### DIFF
--- a/src/main/resources/db/changelog/20231211101743-add-pool-dirty-product-column.xml
+++ b/src/main/resources/db/changelog/20231211101743-add-pool-dirty-product-column.xml
@@ -15,7 +15,7 @@
     <changeSet id="20231211101743-1" author="crog">
         <preConditions onFail="MARK_RAN">
             <not>
-                <columnExists tableName="cp_pool" columnName="dirtyProduct"/>
+                <columnExists tableName="cp_pool" columnName="dirty_product"/>
             </not>
         </preConditions>
 


### PR DESCRIPTION
- Fixed the format of the column name in the precondition for the liquibase task for adding the dirty_product column from camel case to snake case