### PR TITLE
[F] CHAINSAW-358: Updated getEntitlementCertificateSerials serial retrieval

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
@@ -971,7 +971,7 @@ public class ContentAccessSpecTest {
         adminClient.ownerProducts().addContentToProduct(ownerKey, prod.getId(), content.getId(), true);
         adminClient.owners().createPool(ownerKey, Pools.random(prod));
 
-        // We need to sleep here to ensure enough time has passes from the last content update to when
+        // We need to sleep here to ensure enough time has passed from the last content update to when
         // we fetch certificates.
         Thread.sleep(1000);
 


### PR DESCRIPTION
- Updated ConsumerResource.getEntitlementCertificateSerials to retrieve only the X509 certificate from the SCACertificateGenerator when retrieving the content access certificate serial.