### PR TITLE
CHAINSAW-481: IAE when sort_by query parameter not specified

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
@@ -435,6 +435,51 @@ public class OwnerResourceSpecTest {
                 .containsExactlyElementsOf(expectedPoolIds);
         }
 
+        @Test
+        public void shouldPageOwnersPoolsWithOrderByNotSpecified() {
+            int pageSize = 5;
+            List<String> actualPoolsIds = new ArrayList<>();
+            for (int pageIndex = 1; pageIndex * pageSize <= numberOfPools; pageIndex++) {
+                Paging paging = new Paging(pageIndex, pageSize, null, "asc");
+
+                List<String> poolIds = owners.listOwnerPools(ownerKey, paging).stream()
+                    .map(PoolDTO::getId)
+                    .collect(Collectors.toList());
+
+                actualPoolsIds.addAll(poolIds);
+            }
+
+            List<String> expectedPoolIds = pools.stream()
+                .map(PoolDTO::getId)
+                .toList();
+
+            assertThat(actualPoolsIds)
+                .containsExactlyElementsOf(expectedPoolIds);
+        }
+
+        @Test
+        public void shouldPageOwnersPoolsInDescendingOrderWithOrderNotSpecified() {
+            int pageSize = 5;
+            List<String> actualPoolsIds = new ArrayList<>();
+            for (int pageIndex = 1; pageIndex * pageSize <= numberOfPools; pageIndex++) {
+                Paging paging = new Paging(pageIndex, pageSize, "id", null);
+
+                List<String> poolIds = owners.listOwnerPools(ownerKey, paging).stream()
+                    .map(PoolDTO::getId)
+                    .collect(Collectors.toList());
+
+                actualPoolsIds.addAll(poolIds);
+            }
+
+            List<String> expectedPoolIds = pools.stream()
+                .sorted(comparatorMap.get("id").reversed())
+                .map(PoolDTO::getId)
+                .toList();
+
+            assertThat(actualPoolsIds)
+                .containsExactlyElementsOf(expectedPoolIds);
+        }
+
         @ParameterizedTest
         @ValueSource(ints = { 0, -1, -100 })
         public void shouldFailWithInvalidPage(int page) {

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/PoolResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/PoolResourceSpecTest.java
@@ -610,6 +610,51 @@ class PoolResourceSpecTest {
                 .containsExactlyElementsOf(expectedPoolIds);
         }
 
+        @Test
+        public void shouldPagePoolsWithOrderByNotSpecified() {
+            int pageSize = 5;
+            List<String> actualPoolsIds = new ArrayList<>();
+            for (int pageIndex = 1; pageIndex * pageSize <= numberOfPools; pageIndex++) {
+                List<String> poolIds = adminClient.pools()
+                    .listPools(ownerId, null, null, null, null, pageIndex, pageSize, "asc", null)
+                    .stream()
+                    .map(PoolDTO::getId)
+                    .collect(Collectors.toList());
+
+                actualPoolsIds.addAll(poolIds);
+            }
+
+            List<String> expectedPoolIds = pools.stream()
+                .map(PoolDTO::getId)
+                .toList();
+
+            assertThat(actualPoolsIds)
+                .containsExactlyElementsOf(expectedPoolIds);
+        }
+
+        @Test
+        public void shouldPagePoolsInDescendingOrderWithOrderNotSpecified() {
+            int pageSize = 5;
+            List<String> actualPoolsIds = new ArrayList<>();
+            for (int pageIndex = 1; pageIndex * pageSize <= numberOfPools; pageIndex++) {
+                List<String> poolIds = adminClient.pools()
+                    .listPools(ownerId, null, null, null, null, pageIndex, pageSize, null, "id")
+                    .stream()
+                    .map(PoolDTO::getId)
+                    .collect(Collectors.toList());
+
+                actualPoolsIds.addAll(poolIds);
+            }
+
+            List<String> expectedPoolIds = pools.stream()
+                .sorted(comparatorMap.get("id").reversed())
+                .map(PoolDTO::getId)
+                .toList();
+
+            assertThat(actualPoolsIds)
+                .containsExactlyElementsOf(expectedPoolIds);
+        }
+
         @ParameterizedTest
         @ValueSource(ints = { 0, -1, -100 })
         public void shouldFailWithInvalidPage(int page) {

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1354,8 +1354,10 @@ public class OwnerResource implements OwnerApi {
             qualifier.setOffset(pageRequest.getPage())
                 .setLimit(pageRequest.getPerPage());
 
-            boolean reverse = pageRequest.getOrder() == PageRequest.DEFAULT_ORDER;
-            qualifier.addOrder(pageRequest.getSortBy(), reverse);
+            if (pageRequest.getSortBy() != null) {
+                boolean reverse = pageRequest.getOrder() == PageRequest.DEFAULT_ORDER;
+                qualifier.addOrder(pageRequest.getSortBy(), reverse);
+            }
         }
 
         if (key != null) {

--- a/src/main/java/org/candlepin/resource/PoolResource.java
+++ b/src/main/java/org/candlepin/resource/PoolResource.java
@@ -175,8 +175,10 @@ public class PoolResource implements PoolsApi {
             qualifier.setOffset(pageRequest.getPage())
                 .setLimit(pageRequest.getPerPage());
 
-            boolean reverse = pageRequest.getOrder() == PageRequest.DEFAULT_ORDER;
-            qualifier.addOrder(pageRequest.getSortBy(), reverse);
+            if (pageRequest.getSortBy() != null) {
+                boolean reverse = pageRequest.getOrder() == PageRequest.DEFAULT_ORDER;
+                qualifier.addOrder(pageRequest.getSortBy(), reverse);
+            }
         }
 
         Page<List<Pool>> pageResponse = poolManager.listAvailableEntitlementPools(qualifier);

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -1158,6 +1158,74 @@ public class OwnerResourceTest extends DatabaseTestFixture {
     }
 
     @Test
+    public void testListOwnerPoolsWithPagingWithOrderByNotSpecified() {
+        int numberOfPools = 9;
+        int pageSize = 3;
+
+        List<String> expectedPoolIds = new ArrayList<>();
+        for (int i = 0; i < numberOfPools; i++) {
+            Product product = this.createProduct();
+            Pool pool = poolCurator.create(TestUtil.createPool(owner, product));
+            expectedPoolIds.add(pool.getId());
+        }
+
+        Collections.sort(expectedPoolIds);
+
+        for (int page = 1; page <= numberOfPools / pageSize; page++) {
+            ResteasyContext.pushContext(PageRequest.class,
+                new PageRequest()
+                    .setPage(page)
+                    .setPerPage(pageSize)
+                    .setOrder(Order.ASCENDING));
+
+            Stream<PoolDTO> actual = ownerResource.listOwnerPools(
+                owner.getKey(), null, null, null, null, true, null, null,
+                new ArrayList<>(), false, false, null, null, page, pageSize, null, "asc");
+
+            int pageIndex = (page - 1) * pageSize;
+
+            assertThat(actual)
+                .isNotNull()
+                .extracting(PoolDTO::getId)
+                .containsExactlyElementsOf(expectedPoolIds.subList(pageIndex, pageIndex + pageSize));
+        }
+    }
+
+    @Test
+    public void testListOwnerPoolsWithPagingWithOrderNotSpecified() {
+        int numberOfPools = 9;
+        int pageSize = 3;
+
+        List<String> expectedPoolIds = new ArrayList<>();
+        for (int i = 0; i < numberOfPools; i++) {
+            Product product = this.createProduct();
+            Pool pool = poolCurator.create(TestUtil.createPool(owner, product));
+            expectedPoolIds.add(pool.getId());
+        }
+
+        Collections.sort(expectedPoolIds);
+
+        for (int page = 1; page <= numberOfPools / pageSize; page++) {
+            ResteasyContext.pushContext(PageRequest.class,
+                new PageRequest()
+                    .setPage(page)
+                    .setPerPage(pageSize)
+                    .setSortBy("id"));
+
+            Stream<PoolDTO> actual = ownerResource.listOwnerPools(
+                owner.getKey(), null, null, null, null, true, null, null,
+                new ArrayList<>(), false, false, null, null, page, pageSize, "id", null);
+
+            int pageIndex = (page - 1) * pageSize;
+
+            assertThat(actual)
+                .isNotNull()
+                .extracting(PoolDTO::getId)
+                .containsExactlyElementsOf(expectedPoolIds.subList(pageIndex, pageIndex + pageSize));
+        }
+    }
+
+    @Test
     public void testListOwnerPoolsWithInvalidOrderKeyException() {
         ResteasyContext.pushContext(PageRequest.class,
             new PageRequest()


### PR DESCRIPTION
- Updated the GET /owners/{key}/pools and the GET /pools endpoint to not throw an IllegalArgumentException when paging a request and not specifying the sort_by query parameter.