### PR TITLE
[F] CHAINSAW-376: Updated ConsumerResource.exportCertificates exception handling

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -1280,6 +1280,17 @@ paths:
               example:
                 displayMessage: Consumer with this UUID could not be found.
                 requestUuid: c4347004-8792-41fe-a4d8-fccaa0d3898a
+        429:
+          description: |
+            Concurrent requests persisting the same content access data payload caused a database constraint
+            violation. If you receive this status code, retry the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExceptionMessage'
+              example:
+                displayMessage: Unable to create content access payload
+                requestUuid: c4347004-8792-41fe-a4d8-fccaa0d3898a
         default:
           $ref: '#/components/responses/default'
 

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Response.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Response.java
@@ -38,6 +38,7 @@ public class Response {
     private final int code;
     private final byte[] body;
     private final Map<String, List<String>> headers;
+    private final String message;
 
     /**
      * Create a new Response from the given OkHttp Response object.
@@ -60,6 +61,7 @@ public class Response {
             this.code = response.code();
             this.headers = response.headers().toMultimap();
             this.body = body != null ? body.bytes() : new byte[] { };
+            this.message = response.message();
         }
         catch (IOException e) {
             throw new ResponseProcessingException(e);
@@ -126,6 +128,16 @@ public class Response {
         }
 
         return new String(this.body, charset);
+    }
+
+   /**
+     * Fetches the HTTP status message.
+     *
+     * @return
+     *  the HTTP status message for this response
+     */
+    public String getMessage() {
+        return this.message;
     }
 
     /**
@@ -195,5 +207,15 @@ public class Response {
         catch (IOException e) { // Impl note: JsonProcessingException *is* an IOException
             throw new JsonDeserializationException(e);
         }
+    }
+
+    /**
+     * Returns true if the response status code was equal or larger than 200 and lower than 300,
+     * and false otherwise.
+     *
+     * @return whether the request was successful or not
+     */
+    public boolean wasSuccessful() {
+        return this.code >= 200 && this.code < 300;
     }
 }

--- a/src/main/java/org/candlepin/resource/ConsumerResource.java
+++ b/src/main/java/org/candlepin/resource/ConsumerResource.java
@@ -2451,10 +2451,9 @@ public class ConsumerResource implements ConsumerApi {
                 i18n.tr("Unable to create entitlement certificate archive"), e);
         }
         catch (ConcurrentContentPayloadCreationException e) {
-            // TODO: Handle as part of CHAINSAW-376
+            throw new TooManyRequestsException(i18n.tr("Unable to create content access payload"), e)
+                .setRetryAfterTime(CONTENT_PAYLOAD_CREATION_EXCEPTION_RETRY_AFTER_TIME);
         }
-
-        return null;
     }
 
     private Set<Long> extractSerials(String serials) {


### PR DESCRIPTION
- Updated ConsumerResource.exportCertificates to throw TooManyRequestsException (HTTP status code 429) when a conflict in SCA payload generation happens.
- Renamed two tests in ExportSpecTest to be more accurate.