### PR TITLE
[F] CHAINSAW-359: Updated ConsumerResource.getContentAccessBody

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -1148,6 +1148,17 @@ paths:
               example:
                 displayMessage: Consumer with this UUID could not be found.
                 requestUuid: c4347004-8792-41fe-a4d8-fccaa0d3898a
+        429:
+          description: |
+            Concurrent requests persisting the same content access data payload caused a database constraint
+            violation. If you receive this status code, retry the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExceptionMessage'
+              example:
+                displayMessage: Unable to create content access payload
+                requestUuid: c4347004-8792-41fe-a4d8-fccaa0d3898a
         default:
           $ref: '#/components/responses/default'
 

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CandlepinStatusAssert.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/assertions/CandlepinStatusAssert.java
@@ -55,6 +55,11 @@ public class CandlepinStatusAssert extends ThrowableAssert<ApiException> {
         return this;
     }
 
+    public CandlepinStatusAssert isUnavailable() {
+        this.hasFieldOrPropertyWithValue("code", 503);
+        return this;
+    }
+
     public CandlepinStatusAssert hasHeaderWithValue(String name, String value) {
         String time = this.actual.getResponseHeaders().get(name).get(0);
         assertEquals(value, time);

--- a/src/main/java/org/candlepin/model/ContentAccessPayload.java
+++ b/src/main/java/org/candlepin/model/ContentAccessPayload.java
@@ -14,6 +14,8 @@
  */
 package org.candlepin.model;
 
+import org.candlepin.util.Util;
+
 import org.hibernate.annotations.GenericGenerator;
 
 import java.util.Date;
@@ -213,7 +215,7 @@ public class ContentAccessPayload extends AbstractHibernateObject<ContentAccessP
      * @return the timestamp of this instance
      */
     public Date getTimestamp() {
-        return timestamp;
+        return Util.firstOf(this.timestamp, this.getCreated(), new Date());
     }
 
     /**

--- a/src/main/java/org/candlepin/pki/certs/SCACertificateGenerator.java
+++ b/src/main/java/org/candlepin/pki/certs/SCACertificateGenerator.java
@@ -44,7 +44,6 @@ import org.candlepin.pki.impl.Signer;
 import org.candlepin.util.Util;
 import org.candlepin.util.X509V3ExtensionUtil;
 
-import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,6 +69,7 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import javax.persistence.PersistenceException;
 
 
 /**
@@ -344,7 +344,7 @@ public class SCACertificateGenerator {
                 try {
                     contentAccessPayloadCurator.create(payload);
                 }
-                catch (ConstraintViolationException e) {
+                catch (PersistenceException e) {
                     throw new ConcurrentContentPayloadCreationException(e);
                 }
             }


### PR DESCRIPTION
- Updated ConsumerResource.getContentAccessBody to fetch the individual components from the SCACertificateGenerator instead of retrieving the entire assembled certificate.
- Updated ConsumerResource.getContentAccessBody to return a 429 response if there is a constraint violation when persisting the SCA certificate's content access payload.