### PR TITLE
[M] CANDLEPIN-938: Reverted auto-detach when removing child products and content

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
@@ -1411,7 +1411,7 @@ public class ContentAccessSpecTest {
         assertThat(certs).singleElement();
         String initialCert = certs.get(0).getCert();
 
-        adminClient.ownerContent().removeContent(ownerKey, content.getId());
+        adminClient.ownerProducts().removeContentFromProduct(ownerKey, prod.getId(), content.getId());
 
         certs = consumerClient.consumers().fetchCertificates(consumer.getUuid());
         assertThat(certs).singleElement();

--- a/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -401,7 +401,13 @@ public class OwnerContentResource implements OwnerContentApi {
 
         this.validateContentNamespace(owner, content);
 
-        this.contentManager.removeContent(owner, content, true);
+        if (this.contentCurator.contentHasParentProducts(content)) {
+            throw new BadRequestException(i18n.tr(
+                "Content \"{0}\" cannot be deleted while referenced by one or more products",
+                contentId));
+        }
+
+        this.contentManager.removeContent(owner, content);
     }
 
     /**

--- a/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -695,13 +695,19 @@ public class OwnerProductResource implements OwnerProductApi {
 
         this.validateProductNamespace(owner, product);
 
-        if (this.productCurator.productHasSubscriptions(owner, product)) {
+        if (this.productCurator.productHasParentSubscriptions(product)) {
             throw new BadRequestException(i18n.tr(
                 "Product \"{0}\" cannot be deleted while referenced by one or more subscriptions",
                 productId));
         }
 
-        this.productManager.removeProduct(owner, product, true);
+        if (this.productCurator.productHasParentProducts(product)) {
+            throw new BadRequestException(i18n.tr(
+                "Product \"{0}\" cannot be deleted while referenced by one or more products",
+                productId));
+        }
+
+        this.productManager.removeProduct(owner, product);
     }
 
     @Override

--- a/src/main/resources/db/changelog/20241024154545-revert_product_content_delete_cascades.xml
+++ b/src/main/resources/db/changelog/20241024154545-revert_product_content_delete_cascades.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+    <!--
+        Removes the delete cascades and delete nulls added as QoL to allow deleting children without having
+        to manually unlink them from parents first. While this worked fine for what it did, it directly
+        interferes with Hibernate's ability to keep L2 cache in sync, and Hibernate does not provide tools
+        to manually resync the cache without also violating transaction isolation.
+    -->
+
+    <changeSet id="20241024154545-1" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <foreignKeyConstraintExists foreignKeyTableName="cp_products" foreignKeyName="cp_products_fk1" />
+        </preConditions>
+
+        <dropForeignKeyConstraint baseTableName="cp_products" constraintName="cp_products_fk1"/>
+    </changeSet>
+
+    <changeSet id="20241024154545-2" author="crog">
+        <addForeignKeyConstraint baseTableName="cp_products"
+            baseColumnNames="derived_product_uuid"
+            constraintName="cp_products_fk1"
+            referencedTableName="cp_products"
+            referencedColumnNames="uuid"/>
+    </changeSet>
+
+    <changeSet id="20241024154545-3" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <foreignKeyConstraintExists foreignKeyTableName="cp_product_provided_products"
+                foreignKeyName="cp_product_provided_products_fk2" />
+        </preConditions>
+
+        <dropForeignKeyConstraint baseTableName="cp_product_provided_products"
+            constraintName="cp_product_provided_products_fk2"/>
+    </changeSet>
+
+    <changeSet id="20241024154545-4" author="crog">
+        <addForeignKeyConstraint baseTableName="cp_product_provided_products"
+            baseColumnNames="provided_product_uuid"
+            constraintName="cp_product_provided_products_fk2"
+            referencedTableName="cp_products"
+            referencedColumnNames="uuid"/>
+    </changeSet>
+
+    <changeSet id="20241024154545-5" author="crog">
+        <preConditions onFail="MARK_RAN">
+            <foreignKeyConstraintExists foreignKeyTableName="cp_product_contents"
+                foreignKeyName="cp_product_contents_fk2" />
+        </preConditions>
+
+        <dropForeignKeyConstraint baseTableName="cp_product_contents"
+            constraintName="cp_product_contents_fk2"/>
+    </changeSet>
+
+    <changeSet id="20241024154545-6" author="crog">
+        <addForeignKeyConstraint baseTableName="cp_product_contents"
+            baseColumnNames="content_uuid"
+            constraintName="cp_product_contents_fk2"
+            referencedTableName="cp_contents"
+            referencedColumnNames="uuid"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -201,4 +201,5 @@
     <include file="db/changelog/20240802101300-update-anon-cert-table-cert-column.xml"/>
     <include file="db/changelog/202408010000000-create-consumer-cloud-data.xml"/>
     <include file="db/changelog/20240920000000-update-cloud-offering-id-column-size.xml"/>
+    <include file="db/changelog/20241024154545-revert_product_content_delete_cascades.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- Updated the product and content removal functions to no longer automatically remove references from parent products or subscriptions. Endpoints and internal functions will now, instead, fail when attempting to remove/delete a child entity that is still referenced by one or more parent entities.
- Restored a missing check that ensures products and contents being removed or updated are existing, managed entities
- Updated some tests on update and removal to verify the received errors more explicitly to avoid allowing a test pass when receiving an error from a different fail state