### PR TITLE
[M] CANDLEPIN-974: Restored page size header when fetching owner pools

### DIFF
--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -406,11 +406,9 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
             pools = this.takeSubList(qualifier, pools);
         }
 
-        Page<List<Pool>> output = new Page<>();
-        output.setPageData(pools);
-        output.setMaxRecords(maxSize);
-
-        return output;
+        return new Page<List<Pool>>()
+            .setPageData(pools)
+            .setMaxRecords(maxSize);
     }
 
     private Optional<List<Predicate>> getQualifierPredicates(CriteriaQuery<?> query, Root<Pool> root,

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1344,7 +1344,8 @@ public class OwnerResource implements OwnerApi {
             qualifier.setActivationKey(key);
         }
 
-        Page<List<Pool>> poolPage = poolManager.listAvailableEntitlementPools(qualifier);
+        Page<List<Pool>> poolPage = poolManager.listAvailableEntitlementPools(qualifier)
+            .setPageRequest(pageRequest);
 
         List<Pool> poolList = poolPage.getPageData();
         calculatedAttributesUtil.setCalculatedAttributes(poolList, activeOnDate);


### PR DESCRIPTION
- Fixed a bug that prevented the page size header from being set when fetched pools from the GET /owners/{owner_key}/pools endpoint in pages