### PR TITLE
[4.4.1] CANDLEPIN-832: Revoke all entitlements when owner changes to SCA mode

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClient.java
@@ -24,7 +24,6 @@ import org.candlepin.resource.client.v1.ConsumerTypeApi;
 import org.candlepin.resource.client.v1.ContentApi;
 import org.candlepin.resource.client.v1.DeletedConsumerApi;
 import org.candlepin.resource.client.v1.DistributorVersionsApi;
-import org.candlepin.resource.client.v1.EntitlementsApi;
 import org.candlepin.resource.client.v1.GuestIdsApi;
 import org.candlepin.resource.client.v1.HypervisorsApi;
 import org.candlepin.resource.client.v1.OwnerContentApi;
@@ -37,6 +36,7 @@ import org.candlepin.resource.client.v1.SubscriptionApi;
 import org.candlepin.resource.client.v1.UsersApi;
 import org.candlepin.spec.bootstrap.client.api.CloudRegistrationClient;
 import org.candlepin.spec.bootstrap.client.api.ConsumerClient;
+import org.candlepin.spec.bootstrap.client.api.EntitlementClient;
 import org.candlepin.spec.bootstrap.client.api.EnvironmentClient;
 import org.candlepin.spec.bootstrap.client.api.JobsClient;
 import org.candlepin.spec.bootstrap.client.api.OwnerClient;
@@ -118,8 +118,8 @@ public class ApiClient {
         return new DistributorVersionsApi(this.client);
     }
 
-    public EntitlementsApi entitlements() {
-        return new EntitlementsApi(this.client);
+    public EntitlementClient entitlements() {
+        return new EntitlementClient(this.client);
     }
 
     public EnvironmentClient environments() {

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/EntitlementClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/EntitlementClient.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.bootstrap.client.api;
+
+import org.candlepin.dto.api.client.v1.EntitlementDTO;
+import org.candlepin.invoker.client.ApiClient;
+import org.candlepin.resource.client.v1.EntitlementsApi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EntitlementClient extends EntitlementsApi {
+
+    public EntitlementClient(ApiClient client) {
+        super(client);
+    }
+
+    public List<EntitlementDTO> listAllForConsumer(String consumerUuid) {
+        if (consumerUuid == null || consumerUuid.isBlank()) {
+            return new ArrayList<>();
+        }
+
+        return super.listAllForConsumer(consumerUuid, null, null, null, null, null, null);
+    }
+}

--- a/src/main/java/org/candlepin/async/tasks/RevokeEntitlementsJob.java
+++ b/src/main/java/org/candlepin/async/tasks/RevokeEntitlementsJob.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import org.candlepin.async.AsyncJob;
+import org.candlepin.async.JobArguments;
+import org.candlepin.async.JobConfig;
+import org.candlepin.async.JobConfigValidationException;
+import org.candlepin.async.JobConstraints;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.Configuration;
+import org.candlepin.controller.PoolService;
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.activationkeys.ActivationKeyCurator;
+
+import com.google.common.collect.Iterables;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+
+import javax.inject.Inject;
+
+/**
+ * An async job responsible for revoking all entitlements for all non-manifest consumers that belong to a
+ * specified owner. This job also removes activation key pools for the same owner.
+ */
+public class RevokeEntitlementsJob implements AsyncJob {
+    private static final Logger log = LoggerFactory.getLogger(RevokeEntitlementsJob.class);
+    private static final int MAX_RETRY_COUNT = 5;
+
+    public static final String JOB_KEY = "EntitlementRevokingJob";
+    public static final String JOB_NAME = "Entitlement Revoking Job";
+    public static final String CFG_BATCH_SIZE = "batch_size";
+    public static final String OWNER_KEY = "owner_key";
+
+    private Configuration config;
+    private ConsumerCurator consumerCurator;
+    private OwnerCurator ownerCurator;
+    private PoolService poolService;
+    private ActivationKeyCurator activationKeyCurator;
+
+    @Inject
+    public RevokeEntitlementsJob(Configuration config, ConsumerCurator consumerCurator,
+        OwnerCurator ownerCurator, PoolService poolService, ActivationKeyCurator activationKeyCurator) {
+        this.config = Objects.requireNonNull(config);
+        this.consumerCurator = Objects.requireNonNull(consumerCurator);
+        this.ownerCurator = Objects.requireNonNull(ownerCurator);
+        this.poolService = Objects.requireNonNull(poolService);
+        this.activationKeyCurator = Objects.requireNonNull(activationKeyCurator);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        JobArguments jobArguments = context.getJobArguments();
+        String ownerKey = jobArguments.getAsString(OWNER_KEY);
+
+        log.info("{} has started for owner {}", JOB_KEY, ownerKey);
+        Owner owner = ownerCurator.getByKey(ownerKey);
+        if (owner == null) {
+            String msg = String.format("Unable to find owner for owner key \"%s\"", ownerKey);
+            log.error(msg);
+            throw new JobExecutionException(msg, true);
+        }
+
+        int batchSize = getBatchSize();
+
+        int removedPools = activationKeyCurator.removeActivationKeyPools(ownerKey);
+        log.debug("Removed {} activation key pools", removedPools);
+
+        /*
+         * Revoke all entitlements for batches of consumers. Each batch is processed in a seperate
+         * transaction.
+         */
+        List<String> consumerUuids = consumerCurator.getSystemConsumerUuidsByOwner(owner.getKey());
+        int entRevokeCount = 0;
+        for (List<String> batch : Iterables.partition(consumerUuids, batchSize)) {
+            log.debug("Revoking entitlements for consumers with UUIDs: {}", batch);
+            entRevokeCount += poolService.revokeAllEntitlements(batch, false);
+        }
+
+        log.info("{} has run! {} entitlements revoked and {} activation key pools removed.", JOB_KEY,
+            entRevokeCount, removedPools);
+        String msg = "%s completed successfully. %d entitlements revoked and %d pools removed from " +
+            "activation keys.";
+        context.setJobResult(msg, JOB_NAME, entRevokeCount, removedPools);
+    }
+
+    /**
+     * Job configuration object for the {@link RevokeEntitlementsJob}
+     */
+    public static class RevokeEntitlementsJobConfig extends JobConfig<RevokeEntitlementsJobConfig> {
+
+        public RevokeEntitlementsJobConfig() throws JobExecutionException {
+            this.setJobKey(JOB_KEY)
+                .setJobName(JOB_NAME)
+                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY))
+                .setRetryCount(MAX_RETRY_COUNT);
+        }
+
+        /**
+         * Sets the owner for this {@link RevokeEntitlementsJobConfig}.
+         *
+         * @param owner
+         *  the owner to set
+         *
+         * @throws IllegalArgumentException
+         *  if the owner is null or the owner's key is null or blank
+         *
+         * @return a reference to this RevokeEntitlementsJobConfig
+         */
+        @Override
+        public RevokeEntitlementsJobConfig setOwner(Owner owner) {
+            if (owner == null) {
+                throw new IllegalArgumentException("owner is null");
+            }
+
+            if (owner.getKey() == null || owner.getKey().isBlank()) {
+                throw new IllegalArgumentException("owner key is null or blank");
+            }
+
+            this.setContextOwner(owner);
+            this.setJobArgument(OWNER_KEY, owner.getKey());
+
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void validate() throws JobConfigValidationException {
+            super.validate();
+
+            JobArguments arguments = this.getJobArguments();
+
+            String ownerKey = arguments.getAsString(OWNER_KEY);
+            if (ownerKey == null || ownerKey.isBlank()) {
+                throw new JobConfigValidationException("Owner key has not been set or is blank");
+            }
+        }
+    }
+
+    private int getBatchSize() throws JobExecutionException {
+        String configKey = ConfigProperties.jobConfig(JOB_KEY, CFG_BATCH_SIZE);
+        int batchSize = config.getInt(configKey);
+        if (batchSize <= 0) {
+            String errorMessage = String.format(
+                "Invalid value for configuration \"%s\", must be a positive integer: %s", configKey,
+                batchSize);
+
+            log.error(errorMessage);
+            throw new JobExecutionException(errorMessage);
+        }
+
+        return batchSize;
+    }
+}

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -25,6 +25,7 @@ import org.candlepin.async.tasks.InactiveConsumerCleanerJob;
 import org.candlepin.async.tasks.JobCleaner;
 import org.candlepin.async.tasks.ManifestCleanerJob;
 import org.candlepin.async.tasks.OrphanCleanupJob;
+import org.candlepin.async.tasks.RevokeEntitlementsJob;
 import org.candlepin.async.tasks.UnmappedGuestEntitlementCleanerJob;
 import org.candlepin.guice.CandlepinContextListener;
 
@@ -539,6 +540,9 @@ public class ConfigProperties {
             // UnmappedGuestEntitlementCleanerJob
             this.put(jobConfig(UnmappedGuestEntitlementCleanerJob.JOB_KEY, ASYNC_JOBS_JOB_SCHEDULE),
                 UnmappedGuestEntitlementCleanerJob.DEFAULT_SCHEDULE);
+
+            // RevokeEntitlementsJob
+            this.put(jobConfig(RevokeEntitlementsJob.JOB_KEY, RevokeEntitlementsJob.CFG_BATCH_SIZE), "500");
 
             // Set the triggerable jobs list
             this.put(ASYNC_JOBS_TRIGGERABLE_JOBS, String.join(", ", ASYNC_JOBS_TRIGGERABLE_JOBS_LIST));

--- a/src/main/java/org/candlepin/controller/PoolService.java
+++ b/src/main/java/org/candlepin/controller/PoolService.java
@@ -600,6 +600,13 @@ public class PoolService {
     }
 
     @Transactional
+    public int revokeAllEntitlements(Collection<String> consumerUuid, boolean regenCertsAndStatuses) {
+        List<Entitlement> entsToDelete = entitlementCurator.listByConsumerUuids(consumerUuid);
+        revokeEntitlements(entsToDelete, null, regenCertsAndStatuses);
+        return entsToDelete.size();
+    }
+
+    @Transactional
     public Set<Pool> revokeEntitlements(List<Entitlement> entsToRevoke) {
         return revokeEntitlements(entsToRevoke, null, true);
     }

--- a/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -38,6 +38,7 @@ import org.candlepin.async.tasks.RefreshPoolsForProductJob;
 import org.candlepin.async.tasks.RefreshPoolsJob;
 import org.candlepin.async.tasks.RegenEnvEntitlementCertsJob;
 import org.candlepin.async.tasks.RegenProductEntitlementCertsJob;
+import org.candlepin.async.tasks.RevokeEntitlementsJob;
 import org.candlepin.async.tasks.UndoImportsJob;
 import org.candlepin.async.tasks.UnmappedGuestEntitlementCleanerJob;
 import org.candlepin.audit.ArtemisMessageSource;
@@ -462,6 +463,7 @@ public class CandlepinModule extends AbstractModule {
         JobManager.registerJob(InactiveConsumerCleanerJob.JOB_KEY, InactiveConsumerCleanerJob.class);
         JobManager.registerJob(CloudAccountOrgSetupJob.JOB_KEY, CloudAccountOrgSetupJob.class);
         JobManager.registerJob(ConsumerMigrationJob.JOB_KEY, ConsumerMigrationJob.class);
+        JobManager.registerJob(RevokeEntitlementsJob.JOB_KEY, RevokeEntitlementsJob.class);
     }
 
     private void configureExporter() {

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -1848,4 +1848,27 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         return lockedIds;
     }
 
+    /**
+     * Retrieves all the non-manifest type consumer UUIDs that belong to the provided owner.
+     *
+     * @param ownerKey
+     *  the key to the owner to retrieve the UUIDs for
+     *
+     * @return all non-manifest type consumer UUIDs for the provided owner. This method will not return null.
+     */
+    public List<String> getSystemConsumerUuidsByOwner(String ownerKey) {
+        List<String> consumerUuids  = new ArrayList<>();
+        if (ownerKey == null || ownerKey.isBlank()) {
+            return consumerUuids;
+        }
+
+        String jpql = "SELECT c.uuid FROM Consumer c " +
+            "JOIN ConsumerType type ON type.id = c.typeId " +
+            "WHERE c.owner.key = :owner_key AND type.manifest = 'N'";
+
+        return this.getEntityManager()
+            .createQuery(jpql, String.class)
+            .setParameter("owner_key", ownerKey)
+            .getResultList();
+    }
 }

--- a/src/test/java/org/candlepin/TestingModules.java
+++ b/src/test/java/org/candlepin/TestingModules.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.candlepin.async.JobManager;
 import org.candlepin.audit.EventSink;
 import org.candlepin.audit.NoopEventSinkImpl;
 import org.candlepin.auth.Principal;
@@ -275,6 +276,9 @@ public class TestingModules {
             // define test alternative for it.
             bindScope(RequestScoped.class, TestingScope.EAGER_SINGLETON);
             bind(CandlepinRequestScope.class).toInstance(requestScope);
+
+            JobManager mockJobManager = mock(JobManager.class);
+            bind(JobManager.class).toInstance(mockJobManager);
 
             bind(X509ExtensionUtil.class);
 

--- a/src/test/java/org/candlepin/async/tasks/RevokeEntitlementsJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/RevokeEntitlementsJobTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.async.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+
+import org.candlepin.async.JobConfigValidationException;
+import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
+import org.candlepin.async.tasks.RevokeEntitlementsJob.RevokeEntitlementsJobConfig;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.Configuration;
+import org.candlepin.controller.PoolService;
+import org.candlepin.model.AsyncJobStatus;
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.activationkeys.ActivationKeyCurator;
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+public class RevokeEntitlementsJobTest {
+    private static final String JOB_KEY = "EntitlementRevokingJob";
+    private static final String CFG_BATCH_SIZE = "batch_size";
+
+    @Mock
+    private Configuration config;
+    @Mock
+    private ConsumerCurator consumerCurator;
+    @Mock
+    private OwnerCurator ownerCurator;
+    @Mock
+    private PoolService poolService;
+    @Mock
+    private ActivationKeyCurator activationKeyCurator;
+
+    @ParameterizedTest(name = "{displayName} {index}: {0} {1}")
+    @NullAndEmptySource
+    public void testRevokeEntitlementsJobConfigSetOwnerWithInvalidKey(String ownerKey)
+        throws JobExecutionException {
+        RevokeEntitlementsJobConfig jobConfig = new RevokeEntitlementsJobConfig();
+
+        Owner owner = new Owner()
+            .setKey(ownerKey);
+
+        assertThrows(IllegalArgumentException.class, () -> jobConfig.setOwner(owner));
+    }
+
+    @Test
+    public void testRevokeEntitlementsJobConfigSetOwnerWithNullOwner()
+        throws JobExecutionException {
+        RevokeEntitlementsJobConfig jobConfig = new RevokeEntitlementsJobConfig();
+
+        assertThrows(IllegalArgumentException.class, () -> jobConfig.setOwner(null));
+    }
+
+    @Test
+    public void testRevokeEntitlementsJobConfigValidateWithMissingOwnerKey() throws JobExecutionException {
+        RevokeEntitlementsJobConfig jobConfig = new RevokeEntitlementsJobConfig();
+
+        assertThrows(JobConfigValidationException.class, () -> jobConfig.validate());
+    }
+
+    @Test
+    public void testRevokeEntitlementsJobConfigValidate() throws Exception {
+        Owner owner = new Owner()
+            .setKey(TestUtil.randomString());
+
+        RevokeEntitlementsJobConfig jobConfig = new RevokeEntitlementsJobConfig()
+            .setOwner(owner);
+
+        jobConfig.validate();
+
+        // Assert no exception
+    }
+
+    @Test
+    public void testExecuteWithNoExistingOwner() throws JobExecutionException {
+        RevokeEntitlementsJob job = new RevokeEntitlementsJob(config, consumerCurator, ownerCurator,
+            poolService, activationKeyCurator);
+
+        Owner owner = new Owner()
+            .setKey(TestUtil.randomString());
+
+        RevokeEntitlementsJobConfig jobConfig = new RevokeEntitlementsJobConfig()
+            .setOwner(owner);
+
+        AsyncJobStatus jobStatus = new AsyncJobStatus()
+            .setJobArguments(jobConfig.getJobArguments());
+        JobExecutionContext context = new JobExecutionContext(jobStatus);
+
+        assertThrows(JobExecutionException.class, () -> job.execute(context));
+    }
+
+    @Test
+    public void testExecuteWithInvalidBatchSize() throws JobExecutionException {
+        RevokeEntitlementsJob job = new RevokeEntitlementsJob(config, consumerCurator, ownerCurator,
+            poolService, activationKeyCurator);
+
+        String ownerKey = TestUtil.randomString();
+        Owner owner = new Owner();
+        owner.setKey(ownerKey);
+        doReturn(owner).when(ownerCurator).getByKey(ownerKey);
+
+        RevokeEntitlementsJobConfig jobConfig = new RevokeEntitlementsJobConfig()
+            .setOwner(owner);
+
+        AsyncJobStatus jobStatus = new AsyncJobStatus()
+            .setJobArguments(jobConfig.getJobArguments());
+        JobExecutionContext context = new JobExecutionContext(jobStatus);
+
+        doReturn(-10).when(config).getInt(ConfigProperties.jobConfig(JOB_KEY, CFG_BATCH_SIZE));
+
+        assertThrows(JobExecutionException.class, () -> job.execute(context));
+    }
+
+    @Test
+    public void testExecute() throws JobExecutionException {
+        RevokeEntitlementsJob job = new RevokeEntitlementsJob(config, consumerCurator, ownerCurator,
+            poolService, activationKeyCurator);
+
+        String ownerKey = TestUtil.randomString();
+        Owner owner = new Owner();
+        owner.setKey(ownerKey);
+        doReturn(owner).when(ownerCurator).getByKey(ownerKey);
+
+        RevokeEntitlementsJobConfig jobConfig = new RevokeEntitlementsJobConfig()
+            .setOwner(owner);
+
+        AsyncJobStatus jobStatus = new AsyncJobStatus()
+            .setJobArguments(jobConfig.getJobArguments());
+        JobExecutionContext context = new JobExecutionContext(jobStatus);
+
+        int removedPools = 2;
+        doReturn(removedPools).when(activationKeyCurator).removeActivationKeyPools(ownerKey);
+        doReturn(1).when(config).getInt(ConfigProperties.jobConfig(JOB_KEY, CFG_BATCH_SIZE));
+        List<String> consumerUuids = List.of(TestUtil.randomString(), TestUtil.randomString());
+        doReturn(consumerUuids).when(consumerCurator).getSystemConsumerUuidsByOwner(ownerKey);
+        doReturn(1).when(poolService).revokeAllEntitlements(any(List.class), eq(false));
+
+        job.execute(context);
+
+        assertThat(jobStatus.getJobResult())
+            // Validating that one entitlement per consumer was revoked
+            .contains(String.valueOf(consumerUuids.size()))
+            // Validating the pools was removed
+            .contains(String.valueOf(removedPools));
+    }
+}

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerDBTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+import org.candlepin.async.JobManager;
 import org.candlepin.audit.EventSink;
 import org.candlepin.cache.AnonymousCertContentCache;
 import org.candlepin.controller.ContentAccessManager.ContentAccessMode;
@@ -47,6 +48,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.xnap.commons.i18n.I18n;
 
 
 
@@ -68,6 +70,10 @@ public class ContentAccessManagerDBTest extends DatabaseTestFixture {
 
     @Mock
     private ProductServiceAdapter mockProdAdapter;
+    @Mock
+    private JobManager jobManager;
+    @Mock
+    private I18n i18n;
 
     @BeforeEach
     public void setup() throws Exception {
@@ -89,7 +95,7 @@ public class ContentAccessManagerDBTest extends DatabaseTestFixture {
             this.caCertCurator, this.certSerialCurator, this.ownerCurator, this.ownerContentCurator,
             this.consumerCurator, this.consumerTypeCurator, this.environmentCurator, this.caCertCurator,
             this.mockEventSink, this.anonymousCloudConsumerCurator, this.anonymousContentAccessCertCurator,
-            this.mockProdAdapter, this.cache);
+            this.mockProdAdapter, this.cache, this.jobManager, this.i18n);
     }
 
     private Owner createSCAOwner() {

--- a/src/test/java/org/candlepin/model/ActivationKeyCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ActivationKeyCuratorTest.java
@@ -14,14 +14,19 @@
  */
 package org.candlepin.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.model.activationkeys.ActivationKey;
 import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import java.util.List;
 import java.util.Set;
@@ -59,6 +64,78 @@ class ActivationKeyCuratorTest extends DatabaseTestFixture {
 
         assertEquals(1, foundKeys.size());
         assertTrue(foundKeys.stream().map(ActivationKey::getName).allMatch("test-key1"::equals));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testRemoveActivationKeyPoolsWithInvalidOwnerKey(String ownerKey) {
+        assertThrows(IllegalArgumentException.class, () -> activationKeyCurator
+            .removeActivationKeyPools(ownerKey));
+    }
+
+    @Test
+    public void testRemoveActivationKeyPools() {
+        Owner owner1 = this.createOwner();
+        Owner owner2 = this.createOwner();
+
+        Product product1 = this.createProduct();
+        Product product2 = this.createProduct();
+        Pool pool1 = this.createPool(owner1, product1);
+        Pool pool2 = this.createPool(owner1, product2);
+        Pool pool3 = this.createPool(owner2, product2);
+
+        ActivationKey key1 = activationKeyCurator.create(new ActivationKey(TestUtil.randomString(), owner1)
+            .addPool(pool1, 1L));
+        ActivationKey key2 = activationKeyCurator.create(new ActivationKey(TestUtil.randomString(), owner1)
+            .addPool(pool1, 1L));
+        ActivationKey key3 = activationKeyCurator.create(new ActivationKey(TestUtil.randomString(), owner1)
+            .addPool(pool2, 1L));
+        ActivationKey key4 = activationKeyCurator.create(new ActivationKey(TestUtil.randomString(), owner1)
+            .addPool(pool2, 1L));
+        ActivationKey owner2Key = activationKeyCurator
+            .create(new ActivationKey(TestUtil.randomString(), owner2)
+            .addPool(pool3, 1L));
+        String expectedOwner2KeyPoolId = owner2Key.getPools().iterator().next().getId();
+
+        int actual = activationKeyCurator.removeActivationKeyPools(owner1.getKey());
+        assertEquals(4, actual);
+
+        assertThat(listAllActivationKeyPoolIdsByOwner(owner1.getKey()))
+            .isEmpty();
+
+        assertThat(listAllActivationKeyPoolIdsByOwner(owner2.getKey()))
+            .containsExactly(expectedOwner2KeyPoolId);
+
+        assertThat(activationKeyCurator.getByKeyName(owner1, key1.getName()))
+            .isNotNull()
+            .isEqualTo(key1);
+
+        assertThat(activationKeyCurator.getByKeyName(owner1, key2.getName()))
+            .isNotNull()
+            .isEqualTo(key2);
+
+        assertThat(activationKeyCurator.getByKeyName(owner1, key3.getName()))
+            .isNotNull()
+            .isEqualTo(key3);
+
+        assertThat(activationKeyCurator.getByKeyName(owner1, key4.getName()))
+            .isNotNull()
+            .isEqualTo(key4);
+
+        assertThat(activationKeyCurator.getByKeyName(owner2, owner2Key.getName()))
+            .isNotNull()
+            .isEqualTo(owner2Key);
+    }
+
+    private List<String> listAllActivationKeyPoolIdsByOwner(String ownerKey) {
+        String jpql = "SELECT akp.id FROM ActivationKeyPool akp " +
+            "JOIN Pool p ON p.id = akp.pool.id " +
+            "WHERE p.owner.key = :owner_key";
+
+        return this.getEntityManager()
+            .createQuery(jpql, String.class)
+            .setParameter("owner_key", ownerKey)
+            .getResultList();
     }
 
 }

--- a/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.model;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
@@ -38,6 +39,8 @@ import org.candlepin.util.Util;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
@@ -2221,6 +2224,49 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         Assertions.assertThat(lockedIds)
             .hasSize(2)
             .containsExactlyInAnyOrderElementsOf(consumerIds);
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0} {1}")
+    @NullAndEmptySource
+    public void testGetSystemConsumerUuidsByOwnerWithInvalidOwnerKey(String ownerKey) {
+        List<String> actual = consumerCurator.getSystemConsumerUuidsByOwner(ownerKey);
+
+        assertThat(actual)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    public void testGetSystemConsumerUuidsByOwner() {
+        Consumer systemConsumer1 = new Consumer()
+            .setName(TestUtil.randomString())
+            .setUsername(TestUtil.randomString())
+            .setOwner(owner)
+            .setType(ct);
+        systemConsumer1 = consumerCurator.create(systemConsumer1);
+
+        Consumer systemConsumer2 = new Consumer()
+            .setName(TestUtil.randomString())
+            .setUsername(TestUtil.randomString())
+            .setOwner(owner)
+            .setType(ct);
+        systemConsumer2 = consumerCurator.create(systemConsumer2);
+
+        ConsumerType manifestType = new ConsumerType(ConsumerTypeEnum.CANDLEPIN);
+        manifestType = consumerTypeCurator.create(manifestType);
+
+        Consumer manifestConsumer = new Consumer()
+            .setName(TestUtil.randomString())
+            .setUsername(TestUtil.randomString())
+            .setOwner(owner)
+            .setType(manifestType);
+        manifestConsumer = consumerCurator.create(manifestConsumer);
+
+        List<String> actual = consumerCurator.getSystemConsumerUuidsByOwner(owner.getOwnerKey());
+
+        assertThat(actual)
+            .isNotNull()
+            .containsExactlyInAnyOrder(systemConsumer1.getUuid(), systemConsumer2.getUuid());
     }
 
     private IdentityCertificate createIdCert() {


### PR DESCRIPTION
- Created RevokeEntitlementsJob to revoke all entitlements for an owner and remove all activation key pools for an owner's activation keys.
- Created a RevokeEntitlementJob for an owner that changes from entitlement mode to SCA mode.