### PR TITLE
[M] CANDLEPIN-938: Updated product content mapping logic

### DIFF
--- a/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/src/main/java/org/candlepin/controller/ContentManager.java
@@ -110,9 +110,8 @@ public class ContentManager {
 
         log.debug("Creating new content in namespace {}: {}", namespace, cinfo);
 
-        Content entity = new Content()
-            .setNamespace(namespace)
-            .setId(cinfo.getId());
+        Content entity = new Content(cinfo.getId())
+            .setNamespace(namespace);
 
         entity = applyContentChanges(entity, cinfo);
 

--- a/src/main/java/org/candlepin/controller/refresher/mappers/ContentMapper.java
+++ b/src/main/java/org/candlepin/controller/refresher/mappers/ContentMapper.java
@@ -69,7 +69,11 @@ public class ContentMapper extends AbstractEntityMapper<Content, ContentInfo> {
      */
     @Override
     protected String getEntityId(Content entity) {
-        return this.getEntityId((ContentInfo) entity);
+        if (entity == null) {
+            throw new IllegalArgumentException("entity is null");
+        }
+
+        return entity.getId();
     }
 
 }

--- a/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
+++ b/src/main/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitor.java
@@ -54,8 +54,6 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
      *
      */
     private Content applyContentChanges(Content existingEntity, ContentInfo importedEntity) {
-        existingEntity.setId(importedEntity.getId());
-
         if (importedEntity != null) {
             if (importedEntity.getType() != null) {
                 existingEntity.setType(importedEntity.getType());
@@ -160,7 +158,7 @@ public class ContentNodeVisitor implements NodeVisitor<Content, ContentInfo> {
 
         switch (node.getNodeState()) {
             case CREATED:
-                updatedEntity = this.applyContentChanges(new Content(), importedEntity);
+                updatedEntity = this.applyContentChanges(new Content(importedEntity.getId()), importedEntity);
                 updatedEntity = this.contentCurator.create(updatedEntity, false);
 
                 node.setExistingEntity(updatedEntity);

--- a/src/main/java/org/candlepin/model/Content.java
+++ b/src/main/java/org/candlepin/model/Content.java
@@ -139,79 +139,27 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     private String arches;
 
     /**
-     * Default constructor
+     * Zero-arg constructor for Hibernate. Do not use.
      */
-    public Content() {
+    Content() {
         this.modifiedProductIds = new HashSet<>();
     }
 
     /**
-     * ID-based constructor so API users can specify an ID in place of a full object.
+     * Creates a new Content instance with the given content ID. Note that the content ID specified here
+     * is the upstream content ID, not the Candlepin-internal content UUID.
      *
      * @param id
-     *  The ID for this content
+     *  The upstream content ID for the new content instance; cannot be null or empty
      */
     public Content(String id) {
         this();
 
-        this.setId(id);
-    }
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("content ID is null or empty");
+        }
 
-    public Content(String id, String name, String type, String label, String vendor) {
-        this(id);
-
-        this.setName(name);
-        this.setType(type);
-        this.setLabel(label);
-        this.setVendor(vendor);
-    }
-
-    /**
-     * Creates a shallow copy of the specified source content. Attributes and content are not
-     * duplicated, but the joining objects are (ContentAttribute, ContentContent, etc.).
-     * <p></p>
-     * Unlike the merge method, all properties from the source content are copied, including the
-     * state of any null collections and any identifier fields.
-     *
-     * @param source
-     *  The Content instance to copy
-     */
-    protected Content(Content source) {
-        this.setUuid(source.getUuid());
-        this.setId(source.getId());
-
-        this.setCreated(source.getCreated() != null ? (Date) source.getCreated().clone() : null);
-
-        this.merge(source);
-    }
-
-    /**
-     * Copies several properties from the given content on to this content instance. Properties that
-     * are not copied over include any identifiying fields (UUID, ID), the creation date and locking
-     * states. Values on the source content which are null will be ignored.
-     *
-     * @param source
-     *  The source content instance from which to pull content information
-     *
-     * @return
-     *  this content instance
-     */
-    public Content merge(Content source) {
-        this.setUpdated(source.getUpdated() != null ? (Date) source.getUpdated().clone() : null);
-
-        this.setType(source.getType());
-        this.setLabel(source.getLabel());
-        this.setName(source.getName());
-        this.setVendor(source.getVendor());
-        this.setContentUrl(source.getContentUrl());
-        this.setRequiredTags(source.getRequiredTags());
-        this.setReleaseVersion(source.getReleaseVersion());
-        this.setGpgUrl(source.getGpgUrl());
-        this.setMetadataExpiration(source.getMetadataExpiration());
-        this.setArches(source.getArches());
-        this.setModifiedProductIds(source.getModifiedProductIds());
-
-        return this;
+        this.id = id;
     }
 
     @Override
@@ -327,21 +275,6 @@ public class Content extends AbstractHibernateObject implements SharedEntity, Cl
     @Override
     public String getId() {
         return this.id;
-    }
-
-    /**
-     * Sets the content ID for this content. The content ID is the Red Hat content ID and should not
-     * be confused with the object ID.
-     *
-     * @param id
-     *  The new content ID for this content
-     *
-     * @return
-     *  a reference to this content instance
-     */
-    public Content setId(String id) {
-        this.id = id;
-        return this;
     }
 
     @Override

--- a/src/main/java/org/candlepin/model/Product.java
+++ b/src/main/java/org/candlepin/model/Product.java
@@ -867,10 +867,10 @@ public class Product extends AbstractHibernateObject implements SharedEntity, Li
         }
 
         Content content = productContent.getContent();
-        String cid = content.getId();
+        ProductContent pcontent = new ProductContent(this, content, productContent.isEnabled());
 
-        this.productContent.removeIf(elem -> cid.equals(elem.getContentId()));
-        this.productContent.add(new ProductContent(this, content, productContent.isEnabled()));
+        this.productContent.remove(pcontent);
+        this.productContent.add(pcontent);
 
         return this;
     }

--- a/src/main/java/org/candlepin/model/ProductContent.java
+++ b/src/main/java/org/candlepin/model/ProductContent.java
@@ -17,8 +17,6 @@ package org.candlepin.model;
 import org.candlepin.model.dto.ProductContentData;
 import org.candlepin.service.model.ProductContentInfo;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
@@ -127,7 +125,7 @@ public class ProductContent extends AbstractHibernateObject<ProductContent> impl
     }
 
     public String getContentId() {
-        return this.content != null ? this.content.getId() : null;
+        return this.content.getId();
     }
 
     /**
@@ -155,24 +153,15 @@ public class ProductContent extends AbstractHibernateObject<ProductContent> impl
             return true;
         }
 
-        if (obj instanceof ProductContent) {
-            ProductContent that = (ProductContent) obj;
-
-            return new EqualsBuilder()
-                .append(this.getProductId(), that.getProductId())
-                .append(this.getContentId(), that.getContentId())
-                .isEquals();
-        }
-
-        return false;
+        return obj instanceof ProductContent that ?
+            this.getContentId().equals(that.getContentId()) :
+            false;
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(3, 23)
-            .append(this.getProductId())
-            .append(this.getContentId())
-            .toHashCode();
+        return this.getContentId()
+            .hashCode();
     }
 
     /**

--- a/src/main/java/org/candlepin/pki/certs/AnonymousCertificateGenerator.java
+++ b/src/main/java/org/candlepin/pki/certs/AnonymousCertificateGenerator.java
@@ -380,8 +380,7 @@ public class AnonymousCertificateGenerator {
     private ProductContent translateProductContentInfo(ProductContentInfo pcinfo) {
         ContentInfo cinfo = pcinfo.getContent();
 
-        org.candlepin.model.Content converted = new org.candlepin.model.Content()
-            .setId(cinfo.getId())
+        org.candlepin.model.Content converted = new org.candlepin.model.Content(cinfo.getId())
             .setName(cinfo.getName())
             .setType(cinfo.getType())
             .setLabel(cinfo.getLabel())

--- a/src/main/java/org/candlepin/pki/certs/UeberCertificateGenerator.java
+++ b/src/main/java/org/candlepin/pki/certs/UeberCertificateGenerator.java
@@ -265,8 +265,7 @@ public class UeberCertificateGenerator {
         }
 
         private Content createUeberContent(UniqueIdGenerator idGenerator, Owner owner, Product product) {
-            return new Content()
-                .setId(idGenerator.generateId())
+            return new Content(idGenerator.generateId())
                 .setName(UEBER_CONTENT_NAME)
                 .setType("yum")
                 .setLabel(product.getId() + "_" + UEBER_CONTENT_NAME)

--- a/src/main/java/org/candlepin/testext/manifestgen/EntityMapper.java
+++ b/src/main/java/org/candlepin/testext/manifestgen/EntityMapper.java
@@ -115,8 +115,7 @@ public class EntityMapper {
 
             Content fetched = this.contentCurator.getContentById(this.owner.getKey(), cid);
             if (fetched == null) {
-                fetched = new Content()
-                    .setId(cid)
+                fetched = new Content(cid)
                     .setNamespace(this.owner.getKey());
             }
 

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -207,18 +207,17 @@ public class ContentAccessManagerTest {
     }
 
     private Content mockContent(Owner owner) {
-        Content content = new Content();
-        content.setUuid("test_content-uuid");
-        content.setId("1234");
-        content.setName("test_content");
-        content.setLabel("test_content-label");
-        content.setType("yum");
-        content.setVendor("vendor");
-        content.setContentUrl("/content/dist/rhel/$releasever/$basearch/os");
-        content.setGpgUrl("gpgUrl");
-        content.setArches("x86_64");
-        content.setMetadataExpiration(3200L);
-        content.setRequiredTags("TAG1,TAG2");
+        Content content = new Content("1234")
+            .setUuid("test_content-uuid")
+            .setName("test_content")
+            .setLabel("test_content-label")
+            .setType("yum")
+            .setVendor("vendor")
+            .setContentUrl("/content/dist/rhel/$releasever/$basearch/os")
+            .setGpgUrl("gpgUrl")
+            .setArches("x86_64")
+            .setMetadataExpiration(3200L)
+            .setRequiredTags("TAG1,TAG2");
 
         return content;
     }

--- a/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -371,7 +371,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         Method[] methods = getAccessorAndMutator(Content.class, propertyName, initialValue.getClass());
         Method mutator = methods[1];
 
-        Content entity = new Content();
+        Content entity = new Content("test_content");
         ContentInfo update = this.mockContentInfo();
 
         mutator.invoke(entity, initialValue);
@@ -389,7 +389,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         Method[] methods = getAccessorAndMutator(Content.class, propertyName, initialValue.getClass());
         Method mutator = methods[1];
 
-        Content entity = new Content();
+        Content entity = new Content("test_content");
         ContentInfo update = this.mockContentInfo();
 
         mutator.invoke(entity, initialValue);
@@ -407,7 +407,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         Method[] methods = getAccessorAndMutator(Content.class, propertyName, initialValue.getClass());
         Method mutator = methods[1];
 
-        Content entity = new Content();
+        Content entity = new Content("test_content");
         ContentInfo update = this.mockContentInfo();
 
         mutator.invoke(entity, initialValue);
@@ -431,7 +431,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         Method[] methods = getAccessorAndMutator(Content.class, propertyName, String.class);
         Method mutator = methods[1];
 
-        Content entity = new Content();
+        Content entity = new Content("test_content");
         mutator.invoke(entity, new Object[] { null });
 
         ContentInfo update = this.mockAccessor(this.mockContentInfo(), propertyName, "");
@@ -456,7 +456,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         Method[] methods = getAccessorAndMutator(Content.class, propertyName, String.class);
         Method mutator = methods[1];
 
-        Content entity = new Content();
+        Content entity = new Content("test_content");
         mutator.invoke(entity, new Object[] { null });
 
         ContentInfo update = this.mockAccessor(this.mockContentInfo(), propertyName, "");
@@ -469,7 +469,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
     // the content object on that field (never return null).
     @Test
     public void testIsChangedByDetectsChangesInRequiredProducts() {
-        Content entity = new Content();
+        Content entity = new Content("test_content");
         ContentInfo update = this.mockContentInfo();
 
         entity.setModifiedProductIds(List.of("a", "b", "c"));
@@ -481,7 +481,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
 
     @Test
     public void testIsChangedByDetectsChangesInRequiredProductsWithEmptyList() {
-        Content entity = new Content();
+        Content entity = new Content("test_content");
         ContentInfo update = this.mockContentInfo();
 
         entity.setModifiedProductIds(List.of("a", "b", "c"));
@@ -493,7 +493,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
 
     @Test
     public void testIsChangedByIgnoresUnchangedRequiredProductsField() {
-        Content entity = new Content();
+        Content entity = new Content("test_content");
         ContentInfo update = this.mockContentInfo();
 
         entity.setModifiedProductIds(List.of("a", "b", "c"));
@@ -505,7 +505,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
 
     @Test
     public void testIsChangedByIgnoresNullRequiredProductsField() {
-        Content entity = new Content();
+        Content entity = new Content("test_content");
         ContentInfo update = this.mockContentInfo();
 
         entity.setModifiedProductIds(List.of("a", "b", "c"));

--- a/src/test/java/org/candlepin/controller/refresher/RefreshResultTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/RefreshResultTest.java
@@ -66,8 +66,7 @@ public class RefreshResultTest {
         Product product = new Product();
         product.setId("test_product");
 
-        Content content = new Content();
-        content.setId("test_content");
+        Content content = new Content("test_content");
 
         Pool pool = new Pool();
         pool.setId("test_pool");
@@ -181,11 +180,10 @@ public class RefreshResultTest {
     public void testGetEntityDoesNotFetchWrongClass() {
         String entityId = "test_id";
 
-        Product product = new Product();
-        product.setId(entityId);
+        Product product = new Product()
+            .setId(entityId);
 
-        Content content = new Content();
-        content.setId(entityId);
+        Content content = new Content(entityId);
 
         RefreshResult refreshResult = new RefreshResult()
             .addEntity(Product.class, product, EntityState.CREATED)
@@ -247,10 +245,7 @@ public class RefreshResultTest {
             }
 
             public Content generate(String suffix) {
-                Content entity = new Content();
-                entity.setId("test_content-" + suffix);
-
-                return entity;
+                return new Content("test_content-" + suffix);
             }
         });
 
@@ -354,14 +349,9 @@ public class RefreshResultTest {
         Product product3 = new Product();
         product3.setId("test_product-3");
 
-        Content content1 = new Content();
-        content1.setId("test_content-1");
-
-        Content content2 = new Content();
-        content2.setId("test_content-2");
-
-        Content content3 = new Content();
-        content3.setId("test_content-3");
+        Content content1 = new Content("test_content-1");
+        Content content2 = new Content("test_content-2");
+        Content content3 = new Content("test_content-3");
 
         RefreshResult refreshResult = new RefreshResult()
             .addEntity(Product.class, product1, EntityState.CREATED)

--- a/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
@@ -1084,14 +1084,11 @@ public class RefreshWorkerTest {
         ContentInfo cinfo1 = this.mockContentInfo("cid-1", "content-1");
         ContentInfo cinfo2 = this.mockContentInfo("cid-2", "content-2");
         ContentInfo cinfo3 = this.mockContentInfo("cid-3a", "imported_content");
-        Content content1 = new Content()
-            .setId("cid-1")
+        Content content1 = new Content("cid-1")
             .setName("content-1");
-        Content content2 = new Content()
-            .setId("cid-2")
+        Content content2 = new Content("cid-2")
             .setName("content-2");
-        Content content3 = new Content()
-            .setId("cid-3b")
+        Content content3 = new Content("cid-3b")
             .setName("existing_content");
 
         ProductInfo pinfo1 = this.mockProductInfo("pid-1", "product-1");

--- a/src/test/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/AbstractEntityMapperTest.java
@@ -157,20 +157,6 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
         assertTrue(map.isEmpty());
     }
 
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @NullAndEmptySource
-    public void testAddExistingEntityWithNullOrEmptyEntityId(String entityId) {
-        Owner owner = TestUtil.createOwner();
-        E entity = this.buildLocalEntity(owner, entityId);
-
-        EntityMapper<E, I> mapper = this.buildEntityMapper();
-        assertThrows(IllegalArgumentException.class, () -> mapper.addExistingEntity(entity));
-
-        Map<String, E> map = mapper.getExistingEntities();
-        assertNotNull(map);
-        assertTrue(map.isEmpty());
-    }
-
     @Test
     public void testAddExistingEntities() {
         Owner owner = TestUtil.createOwner();
@@ -240,21 +226,6 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
         assertThat(map, hasEntry(this.getEntityId(entity3), entity3));
     }
 
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @NullAndEmptySource
-    public void testAddExistingEntitiesFailsWithNullOrEmptyEntityIds(String entityId) {
-        Owner owner = TestUtil.createOwner();
-        E entity1 = this.buildLocalEntity(owner, "test_id-1");
-        E entity2 = this.buildLocalEntity(owner, "test_id-2");
-        E entity3 = this.buildLocalEntity(owner, "test_id-3");
-        E badEntity = this.buildLocalEntity(owner, entityId);
-
-        EntityMapper<E, I> mapper = this.buildEntityMapper();
-        Collection<E> input = Arrays.asList(entity1, badEntity, entity2, badEntity, entity3);
-
-        assertThrows(IllegalArgumentException.class, () -> mapper.addExistingEntities(input));
-    }
-
     @Test
     public void testGetExistingEntity() {
         Owner owner = TestUtil.createOwner();
@@ -319,9 +290,6 @@ public abstract class AbstractEntityMapperTest<E extends AbstractHibernateObject
             mapped.forEach(expected -> assertThat(output, hasEntry(this.getEntityId(expected), expected)));
         }
     }
-
-
-
 
     @Test
     public void testAddImportedEntity() {

--- a/src/test/java/org/candlepin/controller/refresher/mappers/ContentMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/ContentMapperTest.java
@@ -14,6 +14,9 @@
  */
 package org.candlepin.controller.refresher.mappers;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 import org.candlepin.model.Content;
 import org.candlepin.model.Owner;
 import org.candlepin.service.model.ContentInfo;
@@ -52,16 +55,18 @@ public class ContentMapperTest extends AbstractEntityMapperTest<Content, Content
 
     @Override
     protected Content buildLocalEntity(Owner owner, String entityId) {
-        return new Content()
-            .setId(entityId)
+        return new Content(entityId)
             .setName(String.format("%s-%d", entityId, ++generatedEntityCount));
     }
 
     @Override
     protected ContentInfo buildImportedEntity(Owner owner, String entityId) {
-        return new Content()
-            .setId(entityId)
-            .setName(String.format("%s-%d", entityId, ++generatedEntityCount));
+        ContentInfo mockContentInfo = mock(ContentInfo.class);
+
+        doReturn(entityId).when(mockContentInfo).getId();
+        doReturn(String.format("%s-%d", entityId, ++generatedEntityCount)).when(mockContentInfo).getName();
+
+        return mockContentInfo;
     }
 
 }

--- a/src/test/java/org/candlepin/controller/refresher/mappers/PoolMapperTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/mappers/PoolMapperTest.java
@@ -14,12 +14,23 @@
  */
 package org.candlepin.controller.refresher.mappers;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.candlepin.model.Owner;
 import org.candlepin.model.Pool;
 import org.candlepin.service.model.SubscriptionInfo;
+import org.candlepin.test.TestUtil;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 
 
@@ -58,6 +69,35 @@ public class PoolMapperTest extends AbstractEntityMapperTest<Pool, SubscriptionI
             .setId(entityId)
             .setOwner(owner)
             .setQuantity(10000L + ++generatedEntityCount);
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @NullAndEmptySource
+    public void testAddExistingEntityWithNullOrEmptyEntityId(String entityId) {
+        Owner owner = TestUtil.createOwner();
+        Pool entity = this.buildLocalEntity(owner, entityId);
+
+        EntityMapper<Pool, SubscriptionInfo> mapper = this.buildEntityMapper();
+        assertThrows(IllegalArgumentException.class, () -> mapper.addExistingEntity(entity));
+
+        Map<String, Pool> map = mapper.getExistingEntities();
+        assertNotNull(map);
+        assertTrue(map.isEmpty());
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @NullAndEmptySource
+    public void testAddExistingEntitiesFailsWithNullOrEmptyEntityIds(String entityId) {
+        Owner owner = TestUtil.createOwner();
+        Pool entity1 = this.buildLocalEntity(owner, "test_id-1");
+        Pool entity2 = this.buildLocalEntity(owner, "test_id-2");
+        Pool entity3 = this.buildLocalEntity(owner, "test_id-3");
+        Pool badEntity = this.buildLocalEntity(owner, entityId);
+
+        EntityMapper<Pool, SubscriptionInfo> mapper = this.buildEntityMapper();
+        Collection<Pool> input = List.of(entity1, badEntity, entity2, badEntity, entity3);
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.addExistingEntities(input));
     }
 
 }

--- a/src/test/java/org/candlepin/controller/refresher/nodes/ContentNodeTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/nodes/ContentNodeTest.java
@@ -43,14 +43,12 @@ public class ContentNodeTest extends AbstractNodeTest<Content, ContentInfo> {
 
     @Override
     protected Content buildLocalEntity(Owner owner, String entityId) {
-        return new Content()
-            .setId(entityId);
+        return new Content(entityId);
     }
 
     @Override
     protected ContentInfo buildImportedEntity(Owner owner, String entityId) {
-        return new Content()
-            .setId(entityId);
+        return new Content(entityId);
     }
 
     @Test

--- a/src/test/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitorTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/visitors/ContentNodeVisitorTest.java
@@ -185,8 +185,7 @@ public class ContentNodeVisitorTest extends DatabaseTestFixture {
     @Test
     public void testProcessNodeFlagsCreatedNodeCorrectly() {
         Owner owner = this.createOwner();
-        ContentInfo importedEntity = new Content()
-            .setId("test_content-1")
+        ContentInfo importedEntity = new Content("test_content-1")
             .setName("Test Content");
 
         EntityNode<Content, ContentInfo> pnode = new ContentNode(owner, importedEntity.getId())
@@ -224,8 +223,7 @@ public class ContentNodeVisitorTest extends DatabaseTestFixture {
         String id = "test_content-1";
 
         Owner owner = this.createOwner();
-        Content existingEntity = new Content()
-            .setId(id);
+        Content existingEntity = new Content(id);
 
         this.updateContentField(existingEntity, field, value);
 
@@ -244,8 +242,7 @@ public class ContentNodeVisitorTest extends DatabaseTestFixture {
     @Test
     public void testApplyChangesCreatesNewInstances() {
         Owner owner = this.createOwner();
-        ContentInfo importedEntity = new Content()
-            .setId("test_content")
+        ContentInfo importedEntity = new Content("test_content")
             .setName("test content")
             .setLabel("test content")
             .setVendor("test vendor")
@@ -289,8 +286,7 @@ public class ContentNodeVisitorTest extends DatabaseTestFixture {
     public void testFullCyclePersistsNewEntity() {
         Owner owner = this.createOwner();
 
-        Content content = new Content()
-            .setId("test_content")
+        Content content = new Content("test_content")
             .setName("test content")
             .setLabel("test content")
             .setVendor("test vendor")
@@ -324,8 +320,7 @@ public class ContentNodeVisitorTest extends DatabaseTestFixture {
 
         Content existing = this.createContent("test_content", "content name");
 
-        Content imported = new Content()
-            .setId(existing.getId())
+        Content imported = new Content(existing.getId())
             .setName("updated content");
 
         EntityNode<Content, ContentInfo> pnode = new ContentNode(owner, imported.getId())

--- a/src/test/java/org/candlepin/controller/util/PromotedContentTest.java
+++ b/src/test/java/org/candlepin/controller/util/PromotedContentTest.java
@@ -210,18 +210,17 @@ class PromotedContentTest {
     }
 
     private Content mockContent(String name) {
-        Content content = new Content();
-        content.setUuid("test_content-uuid");
-        content.setId("1234");
-        content.setName(name);
-        content.setLabel("test_content-label");
-        content.setType("yum");
-        content.setVendor("vendor");
-        content.setContentUrl("/content/dist/rhel/$releasever/$basearch/os");
-        content.setGpgUrl("gpgUrl");
-        content.setArches("x86_64");
-        content.setMetadataExpiration(3200L);
-        content.setRequiredTags("TAG1,TAG2");
+        Content content = new Content("1234")
+            .setUuid("test_content-uuid")
+            .setName(name)
+            .setLabel("test_content-label")
+            .setType("yum")
+            .setVendor("vendor")
+            .setContentUrl("/content/dist/rhel/$releasever/$basearch/os")
+            .setGpgUrl("gpgUrl")
+            .setArches("x86_64")
+            .setMetadataExpiration(3200L)
+            .setRequiredTags("TAG1,TAG2");
 
         return content;
     }
@@ -260,8 +259,7 @@ class PromotedContentTest {
     }
 
     private ProductContent createContent(String contentUrl) {
-        Content content = new Content()
-            .setId(CONTENT_ID)
+        Content content = new Content(CONTENT_ID)
             .setContentUrl(contentUrl);
 
         return new ProductContent(content, false);
@@ -278,7 +276,7 @@ class PromotedContentTest {
 
         EnvironmentContent envcontent = new EnvironmentContent()
             .setEnvironment(environment)
-            .setContent(new Content().setId(CONTENT_ID))
+            .setContent(new Content(CONTENT_ID))
             .setEnabled(true);
 
         environment.addEnvironmentContent(envcontent);

--- a/src/test/java/org/candlepin/dto/api/v1/ContentTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/ContentTranslatorTest.java
@@ -22,7 +22,7 @@ import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.api.server.v1.ContentDTO;
 import org.candlepin.model.Content;
 
-import java.util.Arrays;
+import java.util.List;
 
 
 /**
@@ -45,23 +45,19 @@ public class ContentTranslatorTest extends
 
     @Override
     protected Content initSourceObject() {
-        Content source = new Content();
-
-        source.setUuid("test_value");
-        source.setId("test_value");
-        source.setType("test_value");
-        source.setLabel("test_value");
-        source.setName("test_value");
-        source.setVendor("test_value");
-        source.setContentUrl("test_value");
-        source.setRequiredTags("test_value");
-        source.setReleaseVersion("test_value");
-        source.setGpgUrl("test_value");
-        source.setMetadataExpiration(1234L);
-        source.setModifiedProductIds(Arrays.asList("1", "2", "3"));
-        source.setArches("test_value");
-
-        return source;
+        return new Content("test_value")
+            .setUuid("test_value")
+            .setType("test_value")
+            .setLabel("test_value")
+            .setName("test_value")
+            .setVendor("test_value")
+            .setContentUrl("test_value")
+            .setRequiredTags("test_value")
+            .setReleaseVersion("test_value")
+            .setGpgUrl("test_value")
+            .setMetadataExpiration(1234L)
+            .setModifiedProductIds(List.of("1", "2", "3"))
+            .setArches("test_value");
     }
 
     @Override

--- a/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/manifest/v1/ContentTranslatorTest.java
@@ -21,7 +21,7 @@ import org.candlepin.dto.AbstractTranslatorTest;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.model.Content;
 
-import java.util.Arrays;
+import java.util.List;
 
 
 
@@ -45,23 +45,19 @@ public class ContentTranslatorTest extends
 
     @Override
     protected Content initSourceObject() {
-        Content source = new Content();
-
-        source.setUuid("test_value");
-        source.setMetadataExpiration(3L);
-        source.setId("test_value");
-        source.setType("test_value");
-        source.setLabel("test_value");
-        source.setName("test_value");
-        source.setVendor("test_value");
-        source.setContentUrl("test_value");
-        source.setRequiredTags("test_value");
-        source.setReleaseVersion("test_value");
-        source.setGpgUrl("test_value");
-        source.setModifiedProductIds(Arrays.asList("1", "2", "3"));
-        source.setArches("test_value");
-
-        return source;
+        return new Content("test_value")
+            .setUuid("test_value")
+            .setMetadataExpiration(3L)
+            .setType("test_value")
+            .setLabel("test_value")
+            .setName("test_value")
+            .setVendor("test_value")
+            .setContentUrl("test_value")
+            .setRequiredTags("test_value")
+            .setReleaseVersion("test_value")
+            .setGpgUrl("test_value")
+            .setModifiedProductIds(List.of("1", "2", "3"))
+            .setArches("test_value");
     }
 
     @Override

--- a/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -68,8 +68,7 @@ public class ContentCuratorTest extends DatabaseTestFixture {
 
     @Test
     public void testCannotPersistIdenticalProducts() {
-        Content c1 = new Content()
-            .setId("test-content")
+        Content c1 = new Content("test-content")
             .setName("test-content")
             .setType("content-type")
             .setLabel("content-label")
@@ -78,8 +77,7 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         this.contentCurator.create(c1, true);
         this.contentCurator.clear();
 
-        Content c2 = new Content()
-            .setId("test-content")
+        Content c2 = new Content("test-content")
             .setName("test-content")
             .setType("content-type")
             .setLabel("content-label")
@@ -102,8 +100,7 @@ public class ContentCuratorTest extends DatabaseTestFixture {
      *  the newly created content
      */
     private Content createNamespacedContent(String contentId, String namespace) {
-        Content content = new Content()
-            .setId(contentId)
+        Content content = new Content(contentId)
             .setName(contentId)
             .setLabel(contentId + "-label")
             .setType(contentId + "-type")
@@ -116,8 +113,7 @@ public class ContentCuratorTest extends DatabaseTestFixture {
     private Content createContentWithRequiredProductIds(String contentId,
         Collection<String> requiredProductIds) {
 
-        Content content = new Content()
-            .setId(contentId)
+        Content content = new Content(contentId)
             .setName(contentId)
             .setLabel(contentId + "-label")
             .setType(contentId + "-type")
@@ -636,16 +632,14 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         // Impl note: aside from the required fields, we *must* set some modified/required product IDs
         // to populate the child collection table for this test.
 
-        Content content1 = new Content()
-            .setId("test_content-1")
+        Content content1 = new Content("test_content-1")
             .setName("test content 1")
             .setLabel("test_content-1")
             .setType("content-type")
             .setVendor("test vendor")
             .setModifiedProductIds(Set.of("pid1", "pid2", "pid3"));
 
-        Content content2 = new Content()
-            .setId("test_content-2")
+        Content content2 = new Content("test_content-2")
             .setName("test content 2")
             .setLabel("test_content-2")
             .setType("content-type")

--- a/src/test/java/org/candlepin/model/ContentQueryBuilderTest.java
+++ b/src/test/java/org/candlepin/model/ContentQueryBuilderTest.java
@@ -66,8 +66,7 @@ public class ContentQueryBuilderTest extends DatabaseTestFixture {
             List<Content> contents = new ArrayList<>();
 
             for (int c = 0; c < 2; ++c) {
-                Content content = new Content()
-                    .setId(String.format("g-content-%d%s", i, (char) ('a' + c)))
+                Content content = new Content(String.format("g-content-%d%s", i, (char) ('a' + c)))
                     .setName(String.format("global_content_%d%s", i, (char) ('a' + c)))
                     .setLabel(String.format("global content %d%s", i, (char) ('a' + c)))
                     .setType("test")
@@ -95,15 +94,14 @@ public class ContentQueryBuilderTest extends DatabaseTestFixture {
                 List<Content> contents = new ArrayList<>();
 
                 for (int c = 0; c < 2; ++c) {
-                    Content content = new Content()
-                        .setId(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
+                    Content cont = new Content(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
                         .setName(String.format("%s_content_%d%s", owner.getKey(), i, (char) ('a' + c)))
                         .setLabel(String.format("%s content %d%s", owner.getKey(), i, (char) ('a' + c)))
                         .setType("test")
                         .setVendor("vendor")
                         .setNamespace(owner.getKey());
 
-                    contents.add(this.contentCurator.create(content));
+                    contents.add(this.contentCurator.create(cont));
                 }
 
                 Product cprod = new Product()

--- a/src/test/java/org/candlepin/model/ContentTest.java
+++ b/src/test/java/org/candlepin/model/ContentTest.java
@@ -79,7 +79,6 @@ public class ContentTest extends DatabaseTestFixture {
 
     protected static Stream<Arguments> getValuesForEqualityAndReplication() {
         return Stream.of(
-            Arguments.of("Id", "test_value", "alt_value"),
             Arguments.of("Type", "test_value", "alt_value"),
             Arguments.of("Label", "test_value", "alt_value"),
             Arguments.of("Name", "test_value", "alt_value"),

--- a/src/test/java/org/candlepin/model/ProductTest.java
+++ b/src/test/java/org/candlepin/model/ProductTest.java
@@ -46,6 +46,14 @@ import java.util.stream.Stream;
  */
 public class ProductTest {
 
+    protected static Content buildContent(String id, String name, String type, String label, String vendor) {
+        return new Content(id)
+            .setName(name)
+            .setType(type)
+            .setLabel(label)
+            .setVendor(vendor);
+    }
+
     protected static Stream<Object[]> getValuesForEqualityAndReplication() {
         Map<String, String> attributes1 = new HashMap<>();
         attributes1.put("a1", "v1");
@@ -58,12 +66,12 @@ public class ProductTest {
         attributes2.put("a6", "v6");
 
         Content[] content = new Content[] {
-            new Content("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
-            new Content("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
-            new Content("c3", "content-3", "test_type", "test_label-3", "test_vendor-3"),
-            new Content("c4", "content-4", "test_type", "test_label-4", "test_vendor-4"),
-            new Content("c5", "content-5", "test_type", "test_label-5", "test_vendor-5"),
-            new Content("c6", "content-6", "test_type", "test_label-6", "test_vendor-6")
+            buildContent("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
+            buildContent("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
+            buildContent("c3", "content-3", "test_type", "test_label-3", "test_vendor-3"),
+            buildContent("c4", "content-4", "test_type", "test_label-4", "test_vendor-4"),
+            buildContent("c5", "content-5", "test_type", "test_label-5", "test_vendor-5"),
+            buildContent("c6", "content-6", "test_type", "test_label-6", "test_vendor-6")
         };
 
         for (Content cobj : content) {

--- a/src/test/java/org/candlepin/model/dto/ContentDataTest.java
+++ b/src/test/java/org/candlepin/model/dto/ContentDataTest.java
@@ -484,7 +484,6 @@ public class ContentDataTest {
     protected static Stream<Object[]> getValuesPopulationByEntity() {
         return Stream.of(
             new Object[] { "Uuid", "test_value", null },
-            new Object[] { "Id", "test_value", null },
             new Object[] { "Type", "test_value", null },
             new Object[] { "Label", "test_value", null },
             new Object[] { "Name", "test_value", null },
@@ -528,7 +527,7 @@ public class ContentDataTest {
         }
 
         ContentData base = new ContentData();
-        Content source = new Content();
+        Content source = new Content("test_content");
 
         mutator.invoke(source, input);
         base.populate(source);

--- a/src/test/java/org/candlepin/model/dto/ProductContentDataTest.java
+++ b/src/test/java/org/candlepin/model/dto/ProductContentDataTest.java
@@ -199,7 +199,12 @@ public class ProductContentDataTest {
 
     @Test
     public void testPopulateWithEntityContent() {
-        Content contentEntity = new Content("id1", "name1", "type1", "label1", "vendor1");
+        Content contentEntity = new Content("id1")
+            .setName("name1")
+            .setType("type1")
+            .setLabel("label1")
+            .setVendor("vendor1");
+
         ContentData contentData = contentEntity.toDTO();
 
         ProductContentData base = new ProductContentData();

--- a/src/test/java/org/candlepin/model/dto/ProductDataTest.java
+++ b/src/test/java/org/candlepin/model/dto/ProductDataTest.java
@@ -78,6 +78,14 @@ public class ProductDataTest {
         return Stream.of(null, "");
     }
 
+    private Content buildContent(String id, String name, String type, String label, String vendor) {
+        return new Content(id)
+            .setName(name)
+            .setType(type)
+            .setLabel(label)
+            .setVendor(vendor);
+    }
+
     @Test
     public void testGetSetUuid() {
         ProductData dto = new ProductData();
@@ -449,8 +457,8 @@ public class ProductDataTest {
     public void testAddProductContentByEntity() {
         ProductData dto = new ProductData();
         Content[] contentEntities = new Content[] {
-            new Content("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
-            new Content("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
+            buildContent("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
+            buildContent("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
         };
 
         ProductContent pcentity1 = new ProductContent(contentEntities[0], true);
@@ -528,8 +536,8 @@ public class ProductDataTest {
     public void testAddContentByEntity() {
         ProductData dto = new ProductData();
         Content[] contentEntities = new Content[] {
-            new Content("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
-            new Content("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
+            buildContent("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
+            buildContent("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
         };
 
         ProductContent pcentity1 = new ProductContent(contentEntities[0], true);
@@ -651,9 +659,9 @@ public class ProductDataTest {
         ProductContentData pcdata2 = new ProductContentData(content[1], false);
 
         Content[] contentEntities = new Content[] {
-            new Content("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
-            new Content("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
-            new Content("c2", "content-3", "test_type", "test_label-3", "test_vendor-3"),
+            buildContent("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
+            buildContent("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
+            buildContent("c2", "content-3", "test_type", "test_label-3", "test_vendor-3"),
         };
 
         assertNull(dto.getProductContent());
@@ -731,9 +739,9 @@ public class ProductDataTest {
         ProductContentData pcdata2 = new ProductContentData(content[1], false);
 
         Content[] contentEntities = new Content[] {
-            new Content("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
-            new Content("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
-            new Content("c2", "content-3", "test_type", "test_label-3", "test_vendor-3"),
+            buildContent("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
+            buildContent("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
+            buildContent("c2", "content-3", "test_type", "test_label-3", "test_vendor-3"),
         };
 
         ProductContent pcentity1 = new ProductContent(contentEntities[0], true);
@@ -1358,9 +1366,9 @@ public class ProductDataTest {
         Product source = new Product();
 
         Content[] contentEntities = new Content[] {
-            new Content("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
-            new Content("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
-            new Content("c3", "content-3", "test_type", "test_label-3", "test_vendor-3"),
+            buildContent("c1", "content-1", "test_type", "test_label-1", "test_vendor-1"),
+            buildContent("c2", "content-2", "test_type", "test_label-2", "test_vendor-2"),
+            buildContent("c3", "content-3", "test_type", "test_label-3", "test_vendor-3"),
         };
         ProductContent pcentity1 = new ProductContent(contentEntities[0], true);
         ProductContent pcentity2 = new ProductContent(contentEntities[1], false);

--- a/src/test/java/org/candlepin/pki/certs/EntitlementCertificateGeneratorTest.java
+++ b/src/test/java/org/candlepin/pki/certs/EntitlementCertificateGeneratorTest.java
@@ -1061,18 +1061,16 @@ public class EntitlementCertificateGeneratorTest {
         String url, String gpgUrl, String arches) {
 
         TestUtil.createOwner("Example-Corporation");
-        Content content = TestUtil.createContent(id, name);
-
-        content.setId(id + TestUtil.randomInt(10_000));
-        content.setUuid(id + "_uuid");
-        content.setLabel(label);
-        content.setType(type);
-        content.setVendor(vendor);
-        content.setContentUrl(url);
-        content.setGpgUrl(gpgUrl);
-        content.setArches(arches);
-        content.setRequiredTags(REQUIRED_TAGS);
-        content.setMetadataExpiration(CONTENT_METADATA_EXPIRE);
+        Content content = TestUtil.createContent(id + TestUtil.randomInt(10_000), name)
+            .setUuid(id + "_uuid")
+            .setLabel(label)
+            .setType(type)
+            .setVendor(vendor)
+            .setContentUrl(url)
+            .setGpgUrl(gpgUrl)
+            .setArches(arches)
+            .setRequiredTags(REQUIRED_TAGS)
+            .setMetadataExpiration(CONTENT_METADATA_EXPIRE);
 
         return content;
     }

--- a/src/test/java/org/candlepin/pki/certs/EntitlementPayloadGeneratorTest.java
+++ b/src/test/java/org/candlepin/pki/certs/EntitlementPayloadGeneratorTest.java
@@ -212,15 +212,14 @@ public class EntitlementPayloadGeneratorTest {
 
     private Content createContent() {
         String id = "" + TestUtil.randomInt(10_000);
-        Content content = TestUtil.createContent(id, TestUtil.randomString());
-        content.setId(id);
-        content.setUuid(id + "_uuid");
-        content.setLabel("label");
-        content.setType("yum");
-        content.setVendor("vendor");
-        content.setArches("x86_64");
-        content.setRequiredTags("tag1");
-        content.setMetadataExpiration(3200L);
+        Content content = TestUtil.createContent(id, TestUtil.randomString())
+            .setUuid(id + "_uuid")
+            .setLabel("label")
+            .setType("yum")
+            .setVendor("vendor")
+            .setArches("x86_64")
+            .setRequiredTags("tag1")
+            .setMetadataExpiration(3200L);
 
         return content;
     }

--- a/src/test/java/org/candlepin/pki/certs/SCACertificateGeneratorTest.java
+++ b/src/test/java/org/candlepin/pki/certs/SCACertificateGeneratorTest.java
@@ -387,9 +387,8 @@ class SCACertificateGeneratorTest {
     private Content createContent() {
         String id = TestUtil.randomString(6, TestUtil.CHARSET_NUMERIC);
 
-        return new Content()
+        return new Content(id)
             .setUuid("test_content-" + id)
-            .setId(id)
             .setName("test_content-" + id)
             .setLabel("label")
             .setType("yum")

--- a/src/test/java/org/candlepin/resource/ContentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ContentResourceTest.java
@@ -114,8 +114,7 @@ public class ContentResourceTest extends DatabaseTestFixture {
             List<Content> contents = new ArrayList<>();
 
             for (int c = 0; c < 2; ++c) {
-                Content content = new Content()
-                    .setId(String.format("g-content-%d%s", i, (char) ('a' + c)))
+                Content content = new Content(String.format("g-content-%d%s", i, (char) ('a' + c)))
                     .setName(String.format("global_content_%d%s", i, (char) ('a' + c)))
                     .setLabel(String.format("global content %d%s", i, (char) ('a' + c)))
                     .setType("test")
@@ -143,15 +142,14 @@ public class ContentResourceTest extends DatabaseTestFixture {
                 List<Content> contents = new ArrayList<>();
 
                 for (int c = 0; c < 2; ++c) {
-                    Content content = new Content()
-                        .setId(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
+                    Content cont = new Content(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
                         .setName(String.format("%s_content_%d%s", owner.getKey(), i, (char) ('a' + c)))
                         .setLabel(String.format("%s content %d%s", owner.getKey(), i, (char) ('a' + c)))
                         .setType("test")
                         .setVendor("vendor")
                         .setNamespace(owner.getKey());
 
-                    contents.add(this.contentCurator.create(content));
+                    contents.add(this.contentCurator.create(cont));
                 }
 
                 Product cprod = new Product()

--- a/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerContentResourceTest.java
@@ -353,8 +353,7 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
             List<Content> contents = new ArrayList<>();
 
             for (int c = 0; c < 2; ++c) {
-                Content content = new Content()
-                    .setId(String.format("g-content-%d%s", i, (char) ('a' + c)))
+                Content content = new Content(String.format("g-content-%d%s", i, (char) ('a' + c)))
                     .setName(String.format("global_content_%d%s", i, (char) ('a' + c)))
                     .setLabel(String.format("global content %d%s", i, (char) ('a' + c)))
                     .setType("test")
@@ -382,15 +381,14 @@ public class OwnerContentResourceTest extends DatabaseTestFixture {
                 List<Content> contents = new ArrayList<>();
 
                 for (int c = 0; c < 2; ++c) {
-                    Content content = new Content()
-                        .setId(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
+                    Content cont = new Content(String.format("o%d-content-%d%s", oidx, i, (char) ('a' + c)))
                         .setName(String.format("%s_content_%d%s", owner.getKey(), i, (char) ('a' + c)))
                         .setLabel(String.format("%s content %d%s", owner.getKey(), i, (char) ('a' + c)))
                         .setType("test")
                         .setVendor("vendor")
                         .setNamespace(owner.getKey());
 
-                    contents.add(this.contentCurator.create(content));
+                    contents.add(this.contentCurator.create(cont));
                 }
 
                 Product cprod = new Product()

--- a/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
+++ b/src/test/java/org/candlepin/sync/SubscriptionReconcilerTest.java
@@ -65,26 +65,22 @@ public class SubscriptionReconcilerTest {
     }
 
     public Content convertFromDTO(ContentDTO dto) {
-        Content content = null;
-
-        if (dto != null) {
-            content = new Content();
-
-            content.setId(dto.getId());
-            content.setName(dto.getName());
-            content.setType(dto.getType());
-            content.setLabel(dto.getLabel());
-            content.setVendor(dto.getVendor());
-            content.setContentUrl(dto.getContentUrl());
-            content.setRequiredTags(dto.getRequiredTags());
-            content.setReleaseVersion(dto.getReleaseVersion());
-            content.setGpgUrl(dto.getGpgUrl());
-            content.setMetadataExpiration(dto.getMetadataExpiration());
-            content.setModifiedProductIds(dto.getRequiredProductIds());
-            content.setArches(dto.getArches());
+        if (dto == null) {
+            return null;
         }
 
-        return content;
+        return new Content(dto.getId())
+            .setName(dto.getName())
+            .setType(dto.getType())
+            .setLabel(dto.getLabel())
+            .setVendor(dto.getVendor())
+            .setContentUrl(dto.getContentUrl())
+            .setRequiredTags(dto.getRequiredTags())
+            .setReleaseVersion(dto.getReleaseVersion())
+            .setGpgUrl(dto.getGpgUrl())
+            .setMetadataExpiration(dto.getMetadataExpiration())
+            .setModifiedProductIds(dto.getRequiredProductIds())
+            .setArches(dto.getArches());
     }
 
     public Product convertFromDTO(ProductDTO dto) {

--- a/src/test/java/org/candlepin/test/TestUtil.java
+++ b/src/test/java/org/candlepin/test/TestUtil.java
@@ -319,8 +319,7 @@ public class TestUtil {
     }
 
     public static Content createContent(String id, String name) {
-        return new Content()
-            .setId(id)
+        return new Content(id)
             .setName(name)
             .setType("test-type")
             .setLabel("test-label")

--- a/src/test/java/org/candlepin/util/X509ExtensionUtilTest.java
+++ b/src/test/java/org/candlepin/util/X509ExtensionUtilTest.java
@@ -50,8 +50,13 @@ public class X509ExtensionUtilTest {
     public void shouldWorkWithValidContentId() {
         X509ExtensionUtil util = new X509ExtensionUtil(config);
 
-        Content content = new Content("123456", "testcontent", "yum", "testlabel", "testvendor")
+        Content content = new Content("123456")
+            .setName("testcontent")
+            .setType("yum")
+            .setLabel("testlabel")
+            .setVendor("testvendor")
             .setContentUrl("/content_path");
+
         List<ProductContent> contents = List.of(new ProductContent(new Product(), content, true));
         PromotedContent promotedContent = new PromotedContent(contentPathBuilder());
         Set<X509Extension> extensions = util
@@ -68,7 +73,12 @@ public class X509ExtensionUtilTest {
     @MethodSource("invalidContentIds")
     public void failsForInvalidContentIds(String contentId) {
         X509ExtensionUtil util = new X509ExtensionUtil(config);
-        Content content = new Content(contentId, "testcontent", "yum", "testlabel", "testvendor");
+        Content content = new Content(contentId)
+            .setName("testcontent")
+            .setType("yum")
+            .setLabel("testlabel")
+            .setVendor("testvendor");
+
         Product skuProduct = new Product();
         List<ProductContent> contents = List.of(new ProductContent(skuProduct, content, true));
         PromotedContent promotedContent = new PromotedContent(contentPathBuilder());
@@ -82,7 +92,6 @@ public class X509ExtensionUtilTest {
             Arguments.of("123-456"),
             Arguments.of("-"),
             Arguments.of(" ,"),
-            Arguments.of(""),
             Arguments.of("test"),
             Arguments.of("123asd")
         );

--- a/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
+++ b/src/test/java/org/candlepin/util/X509V3ExtensionUtilTest.java
@@ -162,9 +162,8 @@ public class X509V3ExtensionUtilTest {
     private void addContent(Product product, String arches) {
         int size = product.getProductContent().size() + 1;
 
-        Content content = new Content()
+        Content content = new Content("content_" + size)
             .setUuid("content_" + size)
-            .setId("content_" + size)
             .setArches(arches);
 
         product.addContent(content, true);
@@ -216,12 +215,10 @@ public class X509V3ExtensionUtilTest {
             .setId("test-id")
             .setKey("Test Corporation")
             .setDisplayName("Test Corporation");
-        Content content1 = new Content()
-            .setId("cont_id1")
+        Content content1 = new Content("cont_id1")
             .setArches("x86_64")
             .setContentUrl("/cont_id1");
-        Content content2 = new Content()
-            .setId("cont_id2")
+        Content content2 = new Content("cont_id2")
             .setArches("ppc64")
             .setContentUrl("/cont_id2");
         Product engProd = new Product()


### PR DESCRIPTION
- Changed Content entities to always require a non-null, non-blank content ID (not UUID)
- Updated equality and hashcode checks on ProductContent entities to use only the content ID, allowing two ProductContent instances to be considered equal if the contents they reference are logically the same
- Removed the iterative removal of pre-existing product content from Product.addProductContent, instead relying upon the new invariants defined by content