### PR TITLE
[M] Upgrade commons-lang3 and liquibase

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,8 +32,7 @@ checkstyle-sevntu = { module = "com.github.sevntu-checkstyle:sevntu-checks", ver
 commons-codec = { module = "commons-codec:commons-codec", version = "1.17.1" }
 commons-collections = { module = "org.apache.commons:commons-collections4", version = "4.4" }
 commons-io = { module = "commons-io:commons-io", version = "2.18.0" }
-# Do not upgrade commons-lang beyond 3.14 until Liquibase has stopped using RandomStringUtils.random(...)
-commons-lang = { module = "org.apache.commons:commons-lang3", version = { strictly = "3.14.0" } }
+commons-lang = { module = "org.apache.commons:commons-lang3", version = "3.17.0" }
 ehcache = { module = "org.ehcache:ehcache", version = "3.10.8" }
 gettext = { module = "com.googlecode.gettext-commons:gettext-commons", version = "0.9.8" }
 gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
@@ -70,8 +69,7 @@ junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jun
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 keycloak = { module = "org.keycloak:keycloak-servlet-filter-adapter", version = "25.0.3" }
-# Do not upgrade liquibase beyond 4.29 until Liquibase has stopped using RandomStringUtils.random(...)
-liquibase = { module = "org.liquibase:liquibase-core", version = { strictly = "4.29.0" } }
+liquibase = { module = "org.liquibase:liquibase-core", version = "4.30.0" }
 liquibase-slf4j = { module = "com.mattbertolini:liquibase-slf4j", version = "5.1.0" }
 logback = { module = "ch.qos.logback:logback-classic", version = "1.5.12" }
 logstash = { module = "net.logstash.logback:logstash-logback-encoder", version = "8.0" }


### PR DESCRIPTION
- Now that the commons-lang3 bug (in RandomStringUtils.random()) has been fixed (https://issues.apache.org/jira/browse/LANG-1748) and PNC gradle builds honor the 'strictly' directive, we can upgrade these 2 libraries.