### PR TITLE
[M] CANDLEPIN-985: Switched default contentAccessModeList to SCA only

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Owners.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/Owners.java
@@ -27,7 +27,8 @@ import org.candlepin.spec.bootstrap.data.util.StringUtil;
  */
 public final class Owners {
 
-    public static final String ACCESS_MODE_LIST = "entitlement,org_environment";
+    public static final String ACCESS_MODE_LIST_ALL = "entitlement,org_environment";
+    public static final String DEFAULT_ACCESS_MODE_LIST = "org_environment";
     public static final String ENTITLEMENT_ACCESS_MODE = "entitlement";
     public static final String SCA_ACCESS_MODE = "org_environment";
 
@@ -42,7 +43,7 @@ public final class Owners {
             .key("test_owner-" + suffix)
             .displayName("Test Owner " + suffix)
             .contentAccessMode(ENTITLEMENT_ACCESS_MODE)
-            .contentAccessModeList(ACCESS_MODE_LIST);
+            .contentAccessModeList(ACCESS_MODE_LIST_ALL);
     }
 
     public static OwnerDTO randomSca() {

--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
@@ -140,7 +140,7 @@ public class ContentAccessSpecTest {
         adminClient.owners().updateOwner(ownerKey, owner);
         assertThat(adminClient.owners().getOwner(ownerKey))
             .returns(Owners.ENTITLEMENT_ACCESS_MODE, OwnerDTO::getContentAccessMode)
-            .returns(Owners.ACCESS_MODE_LIST, OwnerDTO::getContentAccessModeList);
+            .returns(Owners.ACCESS_MODE_LIST_ALL, OwnerDTO::getContentAccessModeList);
 
         owner.contentAccessModeList(Owners.ENTITLEMENT_ACCESS_MODE);
         adminClient.owners().updateOwner(ownerKey, owner);
@@ -161,7 +161,7 @@ public class ContentAccessSpecTest {
 
         assertThat(owner)
             .returns(Owners.SCA_ACCESS_MODE, OwnerDTO::getContentAccessMode)
-            .returns(Owners.ACCESS_MODE_LIST, OwnerDTO::getContentAccessModeList);
+            .returns(Owners.DEFAULT_ACCESS_MODE_LIST, OwnerDTO::getContentAccessModeList);
     }
 
     @Test
@@ -175,7 +175,7 @@ public class ContentAccessSpecTest {
 
         assertThat(owner)
             .returns(Owners.SCA_ACCESS_MODE, OwnerDTO::getContentAccessMode)
-            .returns(Owners.ACCESS_MODE_LIST, OwnerDTO::getContentAccessModeList);
+            .returns(Owners.DEFAULT_ACCESS_MODE_LIST, OwnerDTO::getContentAccessModeList);
     }
 
     @Test
@@ -224,7 +224,7 @@ public class ContentAccessSpecTest {
         OwnerDTO scaOwner = adminClient.owners().createOwner(Owners.randomSca());
         assertThat(scaOwner)
             .returns(Owners.SCA_ACCESS_MODE, OwnerDTO::getContentAccessMode)
-            .returns(Owners.ACCESS_MODE_LIST, OwnerDTO::getContentAccessModeList);
+            .returns(Owners.ACCESS_MODE_LIST_ALL, OwnerDTO::getContentAccessModeList);
 
         // If we remove SCA mode from the list, the mode should also be forced to the default (entitlement)
         scaOwner.contentAccessMode(null);

--- a/src/main/java/org/candlepin/controller/ContentAccessManager.java
+++ b/src/main/java/org/candlepin/controller/ContentAccessManager.java
@@ -79,8 +79,7 @@ public class ContentAccessManager {
      * @return the default content access mode list database value as a string
      */
     public static String defaultContentAccessModeList() {
-        return String.join(",", ContentAccessMode.ENTITLEMENT.toDatabaseValue(),
-            ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
+        return ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue();
     }
 
     /**

--- a/src/test/java/org/candlepin/model/OwnerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/OwnerCuratorTest.java
@@ -345,7 +345,7 @@ public class OwnerCuratorTest extends DatabaseTestFixture {
     @Test
     public void fetchesOwnerContentAccess() {
         String expectedContentAccessMode = "org_environment";
-        String expectedContentAccessModeList = "entitlement,org_environment";
+        String expectedContentAccessModeList = "org_environment";
         Owner owner = this.createOwner("test_key");
         this.ownerCurator.flush();
         this.ownerCurator.clear();

--- a/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -1504,8 +1504,7 @@ public class ConsumerResourceTest {
     @Test
     void usesDefaultWhenNoCAAvailable() {
         String expectedMode = ContentAccessMode.getDefault().toDatabaseValue();
-        List<String> expectedModeList = Arrays.asList(
-            ContentAccessMode.ENTITLEMENT.toDatabaseValue(),
+        List<String> expectedModeList = List.of(
             ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
         Consumer consumer = createConsumer(createOwner());
         when(consumerCurator.verifyAndLookupConsumer(anyString()))

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -2531,7 +2531,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     @Test
     public void usesDefaultWhenOwnerCANotAvailable() {
         String expectedMode = ContentAccessMode.getDefault().toDatabaseValue();
-        List<String> expectedModeList = Arrays.asList(ContentAccessMode.ENTITLEMENT.toDatabaseValue(),
+        List<String> expectedModeList = List.of(
             ContentAccessMode.ORG_ENVIRONMENT.toDatabaseValue());
         when(mockOwnerCurator.getOwnerContentAccess(anyString()))
             .thenReturn(new OwnerContentAccess(null, null));


### PR DESCRIPTION
- If contentAccessModeList is not specified when creating a new org via Candlepin API, it now defaults to org_environment.
- It no longer includes entitlement by default.
- A caller can still update the owner’s contentAccessModeList to include entitlement for dev/test scenarios or other special cases.