### PR TITLE
[4.6.2] HOTFIX: Added a check to prevent sorting on nested object fields

### DIFF
--- a/src/main/java/org/candlepin/resource/OwnerResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerResource.java
@@ -1354,9 +1354,15 @@ public class OwnerResource implements OwnerApi {
             qualifier.setOffset(pageRequest.getPage())
                 .setLimit(pageRequest.getPerPage());
 
-            if (pageRequest.getSortBy() != null) {
-                boolean reverse = pageRequest.getOrder() == PageRequest.DEFAULT_ORDER;
-                qualifier.addOrder(pageRequest.getSortBy(), reverse);
+            String orderField = pageRequest.getSortBy();
+            if (orderField != null) {
+                if (!orderField.contains(".")) {
+                    boolean reverse = pageRequest.getOrder() == PageRequest.DEFAULT_ORDER;
+                    qualifier.addOrder(orderField, reverse);
+                }
+                else {
+                    log.warn("Obsolete order field provided: {}; ignoring ordering...", orderField);
+                }
             }
         }
 


### PR DESCRIPTION
- Added an emergency patch to prevent attempting to sort on fields of nested children in GET /owner/{key}/pools