### PR TITLE
[M] CHAINSAW-484: Added query parameters to list consumers endpoint

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -5242,6 +5242,27 @@ paths:
             items:
               type: string
               format: key:value
+        - name: pool_contract_number
+          in: query
+          description: The pool contract number
+          schema:
+            type: array
+            items:
+              type: string
+        - name: product_id
+          in: query
+          description: The product ID
+          schema:
+            type: array
+            items:
+              type: string
+        - name: subscription_id
+          in: query
+          description: The subscription ID
+          schema:
+            type: array
+            items:
+              type: string
         - $ref: "#/components/parameters/paging_page"
         - $ref: "#/components/parameters/paging_per_page"
         - $ref: "#/components/parameters/paging_order"

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/OwnerClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/OwnerClient.java
@@ -38,10 +38,21 @@ public class OwnerClient extends OwnerApi {
         return listOwnerConsumers(ownerKey, Set.of());
     }
 
-    public List<ConsumerDTOArrayElement> listOwnerConsumers(
-        String ownerKey, Set<String> consumerTypes) {
-        return super.listConsumers(ownerKey, null, consumerTypes, List.of(), List.of(), List.of(),
-            null, null, null, null);
+    public List<ConsumerDTOArrayElement> listOwnerConsumers(String ownerKey, Set<String> consumerTypes) {
+        return super.listConsumers(
+            ownerKey,
+            null,
+            consumerTypes,
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            null,
+            null,
+            null,
+            null);
     }
 
     public List<PoolDTO> listOwnerPools(String ownerKey) {

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceConsumerFactFilterSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceConsumerFactFilterSpecTest.java
@@ -64,11 +64,13 @@ public class OwnerResourceConsumerFactFilterSpecTest {
     @Test
     public void shouldAllowOwnersFilterConsumersByASingleFact() throws ApiException {
         List<ConsumerDTOArrayElement> consumers = adminClient.owners().listConsumers(
-            owner.getKey(), null, null, null, null, List.of("key:value"), null, null, null, null);
+            owner.getKey(), null, null, null, null, List.of("key:value"), null, null, null, null, null, null,
+            null);
         assertEquals(2, consumers.size());
 
         consumers = adminClient.owners().listConsumers(
-            owner.getKey(), null, null, null, null, List.of("newkey:somevalue"), null, null, null, null);
+            owner.getKey(), null, null, null, null, List.of("newkey:somevalue"), null, null, null, null, null,
+            null, null);
         assertThat(consumers)
             .isNotNull()
             .singleElement()
@@ -80,7 +82,7 @@ public class OwnerResourceConsumerFactFilterSpecTest {
     public void shouldAllowOwnersFilterConsumersByMultipleFacts() throws ApiException {
         List<ConsumerDTOArrayElement> consumers = adminClient.owners().listConsumers(
             owner.getKey(), null, null, null, null, List.of("key:value", "otherkey:someval"),
-            null, null, null, null);
+            null, null, null, null, null, null, null);
         assertThat(consumers)
             .isNotNull()
             .singleElement()
@@ -92,7 +94,7 @@ public class OwnerResourceConsumerFactFilterSpecTest {
     public void shouldAllowOwnersFilterConsumersByMultipleFactsSameKeyAsOr() throws ApiException {
         List<ConsumerDTOArrayElement> consumers = adminClient.owners().listConsumers(
             owner.getKey(), null, null, null, null, List.of("otherkey:othervalue", "otherkey:someval"),
-            null, null, null, null);
+            null, null, null, null, null, null, null);
         assertThat(consumers)
             .isNotNull()
             .hasSize(2);
@@ -101,14 +103,16 @@ public class OwnerResourceConsumerFactFilterSpecTest {
     @Test
     public void shouldAllowOwnersFilterConsumersByFactsWithWildcards() throws ApiException {
         List<ConsumerDTOArrayElement> consumers = adminClient.owners().listConsumers(
-            owner.getKey(), null, null, null, null, List.of("*key*:*val*"), null, null, null, null);
+            owner.getKey(), null, null, null, null, List.of("*key*:*val*"), null, null, null, null, null,
+            null, null);
         assertThat(consumers)
             .isNotNull()
             .hasSize(3);
 
         // Also make sure the value half is checked case insensitively
         consumers = adminClient.owners().listConsumers(
-            owner.getKey(), null, null, null, null, List.of("ot*key*:OTher*"), null, null, null, null);
+            owner.getKey(), null, null, null, null, List.of("ot*key*:OTher*"), null, null, null, null, null,
+            null, null);
         assertThat(consumers)
             .isNotNull()
             .singleElement()

--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1187,6 +1187,9 @@ public class OwnerResource implements OwnerApi {
         @Verify(value = Consumer.class, nullable = true) List<String> uuids,
         List<String> hypervisorIds,
         List<String> facts,
+        List<String> poolContractNumbers,
+        List<String> productIds,
+        List<String> subscriptionIds,
         Integer page, Integer perPage, String order, String sortBy) {
         Owner owner = findOwnerByKey(ownerKey);
         List<ConsumerType> types = this.consumerTypeValidator.findAndValidateTypeLabels(typeLabels);
@@ -1196,7 +1199,10 @@ public class OwnerResource implements OwnerApi {
             .setUsername(username)
             .setUuids(uuids)
             .setTypes(types)
-            .setHypervisorIds(hypervisorIds);
+            .setHypervisorIds(hypervisorIds)
+            .setPoolContractNumbers(poolContractNumbers)
+            .setProductIds(productIds)
+            .setSubscriptionIds(subscriptionIds);
 
         new KeyValueStringParser(this.i18n).parseKeyValuePairs(facts)
             .forEach(kvpair -> queryArgs.addFact(kvpair.getKey(), kvpair.getValue()));

--- a/src/test/java/org/candlepin/resource/OwnerResourceTest.java
+++ b/src/test/java/org/candlepin/resource/OwnerResourceTest.java
@@ -592,9 +592,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         when(this.principalProvider.get()).thenReturn(principal);
         securityInterceptor.enable();
 
-        assertThrows(ForbiddenException.class, () -> ownerResource
-            .listConsumers(owner.getKey(), null, null, new ArrayList<>(),
-                null, null, null, null, null, null));
+        assertThrows(ForbiddenException.class, () -> ownerResource.listConsumers(owner.getKey(), null, null,
+            new ArrayList<>(), null, null, null, null, null, null, null, null, null));
     }
 
     @Test
@@ -610,8 +609,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         types.add("type");
         consumerTypeCurator.create(new ConsumerType("type"));
 
-        Stream<ConsumerDTOArrayElement> result = ownerResource
-            .listConsumers(owner.getKey(), "username", types, uuids, null, null, null, null, null, null);
+        Stream<ConsumerDTOArrayElement> result = ownerResource.listConsumers(owner.getKey(), "username",
+            types, uuids, null, null, null, null, null, null, null, null, null);
 
         assertNotNull(result);
         List<ConsumerDTOArrayElement> consumers = result.collect(Collectors.toList());
@@ -633,8 +632,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         setupPrincipal(owner, Access.ALL);
         securityInterceptor.enable();
 
-        Stream<ConsumerDTOArrayElement> result = ownerResource
-            .listConsumers(owner.getKey(), null, null, uuids, null, null, null, null, null, null);
+        Stream<ConsumerDTOArrayElement> result = ownerResource.listConsumers(owner.getKey(), null, null,
+            uuids, null, null, null, null, null, null, null, null, null);
 
         assertNotNull(result);
         List<ConsumerDTOArrayElement> consumers = result.collect(Collectors.toList());
@@ -653,7 +652,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         BadRequestException ex = assertThrows(BadRequestException.class, () -> ownerResource
             .listConsumers(owner.getKey(), null, types, new ArrayList<>(),
-                null, null, null, null, null, null));
+                null, null, null, null, null, null, null, null, null));
         assertEquals("No such unit type(s): unknown", ex.getMessage());
     }
 
@@ -669,8 +668,8 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         setupPrincipal(owner, Access.ALL);
         securityInterceptor.enable();
 
-        Stream<ConsumerDTOArrayElement> result = ownerResource
-            .listConsumers(owner.getKey(), null, null, uuids, null, null, null, null, null, null);
+        Stream<ConsumerDTOArrayElement> result = ownerResource.listConsumers(owner.getKey(), null, null,
+            uuids, null, null, null, null, null, null, null, null, null);
 
         assertNotNull(result);
         List<ConsumerDTOArrayElement> consumers = result.collect(Collectors.toList());
@@ -758,7 +757,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
 
         OwnerResource resource = this.buildOwnerResource();
         Stream<ConsumerDTOArrayElement> result = resource.listConsumers(owner.getKey(), "username", null,
-            null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null);
 
         assertNotNull(result);
         assertEquals(expected.size(), result.count());
@@ -773,7 +772,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         doReturn(12000L).when(this.mockConsumerCurator).getConsumerCount(any(ConsumerQueryArguments.class));
 
         assertThrows(BadRequestException.class, () -> resource.listConsumers(ownerKey, "username", null, null,
-            null, null, null, null, null, null));
+            null, null, null, null, null, null, null, null, null));
     }
 
     @Test
@@ -790,7 +789,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerResource resource = this.buildOwnerResource();
         ArgumentCaptor<ConsumerQueryArguments> captor = ArgumentCaptor.forClass(ConsumerQueryArguments.class);
         Stream<ConsumerDTOArrayElement> result = resource.listConsumers(owner.getKey(), null,
-            null, null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null, null);
 
         // Verify the input passthrough is working properly
         verify(this.mockConsumerCurator, times(1)).findConsumers(captor.capture());
@@ -803,6 +802,9 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertNull(builder.getTypes());
         assertNull(builder.getHypervisorIds());
         assertNull(builder.getFacts());
+        assertNull(builder.getPoolContractNumbers());
+        assertNull(builder.getProductIds());
+        assertNull(builder.getSubscriptionIds());
 
         // Verify the output passthrough is working properly
         assertNotNull(result);
@@ -827,7 +829,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerResource resource = this.buildOwnerResource();
         ArgumentCaptor<ConsumerQueryArguments> captor = ArgumentCaptor.forClass(ConsumerQueryArguments.class);
         Stream<ConsumerDTOArrayElement> result = resource.listConsumers(owner.getKey(), username, null,
-            null, null, null, null, null, null, null);
+            null, null, null, null, null, null, null, null, null, null);
 
         // Verify the input passthrough is working properly
         verify(this.mockConsumerCurator, times(1)).findConsumers(captor.capture());
@@ -840,6 +842,9 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertNull(builder.getTypes());
         assertNull(builder.getHypervisorIds());
         assertNull(builder.getFacts());
+        assertNull(builder.getPoolContractNumbers());
+        assertNull(builder.getProductIds());
+        assertNull(builder.getSubscriptionIds());
 
         // Verify the output passthrough is working properly
         assertNotNull(result);
@@ -864,7 +869,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerResource resource = this.buildOwnerResource();
         ArgumentCaptor<ConsumerQueryArguments> captor = ArgumentCaptor.forClass(ConsumerQueryArguments.class);
         Stream<ConsumerDTOArrayElement> result = resource.listConsumers(owner.getKey(), null, null,
-            uuids, null, null, null, null, null, null);
+            uuids, null, null, null, null, null, null, null, null, null);
 
         // Verify the input passthrough is working properly
         verify(this.mockConsumerCurator, times(1)).findConsumers(captor.capture());
@@ -877,6 +882,9 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertNull(builder.getTypes());
         assertNull(builder.getHypervisorIds());
         assertNull(builder.getFacts());
+        assertNull(builder.getPoolContractNumbers());
+        assertNull(builder.getProductIds());
+        assertNull(builder.getSubscriptionIds());
 
         // Verify the output passthrough is working properly
         assertNotNull(result);
@@ -923,7 +931,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerResource resource = this.buildOwnerResource();
         ArgumentCaptor<ConsumerQueryArguments> captor = ArgumentCaptor.forClass(ConsumerQueryArguments.class);
         Stream<ConsumerDTOArrayElement> result = resource.listConsumers(owner.getKey(), null,
-            typeMap.keySet(), null, null, null, null, null, null, null);
+            typeMap.keySet(), null, null, null, null, null, null, null, null, null, null);
 
         // Verify the input passthrough is working properly
         verify(this.mockConsumerCurator, times(1)).findConsumers(captor.capture());
@@ -938,6 +946,9 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertTrue(Util.collectionsAreEqual(types, builder.getTypes()));
         assertNull(builder.getHypervisorIds());
         assertNull(builder.getFacts());
+        assertNull(builder.getPoolContractNumbers());
+        assertNull(builder.getProductIds());
+        assertNull(builder.getSubscriptionIds());
 
         // Verify the output passthrough is working properly
         assertNotNull(result);
@@ -962,7 +973,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerResource resource = this.buildOwnerResource();
         ArgumentCaptor<ConsumerQueryArguments> captor = ArgumentCaptor.forClass(ConsumerQueryArguments.class);
         Stream<ConsumerDTOArrayElement> result = resource.listConsumers(owner.getKey(), null, null,
-            null, hids, null, null, null, null, null);
+            null, hids, null, null, null, null, null, null, null, null);
 
         // Verify the input passthrough is working properly
         verify(this.mockConsumerCurator, times(1)).findConsumers(captor.capture());
@@ -975,6 +986,9 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertNull(builder.getTypes());
         assertEquals(hids, builder.getHypervisorIds());
         assertNull(builder.getFacts());
+        assertNull(builder.getPoolContractNumbers());
+        assertNull(builder.getProductIds());
+        assertNull(builder.getSubscriptionIds());
 
         // Verify the output passthrough is working properly
         assertNotNull(result);
@@ -1009,7 +1023,7 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         OwnerResource resource = this.buildOwnerResource();
         ArgumentCaptor<ConsumerQueryArguments> captor = ArgumentCaptor.forClass(ConsumerQueryArguments.class);
         Stream<ConsumerDTOArrayElement> result = resource.listConsumers(owner.getKey(), null, null,
-            null, null, factsParam, null, null, null, null);
+            null, null, factsParam, null, null, null, null, null, null, null);
 
         // Verify the input passthrough is working properly
         verify(this.mockConsumerCurator, times(1)).findConsumers(captor.capture());
@@ -1022,6 +1036,129 @@ public class OwnerResourceTest extends DatabaseTestFixture {
         assertNull(builder.getTypes());
         assertNull(builder.getHypervisorIds());
         assertEquals(factsMap, builder.getFacts());
+        assertNull(builder.getPoolContractNumbers());
+        assertNull(builder.getProductIds());
+        assertNull(builder.getSubscriptionIds());
+
+        // Verify the output passthrough is working properly
+        assertNotNull(result);
+        assertEquals(expected.size(), result.count());
+
+        // Impl note: the DTOs converted from mocks will have nothing in them, so there's no reason
+        // to bother checking that we got the exact ones we're expecting.
+    }
+
+    @Test
+    public void testListConsumersByPoolContractNumbers() {
+        List<String> contractNumbers = List.of("contract-1", "contract-2", "contract-3");
+        Owner owner = this.mockOwner("test_owner");
+        ConsumerType ctype = this.mockConsumerType();
+
+        List<Consumer> expected = Stream.generate(() -> this.mockConsumer(owner, ctype))
+            .limit(3)
+            .collect(Collectors.toList());
+
+        doReturn(expected).when(this.mockConsumerCurator).findConsumers(any(ConsumerQueryArguments.class));
+
+        OwnerResource resource = this.buildOwnerResource();
+        ArgumentCaptor<ConsumerQueryArguments> captor = ArgumentCaptor.forClass(ConsumerQueryArguments.class);
+        Stream<ConsumerDTOArrayElement> result = resource.listConsumers(owner.getKey(), null, null,
+            null, null, null, contractNumbers, null, null, null, null, null, null);
+
+        // Verify the input passthrough is working properly
+        verify(this.mockConsumerCurator, times(1)).findConsumers(captor.capture());
+        ConsumerQueryArguments builder = captor.getValue();
+
+        assertNotNull(builder);
+        assertEquals(owner, builder.getOwner());
+        assertNull(builder.getUsername());
+        assertNull(builder.getUuids());
+        assertNull(builder.getTypes());
+        assertNull(builder.getHypervisorIds());
+        assertNull(builder.getFacts());
+        assertEquals(contractNumbers, builder.getPoolContractNumbers());
+        assertNull(builder.getProductIds());
+        assertNull(builder.getSubscriptionIds());
+
+        // Verify the output passthrough is working properly
+        assertNotNull(result);
+        assertEquals(expected.size(), result.count());
+
+        // Impl note: the DTOs converted from mocks will have nothing in them, so there's no reason
+        // to bother checking that we got the exact ones we're expecting.
+    }
+
+    @Test
+    public void testListConsumersByProductIds() {
+        List<String> productIds = List.of("product-1", "product-2", "product-3");
+        Owner owner = this.mockOwner("test_owner");
+        ConsumerType ctype = this.mockConsumerType();
+
+        List<Consumer> expected = Stream.generate(() -> this.mockConsumer(owner, ctype))
+            .limit(3)
+            .collect(Collectors.toList());
+
+        doReturn(expected).when(this.mockConsumerCurator).findConsumers(any(ConsumerQueryArguments.class));
+
+        OwnerResource resource = this.buildOwnerResource();
+        ArgumentCaptor<ConsumerQueryArguments> captor = ArgumentCaptor.forClass(ConsumerQueryArguments.class);
+        Stream<ConsumerDTOArrayElement> result = resource.listConsumers(owner.getKey(), null, null, null,
+            null, null, null, productIds, null, null, null, null, null);
+
+        // Verify the input passthrough is working properly
+        verify(this.mockConsumerCurator, times(1)).findConsumers(captor.capture());
+        ConsumerQueryArguments builder = captor.getValue();
+
+        assertNotNull(builder);
+        assertEquals(owner, builder.getOwner());
+        assertNull(builder.getUsername());
+        assertNull(builder.getUuids());
+        assertNull(builder.getTypes());
+        assertNull(builder.getHypervisorIds());
+        assertNull(builder.getFacts());
+        assertNull(builder.getPoolContractNumbers());
+        assertEquals(productIds, builder.getProductIds());
+        assertNull(builder.getSubscriptionIds());
+
+        // Verify the output passthrough is working properly
+        assertNotNull(result);
+        assertEquals(expected.size(), result.count());
+
+        // Impl note: the DTOs converted from mocks will have nothing in them, so there's no reason
+        // to bother checking that we got the exact ones we're expecting.
+    }
+
+    @Test
+    public void testListConsumersBySubscriptionIds() {
+        List<String> subscriptionIds = List.of("sub-1", "sub-2", "sub-3");
+        Owner owner = this.mockOwner("test_owner");
+        ConsumerType ctype = this.mockConsumerType();
+
+        List<Consumer> expected = Stream.generate(() -> this.mockConsumer(owner, ctype))
+            .limit(3)
+            .collect(Collectors.toList());
+
+        doReturn(expected).when(this.mockConsumerCurator).findConsumers(any(ConsumerQueryArguments.class));
+
+        OwnerResource resource = this.buildOwnerResource();
+        ArgumentCaptor<ConsumerQueryArguments> captor = ArgumentCaptor.forClass(ConsumerQueryArguments.class);
+        Stream<ConsumerDTOArrayElement> result = resource.listConsumers(owner.getKey(), null, null, null,
+            null, null, null, null, subscriptionIds, null, null, null, null);
+
+        // Verify the input passthrough is working properly
+        verify(this.mockConsumerCurator, times(1)).findConsumers(captor.capture());
+        ConsumerQueryArguments builder = captor.getValue();
+
+        assertNotNull(builder);
+        assertEquals(owner, builder.getOwner());
+        assertNull(builder.getUsername());
+        assertNull(builder.getUuids());
+        assertNull(builder.getTypes());
+        assertNull(builder.getHypervisorIds());
+        assertNull(builder.getFacts());
+        assertNull(builder.getPoolContractNumbers());
+        assertNull(builder.getProductIds());
+        assertEquals(subscriptionIds, builder.getSubscriptionIds());
 
         // Verify the output passthrough is working properly
         assertNotNull(result);


### PR DESCRIPTION
- Added query parameters for pool contract number, product ID, and subscription ID to the GET /owners/{owner_key}/consumers endpoint.

The following queries are the generated by Hibernate for the respective query parameter. I am also including some times to execute the queries based on Prod data.

### pool_contract_number query parameter query

```sql
select distinct consumer0_.id as id1_13_, consumer0_.created as created2_13_, consumer0_.updated as updated3_13_, consumer0_.annotations as annotati4_13_, consumer0_.autoheal as autoheal5_13_, consumer0_.complianceStatusHash as complian6_13_, consumer0_.cont_acc_cert_id as cont_ac25_13_, consumer0_.content_access_mode as content_7_13_, consumer0_.entitlement_count as entitlem8_13_, consumer0_.entitlementStatus as entitlem9_13_, consumer0_.consumer_idcert_id as consume26_13_, consumer0_.keypair_id as keypair27_13_, consumer0_.lastCheckin as lastche10_13_, consumer0_.name as name11_13_, consumer0_.owner_id as owner_i12_13_, consumer0_.reg_auth_method as reg_aut13_13_, consumer0_.releaseVer as release14_13_, consumer0_.rh_cloud_profile_modified as rh_clou15_13_, consumer0_.sp_role as sp_role16_13_, consumer0_.serviceLevel as service17_13_, consumer0_.sp_service_type as sp_serv18_13_, consumer0_.sp_status as sp_stat19_13_, consumer0_.sp_status_hash as sp_stat20_13_, consumer0_.type_id as type_id21_13_, consumer0_.sp_usage as sp_usag22_13_, consumer0_.username as usernam23_13_, consumer0_.uuid as uuid24_13_ 
from cp_consumer consumer0_ 
inner join cp_entitlement entitlemen1_ on consumer0_.id=entitlemen1_.consumer_id 
inner join cp_pool pool2_ on entitlemen1_.pool_id=pool2_.id 
where consumer0_.owner_id=? and (pool2_.contractNumber in (? , ? , ?));
```

Execution in prod: 5905 rows in 7.146 seconds

### product_id query parameter query

```sql
select distinct consumer0_.id as id1_13_, consumer0_.created as created2_13_, consumer0_.updated as updated3_13_, consumer0_.annotations as annotati4_13_, consumer0_.autoheal as autoheal5_13_, consumer0_.complianceStatusHash as complian6_13_, consumer0_.cont_acc_cert_id as cont_ac25_13_, consumer0_.content_access_mode as content_7_13_, consumer0_.entitlement_count as entitlem8_13_, consumer0_.entitlementStatus as entitlem9_13_, consumer0_.consumer_idcert_id as consume26_13_, consumer0_.keypair_id as keypair27_13_, consumer0_.lastCheckin as lastche10_13_, consumer0_.name as name11_13_, consumer0_.owner_id as owner_i12_13_, consumer0_.reg_auth_method as reg_aut13_13_, consumer0_.releaseVer as release14_13_, consumer0_.rh_cloud_profile_modified as rh_clou15_13_, consumer0_.sp_role as sp_role16_13_, consumer0_.serviceLevel as service17_13_, consumer0_.sp_service_type as sp_serv18_13_, consumer0_.sp_status as sp_stat19_13_, consumer0_.sp_status_hash as sp_stat20_13_, consumer0_.type_id as type_id21_13_, consumer0_.sp_usage as sp_usag22_13_, consumer0_.username as usernam23_13_, consumer0_.uuid as uuid24_13_ 
from cp_consumer consumer0_ 
inner join cp_entitlement entitlemen1_ on consumer0_.id=entitlemen1_.consumer_id 
inner join cp_pool pool2_ on entitlemen1_.pool_id=pool2_.id 
inner join cp_products product3_ on pool2_.product_uuid=product3_.uuid 
where consumer0_.owner_id=? and (product3_.product_id in (? , ? , ?));
```

Execution in prod: 5905 rows in 5.428 seconds

### subscription_id query parameter query

```sql
select distinct consumer0_.id as id1_13_, consumer0_.created as created2_13_, consumer0_.updated as updated3_13_, consumer0_.annotations as annotati4_13_, consumer0_.autoheal as autoheal5_13_, consumer0_.complianceStatusHash as complian6_13_, consumer0_.cont_acc_cert_id as cont_ac25_13_, consumer0_.content_access_mode as content_7_13_, consumer0_.entitlement_count as entitlem8_13_, consumer0_.entitlementStatus as entitlem9_13_, consumer0_.consumer_idcert_id as consume26_13_, consumer0_.keypair_id as keypair27_13_, consumer0_.lastCheckin as lastche10_13_, consumer0_.name as name11_13_, consumer0_.owner_id as owner_i12_13_, consumer0_.reg_auth_method as reg_aut13_13_, consumer0_.releaseVer as release14_13_, consumer0_.rh_cloud_profile_modified as rh_clou15_13_, consumer0_.sp_role as sp_role16_13_, consumer0_.serviceLevel as service17_13_, consumer0_.sp_service_type as sp_serv18_13_, consumer0_.sp_status as sp_stat19_13_, consumer0_.sp_status_hash as sp_stat20_13_, consumer0_.type_id as type_id21_13_, consumer0_.sp_usage as sp_usag22_13_, consumer0_.username as usernam23_13_, consumer0_.uuid as uuid24_13_ 
from cp_consumer consumer0_ 
inner join cp_entitlement entitlemen1_ on consumer0_.id=entitlemen1_.consumer_id 
inner join cp_pool pool2_ on entitlemen1_.pool_id=pool2_.id 
inner join cp2_pool_source_sub sourcesubs3_ on pool2_.id=sourcesubs3_.pool_id 
where consumer0_.owner_id=? and (sourcesubs3_.subscription_id in (? , ? , ?));
```

Execution in prod: 5905 rows in 2.717 seconds