### PR TITLE
[M] Added blank address for local pg_hba.conf entry

### DIFF
--- a/ansible/roles/candlepin/tasks/el8/el8_postgresql.yml
+++ b/ansible/roles/candlepin/tasks/el8/el8_postgresql.yml
@@ -37,6 +37,7 @@
     contype: local
     databases: all
     users: all
+    address: ''
     method: trust
     create: true
     state: present

--- a/ansible/roles/candlepin/tasks/el9/el9_postgresql.yml
+++ b/ansible/roles/candlepin/tasks/el9/el9_postgresql.yml
@@ -28,6 +28,7 @@
     contype: local
     databases: all
     users: all
+    address: ''
     method: trust
     create: true
     state: present


### PR DESCRIPTION
- Added a blank address for the el8 and el9 ansible tasks to prevent an issue with the postgresql_pg_hba module and allow the Vagrant VM to be created.

The following is a workaround to an issue with postgresql.postgresql_pg_hba component in Version 3.9.0 that prevents the vagrant VM from being created.

https://github.com/ansible-collections/community.postgresql/issues/777