### PR TITLE
[M] CANDLEPIN-987: Fixed data importer

### DIFF
--- a/bin/deployment/test_data_importer.py
+++ b/bin/deployment/test_data_importer.py
@@ -727,9 +727,13 @@ def create_activation_keys(cp, owners):
     activation_keys = []
 
     # Build a set of activation key data to use to generate our keys
-    for owner_key in owners:
+    for owner_key, owner in owners.items():
         activation_keys.append((owner_key, "default_key", None))
         activation_keys.append((owner_key, "awesome_os_pool", None))
+
+        # If owner(organization) is in Entitlement mode skip creating AK with pools
+        if owner["contentAccessMode"] != "entitlement":
+            continue
 
         pools = cp.list_pools(owner_key)
 


### PR DESCRIPTION
- With the changes introduced in CANDLEPIN-277, adding pools to activation keys for SCA organizations was no longer allowed. This broke our test_data_importer.py script, as it attempted to add pools to all organizations without checking their entitlement mode. This commit updated the script to properly handle SCA organizations and avoid adding pools where not permitted.