### PR TITLE
[M] CANDLEPIN-996: Fixed SAST scan issues

### DIFF
--- a/src/main/java/org/candlepin/async/JobManager.java
+++ b/src/main/java/org/candlepin/async/JobManager.java
@@ -1103,14 +1103,8 @@ public class JobManager implements ModeChangeListener {
             }
         }
         catch (JobStateManagementException e) {
-            if (log.isDebugEnabled()) {
-                log.error("Unable to update state for job: {}; leaving job in its previous state for " +
-                    "state resync upon execution", status.getName(), e);
-            }
-            else {
-                log.error("Unable to update state for job: {}; leaving job in its previous state for " +
-                    "state resync upon execution", status.getName(), e);
-            }
+            log.error("Unable to update state for job: {}; leaving job in its previous state for " +
+                "state resync upon execution", status.getName(), e);
 
             // We were unable to update the state from CREATED->QUEUED, but we were able to send
             // the message to Artemis. We *should* be fine once the job executes and corrects

--- a/src/main/java/org/candlepin/model/ManifestFileRecordCurator.java
+++ b/src/main/java/org/candlepin/model/ManifestFileRecordCurator.java
@@ -69,11 +69,10 @@ public class ManifestFileRecordCurator extends AbstractHibernateCurator<Manifest
     }
 
     private Blob createBlob(File fileToStore) throws IOException {
-        FileInputStream inputStream = new FileInputStream(fileToStore);
         byte[] fileBytes = new byte[(int) fileToStore.length()];
-        inputStream.read(fileBytes);
-        inputStream.close();
-
+        try (FileInputStream inputStream = new FileInputStream(fileToStore)) {
+            inputStream.read(fileBytes);
+        }
         try {
             return new SerialBlob(fileBytes);
         }


### PR DESCRIPTION
- Removed duplicate logging branch logic in JobManager.
- Refactored createBlob method to use try-with-resources to properly close FileInputStream, preventing resource leaks.