### PR TITLE
[M] CHAINSAW-382: Updated dev container image to output Candlepin logs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ The Candlepin production base image is designed to be a base image for your own 
 
 #### Extend Candlepin Production Base Image
 
-The following is an example on how to extend the Candlepin production image using your own configurations and certificates to build a production Candlepin image that you can run.
+The following is an example on how to extend and run the Candlepin production image using your own configurations and certificates.
 
 Example:
 ``` dockerfile
@@ -233,8 +233,7 @@ The Candlepin development image is designed to run right after pulling the image
 
 The following is an example on how to run the Candlepin development container using a docker compose file or a kubernetes file via podman.
 
-Two compose files are in the dev-container directory. They will pull the development image and the most
-current PostgreSQL image. The configuration settings are in those compose files as environment variables.
+Two compose files are in the dev-container directory. They will pull the latest development Candlepin image and the latest PostgreSQL image. The configuration settings are in those compose files as environment variables.
 Refer to the [default configuration](#development-image-default-configurations) section for details on the Candlepin development container's default configurations.
 
 Once configured you can start and stop(remove) the docker container with

--- a/containers/logback.xml
+++ b/containers/logback.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <contextName>candlepin</contextName>
+
+    <turboFilter class="org.candlepin.logging.LoggerAndMDCFilter">
+        <key>logLevel</key>
+        <topLogger>org.candlepin</topLogger>
+        <OnMatch>ACCEPT</OnMatch>
+    </turboFilter>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} [thread=%thread] [%X{requestType}=%X{requestUuid}, %replace(job_key=%X{jobKey}, ){'job_key=, ', ''}org=%X{org}, csid=%X{csid}] %-5p %c - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT"/>
+    </appender>
+
+    <appender name="AUDITLOG" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} %m</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC-AUDITLOG" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="AUDITLOG"/>
+    </appender>
+
+    <logger name="org.candlepin" level="INFO"/>
+    <logger name="org.candlepin.audit.LoggingListener.AuditLog" level="INFO" additivity="false">
+        <appender-ref ref="ASYNC-AUDITLOG"/>
+    </logger>
+
+    <!-- Silence the hibernate deprecation warnings -->
+    <logger name="org.hibernate.orm.deprecation" level="DEBUG" additivity="false"/>
+
+    <root level="WARN">
+        <appender-ref ref="ASYNC"/>
+    </root>
+</configuration>

--- a/containers/release.Containerfile
+++ b/containers/release.Containerfile
@@ -15,9 +15,11 @@ RUN wget https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.76/bin/apache-tomc
     mv apache-tomcat-9.0.76/* /opt/tomcat/
 
 # Prepare Candlepin
-RUN mkdir -p /app/build
+RUN mkdir -p /app/build/candlepin
 WORKDIR /app/build
 COPY ${WAR_FILE} ./candlepin.war
+WORKDIR /app/build/candlepin
+RUN jar xvf /app/build/candlepin.war
 
 # Prepare development certs
 RUN mkdir -p /app/certs
@@ -89,7 +91,7 @@ FROM production as development
 LABEL org.opencontainers.image.title="Candlepin Development Image" \
     org.opencontainers.image.description="Candlepin is an open source subscription & entitlement engine \
 which is designed to manage software subscriptions from both vendor's & customer's perspectives. \
-    This is a development image not intended for production use."
+This is a development image and not intended for production use."
 
 USER root
 
@@ -109,11 +111,13 @@ RUN echo "jpa.config.hibernate.dialect=org.hibernate.dialect.PostgreSQL92Dialect
 # Setup development certificate and key
 WORKDIR /etc/candlepin/certs
 COPY --from=builder /app/certs /etc/candlepin/certs
+
 # Add the certificate to the Java trust store
 RUN ln -s /etc/candlepin/certs/*.crt /etc/pki/ca-trust/source/anchors --force; \
     update-ca-trust;
 
 COPY ./containers/server.xml /opt/tomcat/conf
+COPY ./containers/logback.xml /opt/tomcat/webapps/candlepin/WEB-INF/classes/logback.xml
 
 WORKDIR /opt/tomcat/bin
 

--- a/dev-container/candlepin-deployment.yaml
+++ b/dev-container/candlepin-deployment.yaml
@@ -29,7 +29,6 @@ spec:
             timeoutSeconds: 5
           ports:
             - containerPort: 5432
-              hostPort: 5432
               protocol: TCP
           resources: {}
           restartPolicy: Always

--- a/dev-container/docker-compose.yml
+++ b/dev-container/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_DB: candlepin
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
-      - "5432:5432"
+      - "5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U candlepin -d candlepin"]
       interval: 5s


### PR DESCRIPTION
- Added a ConsoleAppender to the logback.xml for the dev container image so that the Candlepin logs are output to stdout.
- Added a ConsoleAppender to the logback.xml for the dev container image to log the org.candlepin.audit.LoggingListener.AuditLog logs to stdout.
- Removed the host port for the Postgres container in dev-container/docker-compose.yml and dev-container/candlepin-deployment.yml so that the OS will choose the host port number in the port mapping.
- Updated some of the container documentation in CONTRIBUTING.md.

## Testing

To test and verify the changes we can build a new development image and run the container using `podman-compose`, `docker-compose`, or `podman play kube`.

### 1. Build the WAR file

Run the following command to build the WAR file that will be used in our new image. The command includes the extensions used for testing.

`./gradlew war -Ptest_extensions=hostedtest,manifestgen`
 
### 2. Build the container image

Run the following command from the root directory of the Candlepin project to build your image. Note that you will need to insert your image name and tag, and adjust the WAR file version if the version you built is not 4.6.0.

```
podman build -f ./containers/release.Containerfile -t <insert-name:insert-tag> . \
	--target development \
	--build-arg WAR_FILE=./build/libs/candlepin-4.6.0.war \
	--no-cache
```

### 3. Update the compose files to use your new image

Depending on which compose you will run, you will need to update the `image` value to be your newly built image in `dev-container/candlepin-deployment.yaml` and or `dev-container/docker-compose.yml`.

### 4. Start the containers

From the `dev-container` directory, run either `podman-compose up -d`, `docker-compose up -d`, or `podman play kube candlepin-deployment.yaml` to run your containers.

### 5. Run spec tests

Once the Candlepin container is running and started, you can run the spec tests to generate some log output.

`./gradlew spec`

### 6. View the logs

Now we should see the Candlepin logs by using `podman logs -f <container ID>`.

