### PR TITLE
[M] CANDLEPIN-938: Restored L2 caching to product and content entities

### DIFF
--- a/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/src/main/java/org/candlepin/controller/ProductManager.java
@@ -730,21 +730,14 @@ public class ProductManager {
     private static void applyBrandingChanges(Product entity, ProductInfo update) {
         Collection<? extends BrandingInfo> branding = update.getBranding();
         if (branding != null) {
-            Set<Branding> resolved = new HashSet<>();
+            Function<BrandingInfo, Branding> converter = (binfo) -> {
+                return new Branding(entity, binfo.getProductId(), binfo.getName(), binfo.getType());
+            };
 
-            if (!branding.isEmpty()) {
-                for (BrandingInfo binfo : branding) {
-                    if (binfo == null) {
-                        continue;
-                    }
-
-                    resolved.add(new Branding(
-                        entity,
-                        binfo.getProductId(),
-                        binfo.getName(),
-                        binfo.getType()));
-                }
-            }
+            List<Branding> resolved = branding.stream()
+                .filter(Objects::nonNull)
+                .map(converter)
+                .toList();
 
             entity.setBranding(resolved);
         }

--- a/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitor.java
@@ -30,10 +30,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
+import java.util.function.Function;
 
 
 
@@ -180,24 +179,17 @@ public class ProductNodeVisitor implements NodeVisitor<Product, ProductInfo> {
             // Impl note: Oddly enough, branding isn't important enough to keep around, so we just
             // recreate the collection every time.
             if (importedEntity.getBranding() != null) {
-                if (importedEntity.getBranding().isEmpty()) {
-                    entity.setBranding(Collections.emptySet());
-                }
-                else {
-                    Set<Branding> branding = new HashSet<>();
-                    for (BrandingInfo binfo : importedEntity.getBranding()) {
-                        if (binfo != null) {
-                            branding.add(new Branding(
-                                entity,
-                                binfo.getProductId(),
-                                binfo.getName(),
-                                binfo.getType()
-                            ));
-                        }
-                    }
+                Function<BrandingInfo, Branding> converter = (binfo) -> {
+                    return new Branding(entity, binfo.getProductId(), binfo.getName(), binfo.getType());
+                };
 
-                    entity.setBranding(branding);
-                }
+                List<Branding> branding = importedEntity.getBranding()
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .map(converter)
+                    .toList();
+
+                entity.setBranding(branding);
             }
 
             // Perform resolution of children entity references

--- a/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -434,8 +434,8 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
     @Transactional
     public void bulkDelete(Collection<E> entities) {
-        for (E entity : entities) {
-            delete(entity);
+        if (entities != null) {
+            entities.forEach(this::delete);
         }
     }
 

--- a/src/main/java/org/candlepin/model/Branding.java
+++ b/src/main/java/org/candlepin/model/Branding.java
@@ -23,6 +23,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Immutable;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -43,14 +45,12 @@ import javax.validation.constraints.Size;
  * action to take with the brand name.
  *
  * NOTE: Presently only type "OS" is supported client side.
- *
  */
 @Entity
 @Immutable
 @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 @Table(name = Branding.DB_TABLE)
-public class Branding extends AbstractHibernateObject<Branding> implements BrandingInfo,
-    Cloneable {
+public class Branding extends AbstractHibernateObject<Branding> implements BrandingInfo, Cloneable {
 
     /** Name of the table backing this object in the database */
     public static final String DB_TABLE = "cp_product_branding";
@@ -81,24 +81,31 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
     @JoinColumn(name = "product_uuid")
     private Product product;
 
-    public Branding() {
+    /**
+     * Zero-arg constructor for Hibernate. Do not use.
+     */
+    Branding() {
         // Intentionally left empty
     }
 
+    public Branding(String productId, String name, String type) {
+        this.product = null;
+
+        this.productId = Objects.requireNonNull(productId);
+        this.name = Objects.requireNonNull(name);
+        this.type = Objects.requireNonNull(type);
+    }
+
     public Branding(Product parent, String productId, String name, String type) {
-        this.productId = productId;
-        this.type = type;
-        this.name = name;
-        this.product = parent;
+        this.product = Objects.requireNonNull(parent);
+
+        this.productId = Objects.requireNonNull(productId);
+        this.name = Objects.requireNonNull(name);
+        this.type = Objects.requireNonNull(type);
     }
 
     public String getId() {
         return id;
-    }
-
-    public Branding setId(String id) {
-        this.id = id;
-        return this;
     }
 
     /**
@@ -113,22 +120,12 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
         return productId;
     }
 
-    public Branding setProductId(String productId) {
-        this.productId = productId;
-        return this;
-    }
-
     /**
      * @return The brand name to be applied.
      */
     @Override
     public String getName() {
         return name;
-    }
-
-    public Branding setName(String name) {
-        this.name = name;
-        return this;
     }
 
     /**
@@ -141,11 +138,6 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
         return type;
     }
 
-    public Branding setType(String type) {
-        this.type = type;
-        return this;
-    }
-
     /**
      * Returns the parent marketing product that this branding belongs to.
      *
@@ -153,17 +145,6 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
      */
     public Product getProduct() {
         return product;
-    }
-
-    /**
-     * Sets the parent marketing product that this branding belongs to.
-     *
-     * @return
-     *  a reference to this Branding instance
-     */
-    public Branding setProduct(Product product) {
-        this.product = product;
-        return this;
     }
 
     @Override
@@ -192,20 +173,6 @@ public class Branding extends AbstractHibernateObject<Branding> implements Brand
             .append(this.productId)
             .append(this.type)
             .toHashCode();
-    }
-
-    @Override
-    public Branding clone() {
-        Branding copy;
-
-        try {
-            copy = (Branding) super.clone();
-        }
-        catch (CloneNotSupportedException e) {
-            // This should never happen.
-            throw new RuntimeException("Clone not supported", e);
-        }
-        return copy;
     }
 
     @Override

--- a/src/main/java/org/candlepin/model/Content.java
+++ b/src/main/java/org/candlepin/model/Content.java
@@ -21,6 +21,8 @@ import org.candlepin.util.Util;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 
@@ -48,6 +50,7 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @Table(name = Content.DB_TABLE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class Content extends AbstractHibernateObject implements SharedEntity, Cloneable, ContentInfo {
 
     /** Name of the table backing this object in the database */
@@ -128,6 +131,7 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     @CollectionTable(name = "cp_content_required_products", joinColumns = @JoinColumn(name = "content_uuid"))
     @Column(name = "product_id")
     @Size(max = 255)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private Set<String> modifiedProductIds;
 
     @Column(nullable = true)

--- a/src/main/java/org/candlepin/model/dto/ProductData.java
+++ b/src/main/java/org/candlepin/model/dto/ProductData.java
@@ -958,7 +958,7 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
         }
 
         // This is a DTO; we don't want references to Product model entities.
-        branding.setProduct(null);
+        branding = new Branding(branding.getProductId(), branding.getName(), branding.getType());
         return this.branding.add(branding);
     }
 
@@ -1093,17 +1093,7 @@ public class ProductData extends CandlepinDTO implements ProductInfo {
             copy.setProvidedProducts(null);
         }
 
-        Collection<Branding> srcBranding = this.getBranding();
-        if (srcBranding != null) {
-            Set<Branding> destBranding = srcBranding.stream()
-                .map(dto -> dto.clone())
-                .collect(Collectors.toSet());
-
-            copy.setBranding(destBranding);
-        }
-        else {
-            copy.setBranding(null);
-        }
+        copy.setBranding(this.getBranding());
 
         return copy;
     }

--- a/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/src/main/java/org/candlepin/resource/ContentResource.java
@@ -207,7 +207,7 @@ public class ContentResource implements ContentApi {
 
     @Override
     public ContentDTO getContentByUuid(String contentUuid) {
-        Content content = this.contentCurator.getByUuid(contentUuid);
+        Content content = this.contentCurator.get(contentUuid);
 
         if (content == null) {
             throw new NotFoundException(

--- a/src/main/java/org/candlepin/testext/hostedtest/HostedTestDataStore.java
+++ b/src/main/java/org/candlepin/testext/hostedtest/HostedTestDataStore.java
@@ -884,12 +884,7 @@ public class HostedTestDataStore {
                         throw new IllegalArgumentException("Branding lacks a product ID: " + binfo);
                     }
 
-                    Branding bdata = new Branding();
-
-                    bdata.setProductId(binfo.getProductId());
-                    bdata.setType(binfo.getType());
-                    bdata.setName(binfo.getName());
-
+                    Branding bdata = new Branding(binfo.getProductId(), binfo.getName(), binfo.getType());
                     brandMap.put(bdata.getProductId(), bdata);
                 }
             }

--- a/src/main/java/org/candlepin/testext/manifestgen/EntityMapper.java
+++ b/src/main/java/org/candlepin/testext/manifestgen/EntityMapper.java
@@ -99,10 +99,7 @@ public class EntityMapper {
             return null;
         }
 
-        return new Branding()
-            .setName(bdto.getName())
-            .setProductId(bdto.getProductId())
-            .setType(bdto.getType());
+        return new Branding(bdto.getProductId(), bdto.getName(), bdto.getType());
     }
 
     private Content mergeContentData(ContentDTO cdto) {

--- a/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
+++ b/src/main/java/org/candlepin/util/X509V3ExtensionUtil.java
@@ -146,23 +146,24 @@ public class X509V3ExtensionUtil extends X509Util {
      * the pool in question.
      */
     private Branding getBranding(Pool pool, String productId) {
-        Branding resultBranding = null;
-        for (Branding b : pool.getProduct().getBranding()) {
-            if (b.getProductId().equals(productId)) {
-                if (resultBranding == null) {
-                    resultBranding = b;
-                }
-                else {
-                    // Warn, but use the first brand name we encountered:
-                    log.warn("Found multiple brand names: product={}, contract={}, " +
-                            "owner={}", productId, pool.getContractNumber(),
-                        pool.getOwner().getKey());
-                }
-            }
-        }
+        List<Branding> branding = pool.getProduct()
+            .getBranding()
+            .stream()
+            .filter(elem -> productId.equals(elem.getProductId()))
+            .toList();
+
         // If none exist, use null strings
-        return resultBranding != null ? resultBranding :
-            (new Branding(null, productId, null, null));
+        if (branding.isEmpty()) {
+            return new Branding(productId, "", "");
+        }
+
+        // If multiple matching brands found, warn and then use the first
+        if (branding.size() > 1) {
+            log.warn("Found multiple brand names: product={}, contract={}, owner={}",
+                productId, pool.getContractNumber(), pool.getOwner().getKey());
+        }
+
+        return branding.get(0);
     }
 
     /*

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -22,6 +22,7 @@
             <!-- caching setting -->
             <property name="hibernate.cache.region.factory_class" value="org.hibernate.cache.jcache.JCacheRegionFactory"/>
             <property name="hibernate.cache.use_second_level_cache" value="true"/>
+            <property name="hibernate.cache.auto_evict_collection_cache" value="true"/>
             <property name="hibernate.cache.use_query_cache" value="true"/>
             <property name="hibernate.javax.cache.missing_cache_strategy" value="create"/>
 

--- a/src/test/java/org/candlepin/controller/PoolManagerTest.java
+++ b/src/test/java/org/candlepin/controller/PoolManagerTest.java
@@ -748,8 +748,8 @@ public class PoolManagerTest {
         Product product = TestUtil.createProduct();
 
         Subscription sub = TestUtil.createSubscription(owner, product);
-        Branding b1 = new Branding(null, "8000", "Branded Awesome OS", "OS");
-        Branding b2 = new Branding(null, "8001", "Branded Awesome OS 2", "OS");
+        Branding b1 = new Branding("8000", "Branded Awesome OS", "OS");
+        Branding b2 = new Branding("8001", "Branded Awesome OS 2", "OS");
         product.addBranding(b1);
         product.addBranding(b2);
 

--- a/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -491,12 +491,16 @@ public class ProductManagerTest extends DatabaseTestFixture {
 
     @Test
     public void testIsChangedByDTOIsTrueWhenBrandingUpdated() {
+        Branding branding = new Branding("prod_id", "Brand Name", "OS");
+
         Product product = TestUtil.createProduct("p1", "prod1");
-        product.addBranding(new Branding(product, "prod_id", "Brand Name", "OS"));
+        product.addBranding(branding);
 
         Product clone = (Product) product.clone();
         clone.setUuid(null);
-        ((Branding) clone.getBranding().toArray()[0]).setName("New Name!");
+
+        clone.removeBranding(branding);
+        clone.addBranding(new Branding("prod_id", "Brand New Name", "OS"));
 
         assertTrue(ProductManager.isChangedBy(product, clone));
     }
@@ -504,7 +508,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
     @Test
     public void testIsChangedByDTOIsTrueWhenBrandingRemoved() {
         Product product = TestUtil.createProduct("p1", "prod1");
-        product.addBranding(new Branding(product, "prod_id", "Brand Name", "OS"));
+        product.addBranding(new Branding("prod_id", "Brand Name", "OS"));
 
         Product clone = (Product) product.clone();
         clone.setUuid(null);
@@ -526,7 +530,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
     @Test
     public void testIsChangedByDTOIsFalseWhenBrandingWasNotRemovedOrAdded() {
         Product product = TestUtil.createProduct("p1", "prod1");
-        product.addBranding(new Branding(product, "prod_id", "Brand Name", "OS"));
+        product.addBranding(new Branding("prod_id", "Brand Name", "OS"));
 
         Product clone = (Product) product.clone();
         clone.setUuid(null);
@@ -539,35 +543,34 @@ public class ProductManagerTest extends DatabaseTestFixture {
         Product existingProduct = TestUtil.createProduct("p1", "prod1");
         Product newProduct = (Product) existingProduct.clone();
 
-        newProduct.addBranding(new Branding(null, "prod_id", "Brand Name", "OS"));
+        newProduct.addBranding(new Branding("prod_id", "Brand Name", "OS"));
 
         assertTrue(ProductManager.isChangedBy(existingProduct, newProduct));
     }
 
     @Test
     public void testIsChangedByProductInfoIsTrueWhenBrandingUpdated() {
+        Branding oldBranding = new Branding("prod_id", "Brand Name", "OS");
+
         Product existingProduct = TestUtil.createProduct("p1", "prod1");
-        Branding oldBranding = new Branding(existingProduct, "prod_id", "Brand Name", "OS");
-        oldBranding.setId("db_id");
         existingProduct.addBranding(oldBranding);
 
         Product newProduct = (Product) existingProduct.clone();
 
         newProduct.removeBranding(oldBranding);
-        newProduct.addBranding(new Branding(existingProduct, "prod_id", "Brand New Name", "OS"));
+        newProduct.addBranding(new Branding("prod_id", "Brand New Name", "OS"));
 
         assertTrue(ProductManager.isChangedBy(existingProduct, newProduct));
     }
 
     @Test
     public void testIsChangedByProductInfosTrueWhenBrandingRemoved() {
+        Branding oldBranding = new Branding("prod_id", "Brand Name", "OS");
+
         Product existingProduct = TestUtil.createProduct("p1", "prod1");
-        Branding oldBranding = new Branding(existingProduct, "prod_id", "Brand Name", "OS");
-        oldBranding.setId("db_id");
         existingProduct.addBranding(oldBranding);
 
         Product newProduct = (Product) existingProduct.clone();
-
         newProduct.removeBranding(oldBranding);
 
         assertTrue(ProductManager.isChangedBy(existingProduct, newProduct));
@@ -594,15 +597,12 @@ public class ProductManagerTest extends DatabaseTestFixture {
 
     @Test
     public void testIsChangedByProductInfoIsFalseWhenBrandingWasNotRemovedAddedOrUpdated() {
+        Branding oldBranding = new Branding("prod_id", "Brand Name", "OS");
+
         Product existingProduct = TestUtil.createProduct("p1", "prod1");
-        Branding oldBranding = new Branding(existingProduct, "prod_id", "Brand Name", "OS");
-        oldBranding.setId("db_id");
         existingProduct.addBranding(oldBranding);
 
         Product newProduct = (Product) existingProduct.clone();
-
-        newProduct.removeBranding(oldBranding);
-        newProduct.addBranding(new Branding(existingProduct, "prod_id", "Brand Name", "OS"));
 
         assertFalse(ProductManager.isChangedBy(existingProduct, newProduct));
     }

--- a/src/test/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitorTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/ProductNodeVisitorTest.java
@@ -100,13 +100,7 @@ public class ProductNodeVisitorTest extends DatabaseTestFixture {
 
         List<Branding> branding = new ArrayList<>();
         for (int i = 1; i <= 3; ++i) {
-            Branding elem = new Branding()
-                .setId("branding-" + i)
-                .setName("branding " + i)
-                .setProductId("branded_pid-" + i)
-                .setType("btype");
-
-            branding.add(elem);
+            branding.add(new Branding("branded_pid-" + i, "branding " + i, "btype"));
         }
 
         return Stream.of(

--- a/src/test/java/org/candlepin/dto/api/v1/BrandingTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/BrandingTranslatorTest.java
@@ -45,15 +45,11 @@ public class BrandingTranslatorTest extends
 
     @Override
     public Branding initSourceObject() {
-        Branding source = new Branding();
+        Date now = new Date();
 
-        source.setProductId("test-product-id");
-        source.setName("test-name");
-        source.setType("test-type");
-        source.setCreated(new Date());
-        source.setUpdated(new Date());
-
-        return source;
+        return new Branding("test-product-id", "test-name", "test-type")
+            .setCreated(now)
+            .setUpdated(now);
     }
 
     @Override

--- a/src/test/java/org/candlepin/dto/api/v1/ProductTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ProductTranslatorTest.java
@@ -95,7 +95,7 @@ public class ProductTranslatorTest extends
         }
 
         IntStream.rangeClosed(1, 3)
-            .forEach(i -> source.addBranding(TestUtil.createProductBranding(source)));
+            .forEach(i -> source.addBranding(TestUtil.createBranding("b" + 1, "brand" + 1)));
 
         source.setDerivedProduct(this.generateChildProduct(0));
 
@@ -132,7 +132,7 @@ public class ProductTranslatorTest extends
         }
 
         IntStream.rangeClosed(1, 3)
-            .forEach(i -> child.addBranding(TestUtil.createProductBranding(child)));
+            .forEach(i -> child.addBranding(TestUtil.createBranding("b" + 1, "brand" + 1)));
 
         return child;
     }

--- a/src/test/java/org/candlepin/dto/manifest/v1/BrandingTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/BrandingTranslatorTest.java
@@ -41,13 +41,7 @@ public class BrandingTranslatorTest extends
 
     @Override
     protected Branding initSourceObject() {
-        Branding source = new Branding();
-
-        source.setProductId("test-product-id");
-        source.setName("test-name");
-        source.setType("test-type");
-
-        return source;
+        return new Branding("test-product-id", "test-name", "test-type");
     }
 
     @Override

--- a/src/test/java/org/candlepin/dto/manifest/v1/ProductTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/ProductTranslatorTest.java
@@ -80,7 +80,7 @@ public class ProductTranslatorTest extends
         }
 
         IntStream.rangeClosed(1, 3)
-            .forEach(i -> source.addBranding(TestUtil.createProductBranding(source)));
+            .forEach(i -> source.addBranding(TestUtil.createBranding("b" + 1, "brand" + 1)));
 
         source.setDerivedProduct(this.generateChildProduct(0));
 
@@ -115,7 +115,7 @@ public class ProductTranslatorTest extends
         }
 
         IntStream.rangeClosed(1, 3)
-            .forEach(i -> child.addBranding(TestUtil.createProductBranding(child)));
+            .forEach(i -> child.addBranding(TestUtil.createBranding("b" + 1, "brand" + 1)));
 
         return child;
     }

--- a/src/test/java/org/candlepin/dto/shim/BrandingInfoTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/shim/BrandingInfoTranslatorTest.java
@@ -43,13 +43,7 @@ public class BrandingInfoTranslatorTest extends
 
     @Override
     public BrandingInfo initSourceObject() {
-        Branding source = new Branding();
-
-        source.setProductId("test-product-id");
-        source.setName("test-name");
-        source.setType("test-type");
-
-        return source;
+        return new Branding("test-product-id", "test-name", "test-type");
     }
 
     @Override

--- a/src/test/java/org/candlepin/model/BrandingTest.java
+++ b/src/test/java/org/candlepin/model/BrandingTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+
+
+/**
+ * BrandingTest
+ */
+public class BrandingTest {
+
+    @Test
+    public void testBrandingDTOConstructor() {
+        new Branding("branding id", "branding name", "branding type");
+    }
+
+    @Test
+    public void testBrandingProductConstructor() {
+        Product product = new Product();
+        new Branding(product, "branding id", "branding name", "branding type");
+    }
+
+    @Test
+    public void testCannotCreateProductWithBrandingWithNullProductId() {
+        assertThrows(NullPointerException.class, () -> new Branding(null, "branding name", "branding type"));
+    }
+
+    @Test
+    public void testCannotCreateProductWithBrandingWithNullName() {
+        assertThrows(NullPointerException.class, () -> new Branding("branding id", null, "branding type"));
+    }
+
+    @Test
+    public void testCannotCreateProductWithBrandingWithNullType() {
+        assertThrows(NullPointerException.class, () -> new Branding("branding id", "branding name", null));
+    }
+
+    @Test
+    public void testCannotCreateProductWithBrandingWithNullProduct() {
+        assertThrows(NullPointerException.class,
+            () -> new Branding(null, "branding id", "branding name", "branding type"));
+    }
+
+}

--- a/src/test/java/org/candlepin/model/ProductCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ProductCuratorTest.java
@@ -1039,45 +1039,6 @@ public class ProductCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testCannotCreateProductWithBrandingWithNullId() {
-        Product marketingProduct = createTestProduct();
-        marketingProduct.addBranding(
-            new Branding(marketingProduct, null, "Brand No 1", "OS"));
-
-        IllegalStateException ise = assertThrows(IllegalStateException.class,
-            () -> productCurator.create(marketingProduct));
-        assertEquals(ise.getMessage(),
-            "Product contains a Branding with a null product id, name or type.",
-            "The exception should have a different message.");
-    }
-
-    @Test
-    public void testCannotCreateProductWithBrandingWithNullType() {
-        Product marketingProduct = createTestProduct();
-        marketingProduct.addBranding(
-            new Branding(marketingProduct, "eng_prod_id_1", "Brand No 1", null));
-
-        IllegalStateException ise = assertThrows(IllegalStateException.class,
-            () -> productCurator.create(marketingProduct));
-        assertEquals(ise.getMessage(),
-            "Product contains a Branding with a null product id, name or type.",
-            "The exception should have a different message.");
-    }
-
-    @Test
-    public void testCannotCreateProductWithBrandingWithNullName() {
-        Product marketingProduct = createTestProduct();
-        marketingProduct.addBranding(
-            new Branding(marketingProduct, "eng_prod_id_1", null, "OS"));
-
-        IllegalStateException ise = assertThrows(IllegalStateException.class,
-            () -> productCurator.create(marketingProduct));
-        assertEquals(ise.getMessage(),
-            "Product contains a Branding with a null product id, name or type.",
-            "The exception should have a different message.");
-    }
-
-    @Test
     public void testGetPoolsReferencingProducts() {
         Owner owner1 = this.createOwner();
         Owner owner2 = this.createOwner();

--- a/src/test/java/org/candlepin/model/ProductTest.java
+++ b/src/test/java/org/candlepin/model/ProductTest.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 
@@ -83,17 +82,15 @@ public class ProductTest {
             new ProductContent(content[5], true)
         );
 
-        Set<Branding> brandings1 = Stream.of(
-            new Branding(null, "eng_prod_id_1", "eng_prod_name_1", "OS"),
-            new Branding(null, "eng_prod_id_2", "eng_prod_name_2", "OS"),
-            new Branding(null, "eng_prod_id_3", "eng_prod_name_3", "OS")
-        ).collect(Collectors.toSet());
+        Set<Branding> brandings1 = Set.of(
+            new Branding("eng_prod_id_1", "eng_prod_name_1", "OS"),
+            new Branding("eng_prod_id_2", "eng_prod_name_2", "OS"),
+            new Branding("eng_prod_id_3", "eng_prod_name_3", "OS"));
 
-        Set<Branding> brandings2 = Stream.of(
-            new Branding(null, "eng_prod_id_4", "eng_prod_name_4", "OS"),
-            new Branding(null, "eng_prod_id_5", "eng_prod_name_5", "OS"),
-            new Branding(null, "eng_prod_id_6", "eng_prod_name_6", "OS")
-        ).collect(Collectors.toSet());
+        Set<Branding> brandings2 = Set.of(
+            new Branding("eng_prod_id_4", "eng_prod_name_4", "OS"),
+            new Branding("eng_prod_id_5", "eng_prod_name_5", "OS"),
+            new Branding("eng_prod_id_6", "eng_prod_name_6", "OS"));
 
         Set<Product> provProducts1 = Set.of(
             new Product("prov_prod-1", "prov_prod-1", "var1", "ver1", "arch1", "type1").setUuid("pp_uuid-1"),

--- a/src/test/java/org/candlepin/model/dto/ProductDataTest.java
+++ b/src/test/java/org/candlepin/model/dto/ProductDataTest.java
@@ -854,9 +854,9 @@ public class ProductDataTest {
     public void testGetSetBranding() {
         ProductData dto = new ProductData();
         Collection<Branding> input = Arrays.asList(
-            new Branding(null, "eng_id_1", "brand_name_1", "OS"),
-            new Branding(null, "eng_id_2", "brand_name_2", "OS"),
-            new Branding(null, "eng_id_3", "brand_name_3", "OS"));
+            new Branding("eng_id_1", "brand_name_1", "OS"),
+            new Branding("eng_id_2", "brand_name_2", "OS"),
+            new Branding("eng_id_3", "brand_name_3", "OS"));
 
         Collection<Branding> output = dto.getBranding();
         assertNull(output);
@@ -875,31 +875,31 @@ public class ProductDataTest {
         Collection<Branding> brandings = dto.getBranding();
         assertNull(brandings);
 
-        boolean output = dto.addBranding(new Branding(null, "eng_id_1", "brand_name_1", "OS"));
+        boolean output = dto.addBranding(new Branding("eng_id_1", "brand_name_1", "OS"));
         brandings = dto.getBranding();
 
         assertTrue(output);
         assertNotNull(brandings);
         assertTrue(Util.collectionsAreEqual(Arrays.asList(
-            new Branding(null, "eng_id_1", "brand_name_1", "OS")), brandings));
+            new Branding("eng_id_1", "brand_name_1", "OS")), brandings));
 
-        output = dto.addBranding(new Branding(null, "eng_id_2", "brand_name_2", "OS"));
+        output = dto.addBranding(new Branding("eng_id_2", "brand_name_2", "OS"));
         brandings = dto.getBranding();
 
         assertTrue(output);
         assertNotNull(brandings);
         assertTrue(Util.collectionsAreEqual(Arrays.asList(
-            new Branding(null, "eng_id_1", "brand_name_1", "OS"),
-            new Branding(null, "eng_id_2", "brand_name_2", "OS")), brandings));
+            new Branding("eng_id_1", "brand_name_1", "OS"),
+            new Branding("eng_id_2", "brand_name_2", "OS")), brandings));
 
-        output = dto.addBranding(new Branding(null, "eng_id_1", "brand_name_1", "OS"));
+        output = dto.addBranding(new Branding("eng_id_1", "brand_name_1", "OS"));
         brandings = dto.getBranding();
 
         assertFalse(output);
         assertNotNull(brandings);
         assertTrue(Util.collectionsAreEqual(Arrays.asList(
-            new Branding(null, "eng_id_1", "brand_name_1", "OS"),
-            new Branding(null, "eng_id_2", "brand_name_2", "OS")), brandings));
+            new Branding("eng_id_1", "brand_name_1", "OS"),
+            new Branding("eng_id_2", "brand_name_2", "OS")), brandings));
     }
 
     @Test
@@ -909,39 +909,39 @@ public class ProductDataTest {
         Collection<Branding> brandings = dto.getBranding();
         assertNull(brandings);
 
-        boolean output = dto.removeBranding(new Branding(null, "eng_id_1", "brand_name_1", "OS"));
+        boolean output = dto.removeBranding(new Branding("eng_id_1", "brand_name_1", "OS"));
         brandings = dto.getBranding();
 
         assertFalse(output);
         assertNull(brandings);
 
         dto.setBranding(Arrays.asList(
-            new Branding(null, "eng_id_1", "brand_name_1", "OS"),
-            new Branding(null, "eng_id_2", "brand_name_2", "OS")));
+            new Branding("eng_id_1", "brand_name_1", "OS"),
+            new Branding("eng_id_2", "brand_name_2", "OS")));
         brandings = dto.getBranding();
 
         assertNotNull(brandings);
         assertTrue(Util.collectionsAreEqual(Arrays.asList(
-            new Branding(null, "eng_id_1", "brand_name_1", "OS"),
-            new Branding(null, "eng_id_2", "brand_name_2", "OS")), brandings));
+            new Branding("eng_id_1", "brand_name_1", "OS"),
+            new Branding("eng_id_2", "brand_name_2", "OS")), brandings));
 
-        output = dto.removeBranding(new Branding(null, "eng_id_1", "brand_name_1", "OS"));
+        output = dto.removeBranding(new Branding("eng_id_1", "brand_name_1", "OS"));
         brandings = dto.getBranding();
 
         assertTrue(output);
         assertNotNull(brandings);
         assertTrue(Util.collectionsAreEqual(Arrays.asList(
-            new Branding(null, "eng_id_2", "brand_name_2", "OS")), brandings));
+            new Branding("eng_id_2", "brand_name_2", "OS")), brandings));
 
-        output = dto.removeBranding(new Branding(null, "eng_id_3", "brand_name_3", "OS"));
+        output = dto.removeBranding(new Branding("eng_id_3", "brand_name_3", "OS"));
         brandings = dto.getBranding();
 
         assertFalse(output);
         assertNotNull(brandings);
         assertTrue(Util.collectionsAreEqual(Arrays.asList(
-            new Branding(null, "eng_id_2", "brand_name_2", "OS")), brandings));
+            new Branding("eng_id_2", "brand_name_2", "OS")), brandings));
 
-        output = dto.removeBranding(new Branding(null, "eng_id_2", "brand_name_2", "OS"));
+        output = dto.removeBranding(new Branding("eng_id_2", "brand_name_2", "OS"));
         brandings = dto.getBranding();
 
         assertTrue(output);
@@ -1046,14 +1046,14 @@ public class ProductDataTest {
             new ProductContentData(content[5], true));
 
         Collection<BrandingInfo> branding1 = Arrays.asList(
-            new Branding(null, "eng_id_1", "brand_name_1", "OS"),
-            new Branding(null, "eng_id_2", "brand_name_2", "OS"),
-            new Branding(null, "eng_id_3", "brand_name_3", "OS"));
+            new Branding("eng_id_1", "brand_name_1", "OS"),
+            new Branding("eng_id_2", "brand_name_2", "OS"),
+            new Branding("eng_id_3", "brand_name_3", "OS"));
 
         Collection<BrandingInfo> branding2 = Arrays.asList(
-            new Branding(null, "eng_id_4", "brand_name_4", "OS"),
-            new Branding(null, "eng_id_5", "brand_name_5", "OS"),
-            new Branding(null, "eng_id_6", "brand_name_6", "OS"));
+            new Branding("eng_id_4", "brand_name_4", "OS"),
+            new Branding("eng_id_5", "brand_name_5", "OS"),
+            new Branding("eng_id_6", "brand_name_6", "OS"));
 
         Set<ProductData> providedProductData1 = Util.asSet(
             new ProductData("pd1", "providedProduct1"),

--- a/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
+++ b/src/test/java/org/candlepin/policy/js/pool/PoolHelperTest.java
@@ -36,7 +36,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -227,14 +226,17 @@ public class PoolHelperTest {
 
     @Test
     public void clonePoolTest() {
+        Branding branding = new Branding("id", "name", "type");
+
         Product product = TestUtil.createProduct();
-        Product product2 = TestUtil.createProduct();
+        Product product2 = TestUtil.createProduct()
+            .addBranding(branding);
+
         Map<String, String> attributes = new HashMap<>();
         for (int i = 0; i < 3; i++) {
             attributes.put("a" + i, "b" + i);
         }
-        Branding branding = new Branding(null, "id", "name", "type");
-        product2.setBranding(Arrays.asList(branding));
+
         Pool pool = TestUtil.createPool(owner, product);
         String quant = "unlimited";
         Pool clone = PoolHelper.clonePool(pool, product2, quant, attributes, "TaylorSwift",
@@ -250,8 +252,7 @@ public class PoolHelperTest {
         assertEquals(pool.getSourceSubscription().getSubscriptionId(), clone.getSubscriptionId());
         assertEquals(pool.getSourceSubscription().getSubscriptionId(),
             clone.getSourceSubscription().getSubscriptionId());
-        assertEquals("TaylorSwift",
-            clone.getSourceSubscription().getSubscriptionSubKey());
+        assertEquals("TaylorSwift", clone.getSourceSubscription().getSubscriptionSubKey());
 
         assertEquals(1, clone.getProduct().getBranding().size());
         Branding brandingClone = clone.getProduct().getBranding().iterator().next();

--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -502,11 +502,7 @@ public class TestUtil {
     }
 
     public static Branding createBranding(String productId, String brandName) {
-        Branding branding = new Branding();
-        branding.setProductId(productId);
-        branding.setName(brandName);
-        branding.setType("OS");
-        return branding;
+        return new Branding(productId, brandName, "OS");
     }
 
     public static Subscription createSubscription() {
@@ -683,17 +679,6 @@ public class TestUtil {
             .attributes(Collections.<String, String>emptyMap());
 
         return dto;
-    }
-
-    public static Branding createProductBranding(Product product) {
-        Branding productBranding = new Branding();
-        String suffix = randomString();
-        productBranding.setId("test-id-" + suffix);
-        productBranding.setProduct(product);
-        productBranding.setName("test-name-" + suffix);
-        productBranding.setType("test-type-" + suffix);
-        productBranding.setProductId("test-product-id-" + suffix);
-        return productBranding;
     }
 
     public void addPermissionToUser(User u, Access role, Owner o) {

--- a/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
+++ b/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
@@ -70,7 +70,7 @@ public class X509V3ExtensionUtilTest {
         p.setAttribute(Product.Attributes.BRANDING_TYPE, "OS");
         Set<Product> prods = Set.of(p);
         Product mktProd = new Product("mkt", "MKT SKU");
-        mktProd.addBranding(new Branding(null, engProdId, brandedName, "OS"));
+        mktProd.addBranding(new Branding(engProdId, brandedName, "OS"));
         Pool pool = TestUtil.createPool(mktProd);
         Consumer consumer = new Consumer();
         consumer.setOwner(owner);
@@ -161,11 +161,13 @@ public class X509V3ExtensionUtilTest {
 
     private void addContent(Product product, String arches) {
         int size = product.getProductContent().size() + 1;
-        Content c = new Content();
-        c.setUuid("content_" + size);
-        c.setId("content_" + size);
-        c.setArches(arches);
-        product.addContent(c, true);
+
+        Content content = new Content()
+            .setUuid("content_" + size)
+            .setId("content_" + size)
+            .setArches(arches);
+
+        product.addContent(content, true);
     }
 
     @Test
@@ -179,15 +181,20 @@ public class X509V3ExtensionUtilTest {
         Product p = new Product(engProdId, "Eng Product 1000");
         p.setAttribute(Product.Attributes.BRANDING_TYPE, "OS");
         Set<Product> prods = Set.of(p);
-        Product mktProd = new Product("mkt", "MKT SKU");
-        mktProd.addBranding(new Branding(null, engProdId, brandedName, "OS"));
-        mktProd.addBranding(new Branding(null, engProdId, "another brand name", "OS"));
-        mktProd.addBranding(new Branding(null, engProdId, "number 3", "OS"));
+        Product mktProd = new Product("mkt", "MKT SKU")
+            .addBranding(new Branding(engProdId, brandedName, "OS"))
+            .addBranding(new Branding(engProdId, "another brand name", "OS"))
+            .addBranding(new Branding(engProdId, "number 3", "OS"));
+
+        List<String> possibleBrandNames = mktProd.getBranding()
+            .stream()
+            .map(Branding::getName)
+            .toList();
+
         Pool pool = TestUtil.createPool(mktProd);
-        Set<String> possibleBrandNames = new HashSet<>();
-        for (Branding b : mktProd.getBranding()) {
-            possibleBrandNames.add(b.getName());
-        }
+
+
+
         Consumer consumer = new Consumer();
         consumer.setOwner(owner);
 


### PR DESCRIPTION
- Restored the cache annotations to the product and content entities,
  and their respective collections
- Removed use of the deprecated `@fetch` annotation on the product
  entity
- Enabled the setting to automatically evict entity collections when
  the entity itself is evicted from cache in persistence.xml
- Updated the Branding entity to be properly immutable, following
  the changes to ProductContent in an earlier commit
- Removed some extraneous or duplicate operations from
  AbstractHibernateCurator
- Fixed a number of potential avenues for null pointer exceptions
  in AbstractHibernateCurator and derived curators