### PR TITLE
[M] CANDLEPIN-938: Updated query space declarations for native SQL queries

### DIFF
--- a/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -30,7 +30,7 @@ import com.google.inject.persist.Transactional;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.Session;
-import org.hibernate.annotations.QueryHints;
+import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
@@ -960,8 +960,9 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
 
         this.getEntityManager()
             .createNativeQuery(String.format(query, (Object[]) pieces))
+            .unwrap(NativeQuery.class)
+            .addSynchronizedEntityClass(SystemLock.class)
             .setParameter("lock_name", lockName)
-            .setHint(QueryHints.NATIVE_SPACES, SystemLock.class.getName())
             .executeUpdate();
     }
 

--- a/src/main/java/org/candlepin/model/ConsumerContentOverrideCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerContentOverrideCurator.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import org.hibernate.query.NativeQuery;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -122,6 +124,10 @@ public class ConsumerContentOverrideCurator extends
 
         this.getEntityManager()
             .createNativeQuery(sql)
+            .unwrap(NativeQuery.class)
+            .addSynchronizedEntityClass(Consumer.class)
+            .addSynchronizedEntityClass(ConsumerContentOverride.class)
+            .addSynchronizedQuerySpace("cp_consumer_environments")
             .setParameter("consumer_id", consumerId)
             .getResultList()
             .forEach(rowProcessor);

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -28,7 +28,7 @@ import com.google.inject.persist.Transactional;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.Hibernate;
-import org.hibernate.annotations.QueryHints;
+import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -680,11 +680,15 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
                 "The HypervisorHearbeatUpdate cannot execute as the database dialect is not recognized.");
         }
 
-        getEntityManager().createNativeQuery(query)
+        this.getEntityManager()
+            .createNativeQuery(query)
             .setParameter("checkin", checkIn)
             .setParameter("reporter", reporterId)
             .setParameter("ownerKey", ownerKey)
-            .setHint(QueryHints.NATIVE_SPACES, Consumer.class.getName())
+            .unwrap(NativeQuery.class)
+            .addSynchronizedEntityClass(Consumer.class)
+            .addSynchronizedEntityClass(HypervisorId.class)
+            .addSynchronizedEntityClass(Owner.class)
             .executeUpdate();
     }
 

--- a/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/src/main/java/org/candlepin/model/ContentCurator.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.model;
 
+import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -720,8 +721,12 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
                 JOIN active_products ap ON ap.uuid = pc.product_uuid
             """;
 
-        Map<String, Boolean> enablementMap =
-            (Map<String, Boolean>) entityManager.createNativeQuery(sql)
+        Map<String, Boolean> enablementMap = (Map<String, Boolean>) entityManager.createNativeQuery(sql)
+            .unwrap(NativeQuery.class)
+            .addSynchronizedEntityClass(Pool.class)
+            .addSynchronizedEntityClass(Product.class)
+            .addSynchronizedEntityClass(ProductContent.class)
+            .addSynchronizedQuerySpace("cp_product_provided_products")
             .setParameter("owner_id", ownerId)
             .getResultList()
             .stream()

--- a/src/main/java/org/candlepin/model/EnvironmentCurator.java
+++ b/src/main/java/org/candlepin/model/EnvironmentCurator.java
@@ -14,7 +14,7 @@
  */
 package org.candlepin.model;
 
-import org.hibernate.annotations.QueryHints;
+import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -288,11 +288,10 @@ public class EnvironmentCurator extends AbstractHibernateCurator<Environment> {
             Iterable<List<String>> eidBlocks = this.partition(envIds, blockSize);
             Iterable<List<String>> cidBlocks = this.partition(contentIds, blockSize);
 
-            List<String> nativeSpaces = List.of(
-                Environment.class.getName(), EnvironmentContent.class.getName());
-
             Query query = entityManager.createNativeQuery(sql)
-                .setHint(QueryHints.NATIVE_SPACES, nativeSpaces);
+                .unwrap(NativeQuery.class)
+                .addSynchronizedEntityClass(Environment.class)
+                .addSynchronizedEntityClass(EnvironmentContent.class);
 
             for (List<String> eidBlock : eidBlocks) {
                 query.setParameter("env_ids", eidBlock);

--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -22,6 +22,7 @@ import org.candlepin.util.Util;
 import com.google.common.collect.Iterables;
 import com.google.inject.persist.Transactional;
 
+import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1392,7 +1393,10 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
                 "  AND ss2.subscription_sub_key != 'master' " +
                 "  AND ss1.pool_id IN (:pool_ids)";
 
-            Query query = this.getEntityManager().createNativeQuery(sql);
+            Query query = this.getEntityManager()
+                .createNativeQuery(sql)
+                .unwrap(NativeQuery.class)
+                .addSynchronizedEntityClass(SourceSubscription.class);
 
             for (List<String> block : this.partition(poolIds)) {
                 query.setParameter("pool_ids", block);
@@ -1735,7 +1739,11 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
         if (poolIds != null && !poolIds.isEmpty()) {
             Query query = this.getEntityManager()
-                .createNativeQuery(sql);
+                .createNativeQuery(sql)
+                .unwrap(NativeQuery.class)
+                .addSynchronizedEntityClass(Pool.class)
+                .addSynchronizedEntityClass(Product.class)
+                .addSynchronizedQuerySpace("cp_product_provided_products");
 
             for (List<String> block : this.partition(poolIds)) {
                 query.setParameter("pool_ids", block);
@@ -1797,7 +1805,11 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
         if (poolIds != null && !poolIds.isEmpty()) {
             Query query = this.getEntityManager()
-                .createNativeQuery(sql);
+                .createNativeQuery(sql)
+                .unwrap(NativeQuery.class)
+                .addSynchronizedEntityClass(Pool.class)
+                .addSynchronizedEntityClass(Product.class)
+                .addSynchronizedQuerySpace("cp_product_provided_products");
 
             for (List<String> block : this.partition(poolIds)) {
                 query.setParameter("pool_ids", block);
@@ -1963,7 +1975,13 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
             Query query = this.getEntityManager()
                 .createNativeQuery(sql)
-                .setParameter("stackid_attrib_name", Product.Attributes.STACKING_ID);
+                .setParameter("stackid_attrib_name", Product.Attributes.STACKING_ID)
+                .unwrap(NativeQuery.class)
+                .addSynchronizedEntityClass(SourceStack.class)
+                .addSynchronizedEntityClass(Entitlement.class)
+                .addSynchronizedEntityClass(Pool.class)
+                .addSynchronizedEntityClass(Product.class)
+                .addSynchronizedQuerySpace("cp_product_attributes");
 
             int blockSize = Math.min(this.getQueryParameterLimit() - 1, this.getInBlockSize());
             for (List<String> block : Iterables.partition(entitlementIds, blockSize)) {
@@ -1977,7 +1995,13 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
 
             Query query = this.getEntityManager()
                 .createNativeQuery(sql)
-                .setParameter("stackid_attrib_name", Product.Attributes.STACKING_ID);
+                .setParameter("stackid_attrib_name", Product.Attributes.STACKING_ID)
+                .unwrap(NativeQuery.class)
+                .addSynchronizedEntityClass(SourceStack.class)
+                .addSynchronizedEntityClass(Entitlement.class)
+                .addSynchronizedEntityClass(Pool.class)
+                .addSynchronizedEntityClass(Product.class)
+                .addSynchronizedQuerySpace("cp_product_attributes");
 
             output.addAll(query.getResultList());
         }
@@ -2035,6 +2059,10 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
         ((List<Object[]>) this.getEntityManager()
             .createNativeQuery(sql)
             .setParameter("owner_id", ownerId)
+            .unwrap(NativeQuery.class)
+            .addSynchronizedEntityClass(Pool.class)
+            .addSynchronizedEntityClass(Product.class)
+            .addSynchronizedQuerySpace("cp_product_attributes")
             .getResultList())
             .forEach(pair -> output.get((String) pair[0]).addAll(Util.toList((String) pair[1])));
 

--- a/src/main/java/org/candlepin/model/ProductCurator.java
+++ b/src/main/java/org/candlepin/model/ProductCurator.java
@@ -18,6 +18,7 @@ import org.candlepin.util.AttributeValidator;
 
 import com.google.inject.persist.Transactional;
 
+import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -787,7 +788,10 @@ public class ProductCurator extends AbstractHibernateCurator<Product> {
             int blockSize = Math.min(this.getQueryParameterLimit() / 2, this.getInBlockSize());
 
             Query query = this.getEntityManager()
-                .createNativeQuery(sql);
+                .createNativeQuery(sql)
+                .unwrap(NativeQuery.class)
+                .addSynchronizedEntityClass(Product.class)
+                .addSynchronizedQuerySpace("cp_product_provided_products");
 
             for (List<String> block : this.partition(productUuids, blockSize)) {
                 List<Object[]> rows = query.setParameter("product_uuids", block)

--- a/src/main/java/org/candlepin/model/activationkeys/ActivationKeyCurator.java
+++ b/src/main/java/org/candlepin/model/activationkeys/ActivationKeyCurator.java
@@ -18,7 +18,7 @@ import org.candlepin.model.AbstractHibernateCurator;
 import org.candlepin.model.Owner;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.hibernate.annotations.QueryHints;
+import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,7 +138,9 @@ public class ActivationKeyCurator extends AbstractHibernateCurator<ActivationKey
                 "WHERE key_id IN (:key_ids) AND product_id IN (:product_ids)";
 
             Query query = entityManager.createNativeQuery(sql)
-                .setHint(QueryHints.NATIVE_SPACES, ActivationKey.class.getName());
+                .unwrap(NativeQuery.class)
+                .addSynchronizedEntityClass(ActivationKey.class)
+                .addSynchronizedQuerySpace("cp_activation_key_products");
 
             int blockSize = Math.min(this.getQueryParameterLimit() / 2, this.getInBlockSize() / 2);
             Iterable<List<String>> kidBlocks = this.partition(keyIds, blockSize);

--- a/src/main/java/org/candlepin/testext/manifestgen/EntityMapper.java
+++ b/src/main/java/org/candlepin/testext/manifestgen/EntityMapper.java
@@ -31,7 +31,7 @@ import org.candlepin.model.ProductContent;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.util.Util;
 
-import org.hibernate.annotations.QueryHints;
+import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -320,9 +320,10 @@ public class EntityMapper {
 
             int count = this.poolCurator.getEntityManager()
                 .createNativeQuery("UPDATE cp_pool SET id = :new_id WHERE id = :old_id")
-                .setHint(QueryHints.NATIVE_SPACES, Pool.class.getName())
                 .setParameter("old_id", pool.getId())
                 .setParameter("new_id", pid)
+                .unwrap(NativeQuery.class)
+                .addSynchronizedEntityClass(Pool.class)
                 .executeUpdate();
 
             pool = this.poolCurator.get(pid);


### PR DESCRIPTION
- Updated the way query spaces are declared for all native queries to use the table names and/or entity classes as appropriate
- Updated all query space declarations to use the Hibernate API rather than the JPA query hint