### PR TITLE
[M] CANDLEPIN-277: Disallowed creation of AK with Pool(s) specified when on SCA

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceActivationKeySpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceActivationKeySpecTest.java
@@ -657,7 +657,7 @@ public class ConsumerResourceActivationKeySpecTest {
 
     @Test
     public void shouldAllowConsumerToRegisterWithActivationKeyAuthWithoutConsumedSubscriptionInSCA() {
-        OwnerDTO owner = ownerClient.createOwner(Owners.randomSca());
+        OwnerDTO owner = ownerClient.createOwner(Owners.random());
         ProductDTO prod1 = Products.random()
             .addAttributesItem(ProductAttributes.MultiEntitlement.withValue("yes"));
         prod1 = ownerProductApi.createProduct(owner.getKey(), prod1);
@@ -667,6 +667,9 @@ public class ConsumerResourceActivationKeySpecTest {
         ActivationKeyDTO key1 = ownerClient.createActivationKey(owner.getKey(), ActivationKeys.random(owner));
         key1 = activationKeyApi.addPoolToKey(key1.getId(), pool1.getId(), 3L);
         ActivationKeyDTO key2 = ownerClient.createActivationKey(owner.getKey(), ActivationKeys.random(owner));
+
+        owner.setContentAccessMode("org_environment");
+        ownerClient.updateOwner(owner.getKey(), owner);
 
         ApiClient noAuth = ApiClients.noAuth();
         ConsumerDTO consumer = noAuth.consumers().createConsumer(Consumers.random(owner), null,

--- a/src/main/java/org/candlepin/resource/ActivationKeyResource.java
+++ b/src/main/java/org/candlepin/resource/ActivationKeyResource.java
@@ -205,6 +205,15 @@ public class ActivationKeyResource implements ActivationKeyApi {
         Long quantity) {
 
         ActivationKey key = this.fetchActivationKey(activationKeyId);
+
+        // If we're running in SCA mode, don't allow adding (more) pools to the keys,
+        // because owner should see all the pools anyway
+        Owner owner = key.getOwner();
+        if (owner != null && owner.isUsingSimpleContentAccess()) {
+            throw new BadRequestException(i18n.tr("Pools cannot be added to activation keys while" +
+                " the org is operating in simple content access mode"));
+        }
+
         Pool pool = findPool(poolId);
 
         String message = activationKeyRules.validatePoolForActivationKey(key, pool, quantity);

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1095,6 +1095,16 @@ public class OwnerResource implements OwnerApi {
                     dto.getName(), ownerKey));
         }
 
+        // If we're running in SCA mode, don't allow creating keys with pools,
+        // because owner should see all the pools anyway
+        if (owner.isUsingSimpleContentAccess()) {
+            Set<ActivationKeyPoolDTO> pools = dto.getPools();
+            if (pools != null && !pools.isEmpty()) {
+                throw new BadRequestException(i18n.tr("Activation keys cannot be created with pools while" +
+                    " the org is operating in simple content access mode"));
+            }
+        }
+
         serviceLevelValidator.validate(owner.getId(), dto.getServiceLevel());
 
         ActivationKey key = new ActivationKey();


### PR DESCRIPTION
- While SCA mode is enabled for a given organization, activation keys can no longer be created with pools, or have pools added to them