### PR TITLE
[4.5] CANDLEPIN-943: Removed JIRA target check from forks PRs

### DIFF
--- a/.github/workflows/jira_check.yml
+++ b/.github/workflows/jira_check.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   target_version_validation:
+    if: github.event.pull_request.head.repo.fork == false
     name: target version validation
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
- Due to security limitations with token usage in GitHub Actions, the Jira check was executed only for internal pull requests. This prevented workflow failures for forked PRs and ensured that sensitive tokens were not exposed.