### PR TITLE
[M] CANDLEPIN-938: Refactored ContentCurator.getActiveContentByOwner

### DIFF
--- a/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -877,27 +877,6 @@ public class ContentCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testGetActiveContentByOwnerCollision() {
-        Owner owner = createOwner();
-        Content content = createContent();
-
-        createProductContent(owner, true, content);
-        createProductContent(owner, false, content);
-
-        this.contentCurator.flush();
-        this.contentCurator.clear();
-        List<ProductContent> activeContentByOwner = contentCurator.getActiveContentByOwner(owner.getId());
-
-        assertThat(activeContentByOwner).hasSize(1)
-            .extracting(ProductContent::getContent)
-            .containsExactlyInAnyOrder(content);
-
-        assertThat(activeContentByOwner)
-            .extracting(ProductContent::isEnabled)
-            .containsOnly(true);
-    }
-
-    @Test
     public void testGetActiveContentByOwnerMultipleOwners() {
         Owner owner1 = createOwner();
         Owner owner2 = createOwner();


### PR DESCRIPTION
- Updated ContentCurator.getActiveContentByOwner to use Hibernate result translators instead of multiple queries and mappers to fetch active content
- getActiveContentByOwner no longer guarantees uniqueness in its output, instead leaving that responsibility up to its callers
- Removed the now-extraneous unit test for collision resolution in getActiveContentByOwner