### PR TITLE
[M] CANDLEPIN-938: Registered ObjectMapper as an eager singleton

### DIFF
--- a/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -277,7 +277,7 @@ public class CandlepinModule extends AbstractModule {
         bind(JsRunner.class).toProvider(JsRunnerProvider.class);
         bind(SyncUtils.class).asEagerSingleton();
         bind(ObjectMapperFactory.class).asEagerSingleton();
-        bind(ObjectMapper.class).toProvider(ObjectMapperFactory.class);
+        bind(ObjectMapper.class).toProvider(ObjectMapperFactory.class).asEagerSingleton();
         bind(UniqueIdGenerator.class).to(DefaultUniqueIdGenerator.class);
         bind(AttributeValidator.class);
         bind(FactValidator.class);
@@ -526,7 +526,7 @@ public class CandlepinModule extends AbstractModule {
 
     @Provides
     @Singleton
-    @Named("ExportObjectMapper")
+    @Named("RulesObjectMapper")
     private RulesObjectMapper configureRulesObjectMapper() {
         return ObjectMapperFactory.getRulesObjectMapper();
     }

--- a/src/test/java/org/candlepin/TestingModules.java
+++ b/src/test/java/org/candlepin/TestingModules.java
@@ -343,8 +343,7 @@ public class TestingModules {
             bind(CPMSessionFactory.class).to(NoopSessionFactory.class).in(Singleton.class);
             bind(CPMContextListener.class).to(NoopContextListener.class).in(Singleton.class);
             bind(ObjectMapperFactory.class).asEagerSingleton();
-            bind(ObjectMapper.class).toProvider(ObjectMapperFactory.class);
-            bind(RulesObjectMapper.class);
+            bind(ObjectMapper.class).toProvider(ObjectMapperFactory.class).asEagerSingleton();
         }
 
         @Provides
@@ -373,6 +372,13 @@ public class TestingModules {
         @Named("ExportObjectMapper")
         private ObjectMapper configureExportObjectMapper() {
             return ObjectMapperFactory.getSyncObjectMapper(TestConfig.defaults());
+        }
+
+        @Provides
+        @Singleton
+        @Named("RulesObjectMapper")
+        private RulesObjectMapper configureRulesObjectMapper() {
+            return ObjectMapperFactory.getRulesObjectMapper();
         }
     }
 }


### PR DESCRIPTION
- Updated the module configuration for ObjectMapper to ensure it is created as an eager singleton, rather than creating it on every injection