### PR TITLE
[M] CANDLEPIN-996: Additional SAST scan fixes

### DIFF
--- a/buildSrc/src/main/java/org/candlepin/gradle/SpecVersion.java
+++ b/buildSrc/src/main/java/org/candlepin/gradle/SpecVersion.java
@@ -32,10 +32,7 @@ public class SpecVersion implements Plugin<Project> {
         String absPath = project.getRootProject().getProjectDir().getAbsolutePath();
         Path specFilePath = Paths.get(absPath, "candlepin.spec.tmpl");
 
-        try {
-
-            FileReader fileReader = new FileReader(specFilePath.toFile());
-            BufferedReader bufferedReader = new BufferedReader(fileReader);
+        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(specFilePath.toFile()))) {
             String line;
             while ((line = bufferedReader.readLine()) != null) {
                 Matcher matcher = versionPattern.matcher(line);
@@ -50,7 +47,6 @@ public class SpecVersion implements Plugin<Project> {
                     break;
                 }
             }
-            fileReader.close();
         }
         catch (IOException e) {
             throw new GradleException("Error reading spec file", e);

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/DefaultProperties.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/DefaultProperties.java
@@ -26,12 +26,20 @@ public class DefaultProperties implements Supplier<Properties> {
 
     @Override
     public Properties get() {
-        ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        InputStream inputStream = loader.getResourceAsStream("settings.properties");
         Properties properties = new Properties();
-        loadProperties(inputStream, properties);
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try (InputStream inputStream = loader.getResourceAsStream("settings.properties")) {
+            if (inputStream == null) {
+                throw new IllegalStateException("Could not find settings.properties");
+            }
+            loadProperties(inputStream, properties);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Error loading properties", e);
+        }
         return properties;
     }
+
 
     private void loadProperties(InputStream inputStream, Properties properties) {
         try {


### PR DESCRIPTION
- Refactored the get() method to automatically close the InputStream acquired from loader.getResourceAsStream().
- Added a null check for when the "settings.properties" resource was not found.