### PR TITLE
[4.5] Revert "CANDLEPIN-938: Reverted explicit content bulk translation"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=57dafb5c2622c6cc08b993c85b7c06956a2f53536432a30ead46166dbca0f1e9
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/candlepin/model/ContentCurator.java
+++ b/src/main/java/org/candlepin/model/ContentCurator.java
@@ -756,4 +756,45 @@ public class ContentCurator extends AbstractHibernateCurator<Content> {
             .getResultList();
     }
 
+    /**
+     * Fetches the required product IDs for the contents specified by the collection of content UUIDs.
+     * The required product IDs will be returned as a mapping of content UUID to required product ID
+     * collection. If a given content does not have any required product IDs, or the content UUID itself
+     * does not map to an existing content, it will not be represented in the output map. If none of the
+     * given content have any required product IDs, or none of the contents could be found, this method
+     * returns an empty map.
+     *
+     * @param contentUuids
+     *  a collection of UUIDs of the content for which to fetch required (modified) product IDs
+     *
+     * @return
+     *  the required product IDs for the given contents, represented as a map of content UUIDs to required
+     *  product IDs
+     */
+    public Map<String, Set<String>> getRequiredProductIds(Collection<String> contentUuids) {
+        Map<String, Set<String>> output = new HashMap<>();
+
+        if (contentUuids != null && !contentUuids.isEmpty()) {
+            String sql = "SELECT content_uuid, product_id " +
+                "FROM cp_content_required_products WHERE content_uuid IN (:content_uuids)";
+
+            Query query = this.getEntityManager()
+                .createNativeQuery(sql);
+
+            for (List<String> block : this.partition(contentUuids)) {
+                List<Object[]> result = query.setParameter("content_uuids", block)
+                    .getResultList();
+
+                for (Object[] row : result) {
+                    String contentUuid = (String) row[0];
+                    String productId = (String) row[1];
+
+                    output.computeIfAbsent(contentUuid, key -> new HashSet<>())
+                        .add(productId);
+                }
+            }
+        }
+
+        return output;
+    }
 }

--- a/src/main/java/org/candlepin/resource/ContentResource.java
+++ b/src/main/java/org/candlepin/resource/ContentResource.java
@@ -27,14 +27,21 @@ import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.QueryBuilder.Inclusion;
 import org.candlepin.paging.PagingUtilFactory;
 import org.candlepin.resource.server.v1.ContentApi;
+import org.candlepin.util.BatchSpliterator;
+import org.candlepin.util.Util;
 
 import com.google.inject.persist.Transactional;
 
 import org.xnap.commons.i18n.I18n;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.inject.Inject;
 
@@ -91,6 +98,83 @@ public class ContentResource implements ContentApi {
         return owner;
     }
 
+    /**
+     * Translates the collection of content elements to content DTOs, fetching lazily loaded fields in
+     * bulk.
+     *
+     * @param source
+     *  the source collection of content objects to translate
+     *
+     * @return
+     *  a list of translated content DTOs, or null if the given collection was null
+     */
+    private List<ContentDTO> translate(Collection<Content> source) {
+        // Impl note:
+        // This behavior should eventually be moved to the translators, and the translator framework updated
+        // to support bulk translations and generally stuff added after Java 8. However, doing so is a
+        // much larger task than fixing this particular translation has far more concerns in terms of
+        // both scope and design.
+
+        if (source == null) {
+            return null;
+        }
+
+        List<String> cuuids = source.stream()
+            .filter(Objects::nonNull)
+            .map(Content::getUuid)
+            .filter(Objects::nonNull)
+            .toList();
+
+        Map<String, Set<String>> requiredProductsMap = this.contentCurator.getRequiredProductIds(cuuids);
+
+        Function<Content, ContentDTO> translator = content -> new ContentDTO()
+            .uuid(content.getUuid())
+            .id(content.getId())
+            .type(content.getType())
+            .label(content.getLabel())
+            .name(content.getName())
+            .created(Util.toDateTime(content.getCreated()))
+            .updated(Util.toDateTime(content.getUpdated()))
+            .vendor(content.getVendor())
+            .contentUrl(content.getContentUrl())
+            .requiredTags(content.getRequiredTags())
+            .releaseVer(content.getReleaseVersion())
+            .gpgUrl(content.getGpgUrl())
+            .metadataExpire(content.getMetadataExpiration())
+            .modifiedProductIds(requiredProductsMap.getOrDefault(content.getUuid(), Set.of()))
+            .arches(content.getArches());
+
+        return source.stream()
+            .filter(Objects::nonNull)
+            .map(translator)
+            .toList();
+    }
+
+    /**
+     * Translates the stream of content elements to content DTOs, fetching lazily loaded fields in
+     * bulk.
+     *
+     * @param source
+     *  the source stream of content objects to translate
+     *
+     * @return
+     *  a stream of translated content DTOs, or null if the given stream was null
+     */
+    private Stream<ContentDTO> translate(Stream<Content> source) {
+        if (source == null) {
+            return null;
+        }
+
+        // TODO: If this behavior doesn't make it into the Java API, add it ourselves with a custom Stream
+        // implementation somehow
+        int batchSize = this.contentCurator.getInBlockSize();
+        BatchSpliterator<Content> spliterator = new BatchSpliterator<>(source.spliterator(), batchSize);
+
+        return StreamSupport.stream(spliterator, source.isParallel())
+            .map(this::translate)
+            .flatMap(Collection::stream);
+    }
+
     @Override
     @Transactional
     // GET /contents
@@ -115,9 +199,10 @@ public class ContentResource implements ContentApi {
             .setActive(activeInc)
             .setCustom(customInc);
 
-        return this.pagingUtilFactory.forClass(Content.class)
-            .applyPaging(queryBuilder)
-            .map(this.modelTranslator.getStreamMapper(Content.class, ContentDTO.class));
+        Stream<Content> content = this.pagingUtilFactory.forClass(Content.class)
+            .applyPaging(queryBuilder);
+
+        return this.translate(content);
     }
 
     @Override

--- a/src/main/java/org/candlepin/resource/OwnerContentResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerContentResource.java
@@ -34,6 +34,8 @@ import org.candlepin.resource.util.InfoAdapter;
 import org.candlepin.resource.validation.DTOValidator;
 import org.candlepin.service.UniqueIdGenerator;
 import org.candlepin.service.model.ContentInfo;
+import org.candlepin.util.BatchSpliterator;
+import org.candlepin.util.Util;
 
 import com.google.inject.persist.Transactional;
 
@@ -41,10 +43,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.inject.Inject;
 import javax.persistence.LockModeType;
@@ -224,6 +230,83 @@ public class OwnerContentResource implements OwnerContentApi {
         return this.contentManager.createContent(owner, cinfo);
     }
 
+    /**
+     * Translates the collection of content elements to content DTOs, fetching lazily loaded fields in
+     * bulk.
+     *
+     * @param source
+     *  the source collection of content objects to translate
+     *
+     * @return
+     *  a list of translated content DTOs, or null if the given collection was null
+     */
+    private List<ContentDTO> translate(Collection<Content> source) {
+        // Impl note:
+        // This behavior should eventually be moved to the translators, and the translator framework updated
+        // to support bulk translations and generally stuff added after Java 8. However, doing so is a
+        // much larger task than fixing this particular translation has far more concerns in terms of
+        // both scope and design.
+
+        if (source == null) {
+            return null;
+        }
+
+        List<String> cuuids = source.stream()
+            .filter(Objects::nonNull)
+            .map(Content::getUuid)
+            .filter(Objects::nonNull)
+            .toList();
+
+        Map<String, Set<String>> requiredProductsMap = this.contentCurator.getRequiredProductIds(cuuids);
+
+        Function<Content, ContentDTO> translator = content -> new ContentDTO()
+            .uuid(content.getUuid())
+            .id(content.getId())
+            .type(content.getType())
+            .label(content.getLabel())
+            .name(content.getName())
+            .created(Util.toDateTime(content.getCreated()))
+            .updated(Util.toDateTime(content.getUpdated()))
+            .vendor(content.getVendor())
+            .contentUrl(content.getContentUrl())
+            .requiredTags(content.getRequiredTags())
+            .releaseVer(content.getReleaseVersion())
+            .gpgUrl(content.getGpgUrl())
+            .metadataExpire(content.getMetadataExpiration())
+            .modifiedProductIds(requiredProductsMap.getOrDefault(content.getUuid(), Set.of()))
+            .arches(content.getArches());
+
+        return source.stream()
+            .filter(Objects::nonNull)
+            .map(translator)
+            .toList();
+    }
+
+    /**
+     * Translates the stream of content elements to content DTOs, fetching lazily loaded fields in
+     * bulk.
+     *
+     * @param source
+     *  the source stream of content objects to translate
+     *
+     * @return
+     *  a stream of translated content DTOs, or null if the given stream was null
+     */
+    private Stream<ContentDTO> translate(Stream<Content> source) {
+        if (source == null) {
+            return null;
+        }
+
+        // TODO: If this behavior doesn't make it into the Java API, add it ourselves with a custom Stream
+        // implementation somehow
+        int batchSize = this.contentCurator.getInBlockSize();
+        BatchSpliterator<Content> spliterator = new BatchSpliterator<>(source.spliterator(), batchSize);
+
+        return StreamSupport.stream(spliterator, source.isParallel())
+            .map(this::translate)
+            .flatMap(Collection::stream);
+    }
+
     @Override
     @Transactional
     public Stream<ContentDTO> createContentBatch(String ownerKey, List<ContentDTO> contents) {
@@ -290,9 +373,10 @@ public class OwnerContentResource implements OwnerContentApi {
             .setActive(activeInc)
             .setCustom(customInc);
 
-        return this.pagingUtilFactory.forClass(Content.class)
-            .applyPaging(queryBuilder)
-            .map(this.translator.getStreamMapper(Content.class, ContentDTO.class));
+        Stream<Content> content = this.pagingUtilFactory.forClass(Content.class)
+            .applyPaging(queryBuilder);
+
+        return this.translate(content);
     }
 
     @Override

--- a/src/test/java/org/candlepin/model/ContentCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ContentCuratorTest.java
@@ -912,6 +912,60 @@ public class ContentCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testGetRequiredProductIds() {
+        Owner owner = this.createOwner();
+
+        Content content1 = this.createContentWithRequiredProductIds("test_content-1",
+            Set.of("p1", "p2", "p3"));
+
+        Content content2 = this.createContentWithRequiredProductIds("test_content-2",
+            Set.of("p2", "p3", "p4"));
+
+        Content content3 = this.createContentWithRequiredProductIds("test_content-3",
+            Set.of("pA", "pB", "pC"));
+
+        Map<String, Set<String>> expected = Map.of(
+            content1.getUuid(), content1.getRequiredProductIds(),
+            content2.getUuid(), content2.getRequiredProductIds(),
+            content3.getUuid(), content3.getRequiredProductIds());
+
+        Map<String, Set<String>> output = this.contentCurator.getRequiredProductIds(expected.keySet());
+
+        assertThat(output)
+            .isNotNull()
+            .hasSize(expected.size())
+            .containsExactlyInAnyOrderEntriesOf(expected);
+    }
+
+    @Test
+    public void testGetRequiredProductIdsExcludesInvalidConsumerUuids() {
+        Content content1 = this.createContentWithRequiredProductIds("test_content-1",
+            Set.of("p1", "p2", "p3"));
+
+        Map<String, Set<String>> expected = Map.of(
+            content1.getUuid(), content1.getRequiredProductIds());
+
+        List<String> cuuids = Arrays.asList(content1.getUuid(), null, "", "invalid uuid");
+
+        Map<String, Set<String>> output = this.contentCurator.getRequiredProductIds(cuuids);
+
+        assertThat(output)
+            .isNotNull()
+            .hasSize(expected.size())
+            .containsExactlyInAnyOrderEntriesOf(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testGetRequiredProductIdsWithNoInputReturnsEmptyMap(Collection<String> cuuids) {
+        Map<String, Set<String>> output = this.contentCurator.getRequiredProductIds(cuuids);
+
+        assertThat(output)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
     public void testContentHasParentProductsWithoutParentProduct() {
         Content content = this.createContent();
 
@@ -975,5 +1029,4 @@ public class ContentCuratorTest extends DatabaseTestFixture {
         // This should not throw an exception or otherwise fail
         assertFalse(this.contentCurator.contentHasParentProducts(content));
     }
-
 }


### PR DESCRIPTION
- Reverts commit 285644b525460623645831487905a50eac461c69 that reverted the patch for explicit bulk content translation