### PR TITLE
[4.4] CANDLEPIN-1009: Fix Content URLs in SCA cert for Multi Env

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/CertificateUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/CertificateUtil.java
@@ -92,6 +92,32 @@ public final class CertificateUtil {
     }
 
     /**
+     * Extracts the encoded and compressed bodies of the entitlement certificates.
+     *
+     * @param jsonPayload
+     *  the json object that contains the encoded and compressed entitlement certificates
+     *
+     * @return
+     *  a list entitlement certificates in string format (still encoded and compressed)
+     */
+    public static List<String> extractEncodedCertsFromPayload(Object jsonPayload) {
+        if (jsonPayload == null) {
+            return new ArrayList<>();
+        }
+
+        String json = String.valueOf(jsonPayload);
+        if (json == null || json.isEmpty() || json.isBlank()) {
+            return new ArrayList<>();
+        }
+
+        List<String> certs = new ArrayList<>();
+        ((List<Map<String, String>>) jsonPayload)
+            .forEach(entry -> certs.add(entry.get("cert")));
+
+        return certs;
+    }
+
+    /**
      * Decodes and uncompresses a certificate body into a {@link JsonNode}.
      * Note that this will fail if you forgot to make your consumer V3 capable
      *

--- a/src/main/java/org/candlepin/pki/huffman/Huffman.java
+++ b/src/main/java/org/candlepin/pki/huffman/Huffman.java
@@ -135,30 +135,36 @@ public class Huffman {
         }
     }
 
-    private void makePathForURL(StringTokenizer st, PathNode parent, PathNode endMarker) {
-        if (st.hasMoreTokens()) {
-            String childVal = st.nextToken();
-            if (childVal.isEmpty()) {
+    private void makePathForURL(StringTokenizer tokenizer, PathNode parent, PathNode endMarker) {
+        if (tokenizer.hasMoreTokens()) {
+            String nextValue = tokenizer.nextToken();
+            if (nextValue.isEmpty()) {
                 return;
             }
             boolean isNew = true;
-            for (NodePair child : parent.getChildren()) {
-                if (child.getName().equals(childVal) &&
-                    !child.getConnection().equals(endMarker)) {
-                    makePathForURL(st, child.getConnection(), endMarker);
+            for (NodePair peer : parent.getChildren()) {
+                if (peer.getName().equals(nextValue)) {
                     isNew = false;
+                    if (!peer.getConnection().equals(endMarker)) {
+                        if (!tokenizer.hasMoreTokens()) {
+                            peer.getConnection().getChildren().clear();
+                        }
+                        else {
+                            makePathForURL(tokenizer, peer.getConnection(), endMarker);
+                        }
+                    }
                 }
             }
             if (isNew) {
                 PathNode next;
-                if (st.hasMoreTokens()) {
+                if (tokenizer.hasMoreTokens()) {
                     next = new PathNode(this.pathNodeId++);
-                    parent.addChild(new NodePair(childVal, next));
+                    parent.addChild(new NodePair(nextValue, next));
                     next.addParent(parent);
-                    makePathForURL(st, next, endMarker);
+                    makePathForURL(tokenizer, next, endMarker);
                 }
                 else {
-                    parent.addChild(new NodePair(childVal, endMarker));
+                    parent.addChild(new NodePair(nextValue, endMarker));
                     if (!endMarker.getParents().contains(parent)) {
                         endMarker.addParent(parent);
                     }

--- a/src/test/java/org/candlepin/pki/huffman/HuffmanTest.java
+++ b/src/test/java/org/candlepin/pki/huffman/HuffmanTest.java
@@ -176,6 +176,106 @@ public class HuffmanTest {
     }
 
     @Test
+    public void testPathTreeShouldNotContainSubPathIfBasePathIsPresentFirst() {
+        List<org.candlepin.model.dto.Content> contentList = new ArrayList<>();
+
+        org.candlepin.model.dto.Content contentA = new org.candlepin.model.dto.Content();
+        contentA.setPath("/AAA");
+        org.candlepin.model.dto.Content contentB = new org.candlepin.model.dto.Content();
+        contentB.setPath("/AAA/111");
+
+        contentList.add(contentA);
+        contentList.add(contentB);
+
+        PathNode location = this.huffman.makePathTree(contentList, new PathNode(1));
+
+        assertEquals(1, location.getChildren().size());
+        assertEquals("AAA", location.getChildren().get(0).getName());
+        assertEquals(0, location.getChildren().get(0).getConnection().getChildren().size());
+    }
+
+    @Test
+    public void testPathTreeShouldNotContainSubPathIfBasePathIsPresentAfterIt() {
+        List<org.candlepin.model.dto.Content> contentList = new ArrayList<>();
+
+        org.candlepin.model.dto.Content contentA = new org.candlepin.model.dto.Content();
+        contentA.setPath("/AAA/111");
+        org.candlepin.model.dto.Content contentB = new org.candlepin.model.dto.Content();
+        contentB.setPath("/AAA");
+
+        contentList.add(contentA);
+        contentList.add(contentB);
+
+        PathNode location = this.huffman.makePathTree(contentList, new PathNode(1));
+
+        assertEquals(1, location.getChildren().size());
+        assertEquals("AAA", location.getChildren().get(0).getName());
+        assertEquals(0, location.getChildren().get(0).getConnection().getChildren().size());
+    }
+
+    @Test
+    public void testPathTreeShouldContainBothSpecificPathsIfTheyShareABasePath() {
+        List<org.candlepin.model.dto.Content> contentList = new ArrayList<>();
+
+        org.candlepin.model.dto.Content contentA = new org.candlepin.model.dto.Content();
+        contentA.setPath("/AAA/111");
+        org.candlepin.model.dto.Content contentB = new org.candlepin.model.dto.Content();
+        contentB.setPath("/AAA/222");
+
+        contentList.add(contentA);
+        contentList.add(contentB);
+
+        PathNode location = this.huffman.makePathTree(contentList, new PathNode(1));
+
+        assertEquals(1, location.getChildren().size());
+        assertEquals("AAA", location.getChildren().get(0).getName());
+        assertEquals("111", location.getChildren().get(0).getConnection().getChildren().get(0).getName());
+        assertEquals("222", location.getChildren().get(0).getConnection().getChildren().get(1).getName());
+    }
+
+    @Test
+    public void testPathTreeShouldNotContainMultipleSpecificPathsIfBasePathIsPresent() {
+        List<org.candlepin.model.dto.Content> contentList = new ArrayList<>();
+
+        org.candlepin.model.dto.Content contentA = new org.candlepin.model.dto.Content();
+        contentA.setPath("/AAA/111");
+        org.candlepin.model.dto.Content contentB = new org.candlepin.model.dto.Content();
+        contentB.setPath("/AAA/222");
+        org.candlepin.model.dto.Content contentC = new org.candlepin.model.dto.Content();
+        contentC.setPath("/AAA");
+
+        contentList.add(contentA);
+        contentList.add(contentB);
+        contentList.add(contentC);
+
+        PathNode location = this.huffman.makePathTree(contentList, new PathNode(1));
+
+        assertEquals(1, location.getChildren().size());
+        assertEquals("AAA", location.getChildren().get(0).getName());
+        assertEquals(0, location.getChildren().get(0).getConnection().getChildren().size());
+    }
+
+    @Test
+    public void testPathTreeShouldIgnoreDuplicatePaths() {
+        List<org.candlepin.model.dto.Content> contentList = new ArrayList<>();
+
+        org.candlepin.model.dto.Content contentA = new org.candlepin.model.dto.Content();
+        contentA.setPath("/AAA/111");
+        org.candlepin.model.dto.Content contentB = new org.candlepin.model.dto.Content();
+        contentB.setPath("/AAA/111");
+
+        contentList.add(contentA);
+        contentList.add(contentB);
+
+        PathNode location = this.huffman.makePathTree(contentList, new PathNode(1));
+
+        assertEquals(1, location.getChildren().size());
+        assertEquals("AAA", location.getChildren().get(0).getName());
+        assertEquals(1, location.getChildren().get(0).getConnection().getChildren().size());
+        assertEquals("111", location.getChildren().get(0).getConnection().getChildren().get(0).getName());
+    }
+
+    @Test
     public void testPathDictionary() {
         List<org.candlepin.model.dto.Content> contentList = new ArrayList<>();
         org.candlepin.model.dto.Content cont;


### PR DESCRIPTION
- When 2 or more environment names contain slashes, where one environment's name is a sub path of the other, the SCA cert's Authorized Content URLs section will now only contain the path from the environment with the base path (regardless of priority of environments). Example: Given environments A and A/1 in OrgX, applied to a given consumer, only the path /OrgX/A should be present in the cert.