### PR TITLE
[4.4] 2332067: Disallowed Manual Subscription Attachment in SCA Mode

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/AutobindDisabledForOwnerSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/AutobindDisabledForOwnerSpecTest.java
@@ -65,10 +65,7 @@ public class AutobindDisabledForOwnerSpecTest {
         ProductDTO product = adminClient.ownerProducts()
             .createProduct(owner.getKey(), Products.random());
 
-        consumerClient.consumers().bindProduct(consumer.getUuid(), product);
-
-        assertThat(consumerClient.consumers().listEntitlements(consumer.getUuid()))
-            .isEmpty();
+        assertBadRequest(() -> consumerClient.consumers().bindProduct(consumer.getUuid(), product));
     }
 
     @Test

--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
@@ -34,7 +34,6 @@ import org.candlepin.dto.api.client.v1.ComplianceStatusDTO;
 import org.candlepin.dto.api.client.v1.ConsumerDTO;
 import org.candlepin.dto.api.client.v1.ContentDTO;
 import org.candlepin.dto.api.client.v1.ContentToPromoteDTO;
-import org.candlepin.dto.api.client.v1.EntitlementDTO;
 import org.candlepin.dto.api.client.v1.EnvironmentContentDTO;
 import org.candlepin.dto.api.client.v1.EnvironmentDTO;
 import org.candlepin.dto.api.client.v1.OwnerDTO;
@@ -1105,10 +1104,8 @@ public class ContentAccessSpecTest {
         consumer.installedProducts(Set.of(Products.toInstalled(prod2)));
         consumerClient.consumers().updateConsumer(consumer.getUuid(), consumer);
 
-        consumerClient.consumers()
-            .bind(consumer.getUuid(), null, List.of(), null, null, null, false, null, List.of());
-        List<EntitlementDTO> ents = consumerClient.consumers().listEntitlements(consumer.getUuid());
-        assertThat(ents).isEmpty();
+        assertBadRequest(() -> consumerClient.consumers()
+            .bind(consumer.getUuid(), null, List.of(), null, null, null, false, null, List.of()));
 
         // confirm that there is a content access cert
         // and only a content access cert

--- a/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceEntitlementRulesTest.java
@@ -16,7 +16,6 @@ package org.candlepin.resource;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.candlepin.async.JobException;
 import org.candlepin.exceptions.ForbiddenException;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
@@ -52,7 +51,7 @@ public class ConsumerResourceEntitlementRulesTest extends DatabaseTestFixture {
     public void setUp() {
         consumerResource = injector.getInstance(ConsumerResource.class);
         standardSystemType = consumerTypeCurator.create(new ConsumerType("system"));
-        this.owner = this.createOwner("test-owner");
+        this.owner = this.createNonSCAOwner("test-owner");
 
         consumer = TestUtil.createConsumer(standardSystemType, owner);
         consumerCurator.create(consumer);
@@ -65,7 +64,7 @@ public class ConsumerResourceEntitlementRulesTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testMaxMembership() throws JobException {
+    public void testMaxMembership() {
         // 10 entitlements available, lets try to entitle 11 consumers.
         for (int i = 0; i < pool.getQuantity(); i++) {
             Consumer c = TestUtil.createConsumer(standardSystemType, owner);

--- a/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceVirtEntitlementTest.java
@@ -17,11 +17,11 @@ package org.candlepin.resource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.candlepin.async.JobException;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
 import org.candlepin.config.DevConfig;
 import org.candlepin.config.TestConfig;
+import org.candlepin.controller.ContentAccessMode;
 import org.candlepin.controller.PoolManager;
 import org.candlepin.controller.PoolService;
 import org.candlepin.controller.RefresherFactory;
@@ -97,7 +97,8 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
 
         this.owner = this.ownerCurator.create(new Owner()
             .setKey("test-owner")
-            .setDisplayName("test-owner"));
+            .setDisplayName("test-owner")
+            .setContentAccessMode(ContentAccessMode.ENTITLEMENT.toDatabaseValue()));
 
         manifestConsumer = TestUtil.createConsumer(manifestType, owner);
         consumerCurator.create(manifestConsumer);
@@ -146,7 +147,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
      * Checking behavior when the physical pool has a numeric virt_limit
      */
     @Test
-    public void testLimitedPool() throws JobException {
+    public void testLimitedPool() {
         List<Pool> subscribedTo = new ArrayList<>();
         Consumer guestConsumer = TestUtil.createConsumer(systemType, owner);
         guestConsumer.setFact("virt.is_guest", "true");
@@ -203,7 +204,7 @@ public class ConsumerResourceVirtEntitlementTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testUnlimitedPool() throws JobException {
+    public void testUnlimitedPool() {
         List<Pool> subscribedTo = new ArrayList<>();
         Consumer guestConsumer = TestUtil.createConsumer(systemType, owner);
         guestConsumer.setFact("virt.is_guest", "true");

--- a/src/test/java/org/candlepin/test/DatabaseTestFixture.java
+++ b/src/test/java/org/candlepin/test/DatabaseTestFixture.java
@@ -30,6 +30,7 @@ import org.candlepin.auth.permissions.PermissionFactory.PermissionType;
 import org.candlepin.config.Configuration;
 import org.candlepin.config.DevConfig;
 import org.candlepin.config.TestConfig;
+import org.candlepin.controller.ContentAccessMode;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.guice.CandlepinRequestScope;
 import org.candlepin.guice.TestPrincipalProviderSetter;
@@ -633,21 +634,80 @@ public class DatabaseTestFixture {
         return environment;
     }
 
+    /**
+     * Creates an owner with a randomly generated name in SCA (Simple Content Access) mode.
+     *
+     * <p>This method generates a random integer, appends it to the name "Test Owner",
+     * and uses it to create a new owner instance. The owner is created in SCA mode
+     * (default for owners) and is persisted in the database.</p>
+     *
+     * @return a newly created and persisted {@code Owner} instance in SCA mode
+     */
     protected Owner createOwner() {
         return this.createOwner("Test Owner " + TestUtil.randomInt());
     }
 
+    /**
+     * Creates an owner with the specified key and a matching name in SCA (Simple Content Access) mode.
+     *
+     * <p>This method creates a new {@code Owner} instance where both the key and name
+     * are set to the provided {@code key} value. The owner is created in SCA mode
+     * (default for owners) and is persisted in the database.</p>
+     *
+     * @param key the key to use for the owner; it will also be used as the owner's name
+     * @return a newly created and persisted {@code Owner} instance in SCA mode
+     */
     protected Owner createOwner(String key) {
         return this.createOwner(key, key);
     }
 
+    /**
+     * Creates an owner with the specified key and name in SCA (Simple Content Access) mode.
+     *
+     * <p>This method initializes an {@code Owner} instance using the provided key and name,
+     * and persists the owner in the database. The owner is created in SCA mode (default for owners).</p>
+     *
+     * @param key the key to assign to the owner
+     * @param name the display name of the owner
+     * @return a newly created and persisted {@code Owner} instance in SCA mode
+     */
     protected Owner createOwner(String key, String name) {
-        Owner owner = TestUtil.createOwner(key, name);
-        owner.setId(null);
+        Owner owner = TestUtil.createOwner(key, name)
+            .setId(null);
 
-        this.ownerCurator.create(owner);
+        return this.ownerCurator.create(owner);
+    }
 
-        return owner;
+    /**
+     * Creates a non-SCA (Simple Content Access) owner with the specified key.
+     *
+     * <p>This method creates a new {@code Owner} instance in entitlement mode, where
+     * both the key and name are set to the provided {@code key} value. The owner is persisted
+     * in the database.</p>
+     *
+     * @param key the key to use for the owner; it will also be used as the owner's name
+     * @return a newly created and persisted {@code Owner} instance in entitlement mode
+     */
+    protected Owner createNonSCAOwner(String key) {
+        return this.createNonSCAOwner(key, key);
+    }
+
+    /**
+     * Creates a non-SCA (Simple Content Access) owner with the specified key and name.
+     *
+     * <p>This method initializes an {@code Owner} instance with the provided key and name,
+     * sets the content access mode to entitlement mode, and persists the owner in the database.</p>
+     *
+     * @param key the key to assign to the owner
+     * @param name the display name of the owner
+     * @return a newly created and persisted {@code Owner} instance in entitlement mode
+     */
+    protected Owner createNonSCAOwner(String key, String name) {
+        Owner owner = TestUtil.createOwner(key, name)
+            .setId(null)
+            .setContentAccessMode(ContentAccessMode.ENTITLEMENT.toDatabaseValue());
+
+        return this.ownerCurator.create(owner);
     }
 
     /**


### PR DESCRIPTION
- In SCA mode, manual attachment of subscriptions was no longer needed. Auto-attachment had already been disabled at the Candlepin and Satellite (6.9+) levels. Only manifest consumers ('candlepin' or 'satellite' types) were allowed to attach entitlements to ensure manifest generation continued to function properly.