### PR TITLE
[F] CHAINSAW-375: Refactored exceptions

### DIFF
--- a/src/main/java/org/candlepin/exceptions/ServiceUnavailableException.java
+++ b/src/main/java/org/candlepin/exceptions/ServiceUnavailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -14,19 +14,73 @@
  */
 package org.candlepin.exceptions;
 
+import java.util.Map;
+
 import javax.ws.rs.core.Response.Status;
 
 
 /**
- * ServiceUnavailableException
- * Represents a Service Unavailable (HTTP 503) error.
+ * ServiceUnavailableException represents an exception that generates a 503 HTTP response status code.
  */
 public class ServiceUnavailableException extends CandlepinException {
+    private static final String RETRY_AFTER_HEADER_KEY = "Retry-After";
+
+    private Integer retryAfter;
+
+    /**
+     * Creates a new service unavailable exception with the provided message.
+     *
+     * @param message
+     *  the message used to create a new service unavailable exception
+     */
     public ServiceUnavailableException(String message) {
         super(Status.SERVICE_UNAVAILABLE, message);
     }
 
+    /**
+     * Creates a service unavailable exception with the provided message and provided throwable cause.
+     *
+     * @param message
+     *  the message used to create a new service unavailable exception
+     *
+     * @param cause
+     * the throwable cause used to create a new service unavailable exception
+     */
     public ServiceUnavailableException(String message, Throwable cause) {
         super(Status.SERVICE_UNAVAILABLE, message, cause);
     }
+
+    /**
+     * Sets the retry after time value used to populate the 'Retry-After' header. If a null value is provided,
+     * the 'Retry-After' header will not be populated in the response. Subsequent calls will overwrite the
+     * previously set value.
+     *
+     * @param retryAfter
+     *  the value to set for the 'Retry-After' header
+     *
+     * @return this too many requests exception instance
+     */
+    public ServiceUnavailableException setRetryAfterTime(Integer retryAfter) {
+        this.retryAfter = retryAfter;
+        return this;
+    }
+
+    /**
+     * @return the value that will be set for the 'Retry-After' header. A null value indicates that the header
+     *  will not be set
+     */
+    public Integer getRetryAfterTime() {
+        return this.retryAfter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, String> headers() {
+        return this.retryAfter == null ?
+            Map.of() :
+            Map.of(RETRY_AFTER_HEADER_KEY, String.valueOf(this.retryAfter));
+    }
+
 }

--- a/src/main/java/org/candlepin/exceptions/TooManyRequestsException.java
+++ b/src/main/java/org/candlepin/exceptions/TooManyRequestsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -12,34 +12,74 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-
 package org.candlepin.exceptions;
 
-import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
+/**
+ * TooManyRequestsException represents an exception that generates a 429 HTTP response status code.
+ */
 public class TooManyRequestsException extends CandlepinException {
-    private final int retryAfterTime;
+    private static final String RETRY_AFTER_HEADER_KEY = "Retry-After";
+
+    private Integer retryAfter;
 
     /**
-     * @param time
-     *      Time in seconds for Retry-After header
+     * Creates a new too many requests exception with the provided message.
+     *
+     * @param message
+     *  the message used to create a new too many requests exception
      */
-    public TooManyRequestsException(int time) {
-        super(Response.Status.TOO_MANY_REQUESTS, "Too many requests. Retry after: " + time + " seconds.");
-        this.retryAfterTime = time;
+    public TooManyRequestsException(String message) {
+        super(Status.TOO_MANY_REQUESTS, message);
     }
 
+    /**
+     * Creates a new too many requests exception with the provided message and provided throwable cause.
+     *
+     * @param message
+     *  the message used to create a new too many requests exception
+     *
+     * @param cause
+     * the throwable cause used to create a new too many requests exception
+     */
+    public TooManyRequestsException(String message, Throwable cause) {
+        super(Status.TOO_MANY_REQUESTS, message, cause);
+    }
+
+    /**
+     * Sets the retry after time value used to populate the 'Retry-After' header. If a null value is provided,
+     * the 'Retry-After' header will not be populated in the response. Subsequent calls will overwrite the
+     * previously set value.
+     *
+     * @param retryAfter
+     *  the value to set for the 'Retry-After' header
+     *
+     * @return this too many requests exception instance
+     */
+    public TooManyRequestsException setRetryAfterTime(Integer retryAfter) {
+        this.retryAfter = retryAfter;
+        return this;
+    }
+
+    /**
+     * @return the value that will be set for the 'Retry-After' header. A null value indicates that the header
+     *  will not be set
+     */
+    public Integer getRetryAfterTime() {
+        return this.retryAfter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Map<String, String> headers() {
-        HashMap<String, String> negHeaders = new HashMap<>();
-        negHeaders.put("Retry-After", String.valueOf(this.retryAfterTime));
-        return  negHeaders;
+        return this.retryAfter == null ?
+            Map.of() :
+            Map.of(RETRY_AFTER_HEADER_KEY, String.valueOf(this.retryAfter));
     }
 
-    public int getRetryAfterTime() {
-        return this.retryAfterTime;
-    }
 }

--- a/src/main/java/org/candlepin/resteasy/filter/SecurityHoleAuthorizationFilter.java
+++ b/src/main/java/org/candlepin/resteasy/filter/SecurityHoleAuthorizationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -116,10 +116,12 @@ public class SecurityHoleAuthorizationFilter extends AbstractAuthorizationFilter
         AnonymousCloudConsumer anonymousCloudConsumer = principal.getAnonymousCloudConsumer();
         String ownerKey = checkCloudAccountOrganization(anonymousCloudConsumer);
         if (!ownerCurator.existsByKey(ownerKey)) {
-            throw new TooManyRequestsException(ORG_NOT_CREATED_IN_CANDLEPIN);
+            throw new TooManyRequestsException(i18nProvider.get().tr("Owner does not yet exist"))
+                .setRetryAfterTime(ORG_NOT_CREATED_IN_CANDLEPIN);
         }
         if (!poolCurator.hasPoolsForProducts(ownerKey, anonymousCloudConsumer.getProductIds())) {
-            throw new TooManyRequestsException(ORG_DOES_NOT_HAVE_POOLS);
+            throw new TooManyRequestsException(i18nProvider.get().tr("Owner is not yet entitled"))
+                .setRetryAfterTime(ORG_DOES_NOT_HAVE_POOLS);
         }
         anonymousCloudConsumer.setOwnerKey(ownerKey);
     }
@@ -132,10 +134,14 @@ public class SecurityHoleAuthorizationFilter extends AbstractAuthorizationFilter
                 anonymousCloudConsumer.getCloudOfferingId());
         }
         catch (OrgForCloudAccountNotCreatedYetException e) {
-            throw new TooManyRequestsException(ORG_DOES_NOT_EXIST_AT_ALL);
+            throw new TooManyRequestsException(i18nProvider.get()
+                .tr("Anonymous owner not yet created upstream of candlepin"))
+                .setRetryAfterTime(ORG_DOES_NOT_EXIST_AT_ALL);
         }
         catch (OrgForCloudAccountNotEntitledYetException e) {
-            throw new TooManyRequestsException(ORG_IS_NOT_ENTITLED);
+            throw new TooManyRequestsException(i18nProvider.get()
+                .tr("Anonymous owner not yet entitled upstream of candlepin"))
+                .setRetryAfterTime(ORG_IS_NOT_ENTITLED);
         }
     }
 }

--- a/src/test/java/org/candlepin/exceptions/ServiceUnavailableExceptionTest.java
+++ b/src/test/java/org/candlepin/exceptions/ServiceUnavailableExceptionTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class ServiceUnavailableExceptionTest {
+    private static final String RETRY_AFTER_HEADER_KEY = "Retry-After";
+
+    @Test
+    public void testConstructorWithMessage() {
+        String expected = TestUtil.randomString();
+
+        ServiceUnavailableException exception = new ServiceUnavailableException(expected);
+
+        assertThat(exception)
+            .isNotNull()
+            .returns(expected, ServiceUnavailableException::getMessage);
+    }
+
+    @Test
+    public void testConstructorWithNullMessage() {
+        ServiceUnavailableException exception = new ServiceUnavailableException(null);
+
+        assertThat(exception)
+            .isNotNull()
+            .returns(null, ServiceUnavailableException::getMessage);
+    }
+
+    @Test
+    public void testConstructorWithMessageAndThrowable() {
+        String expectedMsg = TestUtil.randomString();
+        Throwable expectedCause = new Throwable(TestUtil.randomString());
+
+        ServiceUnavailableException exception = new ServiceUnavailableException(expectedMsg, expectedCause);
+
+        assertThat(exception)
+            .isNotNull()
+            .returns(expectedMsg, ServiceUnavailableException::getMessage)
+            .returns(expectedCause, ServiceUnavailableException::getCause);
+    }
+
+    @Test
+    public void testConstructorWithNullMessageAndThrowable() {
+        ServiceUnavailableException exception = new ServiceUnavailableException(null, null);
+
+        assertThat(exception)
+            .isNotNull()
+            .returns(null, ServiceUnavailableException::getMessage)
+            .returns(null, ServiceUnavailableException::getCause);
+    }
+
+    @Test
+    public void testSetRetryAfterTime() {
+        ServiceUnavailableException exception = new ServiceUnavailableException(TestUtil.randomString());
+
+        Integer expected = 10;
+        exception.setRetryAfterTime(expected);
+
+        assertThat(exception.getRetryAfterTime())
+            .isNotNull()
+            .isEqualTo(expected);
+
+        exception.setRetryAfterTime(null);
+
+        assertThat(exception.getRetryAfterTime())
+            .isNull();
+
+        expected = 20;
+        exception.setRetryAfterTime(expected);
+        assertThat(exception.getRetryAfterTime())
+            .isNotNull()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void testHeaders() {
+        ServiceUnavailableException exception = new ServiceUnavailableException(TestUtil.randomString());
+        int expected = 25;
+        exception.setRetryAfterTime(expected);
+
+        Map<String, String> headers = exception.headers();
+
+        assertThat(headers)
+            .isNotNull()
+            .containsKeys(RETRY_AFTER_HEADER_KEY)
+            .containsEntry(RETRY_AFTER_HEADER_KEY, String.valueOf(expected));
+    }
+
+    @Test
+    public void testHeadersWithNullRetryAfterTimeValue() {
+        ServiceUnavailableException exception = new ServiceUnavailableException(TestUtil.randomString());
+
+        Map<String, String> headers = exception.headers();
+
+        assertThat(headers)
+            .isNotNull()
+            .doesNotContainKeys(RETRY_AFTER_HEADER_KEY);
+    }
+}

--- a/src/test/java/org/candlepin/exceptions/TooManyRequestsExceptionTest.java
+++ b/src/test/java/org/candlepin/exceptions/TooManyRequestsExceptionTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.candlepin.test.TestUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class TooManyRequestsExceptionTest {
+
+    private static final String RETRY_AFTER_HEADER_KEY = "Retry-After";
+
+    @Test
+    public void testConstructorWithMessage() {
+        String expected = TestUtil.randomString();
+
+        TooManyRequestsException exception = new TooManyRequestsException(expected);
+
+        assertThat(exception)
+            .isNotNull()
+            .returns(expected, TooManyRequestsException::getMessage);
+    }
+
+    @Test
+    public void testConstructorWithNullMessage() {
+        ServiceUnavailableException exception = new ServiceUnavailableException(null);
+
+        assertThat(exception)
+            .isNotNull()
+            .returns(null, ServiceUnavailableException::getMessage);
+    }
+
+    @Test
+    public void testConstructorWithMessageAndThrowable() {
+        String expectedMessage = TestUtil.randomString();
+        Throwable expectedThrowable = new Throwable(TestUtil.randomString());
+
+        TooManyRequestsException exception = new TooManyRequestsException(expectedMessage, expectedThrowable);
+
+        assertThat(exception)
+            .isNotNull()
+            .returns(expectedMessage, TooManyRequestsException::getMessage)
+            .returns(expectedThrowable, TooManyRequestsException::getCause);
+    }
+
+    @Test
+    public void testConstructorWithNullMessageAndThrowable() {
+        ServiceUnavailableException exception = new ServiceUnavailableException(null, null);
+
+        assertThat(exception)
+            .isNotNull()
+            .returns(null, ServiceUnavailableException::getMessage)
+            .returns(null, ServiceUnavailableException::getCause);
+    }
+
+    @Test
+    public void testSetRetryAfterTime() {
+        TooManyRequestsException exception = new TooManyRequestsException(TestUtil.randomString());
+
+        Integer expected = 10;
+        exception.setRetryAfterTime(expected);
+
+        assertThat(exception.getRetryAfterTime())
+            .isNotNull()
+            .isEqualTo(expected);
+
+        exception.setRetryAfterTime(null);
+
+        assertThat(exception.getRetryAfterTime())
+            .isNull();
+
+        expected = 20;
+        exception.setRetryAfterTime(expected);
+        assertThat(exception.getRetryAfterTime())
+            .isNotNull()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void testHeaders() {
+        TooManyRequestsException exception = new TooManyRequestsException(TestUtil.randomString());
+        int expected = 25;
+        exception.setRetryAfterTime(expected);
+
+        Map<String, String> headers = exception.headers();
+
+        assertThat(headers)
+            .isNotNull()
+            .containsKeys(RETRY_AFTER_HEADER_KEY)
+            .containsEntry(RETRY_AFTER_HEADER_KEY, String.valueOf(expected));
+    }
+
+    @Test
+    public void testHeadersWithNullRetryAfterTimeValue() {
+        TooManyRequestsException exception = new TooManyRequestsException(TestUtil.randomString());
+
+        Map<String, String> headers = exception.headers();
+
+        assertThat(headers)
+            .isNotNull()
+            .doesNotContainKeys(RETRY_AFTER_HEADER_KEY);
+    }
+
+}


### PR DESCRIPTION
- Refactored the ServiceUnavailableException and the TooManyRequestsException to have the standard exception constructors.
- Added the ability to define a 'Retry-After' header for the ServiceUnavailableException.
- Added exception messages for TooManyRequestsExceptions in SecurityHoleAuthorizationFilter.

`ServiceUnavailableException` and `TooManyRequestsException` extend a `CandlepinException` and a `CandlepinException` extends a RuntimeException. This means that the headers for both the `ServiceUnavailableException` and `TooManyRequestsException` are added by the `RuntimeExceptionMapper`.

https://github.com/candlepin/candlepin/blob/main/src/main/java/org/candlepin/exceptions/mappers/RuntimeExceptionMapper.java#L67-L69