### PR TITLE
[M] 2018469: Disabled subscription attachment by Activation Key in SCA

### DIFF
--- a/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
+++ b/src/main/java/org/candlepin/resource/util/ConsumerBindUtil.java
@@ -140,12 +140,15 @@ public class ConsumerBindUtil {
                 }
             }
             else {
-                // Activation key does not specify auto-attach; attach designated pools
-
-                // Impl note: while this doesn't make a great deal of sense in SCA mode, compared to
-                // the check above for auto-attach, this is still intended behavior, as attaching
-                // specific pools is still an desired feature in SCA mode.
-                keySuccess &= handleActivationKeyPools(consumer, key);
+                // In SCA mode, attaching specific pools is no longer supported for smoother transition.
+                // Instead, log an informational message and skip pool attachment.
+                if (scaEnabled) {
+                    log.warn("Owner is using simple content access; skipping attaching pools for consumer " +
+                        "with activation key: {}, {}", consumer.getUuid(), key.getName());
+                }
+                else {
+                    keySuccess &= handleActivationKeyPools(consumer, key);
+                }
             }
 
             listSuccess |= keySuccess;

--- a/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
+++ b/src/test/java/org/candlepin/resource/util/ConsumerBindUtilTest.java
@@ -375,33 +375,7 @@ public class ConsumerBindUtilTest {
 
         consumerBindUtil.handleActivationKeys(consumer, Arrays.asList(key1), false);
 
-        verify(this.entitler, times(1)).bindByPoolQuantity(eq(consumer), eq(pool1.getId()), eq(1));
-    }
-
-    @Test
-    public void handleActivationKeysWithoutAutoAttachUsingSCAWhenBindFails() throws Exception {
-        this.owner.setContentAccessModeList(ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
-        this.owner.setContentAccessMode(ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
-
-        Pool pool1 = this.createTestPool(this.owner, 1);
-
-        ActivationKey key1 = new ActivationKey("test_key-1", this.owner);
-        key1.setAutoAttach(false);
-        key1.addPool(pool1, 5L);
-
-        Consumer consumer = new Consumer()
-            .setName("sys.example.com")
-            .setType(this.systemConsumerType);
-
-        ConsumerBindUtil consumerBindUtil = this.buildConsumerBindUtil();
-
-        doThrow(new ForbiddenException("exception")).when(this.entitler)
-            .bindByPoolQuantity(eq(consumer), eq(pool1.getId()), eq(5));
-
-        // This should not throw an exception even though the bind fails
-        consumerBindUtil.handleActivationKeys(consumer, Arrays.asList(key1), false);
-
-        verify(this.entitler, times(1)).bindByPoolQuantity(eq(consumer), eq(pool1.getId()), eq(5));
+        verify(this.entitler, times(0)).bindByPoolQuantity(eq(consumer), eq(pool1.getId()), eq(1));
     }
 
     @Test


### PR DESCRIPTION
- Manual subscription attachment via activation keys in SCA mode was initially allowed to ease the transition from Entitlement, but it was no longer needed. Auto-attachment was disabled at the Candlepin level, and Satellite 6.9+ removed subscription attachment from the UI.