### PR TITLE
[F] CHAINSAW-356: Added last content update field to environments

### DIFF
--- a/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -399,6 +399,8 @@ public class EnvironmentResource implements EnvironmentApi {
         Set<String> contentIds;
         try {
             contentIds = this.batchCreate(contentToPromote, environment);
+            // TODO: Remove the line below once certificate generation based on the `lastContentUpdate` field
+            // in environments is implemented.
             this.contentAccessManager.syncOwnerLastContentUpdate(environment.getOwner());
         }
         catch (PersistenceException pe) {
@@ -440,6 +442,8 @@ public class EnvironmentResource implements EnvironmentApi {
 
         try {
             this.envContentCurator.bulkDelete(demotedContent.values());
+            // TODO: Remove the line below once certificate generation based on the `lastContentUpdate` field
+            // in environments is implemented.
             this.contentAccessManager.syncOwnerLastContentUpdate(environment.getOwner());
         }
         catch (RollbackException hibernateException) {
@@ -453,6 +457,10 @@ public class EnvironmentResource implements EnvironmentApi {
                 throw hibernateException;
             }
         }
+
+        // Set the environment's last content update time so we can regenerate SCA content payloads for
+        // consumers of this environment
+        environment.syncLastContentUpdate();
 
         // Impl note: Unfortunately, we have to make an additional set here, as the keySet isn't
         // serializable. Attempting to use it causes exceptions.
@@ -692,6 +700,10 @@ public class EnvironmentResource implements EnvironmentApi {
         for (EnvironmentContent envcontent : resolved.values()) {
             env.addEnvironmentContent(envcontent);
         }
+
+        // Set the environment's last content update time so we can regenerate SCA content payloads for
+        // consumers of this environment
+        env.syncLastContentUpdate();
 
         this.envCurator.merge(env);
 

--- a/src/main/resources/db/changelog/20250128162900-add-last-content-update-field.xml
+++ b/src/main/resources/db/changelog/20250128162900-add-last-content-update-field.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="20250128162900-1" author="sbakaj">
+        <addColumn tableName="cp_environment">
+            <column name="last_content_update" type="${timestamp.type}" value="NOW()">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -203,4 +203,5 @@
     <include file="db/changelog/20240920000000-update-cloud-offering-id-column-size.xml"/>
     <include file="db/changelog/20241024154545-revert_product_content_delete_cascades.xml"/>
     <include file="db/changelog/20241029000000-drop-fk-cp-owner.xml"/>
+    <include file="/db/changelog/20250128162900-add-last-content-update-field.xml"/>
 </databaseChangeLog>

--- a/src/test/java/org/candlepin/model/EnvironmentTest.java
+++ b/src/test/java/org/candlepin/model/EnvironmentTest.java
@@ -15,11 +15,19 @@
 package org.candlepin.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.test.TestUtil;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Date;
 
 public class EnvironmentTest {
 
@@ -40,6 +48,86 @@ public class EnvironmentTest {
         Environment environment = new Environment();
 
         assertNull(environment.getOwnerKey());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", "normalPrefix", "abc", "TEST_123"})
+    void testSetContentPrefixValidValues(String prefix) {
+        Environment environment = new Environment();
+
+        environment.setContentPrefix(prefix);
+
+        assertEquals(prefix, environment.getContentPrefix());
+    }
+
+    @Test
+    void testSetContentPrefixMaxLength() {
+        Environment environment = new Environment();
+        String maxLengthPrefix = "a".repeat(Environment.CONTENT_PREFIX_MAX_LENGTH);
+
+        environment.setContentPrefix(maxLengthPrefix);
+
+        assertEquals(maxLengthPrefix, environment.getContentPrefix());
+    }
+
+    @Test
+    void testSetContentPrefixTooLong() {
+        Environment environment = new Environment();
+        String tooLongPrefix = "b".repeat(Environment.CONTENT_PREFIX_MAX_LENGTH + 1);
+
+        assertThrows(IllegalArgumentException.class, () -> environment.setContentPrefix(tooLongPrefix));
+    }
+
+    @Test
+    public void testSetContentPrefixChangesLastContentUpdate() {
+        Environment environment = new Environment();
+        Date before = minusTwoSeconds();
+        environment.setLastContentUpdate(before);
+
+        environment.setContentPrefix("newPrefix");
+        Date after = environment.getLastContentUpdate();
+
+        assertTrue(after.after(before));
+    }
+
+    @Test
+    public void testSetLastContentUpdate() {
+        Environment environment = new Environment();
+        Date date = minusTwoSeconds();
+
+        environment.setLastContentUpdate(date);
+
+        assertEquals(date, environment.getLastContentUpdate());
+    }
+
+    @Test
+    public void testSetLastContentUpdateThrowsExceptionOnNullInput() {
+        Environment environment = new Environment();
+
+        assertThrows(IllegalArgumentException.class, () -> environment.setLastContentUpdate(null));
+    }
+
+    @Test
+    public void testGetLastContentUpdate() {
+        Environment environment = new Environment();
+
+        assertNotNull(environment.getLastContentUpdate());
+    }
+
+    @Test
+    public void testSyncLastContentUpdate() {
+        Environment environment = new Environment();
+        Date before = minusTwoSeconds();
+        environment.setLastContentUpdate(before);
+
+        environment.syncLastContentUpdate();
+
+        assertTrue(before.before(environment.getLastContentUpdate()));
+    }
+
+    private Date minusTwoSeconds() {
+        return new Date(System.currentTimeMillis() - 2000);
     }
 
 }

--- a/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
+++ b/src/test/java/org/candlepin/resource/EnvironmentResourceTest.java
@@ -40,6 +40,7 @@ import org.candlepin.dto.SimpleModelTranslator;
 import org.candlepin.dto.api.server.v1.ConsumerDTO;
 import org.candlepin.dto.api.server.v1.ContentDTO;
 import org.candlepin.dto.api.server.v1.ContentOverrideDTO;
+import org.candlepin.dto.api.server.v1.ContentToPromoteDTO;
 import org.candlepin.dto.api.server.v1.EnvironmentContentDTO;
 import org.candlepin.dto.api.server.v1.EnvironmentDTO;
 import org.candlepin.dto.api.server.v1.NestedOwnerDTO;
@@ -663,6 +664,68 @@ class EnvironmentResourceTest {
         assertEquals("env1", dto.getEnvironments().get(0).getId());
         assertEquals("env3", dto.getEnvironments().get(1).getId());
         assertEquals("env2", dto.getEnvironments().get(2).getId());
+    }
+
+    @Test
+    public void shouldUpdateLastContentFieldOnContentPromote() {
+        Date beforePromote = minusTwoSeconds();
+        Environment env = this.createMockedEnvironment()
+            .setOwner(this.owner)
+            .setLastContentUpdate(beforePromote);
+        ContentToPromoteDTO dto = new ContentToPromoteDTO()
+            .contentId("con-1");
+        Content content = new Content("con-1");
+
+        when(contentCurator.resolveContentId(anyString(), anyString())).thenReturn(content);
+
+        this.environmentResource.promoteContent(env.getId(), List.of(dto), true);
+        Date afterPromote = env.getLastContentUpdate();
+
+        assertThat(beforePromote)
+            .isBefore(afterPromote);
+    }
+
+    @Test
+    public void shouldUpdateLastContentFieldOnContentDemote() {
+        Content content = new Content("con-1");
+        EnvironmentContent enContent = new EnvironmentContent()
+            .setContent(content);
+        Date beforeDemote = minusTwoSeconds();
+        Environment env = this.createMockedEnvironment()
+            .setOwner(this.owner)
+            .setEnvironmentContent(Set.of(enContent))
+            .setLastContentUpdate(beforeDemote);
+
+        when(envContentCurator.getByEnvironmentAndContent(any(), anyString())).thenReturn(enContent);
+
+        this.environmentResource.demoteContent(env.getId(), List.of(content.getId()), true);
+        Date afterDemote = env.getLastContentUpdate();
+
+        assertThat(beforeDemote)
+            .isBefore(afterDemote);
+    }
+
+    @Test
+    public void shouldUpdateLastContentFieldOnContentPrefixChange() {
+        Date beforeUpdate = minusTwoSeconds();
+        Environment env = this.createMockedEnvironment()
+            .setOwner(this.owner)
+            .setContentPrefix("contentPrefix")
+            .setLastContentUpdate(beforeUpdate);
+        EnvironmentDTO dto = new EnvironmentDTO()
+            .contentPrefix("newContentUrl");
+
+        this.environmentResource.updateEnvironment(env.getId(), dto);
+        Date afterUpdate = env.getLastContentUpdate();
+
+        assertThat(env.getContentPrefix())
+            .isEqualTo("newContentUrl");
+        assertThat(beforeUpdate)
+            .isBefore(afterUpdate);
+    }
+
+    private Date minusTwoSeconds() {
+        return new Date(System.currentTimeMillis() - 2000);
     }
 
     private Environment createEnvironment(Owner owner, String id) {


### PR DESCRIPTION
- Updated environments to record the last content update timestamp whenever content was promoted or demoted to an environment, or the environment's prefix was changed. Used this timestamp to determine if the SCA certificate needed regeneration: if the last content update is newer than the certificate’s timestamp, the certificate needs to be regenerated.