### PR TITLE
[M] CANDLEPIN-945: Handle EntityNotFoundException in ConsumerStore.lookup

### DIFF
--- a/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
+++ b/src/main/java/org/candlepin/resteasy/filter/StoreFactory.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import javax.persistence.EntityNotFoundException;
 
 
 
@@ -165,15 +166,24 @@ public class StoreFactory {
 
         @Override
         public Consumer lookup(final String consumerUuid) {
-            final Consumer byUuid = consumerCurator.findByUuid(consumerUuid);
-            if (byUuid != null) {
-                return byUuid;
+            Consumer consumer = null;
+            try {
+                consumer = consumerCurator.findByUuid(consumerUuid);
             }
+            catch (EntityNotFoundException e) {
+                // Intentionally ignoring exception
+            }
+
+            if (consumer != null) {
+                return consumer;
+            }
+
             if (wasDeleted(consumerUuid)) {
                 throw new GoneException(i18nProvider.get()
                     .tr("Unit {0} has been deleted", consumerUuid), consumerUuid);
             }
-            return null;
+
+            return consumer;
         }
 
         private boolean wasDeleted(final String consumerUuid) {


### PR DESCRIPTION
- Ignored EntityNotFoundException in ConsumerStore.lookup which can occur when a consumer is concurrently being deleted while being retrieved. By ignoring the exception we return a 404 or 410 response status code to the client instead of a 500 response status code.

## Background

This issue was discovered by a flaky spec test (ConsumerResourceSpecTest.shouldReturn404Or410WhenConcurrentRegisterIsDeletedByAnotherRequest) where a 500 response would occasionally be returned because a consumer was being retrieved by VerifyAuthorizationFilter while the consumer was concurrently being deleted.

To recreate the issue, you can run the ConsumerResourceSpecTest.shouldReturn404Or410WhenConcurrentRegisterIsDeletedByAnotherRequest test in a loop about 100 times and you will eventually run into the error. The following is the stack trace of the error that you will get:

```
2024-10-28 13:20:16,896 [thread=https-jsse-nio-8443-exec-35] [req=adcbe6a0-e1c8-4e1f-b0d3-46d75ca1de39, org=, csid=] ERROR org.candlepin.exceptions.mappers.CandlepinExceptionMapper - Runtime Error Unable to find org.candlepin.model.IdentityCertificate with id 2c92808392d342d80192d348ccc21f3f at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl$JpaEntityNotFoundDelegate.handleEntityNotFound:177
javax.persistence.EntityNotFoundException: Unable to find org.candlepin.model.IdentityCertificate with id 2c92808392d342d80192d348ccc21f3f
        at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl$JpaEntityNotFoundDelegate.handleEntityNotFound(EntityManagerFactoryBuilderImpl.java:177)
        at org.hibernate.event.internal.DefaultLoadEventListener.load(DefaultLoadEventListener.java:216)
        at org.hibernate.event.internal.DefaultLoadEventListener.proxyOrLoad(DefaultLoadEventListener.java:327)
        at org.hibernate.event.internal.DefaultLoadEventListener.doOnLoad(DefaultLoadEventListener.java:108)
        at org.hibernate.event.internal.DefaultLoadEventListener.onLoad(DefaultLoadEventListener.java:74)
        at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:118)
        at org.hibernate.internal.SessionImpl.fireLoadNoChecks(SessionImpl.java:1231)
        at org.hibernate.internal.SessionImpl.internalLoad(SessionImpl.java:1096)
        at org.hibernate.type.EntityType.resolveIdentifier(EntityType.java:706)
        at org.hibernate.type.EntityType.resolve(EntityType.java:465)
        at org.hibernate.type.ManyToOneType.resolve(ManyToOneType.java:265)
        at org.hibernate.engine.internal.TwoPhaseLoad$EntityResolver.lambda$static$0(TwoPhaseLoad.java:576)
        at org.hibernate.engine.internal.TwoPhaseLoad.initializeEntityEntryLoadedState(TwoPhaseLoad.java:221)
        at org.hibernate.engine.internal.TwoPhaseLoad.initializeEntity(TwoPhaseLoad.java:155)
        at org.hibernate.engine.internal.TwoPhaseLoad.initializeEntity(TwoPhaseLoad.java:126)
        at org.hibernate.loader.Loader.initializeEntitiesAndCollections(Loader.java:1201)
        at org.hibernate.loader.Loader.processResultSet(Loader.java:1009)
        at org.hibernate.loader.Loader.doQuery(Loader.java:967)
        at org.hibernate.loader.Loader.doQueryAndInitializeNonLazyCollections(Loader.java:357)
        at org.hibernate.loader.Loader.doList(Loader.java:2868)
        at org.hibernate.loader.Loader.doList(Loader.java:2850)
        at org.hibernate.loader.Loader.listIgnoreQueryCache(Loader.java:2682)
        at org.hibernate.loader.Loader.list(Loader.java:2677)
        at org.hibernate.loader.hql.QueryLoader.list(QueryLoader.java:540)
        at org.hibernate.hql.internal.ast.QueryTranslatorImpl.list(QueryTranslatorImpl.java:400)
        at org.hibernate.engine.query.spi.HQLQueryPlan.performList(HQLQueryPlan.java:218)
        at org.hibernate.internal.SessionImpl.list(SessionImpl.java:1459)
        at org.hibernate.query.internal.AbstractProducedQuery.doList(AbstractProducedQuery.java:1649)
        at org.hibernate.query.internal.AbstractProducedQuery.list(AbstractProducedQuery.java:1617)
        at org.hibernate.query.internal.AbstractProducedQuery.getSingleResult(AbstractProducedQuery.java:1665)
        at org.hibernate.query.criteria.internal.compile.CriteriaQueryTypeQueryAdapter.getSingleResult(CriteriaQueryTypeQueryAdapter.java:111)
        at org.candlepin.model.ConsumerCurator.getConsumer(ConsumerCurator.java:489)
        at org.candlepin.model.ConsumerCurator.findByUuid(ConsumerCurator.java:399)
        at com.google.inject.persist.jpa.JpaLocalTxnInterceptor.invoke(JpaLocalTxnInterceptor.java:66)
        at org.candlepin.resteasy.filter.StoreFactory$ConsumerStore.lookup(StoreFactory.java:168)
        at org.candlepin.resteasy.filter.StoreFactory$ConsumerStore.lookup(StoreFactory.java:149)
        at org.candlepin.resteasy.filter.VerifyAuthorizationFilter.getAccessedEntities(VerifyAuthorizationFilter.java:262)
        at org.candlepin.resteasy.filter.VerifyAuthorizationFilter.hasAccess(VerifyAuthorizationFilter.java:201)
        at org.candlepin.resteasy.filter.VerifyAuthorizationFilter.runFilter(VerifyAuthorizationFilter.java:107)
        at org.candlepin.resteasy.filter.AbstractAuthorizationFilter.filter(AbstractAuthorizationFilter.java:56)
        at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:312)
        at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:476)
        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:434)
        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:408)
        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:69)
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:492)
        at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:261)
        at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:161)
```

**Relevant build failures:**
https://github.com/candlepin/candlepin/actions/runs/11554659076/job/32158343972?pr=4896
https://github.com/candlepin/candlepin/actions/runs/11481568360/job/32002020813?pr=4888