### PR TITLE
[M] CANDLEPIN-990: Updated cp_consumer_environments.priority to tinyint

### DIFF
--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -336,7 +336,7 @@ public class Consumer extends AbstractHibernateObject<Consumer> implements Linka
     @Cascade({org.hibernate.annotations.CascadeType.ALL})
     @Fetch(FetchMode.SELECT)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-    private Map<String, String> environmentIds;
+    private Map<Integer, String> environmentIds;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "reg_auth_method")
@@ -1237,7 +1237,7 @@ public class Consumer extends AbstractHibernateObject<Consumer> implements Linka
         }
 
         return this.environmentIds.entrySet().stream()
-            .sorted(Comparator.comparingInt(entry -> Integer.parseInt(entry.getKey())))
+            .sorted(Comparator.comparingInt(entry -> entry.getKey()))
             .map(Map.Entry::getValue)
             .collect(Collectors.toUnmodifiableList());
     }
@@ -1263,7 +1263,7 @@ public class Consumer extends AbstractHibernateObject<Consumer> implements Linka
             }
 
             for (String envId : environmentIds) {
-                this.environmentIds.put(String.valueOf(this.environmentIds.size()), envId);
+                this.environmentIds.put(this.environmentIds.size(), envId);
             }
         }
         return this;
@@ -1313,7 +1313,7 @@ public class Consumer extends AbstractHibernateObject<Consumer> implements Linka
                     " specified more than once.");
             }
 
-            this.environmentIds.put(String.valueOf(this.environmentIds.size()), environment.getId());
+            this.environmentIds.put(this.environmentIds.size(), environment.getId());
         }
 
         return this;

--- a/src/main/java/org/candlepin/model/EntitlementCurator.java
+++ b/src/main/java/org/candlepin/model/EntitlementCurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -561,7 +561,7 @@ public class EntitlementCurator extends AbstractHibernateCurator<Entitlement> {
         CriteriaQuery<Entitlement> query = cb.createQuery(Entitlement.class);
         Root<Entitlement> root = query.from(Entitlement.class);
         Join<Entitlement, Consumer> consumer = root.join(Entitlement_.consumer);
-        MapJoin<Consumer, String, String> consumerEnvironments = consumer.join(Consumer_.environmentIds);
+        MapJoin<Consumer, Integer, String> consumerEnvironments = consumer.join(Consumer_.environmentIds);
 
         query.select(root)
             .distinct(true)

--- a/src/main/resources/db/changelog/20250325000000-update-env-priority-column-type.xml
+++ b/src/main/resources/db/changelog/20250325000000-update-env-priority-column-type.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.19.xsd">
+
+    <changeSet id="20250325000000-1" author="jalbrech">
+        <sql dbms="mysql, mariadb">
+            DELETE FROM cp_consumer_environments WHERE priority REGEXP '[^0-9]+';
+        </sql>
+
+        <sql dbms="postgresql">
+            DELETE FROM cp_consumer_environments WHERE priority ~ '[^0-9]+';
+        </sql>
+
+        <modifyDataType tableName="cp_consumer_environments"
+            columnName="priority"
+            newDataType="SMALLINT" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changelog-update.xml
+++ b/src/main/resources/db/changelog/changelog-update.xml
@@ -205,4 +205,5 @@
     <include file="db/changelog/20241029000000-drop-fk-cp-owner.xml"/>
     <include file="/db/changelog/20250128162900-add-last-content-update-field.xml"/>
     <include file="db/changelog/20250130000000-add-cp-content-access-payload-table.xml" />
+    <include file="db/changelog/20250325000000-update-env-priority-column-type.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
- Updated the cp_consumer_environments.priority column from a varchar to a tinyint to prevent ordering issues when a consumer has more than 10 environments.