### PR TITLE
[4.4.1] CANDLEPIN-946: Update apiJar dependency list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -391,12 +391,14 @@ tasks.register('apiJar', Jar) {
     archiveBaseName = 'candlepin-api'
     from sourceSets.main.output
     includes = [
+            'async',
             'auth',
             'config',
             'controller',
             'exceptions',
             'jackson',
             'model',
+            'paging',
             'pki',
             'resteasy',
             'service',


### PR DESCRIPTION
- Added the "async" and "paging" packages to the apiJar gradle task so that the classes are included in the candlepin-api jar.

# Verification

Verified the changes by running the `./gradlew apiJar` command to produce the candlepin-api jar and then decompiled the candlepin-api jar to verify that the classes from the "async" and "paging" packages are included.