### PR TITLE
[M] CANDLEPIN-944: Droped FK for cp2_owner_content/product on cp_owner

### DIFF
--- a/src/main/resources/db/changelog/20241029000000-drop-fk-cp-owner.xml
+++ b/src/main/resources/db/changelog/20241029000000-drop-fk-cp-owner.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+    <changeSet id="20241029000000-1" author="sbakaj">
+        <preConditions onFail="MARK_RAN">
+            <foreignKeyConstraintExists foreignKeyTableName="cp2_owner_products"
+                foreignKeyName="cp2_owner_products_fk1" />
+        </preConditions>
+        <dropForeignKeyConstraint baseTableName="cp2_owner_products" constraintName="cp2_owner_products_fk1" />
+    </changeSet>
+
+    <changeSet id="20241029000000-2" author="sbakaj">
+        <preConditions onFail="MARK_RAN">
+            <foreignKeyConstraintExists foreignKeyTableName="cp2_owner_content"
+                foreignKeyName="cp2_owner_content_fk1" />
+        </preConditions>
+        <dropForeignKeyConstraint baseTableName="cp2_owner_content" constraintName="cp2_owner_content_fk1" />
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -202,4 +202,5 @@
     <include file="db/changelog/202408010000000-create-consumer-cloud-data.xml"/>
     <include file="db/changelog/20240920000000-update-cloud-offering-id-column-size.xml"/>
     <include file="db/changelog/20241024154545-revert_product_content_delete_cascades.xml"/>
+    <include file="db/changelog/20241029000000-drop-fk-cp-owner.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
- When the satellite tried to update from version 6.15 to 6.16, we decided not to use cp2_ownerproduct/content anymore and to utilize new tables for that purpose. However, we chose to keep the original tables in case we needed to revert to the previous version. We didn’t delete the foreign keys (FK) on those tables, which prevented the deletion of custom owners due to constraint violations.