### PR TITLE
[4.4] CANDLEPIN-954: Relaxed constraint on null values in ConsumerCloudData

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/ConsumerClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/ConsumerClient.java
@@ -81,6 +81,7 @@ public class ConsumerClient extends ConsumerApi {
     public ConsumerDTO createPersonConsumer(ConsumerDTO consumer, String username) {
         return super.createConsumer(consumer, username, consumer.getOwner().getKey(), null, true);
     }
+
     public ConsumerDTO createConsumerWithoutOwner(ConsumerDTO consumer) {
         return super.createConsumer(consumer, null, null, null, true);
     }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Request.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Request.java
@@ -66,7 +66,7 @@ public class Request {
      * @throws IllegalArgumentException
      *  if the provided client is null
      */
-    public Request(org.candlepin.invoker.client.ApiClient client) {
+    private Request(org.candlepin.invoker.client.ApiClient client) {
         if (client == null) {
             throw new IllegalArgumentException("client is null");
         }
@@ -201,7 +201,7 @@ public class Request {
             throw new IllegalArgumentException("value is null or empty");
         }
 
-        this.pathParams.put(key, value);
+        this.pathParams.put(key, value != null ? value : "");
         return this;
     }
 
@@ -226,7 +226,7 @@ public class Request {
             throw new IllegalArgumentException("header is null or empty");
         }
 
-        this.headers.put(header, value);
+        this.headers.put(header, value != null ? value : "");
         return this;
     }
 
@@ -254,7 +254,7 @@ public class Request {
         }
 
         this.queryParams.computeIfAbsent(key, (k) -> new ArrayList<>())
-            .add(value);
+            .add(value != null ? value : "");
 
         return this;
     }
@@ -290,8 +290,10 @@ public class Request {
             return this;
         }
 
-        this.queryParams.computeIfAbsent(key, (k) -> new ArrayList<>())
-            .addAll(values);
+        List<String> queryParams = this.queryParams.computeIfAbsent(key, (k) -> new ArrayList<>());
+        for (String value : values) {
+            queryParams.add(value != null ? value : "");
+        }
 
         return this;
     }
@@ -336,7 +338,7 @@ public class Request {
 
         // Translate the bits we need to translate...
         String path = PATH_PARAM_REGEX.matcher(this.endpoint)
-            .replaceAll((match) -> this.pathParams.get(match.group(1)));
+            .replaceAll((match) -> this.pathParams.getOrDefault(match.group(1), ""));
 
         String method = this.method != null ? this.method : "GET";
 

--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -1274,6 +1274,10 @@ public class Consumer extends AbstractHibernateObject<Consumer> implements Linka
 
     public Consumer setConsumerCloudData(ConsumerCloudData consumerCloudData) {
         this.consumerCloudData = consumerCloudData;
+        if (this.consumerCloudData != null) {
+            this.consumerCloudData.setConsumer(this);
+        }
+
         return this;
     }
 

--- a/src/test/java/org/candlepin/model/ConsumerTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -695,12 +696,11 @@ public class ConsumerTest extends DatabaseTestFixture {
     @Test
     public void testSetConsumerCloudData() {
         Consumer consumer = new Consumer();
-        ConsumerCloudData consumerCloudData = new ConsumerCloudData()
-            .setId("id-123");
+        ConsumerCloudData consumerCloudData = new ConsumerCloudData();
 
         consumer.setConsumerCloudData(consumerCloudData);
 
-        assertEquals(consumerCloudData.getId(), consumer.getConsumerCloudData().getId());
+        assertSame(consumerCloudData, consumer.getConsumerCloudData());
     }
 
     private Consumer createConsumerWithIdCert(Owner owner) {

--- a/src/test/java/org/candlepin/service/model/CloudCheckInEventTest.java
+++ b/src/test/java/org/candlepin/service/model/CloudCheckInEventTest.java
@@ -110,7 +110,6 @@ public class CloudCheckInEventTest {
     @NullAndEmptySource
     public void testConstructorWithInvalidCloudProviderShortName(String shortName) {
         ConsumerCloudData cloudData = new ConsumerCloudData()
-            .setId(TestUtil.randomString())
             .setCloudAccountId(TestUtil.randomString())
             .setCloudInstanceId(TestUtil.randomString())
             .setCloudOfferingIds(List.of(TestUtil.randomString(), TestUtil.randomString()))
@@ -202,7 +201,6 @@ public class CloudCheckInEventTest {
             .setLastCheckin(new Date());
 
         ConsumerCloudData cloudData = new ConsumerCloudData()
-            .setId(TestUtil.randomString())
             .setCloudAccountId(TestUtil.randomString())
             .setCloudInstanceId(TestUtil.randomString())
             .setCloudOfferingIds(List.of(TestUtil.randomString(), TestUtil.randomString()))
@@ -227,7 +225,6 @@ public class CloudCheckInEventTest {
             .setLastCheckin(new Date());
 
         ConsumerCloudData cloudData = new ConsumerCloudData()
-            .setId(TestUtil.randomString())
             .setCloudAccountId(TestUtil.randomString())
             .setCloudInstanceId(TestUtil.randomString())
             .setCloudOfferingIds(List.of(TestUtil.randomString(), TestUtil.randomString()))
@@ -285,7 +282,6 @@ public class CloudCheckInEventTest {
             .setLastCheckin(new Date());
 
         ConsumerCloudData cloudData = new ConsumerCloudData()
-            .setId(TestUtil.randomString())
             .setCloudAccountId(TestUtil.randomString())
             .setCloudInstanceId(TestUtil.randomString())
             .setCloudOfferingIds(List.of(TestUtil.randomString(), TestUtil.randomString()))
@@ -310,7 +306,6 @@ public class CloudCheckInEventTest {
             .setLastCheckin(new Date());
 
         ConsumerCloudData cloudData = new ConsumerCloudData()
-            .setId(TestUtil.randomString())
             .setCloudAccountId(TestUtil.randomString())
             .setCloudInstanceId(TestUtil.randomString())
             .setCloudOfferingIds(List.of(TestUtil.randomString(), TestUtil.randomString()))
@@ -369,7 +364,6 @@ public class CloudCheckInEventTest {
 
     private ConsumerCloudData createCloudData() {
         return new ConsumerCloudData()
-            .setId(TestUtil.randomString())
             .setCloudAccountId(TestUtil.randomString())
             .setCloudInstanceId(TestUtil.randomString())
             .setCloudOfferingIds(List.of(TestUtil.randomString(), TestUtil.randomString()))


### PR DESCRIPTION
- ConsumerCloudData.addCloudOfferingIds and .setCloudOfferingIds now accept null collections and collections with null or empty values, but will silently ignore them for the purposes of collecting and retaining the offering IDs
- Removed use of Apache Commons StringUtil from the Util class
- Removed ConsumerCloudData.setId, .equals, and .hashCode
- Fixed a bug in the Request object which would pass through null values to the underlying regex replace operation