### PR TITLE
[M] Add validation for name during consumer update

### DIFF
--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationLiberalNameRules.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationLiberalNameRules.java
@@ -15,21 +15,329 @@
 package org.candlepin.resource;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 
+import org.candlepin.async.JobManager;
+import org.candlepin.audit.EventFactory;
+import org.candlepin.audit.EventSink;
+import org.candlepin.auth.Access;
+import org.candlepin.auth.Principal;
+import org.candlepin.auth.UserPrincipal;
+import org.candlepin.auth.permissions.OwnerPermission;
+import org.candlepin.auth.permissions.Permission;
+import org.candlepin.auth.permissions.PermissionFactory;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.DevConfig;
 import org.candlepin.config.TestConfig;
+import org.candlepin.controller.ContentAccessManager;
+import org.candlepin.controller.EntitlementCertificateService;
+import org.candlepin.controller.Entitler;
+import org.candlepin.controller.ManifestManager;
+import org.candlepin.controller.PoolManager;
+import org.candlepin.controller.PoolService;
+import org.candlepin.controller.RefresherFactory;
+import org.candlepin.dto.ModelTranslator;
+import org.candlepin.dto.StandardTranslator;
+import org.candlepin.dto.api.server.v1.ConsumerDTO;
+import org.candlepin.dto.api.server.v1.ConsumerTypeDTO;
+import org.candlepin.exceptions.BadRequestException;
+import org.candlepin.guice.PrincipalProvider;
+import org.candlepin.model.AnonymousCloudConsumerCurator;
+import org.candlepin.model.AnonymousContentAccessCertificateCurator;
+import org.candlepin.model.CertificateSerial;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.ConsumerContentOverrideCurator;
+import org.candlepin.model.ConsumerCurator;
+import org.candlepin.model.ConsumerType;
+import org.candlepin.model.ConsumerTypeCurator;
+import org.candlepin.model.DeletedConsumerCurator;
+import org.candlepin.model.DistributorVersionCurator;
+import org.candlepin.model.EntitlementCurator;
+import org.candlepin.model.EnvironmentContentCurator;
+import org.candlepin.model.EnvironmentCurator;
+import org.candlepin.model.IdentityCertificate;
+import org.candlepin.model.Owner;
+import org.candlepin.model.OwnerCurator;
+import org.candlepin.model.PermissionBlueprint;
+import org.candlepin.model.Role;
+import org.candlepin.model.User;
+import org.candlepin.model.activationkeys.ActivationKeyCurator;
+import org.candlepin.pki.certs.AnonymousCertificateGenerator;
+import org.candlepin.pki.certs.IdentityCertificateGenerator;
+import org.candlepin.pki.certs.SCACertificateGenerator;
+import org.candlepin.policy.SystemPurposeComplianceRules;
+import org.candlepin.policy.js.compliance.ComplianceRules;
+import org.candlepin.policy.js.compliance.ComplianceStatus;
+import org.candlepin.policy.js.consumer.ConsumerRules;
+import org.candlepin.resource.util.CalculatedAttributesUtil;
+import org.candlepin.resource.util.ConsumerBindUtil;
+import org.candlepin.resource.util.ConsumerCloudDataBuilder;
+import org.candlepin.resource.util.ConsumerEnricher;
+import org.candlepin.resource.util.ConsumerTypeValidator;
+import org.candlepin.resource.util.GuestMigration;
+import org.candlepin.resource.validation.DTOValidator;
+import org.candlepin.service.EntitlementCertServiceAdapter;
+import org.candlepin.service.OwnerServiceAdapter;
+import org.candlepin.service.SubscriptionServiceAdapter;
+import org.candlepin.service.UserServiceAdapter;
+import org.candlepin.test.TestUtil;
+import org.candlepin.util.ContentOverrideValidator;
+import org.candlepin.util.FactValidator;
 
+import com.google.inject.util.Providers;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Locale;
 
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class ConsumerResourceCreationLiberalNameRules extends ConsumerResourceCreationTest {
+public class ConsumerResourceCreationLiberalNameRules {
+
+    private static final Logger log = LoggerFactory.getLogger(ConsumerResourceCreationTest.class);
+
+    private static final String USER = "testuser";
+
+    @Mock
+    protected UserServiceAdapter userService;
+    @Mock
+    protected IdentityCertificateGenerator idCertGenerator;
+    @Mock
+    protected SubscriptionServiceAdapter subscriptionService;
+    @Mock
+    protected ConsumerCurator consumerCurator;
+    @Mock
+    protected ConsumerTypeCurator consumerTypeCurator;
+    @Mock
+    protected OwnerCurator ownerCurator;
+    @Mock
+    private EntitlementCurator entitlementCurator;
+    @Mock
+    private EntitlementCertServiceAdapter entitlementCertServiceAdapter;
+    @Mock
+    protected EventSink sink;
+    @Mock
+    protected ActivationKeyCurator activationKeyCurator;
+    @Mock
+    protected ComplianceRules complianceRules;
+    @Mock
+    protected SystemPurposeComplianceRules systemPurposeComplianceRules;
+    @Mock
+    protected DeletedConsumerCurator deletedConsumerCurator;
+    @Mock
+    protected ConsumerContentOverrideCurator consumerContentOverrideCurator;
+    @Mock
+    protected ConsumerBindUtil consumerBindUtil;
+    @Mock
+    protected ConsumerEnricher consumerEnricher;
+    @Mock
+    protected EnvironmentCurator environmentCurator;
+    @Mock
+    protected JobManager jobManager;
+    @Mock
+    protected DTOValidator dtoValidator;
+    @Mock
+    private PoolManager poolManager;
+    @Mock
+    private RefresherFactory refresherFactory;
+    @Mock
+    private EventFactory eventFactory;
+    @Mock
+    private ContentAccessManager contentAccessManager;
+    @Mock
+    private Entitler entitler;
+    @Mock
+    private ManifestManager manifestManager;
+    @Mock
+    private ConsumerRules consumerRules;
+    @Mock
+    private CalculatedAttributesUtil calculatedAttributesUtil;
+    @Mock
+    private DistributorVersionCurator distributorVersionCurator;
+    @Mock
+    private PrincipalProvider principalProvider;
+    @Mock
+    private ContentOverrideValidator contentOverrideValidator;
+    @Mock
+    private EnvironmentContentCurator environmentContentCurator;
+    @Mock
+    private EntitlementCertificateService entCertService;
+    @Mock
+    private PoolService poolService;
+    @Mock
+    private SCACertificateGenerator scaCertificateGenerator;
+    @Mock
+    private AnonymousCertificateGenerator anonymousCertificateGenerator;
+    @Mock
+    private AnonymousCloudConsumerCurator anonymousConsumerCurator;
+    @Mock
+    private AnonymousContentAccessCertificateCurator anonymousCertCurator;
+    @Mock
+    private OwnerServiceAdapter ownerService;
+    @Mock
+    private ConsumerCloudDataBuilder consumerCloudDataBuilder;
+    protected ModelTranslator modelTranslator;
+
+    private I18n i18n;
+
+    private ConsumerResource resource;
+    private ConsumerTypeDTO systemDto;
+    private ConsumerType system;
+    protected DevConfig config;
+    protected Owner owner;
+    protected Role role;
+    private User user;
+
+    @BeforeEach
+    public void init() throws Exception {
+        this.i18n = I18nFactory.getI18n(getClass(), Locale.US, I18nFactory.FALLBACK);
+
+        this.modelTranslator = new StandardTranslator(this.consumerTypeCurator, this.environmentCurator,
+            this.ownerCurator);
+
+        this.config = initConfig();
+        this.resource = new ConsumerResource(
+            this.consumerCurator,
+            this.consumerTypeCurator,
+            this.subscriptionService,
+            this.entitlementCurator,
+            this.idCertGenerator,
+            this.entitlementCertServiceAdapter,
+            this.i18n,
+            this.sink,
+            this.eventFactory,
+            this.userService,
+            this.poolManager,
+            this.refresherFactory,
+            this.consumerRules,
+            this.ownerCurator,
+            this.activationKeyCurator,
+            this.entitler,
+            this.complianceRules,
+            this.systemPurposeComplianceRules,
+            this.deletedConsumerCurator,
+            this.environmentCurator,
+            this.distributorVersionCurator,
+            this.config,
+            this.calculatedAttributesUtil,
+            this.consumerBindUtil,
+            this.manifestManager,
+            this.contentAccessManager,
+            new FactValidator(this.config, () -> this.i18n),
+            new ConsumerTypeValidator(consumerTypeCurator, i18n),
+            this.consumerEnricher,
+            Providers.of(new GuestMigration(consumerCurator)),
+            this.modelTranslator,
+            this.jobManager,
+            this.dtoValidator,
+            this.principalProvider,
+            this.contentOverrideValidator,
+            this.consumerContentOverrideCurator,
+            this.entCertService,
+            this.poolService,
+            this.environmentContentCurator,
+            this.anonymousConsumerCurator,
+            this.anonymousCertCurator,
+            this.ownerService,
+            this.scaCertificateGenerator,
+            this.anonymousCertificateGenerator,
+            this.consumerCloudDataBuilder
+        );
+
+        this.system = this.initConsumerType();
+        this.mockConsumerType(this.system);
+        this.systemDto = this.modelTranslator.translate(this.system, ConsumerTypeDTO.class);
+
+        this.owner = new Owner()
+            .setId(TestUtil.randomString())
+            .setKey("test_owner")
+            .setDisplayName("test_owner");
+
+        user = new User(USER, "");
+        PermissionBlueprint p = new PermissionBlueprint(PermissionFactory.PermissionType.OWNER, owner,
+            Access.ALL);
+        role = new Role();
+        role.addPermission(p);
+        role.addUser(user);
+
+        when(consumerCurator.create(any(Consumer.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        when(consumerCurator.create(any(Consumer.class), any(Boolean.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        when(consumerCurator.update(any(Consumer.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        when(userService.findByLogin(USER)).thenReturn(user);
+        IdentityCertificate cert = new IdentityCertificate();
+        cert.setKey("testKey");
+        cert.setCert("testCert");
+        cert.setId("testId");
+        cert.setSerial(new CertificateSerial(new Date()));
+        when(idCertGenerator.generate(any(Consumer.class))).thenReturn(cert);
+        when(ownerCurator.getByKey(owner.getKey())).thenReturn(owner);
+        when(complianceRules.getStatus(
+            any(Consumer.class), any(Date.class), any(Boolean.class), any(Boolean.class)))
+            .thenReturn(new ComplianceStatus(new Date()));
+    }
+
+    public ConsumerType initConsumerType() {
+        return new ConsumerType(ConsumerType.ConsumerTypeEnum.SYSTEM);
+    }
+
+    protected ConsumerType mockConsumerType(ConsumerType ctype) {
+        if (ctype != null) {
+            // Ensure the type has an ID
+            if (ctype.getId() == null) {
+                ctype.setId("test-ctype-" + ctype.getLabel() + "-" + TestUtil.randomInt());
+            }
+
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()))).thenReturn(ctype);
+            when(consumerTypeCurator.getByLabel(eq(ctype.getLabel()), anyBoolean())).thenReturn(ctype);
+            when(consumerTypeCurator.get(eq(ctype.getId()))).thenReturn(ctype);
+
+            doAnswer((Answer<ConsumerType>) invocation -> {
+                Object[] args = invocation.getArguments();
+                Consumer consumer = (Consumer) args[0];
+                ConsumerTypeCurator curator = (ConsumerTypeCurator) invocation.getMock();
+                ConsumerType ctype1;
+
+                if (consumer == null || consumer.getTypeId() == null) {
+                    throw new IllegalArgumentException("consumer is null or lacks a type ID");
+                }
+
+                ctype1 = curator.get(consumer.getTypeId());
+                if (ctype1 == null) {
+                    throw new IllegalStateException("No such consumer type: " + consumer.getTypeId());
+                }
+
+                return ctype1;
+            }).when(consumerTypeCurator).getConsumerType(any(Consumer.class));
+        }
+
+        return ctype;
+    }
 
     public DevConfig initConfig() {
         DevConfig config = TestConfig.defaults();
@@ -41,34 +349,70 @@ public class ConsumerResourceCreationLiberalNameRules extends ConsumerResourceCr
         return config;
     }
 
+    protected ConsumerDTO createConsumer(String consumerName) {
+        Collection<Permission> perms = new HashSet<>();
+        perms.add(new OwnerPermission(owner, Access.ALL));
+        Principal principal = new UserPrincipal(USER, perms, false);
+
+        return createConsumer(consumerName, principal);
+    }
+
+    private ConsumerDTO createConsumer(String consumerName, Principal principal) {
+        when(this.principalProvider.get()).thenReturn(principal);
+        ConsumerDTO consumer = TestUtil.createConsumerDTO(consumerName, null, null, systemDto);
+        return this.resource.createConsumer(consumer, USER, owner.getKey(), null, true);
+    }
+
+    // These overridden tests should receive an error with the default regex (from superclass),
+    // but should be okay here
+
     @Test
-    public void containsMultibyteKorean() {
+    public void allowNameThatContainsMultibyteKorean() {
         assertNotNull(createConsumer("서브스크립션 "));
     }
 
     @Test
-    public void containsMultibyteOriya() {
+    public void allowNameThatContainsMultibyteOriya() {
         assertNotNull(createConsumer("ପରିବେଶ"));
     }
 
-    // This fails with the normal regex, but should be okay here
     @Test
-    public void containsBadCharacter() {
+    public void allowNameThatContainsBadCharacter() {
         createConsumer("bar$%camp");
     }
 
     @Test
-    public void containsJustAboutEverything() {
+    public void allowNameThatContainsWhitespace() {
+        createConsumer("abc123 456");
+    }
+
+    @Test
+    public void allowNameThatStartsWithBadCharacter() {
+        createConsumer("<foo");
+    }
+
+    /*
+     * This is a special case. We should never allow a name starting with pound,
+     * regardless of the regex config.
+     */
+    @Test
+    public void disallowNameThatStartsWithPound() {
+        assertThrows(BadRequestException.class,
+            () -> createConsumer("#pound"));
+    }
+
+    @Test
+    public void allowNameThatContainsJustAboutEverything() {
         createConsumer("0123456789-=~!@#$%^&*()_+{}[]|\\:;\"'<>,.?/");
     }
 
     @Test
-    public void containsRockDots() {
+    public void allowNameThatContainsRockDots() {
         createConsumer("áàéíñó€áâæÀÁåàüÄÆùúÆÔÓû");
     }
 
     @Test
-    public void containsFunUnicode() {
+    public void allowNameThatContainsFunUnicode() {
         // this is roughly: skull and crossbones,
         // snowman, neigher less than nor greater than,
         // intterobang

--- a/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceCreationTest.java
@@ -387,84 +387,90 @@ public class ConsumerResourceCreationTest {
     }
 
     @Test
-    public void acceptedConsumerName() {
+    public void allowNameWithUnderscore() {
         assertNotNull(createConsumer("test_user"));
     }
 
     @Test
-    public void camelCaseName() {
+    public void allowNameWithCamelCase() {
         assertNotNull(createConsumer("ConsumerTest32953"));
     }
 
     @Test
-    public void startsWithUnderscore() {
+    public void allowNameThatStartsWithUnderscore() {
         assertNotNull(createConsumer("__init__"));
     }
 
     @Test
-    public void startsWithDash() {
+    public void allowNameThatStartsWithDash() {
         assertNotNull(createConsumer("-dash"));
     }
 
     @Test
-    public void containsNumbers() {
+    public void allowNameThatContainsNumbers() {
         assertNotNull(createConsumer("testmachine99"));
     }
 
     @Test
-    public void startsWithNumbers() {
+    public void allowNameThatStartsWithNumbers() {
         assertNotNull(createConsumer("001test7"));
     }
 
     @Test
-    public void containsPeriods() {
+    public void allowNameThatContainsPeriods() {
         assertNotNull(createConsumer("test-system.resource.net"));
     }
 
     @Test
-    public void containsUserServiceChars() {
+    public void allowNameThatContainsUserServiceChars() {
         assertNotNull(createConsumer("{bob}'s_b!g_#boi.`?uestlove!x"));
     }
 
     // These fail with the default consumer name pattern
     @Test
-    public void containsMultibyteKorean() {
+    public void disallowNameThatContainsMultibyteKorean() {
         assertThrows(BadRequestException.class,
             () -> createConsumer("서브스크립션 "));
     }
 
     @Test
-    public void containsMultibyteOriya() {
+    public void disallowNameThatContainsMultibyteOriya() {
         assertThrows(BadRequestException.class,
             () -> createConsumer("ପରିବେଶ"));
     }
 
     @Test
-    public void startsWithPound() {
+    public void disallowNameThatStartsWithPound() {
         assertThrows(BadRequestException.class,
             () -> createConsumer("#pound"));
     }
 
     @Test
-    public void emptyConsumerName() {
+    public void disallowEmptyConsumerName() {
         assertThrows(BadRequestException.class,
             () -> createConsumer(""));
     }
 
     @Test
-    public void nullConsumerName() {
+    public void disallowNameThatContainsWhitespace() {
+        assertThrows(BadRequestException.class,
+            () -> createConsumer("abc123 456"));
+    }
+
+    @Test
+    public void disallowNullConsumerName() {
         assertThrows(BadRequestException.class,
             () -> createConsumer(null));
     }
 
     @Test
-    public void startsWithBadCharacter() {
+    public void disallowNameThatStartsWithBadCharacter() {
         assertThrows(BadRequestException.class,
-            () -> createConsumer("#foo"));
+            () -> createConsumer("<foo"));
     }
 
     @Test
-    public void containsBadCharacter() {
+    public void disallowNameThatContainsBadCharacter() {
         assertThrows(BadRequestException.class,
             () -> createConsumer("bar$%camp"));
     }

--- a/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
+++ b/src/test/java/org/candlepin/resource/ConsumerResourceUpdateTest.java
@@ -408,6 +408,109 @@ public class ConsumerResourceUpdateTest {
     }
 
     @Test
+    public void allowNameWithUnderscore() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("test_user"));
+    }
+
+    @Test
+    public void allowNameWithCamelCase() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("ConsumerTest32953"));
+    }
+
+    @Test
+    public void allowNameThatStartsWithUnderscore() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("__init__"));
+    }
+
+    @Test
+    public void allowNameThatStartsWithDash() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("-dash"));
+    }
+
+    @Test
+    public void allowNameThatContainsNumbers() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("testmachine99"));
+    }
+
+    @Test
+    public void allowNameThatStartsWithNumbers() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("001test7"));
+    }
+
+    @Test
+    public void allowNameThatContainsPeriods() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("test-system.resource.net"));
+    }
+
+    @Test
+    public void allowNameThatContainsUserServiceChars() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        this.resource.updateConsumer(consumer.getUuid(),
+            new ConsumerDTO().name("{bob}'s_b!g_#boi.`?uestlove!x"));
+    }
+
+    // These should receive an error with the default consumer name pattern
+    @Test
+    public void disallowNameThatContainsMultibyteKorean() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        assertThrows(BadRequestException.class,
+            () -> this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("서브스크립션")));
+    }
+
+    @Test
+    public void disallowNameThatContainsMultibyteOriya() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        assertThrows(BadRequestException.class,
+            () -> this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("ପରିବେଶ")));
+    }
+
+    @Test
+    public void disallowEmptyConsumerName() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        assertThrows(BadRequestException.class,
+            () -> this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("")));
+    }
+
+    @Test
+    public void disallowNameThatContainsWhitespace() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        assertThrows(BadRequestException.class,
+            () -> this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("abc123 456")));
+    }
+
+    @Test
+    public void disallowNameThatStartsWithBadCharacter() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        assertThrows(BadRequestException.class,
+            () -> this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("<foo")));
+    }
+
+    @Test
+    public void disallowNameThatContainsBadCharacter() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        assertThrows(BadRequestException.class,
+            () -> this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("bar$%camp")));
+    }
+
+    /*
+     * This is a special case. We should never allow a name starting with pound,
+     * regardless of the regex config.
+     */
+    @Test
+    public void disallowNameThatStartsWithPound() {
+        ConsumerDTO consumer = getFakeConsumerDTO();
+        assertThrows(BadRequestException.class,
+            () -> this.resource.updateConsumer(consumer.getUuid(), new ConsumerDTO().name("#pound")));
+    }
+
+    @Test
     public void testUpdatesOnContentTagChanges() {
         HashSet<String> originalTags = new HashSet<>(Arrays.asList("hello", "world"));
         HashSet<String> changedTags = new HashSet<>(Arrays.asList("x", "y"));
@@ -1011,7 +1114,7 @@ public class ConsumerResourceUpdateTest {
     public void canUpdateName() {
         ConsumerDTO consumer = getFakeConsumerDTO();
         ConsumerDTO updated = new ConsumerDTO();
-        updated.setName("new name");
+        updated.setName("newname");
 
         ArgumentCaptor<Consumer> consumerCaptor = ArgumentCaptor.forClass(Consumer.class);
         resource.updateConsumer(consumer.getUuid(), updated);
@@ -1025,7 +1128,7 @@ public class ConsumerResourceUpdateTest {
     public void updatedNameRegeneratesIdCert() {
         ConsumerDTO consumer = getFakeConsumerDTO();
         ConsumerDTO updated = new ConsumerDTO();
-        updated.setName("new name");
+        updated.setName("newname");
 
         ArgumentCaptor<Consumer> consumerCaptor = ArgumentCaptor.forClass(Consumer.class);
         resource.updateConsumer(consumer.getUuid(), updated);
@@ -1039,9 +1142,9 @@ public class ConsumerResourceUpdateTest {
     @Test
     public void sameNameDoesntRegenIdCert() {
         ConsumerDTO consumer = getFakeConsumerDTO();
-        consumer.setName("old name");
+        consumer.setName("oldname");
         ConsumerDTO updated = new ConsumerDTO();
-        updated.setName("old name");
+        updated.setName("oldname");
 
         resource.updateConsumer(consumer.getUuid(), updated);
 

--- a/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
+++ b/src/test/java/org/candlepin/resource/PersonConsumerResourceCreationLiberalNameRules.java
@@ -39,7 +39,7 @@ import org.mockito.quality.Strictness;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class PersonConsumerResourceCreationLiberalNameRules extends
-    ConsumerResourceCreationLiberalNameRules {
+    ConsumerResourceCreationTest {
 
     @Override
     public ConsumerType initConsumerType() {


### PR DESCRIPTION
- Centralized all checks for consumer name into one method.
- Applied that method to both consumer create and update.
- Renamed tests to be more descriptive.