### PR TITLE
[M] CANDLEPIN-999: Fixed paging for list owner pools

### DIFF
--- a/src/main/java/org/candlepin/controller/PoolManager.java
+++ b/src/main/java/org/candlepin/controller/PoolManager.java
@@ -1568,12 +1568,8 @@ public class PoolManager {
 
         // Set maxRecords once we are done filtering
         page.setMaxRecords(resultingPools.size());
-
-        if (qualifier.getOffset() != null && qualifier.getLimit() != null) {
-            resultingPools = poolCurator.takeSubList(qualifier, resultingPools);
-        }
-
         page.setPageData(resultingPools);
+
         return page;
     }
 

--- a/src/main/java/org/candlepin/model/PoolCurator.java
+++ b/src/main/java/org/candlepin/model/PoolCurator.java
@@ -399,16 +399,9 @@ public class PoolCurator extends AbstractHibernateCurator<Pool> {
             .createQuery(query)
             .getResultList();
 
-        int maxSize = pools.size();
-
-        // Filter the Pools if paging is needed
-        if (qualifier.getOffset() != null && qualifier.getLimit() != null) {
-            pools = this.takeSubList(qualifier, pools);
-        }
-
         return new Page<List<Pool>>()
             .setPageData(pools)
-            .setMaxRecords(maxSize);
+            .setMaxRecords(pools.size());
     }
 
     private Optional<List<Predicate>> getQualifierPredicates(CriteriaQuery<?> query, Root<Pool> root,


### PR DESCRIPTION
- Updated the list owner pools endpoint to not filter the pools twice when paging is requested.
- Updated list owner pools to return a bad request response instead of an internal server error response when an invalid order key is provided in the request.
- Moved the paging of the pools out of the PoolManager class and into the OwnerResource.listOwnerPools and PoolResource.listPools.