### PR TITLE
[M] CANDLEPIN-978: Removed extranous null check during consumer check in

### DIFF
--- a/src/main/java/org/candlepin/controller/ConsumerManager.java
+++ b/src/main/java/org/candlepin/controller/ConsumerManager.java
@@ -16,6 +16,7 @@
 package org.candlepin.controller;
 
 import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerCloudData;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.service.EventAdapter;
 import org.candlepin.service.model.CloudCheckInEvent;
@@ -63,9 +64,9 @@ public class ConsumerManager {
         consumer.setLastCheckin(new Date());
         consumer = consumerCurator.merge(consumer);
 
-        if (consumer.getConsumerCloudData() != null) {
-            CloudCheckInEvent cloudCheckInEvent =
-                new CloudCheckInEvent(consumer.getConsumerCloudData(), objectMapper);
+        ConsumerCloudData cloudData = consumer.getConsumerCloudData();
+        if (cloudData != null) {
+            CloudCheckInEvent cloudCheckInEvent = new CloudCheckInEvent(cloudData, objectMapper);
             eventAdapter.publish(cloudCheckInEvent);
         }
     }

--- a/src/main/java/org/candlepin/service/model/CloudCheckInEvent.java
+++ b/src/main/java/org/candlepin/service/model/CloudCheckInEvent.java
@@ -95,15 +95,10 @@ public class CloudCheckInEvent implements AdapterEvent {
             throw new IllegalStateException("cloud provider shortname is null or blank");
         }
 
-        String cloudAccountId = cloudData.getCloudAccountId();
-        if (cloudAccountId == null || cloudAccountId.isBlank()) {
-            throw new IllegalStateException("cloud account ID is null or blank");
-        }
-
         this.consumerUuid = consumerUuid;
         this.checkIn = checkIn;
         this.cloudProviderId = cloudProviderId;
-        this.cloudAccountId = cloudAccountId;
+        this.cloudAccountId = cloudData.getCloudAccountId();
         this.cloudOfferingIds = cloudData.getCloudOfferingIds();
 
         try {

--- a/src/test/java/org/candlepin/service/model/CloudCheckInEventTest.java
+++ b/src/test/java/org/candlepin/service/model/CloudCheckInEventTest.java
@@ -123,13 +123,13 @@ public class CloudCheckInEventTest {
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
     @NullAndEmptySource
-    public void testConstructorWithInvalidCloudAccountId(String accountId) {
+    public void testConstructorWithNullOrEmptyCloudAccountId(String accountId) {
         ConsumerCloudData cloudData = createCloudData()
             .setCloudAccountId(accountId);
 
-        assertThrows(IllegalStateException.class, () -> {
-            new CloudCheckInEvent(cloudData, mapper);
-        });
+        CloudCheckInEvent event = new CloudCheckInEvent(cloudData, mapper);
+
+        // No exception is expected to be thrown
     }
 
     @Test


### PR DESCRIPTION
- Removed an extraneous null/empty check on consumer cloud data while generating the cloud consumer check in event during any consumer check-in operation