### PR TITLE
[M] CANDLEPIN-980: Updated RHEL dependency from pki-servlet-engine to tomcat

### DIFF
--- a/candlepin.spec.tmpl
+++ b/candlepin.spec.tmpl
@@ -45,11 +45,7 @@ BuildRequires: selinux-policy-doc
 Requires: java-17 >= 1:17.0.0
 Requires: wget
 # TODO: remove the version restriction on Tomcat once CP supports the Java EE namespace changes
-%if 0%{?fedora} || 0%{?rhel} >= 9
 Requires: tomcat < 1:10.0.0
-%else
-Requires: pki-servlet-engine
-%endif
 Requires: javapackages-tools
 
 %description


### PR DESCRIPTION
- Re-introduced the 'tomcat' package on all supported RHELs(RHEL8 and RHEL9) and deprecated 'pki-servlet-engine'.