### PR TITLE
[F] CHAINSAW-361: Removed obsoleted methods from ContentAccessManager

### DIFF
--- a/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -24,8 +24,6 @@ import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ContentAccessCertificateCurator;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
-import org.candlepin.model.SCACertificate;
-import org.candlepin.util.Util;
 
 import com.google.inject.persist.Transactional;
 
@@ -35,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 
-import java.util.Date;
 import java.util.Objects;
 
 import javax.inject.Inject;
@@ -80,78 +77,6 @@ public class ContentAccessManager {
     public static String defaultContentAccessModeList() {
         return String.join(",", ContentAccessMode.ENTITLEMENT.toDatabaseValue(),
             ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
-    }
-
-    /**
-     * Checks if the content view for the given consumer has changed since date provided. This will
-     * be true if the consumer is currently operating in simple content access mode (SCA), and any
-     * of the following are true:
-     *
-     *  - the consumer does not currently have a certificate or certificate body/payload
-     *  - the consumer's certificate or payload was generated after the date provided
-     *  - the consumer's certificate has expired since the date provided
-     *  - the consumer's certificate or payload was generated before the date provided, but the
-     *    organization's content view has changed since the date provided
-     *
-     * If the consumer is not operating in SCA mode, or none of the above conditions are met, this
-     * method returns false.
-     *
-     * @param consumer
-     *  the consumer to check for certificate updates
-     *
-     * @param date
-     *  the date to use for update checks
-     *
-     * @throws IllegalArgumentException
-     *  if consumer or date are null
-     *
-     * @return
-     *  true if the cert or its content has changed since the date provided; false otherwise
-     */
-    public boolean hasCertChangedSince(Consumer consumer, Date date) {
-        if (consumer == null) {
-            throw new IllegalArgumentException("consumer is null");
-        }
-
-        if (date == null) {
-            throw new IllegalArgumentException("date is null");
-        }
-
-        Owner owner = consumer.getOwner();
-
-        // Impl note:
-        // This method is kinda... sketch, and prone to erroneous results. Since the cert, cert
-        // serial, and payload  have different created/updated timestamps, they can be updated
-        // individually. Depending on which date is used as input, this may or may not trigger an
-        // update when an update is not strictly necessary.
-        // We try to minimize this by providing the "best" creation/update date above, but that still
-        // doesn't prevent this method from being called with a datetime that lies between the
-        // persistence of the cert and the payload, triggering a false positive.
-        // When time permits to refactor all of this logic, we should examine everything surrounding
-        // this design and determine whether or not we need two separate objects, or if this question
-        // has any real value.
-
-        if (owner.isUsingSimpleContentAccess()) {
-            // Check if the owner's content view has changed since the date
-            if (!date.after(owner.getLastContentUpdate())) {
-                return true;
-            }
-
-            // Check cert properties
-            SCACertificate cert = consumer.getContentAccessCert();
-            if (cert == null) {
-                return true;
-            }
-
-            // The date provided by the client does not preserve milliseconds, so we need to round down
-            // the dates preserved on the server by removing milliseconds for a proper date comparison
-            Date certUpdatedDate = Util.roundDownToSeconds(cert.getUpdated());
-            Date certExpirationDate = Util.roundDownToSeconds(cert.getSerial().getExpiration());
-            return date.before(certUpdatedDate) ||
-                date.after(certExpirationDate);
-        }
-
-        return false;
     }
 
     @Transactional
@@ -271,7 +196,7 @@ public class ContentAccessManager {
             }
 
             // Update sync times & report
-            this.syncOwnerLastContentUpdate(owner);
+            owner.syncLastContentUpdate();
             this.eventSink.emitOwnerContentAccessModeChanged(owner);
 
             log.info("Content access mode changed from {} to {} for owner {}", currentMode,
@@ -350,28 +275,6 @@ public class ContentAccessManager {
         }
 
         return value;
-    }
-
-    /**
-     * Synchronizes the last content update time for the given owner and persists the update.
-     *
-     * @param owner
-     *  the owner for which to synchronize the last content update time
-     *
-     * @throws IllegalArgumentException
-     *  if owner is null
-     *
-     * @return
-     *  the synchronized owner
-     */
-    @Transactional
-    public Owner syncOwnerLastContentUpdate(Owner owner) {
-        if (owner == null) {
-            throw new IllegalArgumentException("owner is null");
-        }
-
-        owner.syncLastContentUpdate();
-        return this.ownerCurator.merge(owner);
     }
 
 }

--- a/src/main/java/org/candlepin/controller/ContentManager.java
+++ b/src/main/java/org/candlepin/controller/ContentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -119,7 +119,7 @@ public class ContentManager {
         entity = this.contentCurator.create(entity);
 
         log.debug("Synchronizing last content update for org: {}", owner);
-        this.contentAccessManager.syncOwnerLastContentUpdate(owner);
+        owner.syncLastContentUpdate();
 
         return entity;
     }
@@ -181,7 +181,7 @@ public class ContentManager {
             content = this.contentCurator.merge(content);
 
             log.debug("Synchronizing last content update for org: {}", owner);
-            this.contentAccessManager.syncOwnerLastContentUpdate(owner);
+            owner.syncLastContentUpdate();
 
             List<Product> affectedProducts = regenCerts ?
                 this.productCurator.getProductsReferencingContent(content.getUuid()) :
@@ -254,7 +254,7 @@ public class ContentManager {
         this.contentCurator.delete(content);
 
         log.debug("Synchronizing last content update for org: {}", owner);
-        this.contentAccessManager.syncOwnerLastContentUpdate(owner);
+        owner.syncLastContentUpdate();
 
         return content;
     }

--- a/src/main/java/org/candlepin/controller/ProductManager.java
+++ b/src/main/java/org/candlepin/controller/ProductManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -248,7 +248,7 @@ public class ProductManager {
         entity = this.productCurator.create(entity);
 
         log.debug("Synchronizing last content update for org: {}", owner);
-        this.contentAccessManager.syncOwnerLastContentUpdate(owner);
+        owner.syncLastContentUpdate();
 
         return entity;
     }
@@ -312,7 +312,7 @@ public class ProductManager {
             product = this.productCurator.create(product);
 
             log.debug("Synchronizing last content update for org: {}", owner);
-            this.contentAccessManager.syncOwnerLastContentUpdate(owner);
+            owner.syncLastContentUpdate();
 
             if (regenCerts) {
                 log.debug("Flagging entitlement certificates of 1 affected product for regeneration");
@@ -383,7 +383,7 @@ public class ProductManager {
         this.productCurator.delete(product);
 
         log.debug("Synchronizing last content update for org: {}", owner);
-        this.contentAccessManager.syncOwnerLastContentUpdate(owner);
+        owner.syncLastContentUpdate();
 
         return product;
     }

--- a/src/main/java/org/candlepin/model/AbstractHibernateObject.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateObject.java
@@ -138,7 +138,7 @@ public abstract class AbstractHibernateObject<T extends AbstractHibernateObject>
 
     /**
      * Fetches the date this entity was last updated, generally indicating the time at which it was
-     * last persisted to the database. If the entity has not yet bene persisted or the last-update
+     * last persisted to the database. If the entity has not yet been persisted or the last-update
      * date has not yet been set, this method returns null.
      *
      * @return

--- a/src/main/java/org/candlepin/resource/EnvironmentResource.java
+++ b/src/main/java/org/candlepin/resource/EnvironmentResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -401,7 +401,7 @@ public class EnvironmentResource implements EnvironmentApi {
             contentIds = this.batchCreate(contentToPromote, environment);
             // TODO: Remove the line below once certificate generation based on the `lastContentUpdate` field
             // in environments is implemented.
-            this.contentAccessManager.syncOwnerLastContentUpdate(environment.getOwner());
+            environment.getOwner().syncLastContentUpdate();
         }
         catch (PersistenceException pe) {
             if (rdbmsExceptionTranslator.isConstraintViolationDuplicateEntry(pe)) {
@@ -444,7 +444,7 @@ public class EnvironmentResource implements EnvironmentApi {
             this.envContentCurator.bulkDelete(demotedContent.values());
             // TODO: Remove the line below once certificate generation based on the `lastContentUpdate` field
             // in environments is implemented.
-            this.contentAccessManager.syncOwnerLastContentUpdate(environment.getOwner());
+            environment.getOwner().syncLastContentUpdate();
         }
         catch (RollbackException hibernateException) {
             if (rdbmsExceptionTranslator.isUpdateHadNoEffectException(hibernateException)) {

--- a/src/main/java/org/candlepin/resource/SubscriptionResource.java
+++ b/src/main/java/org/candlepin/resource/SubscriptionResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -148,7 +148,7 @@ public class SubscriptionResource implements SubscriptionApi {
 
         for (Owner owner : owners) {
             log.debug("Synchronizing last content update for org: {}", owner);
-            this.contentAccessManager.syncOwnerLastContentUpdate(owner);
+            owner.syncLastContentUpdate();
         }
     }
 

--- a/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentAccessManagerTest.java
@@ -15,12 +15,11 @@
 package org.candlepin.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -498,13 +497,18 @@ public class ContentAccessManagerTest {
     }
 
     @Test
-    public void testUpdateOwnerContentAccessModeChangedFromEntModeToSCA() throws JobException {
-        Owner owner = new Owner();
-        owner.setKey(TestUtil.randomString());
-        owner.setContentAccessMode(entitlementMode);
+    public void testUpdateOwnerContentAccessModeChangedFromEntModeToSCA() throws Exception {
+        Owner owner = new Owner()
+            .setKey(TestUtil.randomString())
+            .setContentAccessMode(entitlementMode);
+
+        Date initialLastContentUpdate = owner.getLastContentUpdate();
 
         String contentAccessModeList = entitlementMode + "," + orgEnvironmentMode;
         String contentAccessMode = orgEnvironmentMode;
+
+        // Sleep to gaurantee the last content update dates will be different
+        Thread.sleep(5);
 
         ContentAccessManager manager = this.createManager();
         manager.updateOwnerContentAccess(owner, contentAccessModeList, contentAccessMode);
@@ -512,6 +516,7 @@ public class ContentAccessManagerTest {
         assertEquals(owner.getContentAccessModeList(), contentAccessModeList);
         assertEquals(owner.getContentAccessMode(), contentAccessMode);
         verify(jobManager).queueJob(any(RevokeEntitlementsJobConfig.class));
+        assertNotEquals(initialLastContentUpdate, owner.getLastContentUpdate());
     }
 
     @Test
@@ -554,148 +559,4 @@ public class ContentAccessManagerTest {
         assertNull(consumer.getContentAccessCert());
     }
 
-    @Test
-    public void testHasCertChangedSinceOnlyCheckSecondsOnCertUpdatedDate() {
-        Owner owner = this.mockOwner();
-        Consumer consumer = this.mockConsumer(owner);
-        ContentAccessManager manager = this.createManager();
-        SCACertificate cert = this.mockContentAccessCertificate(consumer);
-        consumer.setContentAccessCert(cert);
-
-        // Set Owner's last content update to be long ago
-        owner.setLastContentUpdate(TestUtil.createDateOffset(-1, 0, 0));
-
-        // Set SCA cert 'updated' date (but without any rounding)
-        long currentTimeMillis = System.currentTimeMillis();
-        Date currentTime = new Date(currentTimeMillis);
-        cert.setUpdated(currentTime);
-
-        // Set expiration long enough into the future
-        CertificateSerial serial = new CertificateSerial();
-        serial.setExpiration(TestUtil.createDateOffset(1, 0, 0));
-        cert.setSerial(serial);
-
-        // Simulate 'lastUpdate' date sent by subscription-manager to be the same as
-        // the SCA cert 'updated' date, but without the milliseconds
-        Date lastUpdateRoundedDown = Util.roundDownToSeconds(currentTime);
-        boolean changed = manager.hasCertChangedSince(consumer, lastUpdateRoundedDown);
-
-        assertFalse(changed);
-    }
-
-    @Test
-    public void testHasCertChangedSinceOnlyCheckSecondsOnCertExpirationDate() {
-        Owner owner = this.mockOwner();
-        Consumer consumer = this.mockConsumer(owner);
-        ContentAccessManager manager = this.createManager();
-        SCACertificate cert = this.mockContentAccessCertificate(consumer);
-        consumer.setContentAccessCert(cert);
-
-        // Set Owner's last content update to be long ago
-        owner.setLastContentUpdate(TestUtil.createDateOffset(-1, 0, 0));
-
-        // Set SCA cert 'updated' date (but without any rounding)
-        long currentTimeMillis = System.currentTimeMillis();
-        Date currentTime = new Date(currentTimeMillis);
-        cert.setUpdated(currentTime);
-
-        // Set expiration date to be the same as the 'updated' date, but without the rounding
-        CertificateSerial serial = new CertificateSerial();
-        serial.setExpiration(currentTime);
-        cert.setSerial(serial);
-
-        // Simulate 'lastUpdate' date sent by subscription-manager to be the same as
-        // the SCA cert 'updated' date, but without the milliseconds
-        Date lastUpdateRoundedDown = Util.roundDownToSeconds(currentTime);
-        boolean changed = manager.hasCertChangedSince(consumer, lastUpdateRoundedDown);
-
-        assertFalse(changed);
-    }
-
-    @Test
-    public void testHasCertChangedSinceOwnerContentUpdated() {
-        Owner owner = this.mockOwner();
-        Consumer consumer = this.mockConsumer(owner);
-        ContentAccessManager manager = this.createManager();
-        SCACertificate cert = this.mockContentAccessCertificate(consumer);
-        consumer.setContentAccessCert(cert);
-
-        // Set Owner's last content update to be now
-        owner.setLastContentUpdate(new Date());
-
-        // Set SCA cert 'updated' date to be in the past
-        Date lastUpdated = TestUtil.createDateOffset(-1, 0, 0);
-        cert.setUpdated(lastUpdated);
-
-        boolean changed = manager.hasCertChangedSince(consumer, lastUpdated);
-
-        assertTrue(changed);
-    }
-
-    @Test
-    public void testHasCertChangedSinceReturnAlwaysFalseWhenNotSimpleContentAccess() {
-        Owner owner = this.mockOwner();
-        owner.setContentAccessMode(ContentAccessMode.ENTITLEMENT.toDatabaseValue());
-        Consumer consumer = this.mockConsumer(owner);
-        ContentAccessManager manager = this.createManager();
-
-        // Set SCA cert 'updated' date to be in the past
-        Date lastUpdated = TestUtil.createDateOffset(-1, 0, 0);
-        boolean changed = manager.hasCertChangedSince(consumer, lastUpdated);
-        assertFalse(changed);
-
-        // Set SCA cert 'updated' date to be in the future
-        lastUpdated = TestUtil.createDateOffset(1, 0, 0);
-        changed = manager.hasCertChangedSince(consumer, lastUpdated);
-        assertFalse(changed);
-
-        // Set SCA cert 'updated' date to be now
-        changed = manager.hasCertChangedSince(consumer, new Date());
-        assertFalse(changed);
-    }
-
-    @Test
-    public void testHasCertChangedSinceReturnAlwaysTrueWhenSCACertIsNull() {
-        Owner owner = this.mockOwner();
-        Consumer consumer = this.mockConsumer(owner);
-        consumer.setContentAccessCert(null);
-        ContentAccessManager manager = this.createManager();
-
-        // Set SCA cert 'updated' date to be in the past
-        Date lastUpdated = TestUtil.createDateOffset(-1, 0, 0);
-        boolean changed = manager.hasCertChangedSince(consumer, lastUpdated);
-        assertTrue(changed);
-
-        // Set SCA cert 'updated' date to be in the future
-        lastUpdated = TestUtil.createDateOffset(1, 0, 0);
-        changed = manager.hasCertChangedSince(consumer, lastUpdated);
-        assertTrue(changed);
-
-        // Set SCA cert 'updated' date to be now
-        changed = manager.hasCertChangedSince(consumer, new Date());
-        assertTrue(changed);
-    }
-
-    @Test
-    public void testHasCertChangedSinceThrowsExceptionWhenConsumerIsNull() {
-        ContentAccessManager manager = this.createManager();
-
-        assertThrows(IllegalArgumentException.class, () -> manager.hasCertChangedSince(null, new Date()));
-    }
-
-    @Test
-    public void testHasCertChangedSinceThrowsExceptionWhenDateIsNull() {
-        Owner owner = this.mockOwner();
-        Consumer consumer = this.mockConsumer(owner);
-        ContentAccessManager manager = this.createManager();
-
-        assertThrows(IllegalArgumentException.class, () -> manager.hasCertChangedSince(consumer, null));
-    }
-
-    @Test
-    public void testSyncOwnerLastContentUpdateThrowsExceptionWhenOwnerIsNull() {
-        ContentAccessManager manager = this.createManager();
-
-        assertThrows(IllegalArgumentException.class, () -> manager.syncOwnerLastContentUpdate(null));
-    }
 }

--- a/src/test/java/org/candlepin/controller/ContentManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ContentManagerTest.java
@@ -17,6 +17,7 @@ package org.candlepin.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -46,6 +47,7 @@ import org.mockito.ArgumentMatcher;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -130,6 +132,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
     @Test
     public void testCreateContent() {
         Owner owner = this.createOwner("test-owner", "Test Owner");
+        Date initialLastContentUpdate = owner.getLastContentUpdate();
         Content content = TestUtil.createContent("c1", "content-1")
             .setNamespace(owner.getKey())
             .setLabel("test-label")
@@ -141,6 +144,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         Content output = this.contentManager.createContent(owner, content);
 
         assertEquals(output, this.contentCurator.getContentById(owner.getKey(), content.getId()));
+        assertNotEquals(initialLastContentUpdate, owner.getLastContentUpdate());
     }
 
     @Test
@@ -203,6 +207,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
     @ValueSource(strings = {"false", "true"})
     public void testUpdateContent(boolean regenCerts) {
         Owner owner = this.createOwner("test-owner", "Test Owner");
+        Date initialLastContentUpdate = owner.getLastContentUpdate();
         Content content = TestUtil.createContent("c1", "content-1")
             .setNamespace(owner.getKey());
         this.createContent(content);
@@ -215,8 +220,8 @@ public class ContentManagerTest extends DatabaseTestFixture {
         Content output = this.contentManager.updateContent(owner, content, update, regenCerts);
 
         assertEquals(output.getName(), update.getName());
-
         assertNotNull(this.contentCurator.getContentById(owner.getKey(), content.getId()));
+        assertNotEquals(initialLastContentUpdate, owner.getLastContentUpdate());
 
         if (regenCerts) {
             verify(this.mockEntCertService, times(1)).regenerateCertificatesOf(
@@ -247,6 +252,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
     @Test
     public void testRemoveContent() {
         Owner owner = this.createOwner("test-owner-1", "Test Owner 1");
+        Date initialLastContentUpdate = owner.getLastContentUpdate();
         Content content = TestUtil.createContent("c1", "content-1")
             .setNamespace(owner.getKey());
         content = this.createContent(content);
@@ -257,6 +263,7 @@ public class ContentManagerTest extends DatabaseTestFixture {
         this.contentManager.removeContent(owner, content);
 
         assertNull(this.contentCurator.get(content.getUuid()));
+        assertNotEquals(initialLastContentUpdate, owner.getLastContentUpdate());
     }
 
     @Test

--- a/src/test/java/org/candlepin/controller/ProductManagerTest.java
+++ b/src/test/java/org/candlepin/controller/ProductManagerTest.java
@@ -17,6 +17,7 @@ package org.candlepin.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -74,6 +75,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
     @Test
     public void testCreateProduct() {
         Owner owner = this.createOwner("test-owner", "Test Owner");
+        Date initialLastContentUpdate = owner.getLastContentUpdate();
         ProductInfo productInfo = TestUtil.createProductInfo("p1", "prod1");
 
         assertNull(this.productCurator.getProductById(owner.getKey(), productInfo.getId()));
@@ -81,6 +83,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         Product output = this.productManager.createProduct(owner, productInfo);
 
         assertEquals(output, this.productCurator.getProductById(owner.getKey(), productInfo.getId()));
+        assertNotEquals(initialLastContentUpdate, owner.getLastContentUpdate());
     }
 
     @Test
@@ -131,6 +134,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
     @ValueSource(strings = {"false", "true"})
     public void testUpdateProduct(boolean regenCerts) {
         Owner owner = this.createOwner("test-owner", "Test Owner");
+        Date initialLastContentUpdate = owner.getLastContentUpdate();
         Product product = TestUtil.createProduct("p1", "prod1")
             .setNamespace(owner.getKey());
         this.createProduct(product);
@@ -140,6 +144,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         Product output = this.productManager.updateProduct(owner, product, update, regenCerts);
 
         assertEquals(output.getName(), update.getName());
+        assertNotEquals(initialLastContentUpdate, owner.getLastContentUpdate());
 
         if (regenCerts) {
             verify(this.mockEntCertService, times(1))
@@ -227,6 +232,8 @@ public class ProductManagerTest extends DatabaseTestFixture {
     @Test
     public void testRemoveProduct() {
         Owner owner = this.createOwner("test-owner-1", "Test Owner 1");
+        Date initialLastContentUpdate = owner.getLastContentUpdate();
+
         Product product = TestUtil.createProduct("p1", "prod1")
             .setNamespace(owner.getKey());
         this.productCurator.create(product);
@@ -236,6 +243,7 @@ public class ProductManagerTest extends DatabaseTestFixture {
         this.productManager.removeProduct(owner, product);
 
         assertNull(this.productCurator.get(product.getUuid()));
+        assertNotEquals(initialLastContentUpdate, owner.getLastContentUpdate());
     }
 
     @Test


### PR DESCRIPTION
- Removed the 'hasCertChangesSince' and 'syncOwnerLastContentUpdate' methods from the ContentAccessManager class.