### PR TITLE
[4.3] Updated hard coded unit test date

### DIFF
--- a/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceTest.java
@@ -715,7 +715,7 @@ public class ConsumerResourceTest {
         ComplianceStatus status = new ComplianceStatus();
         when(complianceRules.getStatus(any(Consumer.class), any(Date.class), anyBoolean()))
             .thenReturn(status);
-        consumer.setIdCert(createIdCert(TestUtil.createDate(2025, 6, 9)));
+        consumer.setIdCert(createIdCert(TestUtil.createDateOffset(1, 0, 0)));
         long origSerial = consumer.getIdCert().getSerial().getSerial().longValue();
 
         ConsumerDTO c = consumerResource.getConsumer(consumer.getUuid());


### PR DESCRIPTION
- Updated ConsumerResourceTest.validIdCertDoesNotRegenerate to not use a hard coded date that was causing the test to fail.