### PR TITLE
[4.3] Increased upload action version due to deprecation

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -50,13 +50,13 @@ jobs:
         run: echo ${{ github.event.number }} > PR_NUMBER.txt
 
       - name: Archive PR number
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: PR_NUMBER.txt
 
       - name: Archive reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit_test_reports
           path: |


### PR DESCRIPTION
Version 3 was deprecated at the beginning of the year.[1]

[1] https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/