### PR TITLE
CANDLEPIN-930: Created the POST /hypervisors/{owner}/guests endpoint

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -4059,6 +4059,57 @@ paths:
         default:
           $ref: '#/components/responses/default'
 
+  /hypervisors/{owner}/guests:
+    # Note that we had to use the POST verb instead of the GET verb here because we need to provide a list of
+    # consumer UUIDs in the body of the request, but OpenAPI 3.0 does not allow a body of a GET request.
+    post:
+      tags:
+        - hypervisors
+      description: |
+        Retrieves the latest hypervisor host information for the provided list of guest consumer UUIDs. If a
+        guest is mapped to multiple hypervisor host consumers, then the most recent host will be returned.
+        This endpoint accounts for case sensitivity and endianness differences in the guest virtual UUID that 
+        is returned by different hypervisors.
+      operationId: getHypervisorsAndGuests
+      parameters:
+        - name: owner
+          in: path
+          description: Owner key
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: |
+          Contains the list of guest Consumer UUIDs to retrieve host information for. Any non-guest
+          Consumer UUIDs that are provided will be ignored.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+      security: []
+      x-java-response:
+        type: java.util.stream.Stream
+        isContainer: true
+      responses:
+        200:
+          description: A successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HypervisorConsumerWithGuestDTO'
+        400:
+          description: |
+            Invalid owner key or the number of provided guest consumer UUIDs exceeds the configured limit.
+        404:
+          description: Owner with provided key was not found.
+        default:
+          $ref: '#/components/responses/default'
+
   /hypervisors/{owner}/heartbeat:
     put:
       tags:
@@ -9502,6 +9553,17 @@ components:
           uniqueItems: true
           items:
             type: string
+
+    HypervisorConsumerWithGuestDTO:
+      properties:
+        hypervisorConsumerUuid:
+          type: string
+        hypervisorConsumerName:
+          type: string
+        guestUuid:
+          type: string
+        guestId:
+          type: string
 
     ImportRecordDTO:
       description: Represents a import record details

--- a/spec-tests/src/test/java/org/candlepin/spec/hypervisors/HypervisorResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/hypervisors/HypervisorResourceSpecTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.hypervisors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertBadRequest;
+
+import org.candlepin.dto.api.client.v1.ConsumerDTO;
+import org.candlepin.dto.api.client.v1.GuestIdDTO;
+import org.candlepin.dto.api.client.v1.HypervisorConsumerWithGuestDTO;
+import org.candlepin.dto.api.client.v1.OwnerDTO;
+import org.candlepin.spec.bootstrap.client.ApiClient;
+import org.candlepin.spec.bootstrap.client.ApiClients;
+import org.candlepin.spec.bootstrap.client.SpecTest;
+import org.candlepin.spec.bootstrap.data.builder.Consumers;
+import org.candlepin.spec.bootstrap.data.builder.Facts;
+import org.candlepin.spec.bootstrap.data.builder.Owners;
+import org.candlepin.spec.bootstrap.data.util.StringUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@SpecTest
+public class HypervisorResourceSpecTest {
+
+    private static final int MAX_CONSUMER_UUIDS = 1000;
+
+    @Test
+    public void shouldNotRetrieveHypervisorsAndGuestsWithExceedingTheConsumerUuidLimit() {
+        ApiClient admin = ApiClients.admin();
+        OwnerDTO owner = admin.owners().createOwner(Owners.random());
+
+        List<String> consumerUuids = new ArrayList<>();
+        for (int i = 0; i < MAX_CONSUMER_UUIDS + 1; i++) {
+            consumerUuids.add(StringUtil.random("consumer-uuid-"));
+        }
+
+        assertBadRequest(() -> admin.hypervisors()
+            .getHypervisorsAndGuests(owner.getKey(), consumerUuids));
+    }
+
+    @Test
+    public void shouldRetrieveHypervisorsAndGuestsWithUnknownConsumerUuid() {
+        ApiClient admin = ApiClients.admin();
+        OwnerDTO owner = admin.owners().createOwner(Owners.random());
+
+        ConsumerDTO host = admin.consumers().createConsumer(Consumers.random(owner));
+        String guestVirtUuid = StringUtil.random("guest-virt-uuid-");
+        ConsumerDTO guest = createGuest(admin, owner, guestVirtUuid);
+        linkHostToGuests(admin, host, guestVirtUuid);
+
+        HypervisorConsumerWithGuestDTO expected = new HypervisorConsumerWithGuestDTO()
+            .hypervisorConsumerName(host.getName())
+            .hypervisorConsumerUuid(host.getUuid())
+            .guestId(guestVirtUuid)
+            .guestUuid(guest.getUuid());
+
+        List<HypervisorConsumerWithGuestDTO> actual = admin.hypervisors()
+            .getHypervisorsAndGuests(owner.getKey(), List.of(guest.getUuid(), StringUtil.random("unknown-")));
+
+        assertThat(actual)
+            .isNotNull()
+            .singleElement()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRetrieveHypervisorsAndGuestsWithUnknownOwner() {
+        ApiClient admin = ApiClients.admin();
+        OwnerDTO owner1 = admin.owners().createOwner(Owners.random());
+        OwnerDTO owner2 = admin.owners().createOwner(Owners.random());
+
+        ConsumerDTO host = admin.consumers().createConsumer(Consumers.random(owner1));
+        String guestVirtUuid = StringUtil.random("guest-virt-uuid-");
+        ConsumerDTO guest = createGuest(admin, owner1, guestVirtUuid);
+        linkHostToGuests(admin, host, guestVirtUuid);
+
+        List<HypervisorConsumerWithGuestDTO> actual = admin.hypervisors()
+            .getHypervisorsAndGuests(owner2.getKey(), List.of(guest.getUuid()));
+
+        assertThat(actual)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    public void shouldIgnoreHostUuidWhenRetrievingHypervisorsAndGuests() {
+        ApiClient admin = ApiClients.admin();
+        OwnerDTO owner = admin.owners().createOwner(Owners.random());
+
+        ConsumerDTO host = admin.consumers().createConsumer(Consumers.random(owner));
+        String guestVirtUuid = StringUtil.random("guest-virt-uuid-");
+        ConsumerDTO guest = createGuest(admin, owner, guestVirtUuid);
+        linkHostToGuests(admin, host, guestVirtUuid);
+
+        HypervisorConsumerWithGuestDTO expected = new HypervisorConsumerWithGuestDTO()
+            .hypervisorConsumerName(host.getName())
+            .hypervisorConsumerUuid(host.getUuid())
+            .guestId(guestVirtUuid)
+            .guestUuid(guest.getUuid());
+
+        List<HypervisorConsumerWithGuestDTO> actual = admin.hypervisors()
+            .getHypervisorsAndGuests(owner.getKey(), List.of(guest.getUuid(), host.getUuid()));
+
+        assertThat(actual)
+            .isNotNull()
+            .singleElement()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRetrieveHypervisorsAndGuestsWithUuidCaseDifferences() {
+        ApiClient admin = ApiClients.admin();
+        OwnerDTO owner = admin.owners().createOwner(Owners.random());
+
+        ConsumerDTO host = admin.consumers().createConsumer(Consumers.random(owner));
+        String guestVirtUuid = StringUtil.random("guest-virt-uuid-");
+        ConsumerDTO guest = createGuest(admin, owner, guestVirtUuid);
+        linkHostToGuests(admin, host, guestVirtUuid.toUpperCase());
+
+        HypervisorConsumerWithGuestDTO expected = new HypervisorConsumerWithGuestDTO()
+            .hypervisorConsumerName(host.getName())
+            .hypervisorConsumerUuid(host.getUuid())
+            .guestId(guestVirtUuid)
+            .guestUuid(guest.getUuid());
+
+        List<HypervisorConsumerWithGuestDTO> actual = admin.hypervisors()
+            .getHypervisorsAndGuests(owner.getKey(), List.of(guest.getUuid()));
+
+        assertThat(actual)
+            .isNotNull()
+            .singleElement()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRetrieveHypervisorsAndGuestsWithReverseEndianness() {
+        ApiClient admin = ApiClients.admin();
+        OwnerDTO owner = admin.owners().createOwner(Owners.random());
+
+        ConsumerDTO host = admin.consumers().createConsumer(Consumers.random(owner));
+        String guestVirtUuid = "78d7e200-b7d6-4cfe-b7a9-5700e8094df3";
+        ConsumerDTO guest = createGuest(admin, owner, guestVirtUuid);
+        // virt-uuid has reversed-endianness in the first 3 sections
+        linkHostToGuests(admin, host, "00e2d778-d6b7-fe4c-b7a9-5700e8094df3");
+
+        HypervisorConsumerWithGuestDTO expected = new HypervisorConsumerWithGuestDTO()
+            .hypervisorConsumerName(host.getName())
+            .hypervisorConsumerUuid(host.getUuid())
+            .guestId(guestVirtUuid)
+            .guestUuid(guest.getUuid());
+
+        List<HypervisorConsumerWithGuestDTO> actual = admin.hypervisors()
+            .getHypervisorsAndGuests(owner.getKey(), List.of(guest.getUuid()));
+
+        assertThat(actual)
+            .isNotNull()
+            .singleElement()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRetrieveMostRecentHypervisorAndGuest() throws Exception {
+        ApiClient admin = ApiClients.admin();
+        OwnerDTO owner = admin.owners().createOwner(Owners.random());
+
+        ConsumerDTO oldHost = admin.consumers().createConsumer(Consumers.random(owner));
+        ConsumerDTO newHost = admin.consumers().createConsumer(Consumers.random(owner));
+
+        String guestVirtUuid = StringUtil.random("guest-virt-uuid-");
+        ConsumerDTO guest = createGuest(admin, owner, guestVirtUuid);
+        linkHostToGuests(admin, oldHost, guestVirtUuid);
+
+        Thread.sleep(1000);
+
+        linkHostToGuests(admin, newHost, guestVirtUuid);
+
+        HypervisorConsumerWithGuestDTO expected = new HypervisorConsumerWithGuestDTO()
+            .hypervisorConsumerName(newHost.getName())
+            .hypervisorConsumerUuid(newHost.getUuid())
+            .guestId(guestVirtUuid)
+            .guestUuid(guest.getUuid());
+
+        List<HypervisorConsumerWithGuestDTO> actual = admin.hypervisors()
+            .getHypervisorsAndGuests(owner.getKey(), List.of(guest.getUuid()));
+
+        assertThat(actual)
+            .isNotNull()
+            .singleElement()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRetrieveHypervisorsAndGuests() {
+        ApiClient admin = ApiClients.admin();
+        OwnerDTO owner = admin.owners().createOwner(Owners.random());
+
+        ConsumerDTO host1 = admin.consumers().createConsumer(Consumers.random(owner));
+        String host1Guest1VirtUuid = StringUtil.random("host1-guest1-virt-uuid-");
+        String host1Guest2VirtUuid = StringUtil.random("host1-guest2-virt-uuid-");
+        ConsumerDTO host1Guest1 = createGuest(admin, owner, host1Guest1VirtUuid);
+        ConsumerDTO host1Guest2 = createGuest(admin, owner, host1Guest2VirtUuid);
+        linkHostToGuests(admin, host1, host1Guest1VirtUuid, host1Guest2VirtUuid);
+
+        ConsumerDTO host2 = admin.consumers().createConsumer(Consumers.random(owner));
+        String host2Guest1VirtUuid = StringUtil.random("host2-guest1-virt-uuid-");
+        String host2Guest2VirtUuid = StringUtil.random("host2-guest2-virt-uuid-");
+        ConsumerDTO host2Guest1 = createGuest(admin, owner, host2Guest1VirtUuid);
+        ConsumerDTO host2Guest2 = createGuest(admin, owner, host2Guest2VirtUuid);
+        linkHostToGuests(admin, host2, host2Guest1VirtUuid, host2Guest2VirtUuid);
+
+        HypervisorConsumerWithGuestDTO expected1 = new HypervisorConsumerWithGuestDTO()
+            .hypervisorConsumerName(host1.getName())
+            .hypervisorConsumerUuid(host1.getUuid())
+            .guestId(host1Guest1VirtUuid)
+            .guestUuid(host1Guest1.getUuid());
+        HypervisorConsumerWithGuestDTO expected2 = new HypervisorConsumerWithGuestDTO()
+            .hypervisorConsumerName(host1.getName())
+            .hypervisorConsumerUuid(host1.getUuid())
+            .guestId(host1Guest2VirtUuid)
+            .guestUuid(host1Guest2.getUuid());
+        HypervisorConsumerWithGuestDTO expected3 = new HypervisorConsumerWithGuestDTO()
+            .hypervisorConsumerName(host2.getName())
+            .hypervisorConsumerUuid(host2.getUuid())
+            .guestId(host2Guest1VirtUuid)
+            .guestUuid(host2Guest1.getUuid());
+        HypervisorConsumerWithGuestDTO expected4 = new HypervisorConsumerWithGuestDTO()
+            .hypervisorConsumerName(host2.getName())
+            .hypervisorConsumerUuid(host2.getUuid())
+            .guestId(host2Guest2VirtUuid)
+            .guestUuid(host2Guest2.getUuid());
+
+        // The hosts should be ignored.
+        List<String> body =  List.of(host1Guest1.getUuid(),
+            host1Guest2.getUuid(),
+            host2Guest1.getUuid(),
+            host2Guest2.getUuid());
+
+        List<HypervisorConsumerWithGuestDTO> actual = admin.hypervisors()
+            .getHypervisorsAndGuests(owner.getKey(), body);
+
+        assertThat(actual)
+            .isNotNull()
+            .hasSize(4)
+            .containsExactlyInAnyOrder(expected1, expected2, expected3, expected4);
+    }
+
+    private ConsumerDTO createGuest(ApiClient client, OwnerDTO owner, String virtUuid) {
+        return client.consumers().createConsumer(Consumers.random(owner).facts(Map.ofEntries(
+            Facts.VirtUuid.withValue(virtUuid),
+            Facts.VirtIsGuest.withValue("true"),
+            Facts.Arch.withValue("x86_64")
+        )));
+    }
+
+    private void linkHostToGuests(ApiClient client, ConsumerDTO host, Collection<String> virtUuids) {
+        List<GuestIdDTO> guestIds = virtUuids.stream()
+            .map(this::toGuestId)
+            .collect(Collectors.toList());
+
+        linkHostToGuests(client, host, guestIds);
+    }
+
+    private void linkHostToGuests(ApiClient client, ConsumerDTO host, String... virtUuid) {
+        List<GuestIdDTO> guestIds = Arrays.stream(virtUuid)
+            .map(this::toGuestId)
+            .collect(Collectors.toList());
+
+        linkHostToGuests(client, host, guestIds);
+    }
+
+    private void linkHostToGuests(ApiClient client, ConsumerDTO host, List<GuestIdDTO> guestIds) {
+        client.consumers()
+            .updateConsumer(host.getUuid(), host.guestIds(guestIds));
+    }
+
+    private GuestIdDTO toGuestId(String guestId) {
+        return new GuestIdDTO()
+            .guestId(guestId);
+    }
+
+}

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -308,6 +308,9 @@ public class ConfigProperties {
     /** The list of content fields which cannot be overridden, comma delimited; defaults to "baseurl" */
     public static final String CONTENT_OVERRIDE_BLOCKLIST = "candlepin.content.overrides.blocklist";
 
+    public static final String HYPERVISORS_AND_GUEST_RETRIEVAL_LIMIT
+        = "candlepin.hypervisors_and_guests.retrieval_limit";
+
     /**
      * Fetches a string representing the prefix for all per-job configuration for the specified job.
      * The job key or class name may be used, but the usage must be consistent.
@@ -562,6 +565,8 @@ public class ConfigProperties {
             this.put(DatabaseConfigFactory.QUERY_PARAMETER_LIMIT, "32000");
 
             this.put(CONTENT_OVERRIDE_BLOCKLIST, "");
+
+            this.put(HYPERVISORS_AND_GUEST_RETRIEVAL_LIMIT, "1000");
         }
     };
 
@@ -584,6 +589,9 @@ public class ConfigProperties {
                 .min(1));
 
             this.add(new StringConfigurationValidator(DB_DRIVER_CLASS));
+
+            this.add(new IntegerConfigurationValidator(HYPERVISORS_AND_GUEST_RETRIEVAL_LIMIT)
+                .min(1));
         }
     };
 }

--- a/src/main/java/org/candlepin/dto/StandardTranslator.java
+++ b/src/main/java/org/candlepin/dto/StandardTranslator.java
@@ -31,6 +31,7 @@ import org.candlepin.dto.api.server.v1.EnvironmentDTO;
 import org.candlepin.dto.api.server.v1.GuestIdDTO;
 import org.candlepin.dto.api.server.v1.GuestIdDTOArrayElement;
 import org.candlepin.dto.api.server.v1.HypervisorConsumerDTO;
+import org.candlepin.dto.api.server.v1.HypervisorConsumerWithGuestDTO;
 import org.candlepin.dto.api.server.v1.HypervisorIdDTO;
 import org.candlepin.dto.api.server.v1.ImportRecordDTO;
 import org.candlepin.dto.api.server.v1.ImportUpstreamConsumerDTO;
@@ -63,6 +64,7 @@ import org.candlepin.dto.api.v1.EnvironmentTranslator;
 import org.candlepin.dto.api.v1.GuestIdArrayElementTranslator;
 import org.candlepin.dto.api.v1.GuestIdTranslator;
 import org.candlepin.dto.api.v1.HypervisorConsumerTranslator;
+import org.candlepin.dto.api.v1.HypervisorConsumerWithGuestTranslator;
 import org.candlepin.dto.api.v1.HypervisorIdTranslator;
 import org.candlepin.dto.api.v1.ImportRecordTranslator;
 import org.candlepin.dto.api.v1.ImportUpstreamConsumerTranslator;
@@ -106,6 +108,7 @@ import org.candlepin.model.Entitlement;
 import org.candlepin.model.Environment;
 import org.candlepin.model.EnvironmentCurator;
 import org.candlepin.model.GuestId;
+import org.candlepin.model.HypervisorConsumerWithGuest;
 import org.candlepin.model.HypervisorId;
 import org.candlepin.model.ImportRecord;
 import org.candlepin.model.ImportUpstreamConsumer;
@@ -255,6 +258,8 @@ public class StandardTranslator extends SimpleModelTranslator {
             new UserTranslator(), User.class, UserDTO.class);
         this.registerTranslator(
             new UserInfoTranslator(), UserInfo.class, UserDTO.class);
+        this.registerTranslator(new HypervisorConsumerWithGuestTranslator(),
+            HypervisorConsumerWithGuest.class, HypervisorConsumerWithGuestDTO.class);
 
         // Manifest import/export translators
         /////////////////////////////////////////////

--- a/src/main/java/org/candlepin/dto/api/v1/HypervisorConsumerWithGuestTranslator.java
+++ b/src/main/java/org/candlepin/dto/api/v1/HypervisorConsumerWithGuestTranslator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.ObjectTranslator;
+import org.candlepin.dto.api.server.v1.HypervisorConsumerWithGuestDTO;
+import org.candlepin.model.HypervisorConsumerWithGuest;
+
+public class HypervisorConsumerWithGuestTranslator
+    implements ObjectTranslator<HypervisorConsumerWithGuest, HypervisorConsumerWithGuestDTO> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HypervisorConsumerWithGuestDTO translate(HypervisorConsumerWithGuest source) {
+        return this.translate(null, source);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HypervisorConsumerWithGuestDTO translate(ModelTranslator translator,
+        HypervisorConsumerWithGuest source) {
+
+        return source != null ?
+            this.populate(translator, source, new HypervisorConsumerWithGuestDTO()) :
+            null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HypervisorConsumerWithGuestDTO populate(HypervisorConsumerWithGuest source,
+        HypervisorConsumerWithGuestDTO destination) {
+        return this.populate(null, source, destination);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HypervisorConsumerWithGuestDTO populate(ModelTranslator translator,
+        HypervisorConsumerWithGuest source, HypervisorConsumerWithGuestDTO destination) {
+
+        if (source == null) {
+            throw new IllegalArgumentException("source is null");
+        }
+
+        if (destination == null) {
+            throw new IllegalArgumentException("destination is null");
+        }
+
+        destination.setHypervisorConsumerUuid(source.getHypervisorConsumerUuid());
+        destination.setHypervisorConsumerName(source.getHypervisorConsumerName());
+        destination.setGuestUuid(source.getGuestConsumerUuid());
+        destination.setGuestId(source.getGuestId());
+
+        return destination;
+    }
+
+}
+

--- a/src/main/java/org/candlepin/model/HypervisorConsumerWithGuest.java
+++ b/src/main/java/org/candlepin/model/HypervisorConsumerWithGuest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+/**
+ * Internal POJO class for encapsulating a guest {@link Consumer} information with the most recent hypervisor
+ * {@link Consumer} information.
+ */
+public class HypervisorConsumerWithGuest {
+
+    private String hypervisorConsumerUuid;
+    private String hypervisorConsumerName;
+    private String guestConsumerUuid;
+    private String guestId;
+
+    public HypervisorConsumerWithGuest(String hypervisorConsumerUuid, String hypervisorConsumerName,
+        String guestConsumerUuid, String guestId) {
+
+        this.hypervisorConsumerUuid = hypervisorConsumerUuid;
+        this.hypervisorConsumerName = hypervisorConsumerName;
+        this.guestConsumerUuid = guestConsumerUuid;
+        this.guestId = guestId;
+    }
+
+    /**
+     * @return the hypervisor {@link Consumer} UUID
+     */
+    public String getHypervisorConsumerUuid() {
+        return hypervisorConsumerUuid;
+    }
+
+    /**
+     * Sets the hypervisor's {@link Consumer} UUID.
+     *
+     * @param hypervisorConsumerUuid
+     *  the UUID of the hypervisor's consumer
+     *
+     * @return this instance
+     */
+    public HypervisorConsumerWithGuest setHypervisorConsumerUuid(String hypervisorConsumerUuid) {
+        this.hypervisorConsumerUuid = hypervisorConsumerUuid;
+        return this;
+    }
+
+    /**
+     * @return the hypervisor {@link Consumer} name
+     */
+    public String getHypervisorConsumerName() {
+        return hypervisorConsumerName;
+    }
+
+    /**
+     * Sets the hypervisor's {@link Consumer} name.
+     *
+     * @param hypervisorConsumerName
+     *  the name of the hypervisor's consumer
+     *
+     * @return this instance
+     */
+    public HypervisorConsumerWithGuest setHypervisorConsumerName(String hypervisorConsumerName) {
+        this.hypervisorConsumerName = hypervisorConsumerName;
+        return this;
+    }
+
+    /**
+     * @return the guest {@link Consumer} UUID
+     */
+    public String getGuestConsumerUuid() {
+        return guestConsumerUuid;
+    }
+
+    /**
+     * Sets the guest's {@link Consumer} UUID.
+     *
+     * @param guestConsumerUuid
+     *  the UUID of the guest consumer
+     *
+     * @return this instance
+     */
+    public HypervisorConsumerWithGuest setGuestConsumerUuid(String guestConsumerUuid) {
+        this.guestConsumerUuid = guestConsumerUuid;
+        return this;
+    }
+
+    /**
+     * @return the guest ID. This ID is the {@link GuestId} getGuestId value.
+     */
+    public String getGuestId() {
+        return guestId;
+    }
+
+    /**
+     * Sets the guest's ID. This ID is the {@link GuestId} getGuestId value.
+     *
+     * @param guestId
+     *  the ID of the guest
+     *
+     * @return this instance
+     */
+    public HypervisorConsumerWithGuest setGuestId(String guestId) {
+        this.guestId = guestId;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+
+        if (!(object instanceof HypervisorConsumerWithGuest)) {
+            return false;
+        }
+
+        HypervisorConsumerWithGuest other = (HypervisorConsumerWithGuest) object;
+
+        EqualsBuilder builder = new EqualsBuilder()
+            .append(this.getHypervisorConsumerUuid(), other.getHypervisorConsumerUuid())
+            .append(this.getHypervisorConsumerName(), other.getHypervisorConsumerName())
+            .append(this.getGuestConsumerUuid(), other.getGuestConsumerUuid())
+            .append(this.getGuestId(), other.getGuestId());
+
+        return builder.isEquals();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        HashCodeBuilder builder = new HashCodeBuilder(37, 7)
+            .append(this.getHypervisorConsumerUuid())
+            .append(this.getHypervisorConsumerName())
+            .append(this.getGuestConsumerUuid())
+            .append(this.getGuestId());
+
+        return builder.toHashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return String.format("HypervisorConsumerWithGuest [" +
+            "hypervisorConsumerUuid: %s, " +
+            "hypervisorConsumerName: %s, " +
+            "guestUuid: %s, " +
+            "guestId: %s]", hypervisorConsumerUuid, hypervisorConsumerName, guestConsumerUuid, guestId);
+    }
+
+}

--- a/src/test/java/org/candlepin/dto/api/v1/HypervisorConsumerWithGuestTranslatorTest.java
+++ b/src/test/java/org/candlepin/dto/api/v1/HypervisorConsumerWithGuestTranslatorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.dto.api.v1;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.candlepin.dto.AbstractTranslatorTest;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.api.server.v1.HypervisorConsumerWithGuestDTO;
+import org.candlepin.model.HypervisorConsumerWithGuest;
+
+public class HypervisorConsumerWithGuestTranslatorTest extends
+    AbstractTranslatorTest<HypervisorConsumerWithGuest, HypervisorConsumerWithGuestDTO,
+        HypervisorConsumerWithGuestTranslator> {
+
+    private HypervisorConsumerWithGuestTranslator translator = new HypervisorConsumerWithGuestTranslator();
+
+    @Override
+    protected void initModelTranslator(ModelTranslator modelTranslator) {
+        modelTranslator.registerTranslator(translator, HypervisorConsumerWithGuest.class,
+            HypervisorConsumerWithGuestDTO.class);
+    }
+
+    @Override
+    protected HypervisorConsumerWithGuestTranslator initObjectTranslator() {
+        return translator;
+    }
+
+    @Override
+    protected HypervisorConsumerWithGuest initSourceObject() {
+        return new HypervisorConsumerWithGuest("hypervisor-consumer-uuid",
+            "hypervisor-consumer-name",
+            "guest-uuid",
+            "guest-id");
+    }
+
+    @Override
+    protected HypervisorConsumerWithGuestDTO initDestinationObject() {
+        return new HypervisorConsumerWithGuestDTO();
+    }
+
+    @Override
+    protected void verifyOutput(HypervisorConsumerWithGuest source, HypervisorConsumerWithGuestDTO dest,
+        boolean childrenGenerated) {
+        if (source == null) {
+            assertNull(source);
+        }
+
+        assertEquals(source.getHypervisorConsumerUuid(), dest.getHypervisorConsumerUuid());
+        assertEquals(source.getHypervisorConsumerName(), dest.getHypervisorConsumerName());
+        assertEquals(source.getGuestConsumerUuid(), dest.getGuestUuid());
+        assertEquals(source.getGuestId(), dest.getGuestId());
+    }
+
+}
+

--- a/src/test/java/org/candlepin/model/HypervisorConsumerWithGuestTest.java
+++ b/src/test/java/org/candlepin/model/HypervisorConsumerWithGuestTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.Test;
+
+public class HypervisorConsumerWithGuestTest {
+
+    @Test
+    public void testConstructor() {
+        String hypervisorConsumerUuid = "hypervisor-consumer-uuid";
+        String hypervisorConsumerName = "hypervisor-consumer-name";
+        String guestConsumerUuid = "guest-consumer-uuid";
+        String guestId = "guest-id";
+
+        HypervisorConsumerWithGuest actual = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, guestConsumerUuid, guestId);
+
+        assertEquals(hypervisorConsumerUuid, actual.getHypervisorConsumerUuid());
+        assertEquals(hypervisorConsumerName, actual.getHypervisorConsumerName());
+        assertEquals(guestConsumerUuid, actual.getGuestConsumerUuid());
+        assertEquals(guestId, actual.getGuestId());
+    }
+
+    @Test
+    public void testSetHypervisorConsumerUuid() {
+        HypervisorConsumerWithGuest actual = new HypervisorConsumerWithGuest("hypervisor-consumer-uuid",
+            "hypervisor-consumer-name", "guest-consumer-uuid", "guest-id");
+
+        String updatedValue = "updated-value";
+        actual.setHypervisorConsumerUuid(updatedValue);
+
+        assertEquals(updatedValue, actual.getHypervisorConsumerUuid());
+    }
+
+    @Test
+    public void testSetHypervisorConsumerName() {
+        HypervisorConsumerWithGuest actual = new HypervisorConsumerWithGuest("hypervisor-consumer-uuid",
+            "hypervisor-consumer-name", "guest-consumer-uuid", "guest-id");
+
+        String updatedValue = "updated-value";
+        actual.setHypervisorConsumerName(updatedValue);
+
+        assertEquals(updatedValue, actual.getHypervisorConsumerName());
+    }
+
+    @Test
+    public void testSetGuestConsumerUuid() {
+        HypervisorConsumerWithGuest actual = new HypervisorConsumerWithGuest("hypervisor-consumer-uuid",
+            "hypervisor-consumer-name", "guest-consumer-uuid", "guest-id");
+
+        String updatedValue = "updated-value";
+        actual.setGuestConsumerUuid(updatedValue);
+
+        assertEquals(updatedValue, actual.getGuestConsumerUuid());
+    }
+
+    @Test
+    public void testSetGuestId() {
+        HypervisorConsumerWithGuest actual = new HypervisorConsumerWithGuest("hypervisor-consumer-uuid",
+            "hypervisor-consumer-name", "guest-consumer-uuid", "guest-id");
+
+        String updatedValue = "updated-value";
+        actual.setGuestId(updatedValue);
+
+        assertEquals(updatedValue, actual.getGuestId());
+    }
+
+    @Test
+    public void testEqualsWithSameInstance() {
+        HypervisorConsumerWithGuest actual = new HypervisorConsumerWithGuest("hypervisor-consumer-uuid",
+            "hypervisor-consumer-name", "guest-consumer-uuid", "guest-id");
+
+        assertTrue(actual.equals(actual));
+    }
+
+    @Test
+    public void testEqualsWithDifferentClass() {
+        HypervisorConsumerWithGuest actual = new HypervisorConsumerWithGuest("hypervisor-consumer-uuid",
+            "hypervisor-consumer-name", "guest-consumer-uuid", "guest-id");
+
+        assertFalse(actual.equals(TestUtil.randomString()));
+    }
+
+    @Test
+    public void testEqualsWithDifferentHypervisorConsumerUuid() {
+        String hypervisorConsumerUuid = "hypervisor-consumer-uuid";
+        String hypervisorConsumerName = "hypervisor-consumer-name";
+        String guestConsumerUuid = "guest-consumer-uuid";
+        String guestId = "guest-consumer-uuid";
+
+        HypervisorConsumerWithGuest obj1 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, guestConsumerUuid, guestId);
+
+        HypervisorConsumerWithGuest obj2 = new HypervisorConsumerWithGuest("different",
+            hypervisorConsumerName, guestConsumerUuid, guestId);
+
+        assertFalse(obj1.equals(obj2));
+    }
+
+    @Test
+    public void testEqualsWithDifferentHypervisorConsumerName() {
+        String hypervisorConsumerUuid = "hypervisor-consumer-uuid";
+        String hypervisorConsumerName = "hypervisor-consumer-name";
+        String guestConsumerUuid = "guest-consumer-uuid";
+        String guestId = "guest-consumer-uuid";
+
+        HypervisorConsumerWithGuest obj1 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, guestConsumerUuid, guestId);
+
+        HypervisorConsumerWithGuest obj2 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            "different", guestConsumerUuid, guestId);
+
+        assertFalse(obj1.equals(obj2));
+    }
+
+    @Test
+    public void testEqualsWithDifferentGuestConsumerUuid() {
+        String hypervisorConsumerUuid = "hypervisor-consumer-uuid";
+        String hypervisorConsumerName = "hypervisor-consumer-name";
+        String guestConsumerUuid = "guest-consumer-uuid";
+        String guestId = "guest-consumer-uuid";
+
+        HypervisorConsumerWithGuest obj1 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, guestConsumerUuid, guestId);
+
+        HypervisorConsumerWithGuest obj2 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, "different", guestId);
+
+        assertFalse(obj1.equals(obj2));
+    }
+
+    @Test
+    public void testEqualsWithDifferentGuestId() {
+        String hypervisorConsumerUuid = "hypervisor-consumer-uuid";
+        String hypervisorConsumerName = "hypervisor-consumer-name";
+        String guestConsumerUuid = "guest-consumer-uuid";
+        String guestId = "guest-consumer-uuid";
+
+        HypervisorConsumerWithGuest obj1 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, guestConsumerUuid, guestId);
+
+        HypervisorConsumerWithGuest obj2 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, guestConsumerUuid, "different");
+
+        assertFalse(obj1.equals(obj2));
+    }
+
+    @Test
+    public void testEquals() {
+        String hypervisorConsumerUuid = "hypervisor-consumer-uuid";
+        String hypervisorConsumerName = "hypervisor-consumer-name";
+        String guestConsumerUuid = "guest-consumer-uuid";
+        String guestId = "guest-consumer-uuid";
+
+        HypervisorConsumerWithGuest obj1 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, guestConsumerUuid, guestId);
+
+        HypervisorConsumerWithGuest obj2 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, guestConsumerUuid, guestId);
+
+        assertTrue(obj1.equals(obj2));
+    }
+
+    @Test
+    public void testHashCode() {
+        String hypervisorConsumerUuid = "hypervisor-consumer-uuid";
+        String hypervisorConsumerName = "hypervisor-consumer-name";
+        String guestConsumerUuid = "guest-consumer-uuid";
+        String guestId = "guest-consumer-uuid";
+
+        HypervisorConsumerWithGuest obj1 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, guestConsumerUuid, guestId);
+
+        HypervisorConsumerWithGuest obj2 = new HypervisorConsumerWithGuest(hypervisorConsumerUuid,
+            hypervisorConsumerName, guestConsumerUuid, guestId);
+
+        assertEquals(obj1.hashCode(), obj2.hashCode());
+    }
+
+}
+

--- a/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
+++ b/src/test/java/org/candlepin/resource/HypervisorResourceTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2009 - 2024 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+
+import org.candlepin.async.JobManager;
+import org.candlepin.config.ConfigProperties;
+import org.candlepin.config.Configuration;
+import org.candlepin.dto.api.server.v1.HypervisorConsumerWithGuestDTO;
+import org.candlepin.exceptions.BadRequestException;
+import org.candlepin.guice.PrincipalProvider;
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.HypervisorConsumerWithGuest;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.resource.util.GuestMigration;
+import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestUtil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.xnap.commons.i18n.I18n;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.inject.Provider;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class HypervisorResourceTest extends DatabaseTestFixture {
+
+    private static final int MAX_CONSUMER_UUIDS = 10;
+
+    @Mock
+    private ConsumerResource consumerResource;
+    @Mock
+    private ConsumerCurator consumerCurator;
+    @Mock
+    private ConsumerTypeCurator consumerTypeCurator;
+    @Mock
+    private I18n i18n;
+    @Mock
+    private OwnerCurator ownerCurator;
+    @Mock
+    private Provider<GuestMigration> migrationProvider;
+    @Mock
+    private JobManager jobManager;
+    @Mock
+    private PrincipalProvider principalProvider;
+    @Mock
+    private ObjectMapper mapper;
+    @Mock
+    private Configuration config;
+
+    private HypervisorResource hypervisorResource;
+
+    private Owner owner;
+    private String ownerKey;
+
+    @BeforeEach
+    private void beforeEach() {
+        hypervisorResource = new HypervisorResource(this.consumerResource,
+            this.consumerCurator,
+            this.consumerTypeCurator,
+            this.i18n,
+            this.ownerCurator,
+            this.migrationProvider,
+            this.modelTranslator,
+            this.jobManager,
+            this.principalProvider,
+            this.mapper,
+            this.config);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testGetHypervisorsAndGuestsWithInvalidOwnerKey(String invalidKey) {
+        assertThrows(BadRequestException.class, () -> {
+            hypervisorResource.getHypervisorsAndGuests(invalidKey, List.of("uuid"));
+        });
+    }
+
+    @Test
+    public void testGetHypervisorsAndGuestsWithExceedingTheRetrievalLimit() {
+        doReturn(MAX_CONSUMER_UUIDS).when(config)
+            .getInt(ConfigProperties.HYPERVISORS_AND_GUEST_RETRIEVAL_LIMIT);
+
+        List<String> consumerUuids = new ArrayList<>();
+        for (int i = 0; i < MAX_CONSUMER_UUIDS + 1; i++) {
+            consumerUuids.add(TestUtil.randomString());
+        }
+
+        assertThrows(BadRequestException.class, () -> {
+            hypervisorResource.getHypervisorsAndGuests("owner-key", consumerUuids);
+        });
+    }
+
+    @Test
+    public void testGetHypervisorsAndGuests() {
+        doReturn(MAX_CONSUMER_UUIDS).when(config)
+            .getInt(ConfigProperties.HYPERVISORS_AND_GUEST_RETRIEVAL_LIMIT);
+
+        ownerKey = TestUtil.randomString("owner-key-");
+        owner = new Owner()
+            .setId(TestUtil.randomString("id-"))
+            .setKey(ownerKey);
+
+        doReturn(owner).when(ownerCurator).getByKey(ownerKey);
+
+        List<String> consumerUuids = List.of("consumer-uuid-1", "consumer-uuid-2");
+
+        String h1GuestId = TestUtil.randomString("host-1-guest-id-");
+        String h1GuestUuid = TestUtil.randomString("host-1-guest-uuid-");
+        String h1HostName = TestUtil.randomString("host-1-host-name-");
+        String h1HostUuid = TestUtil.randomString("host-1-host-uuid-");
+        HypervisorConsumerWithGuest hostGuest1 = new HypervisorConsumerWithGuest(h1HostUuid, h1HostName,
+            h1GuestUuid, h1GuestId);
+
+        String h2GuestId = TestUtil.randomString("host-2-guest-id-");
+        String h2GuestUuid = TestUtil.randomString("host-2-guest-uuid-");
+        String h2HostName = TestUtil.randomString("host-2-host-name-");
+        String h2HostUuid = TestUtil.randomString("host-2-host-uuid-");
+        HypervisorConsumerWithGuest hostGuest2 = new HypervisorConsumerWithGuest(h2HostUuid, h2HostName,
+            h2GuestUuid, h2GuestId);
+
+        doReturn(List.of(hostGuest1, hostGuest2)).when(consumerCurator)
+            .getHypervisorConsumersWithGuests(consumerUuids, owner.getOwnerId());
+
+        Stream<HypervisorConsumerWithGuestDTO> actual = hypervisorResource
+            .getHypervisorsAndGuests(ownerKey, consumerUuids);
+
+        List<HypervisorConsumerWithGuestDTO> expected = List.of(hostGuest1, hostGuest2)
+            .stream()
+            .map(this.modelTranslator.getStreamMapper(HypervisorConsumerWithGuest.class,
+                HypervisorConsumerWithGuestDTO.class))
+            .toList();
+
+        assertThat(actual)
+            .isNotNull()
+            .containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+}


### PR DESCRIPTION
- Created the POST /hypervisors/{owner}/guests endpoint for retrieving the most recent hypervisor host consumer information for a list of provided guest consumer UUIDs.

# Notes on the changes

## Endpoint definition

Unfortunately we could not use the GET verb for this endpoint definition because OpenApi 3.0 does not allow for a request body for GET requests. So, the generated client will not send a body for this endpoint if it uses the GET verb.

Quote from the following link:

> GET, DELETE and HEAD are no longer allowed to have request body because it does not have defined semantics as per [RFC 7231](https://tools.ietf.org/html/rfc7231#section-4.3).

https://swagger.io/docs/specification/v3_0/describing-request-body/describing-request-body/

## Performance

To get an idea of performance, I created a spec test to create 1000 guest consumers that mapped to 1 host consumer each, and then made a request to the endpoint with all 1000 consumer UUIDs. I got the following total request response times:
- 635 ms
- 591 ms

The performance spec test:
```Java
    @Test
    public void perf() {
        ApiClient admin = ApiClients.admin();
        OwnerDTO owner = admin.owners().createOwner(Owners.random());

        List<String> consumerUuids = new ArrayList<>();

        for (int i = 0; i < 1000; i++) {
            ConsumerDTO host = admin.consumers().createConsumer(Consumers.random(owner)
                .name(StringUtil.random("host-" + i + "-")));

            String guestVirtUuid = StringUtil.random("host-" + i + "-guest-virt-uuid-");
            ConsumerDTO guest = createGuest(admin, owner, guestVirtUuid);

            consumerUuids.add(guest.getUuid());
            linkHostToGuests(admin, host, guestVirtUuid);
        }

        List<HypervisorConsumerWithGuestDTO> actual = admin.hypervisors()
            .getHypervisorsAndGuests(owner.getKey(), consumerUuids);

        assertThat(actual)
            .isNotNull()
            .hasSize(1000);
    }
```