### PR TITLE
[M] CANDLEPIN-1028: Added event generation to the inactive consumer cleanup job

### DIFF
--- a/src/main/java/org/candlepin/audit/Event.java
+++ b/src/main/java/org/candlepin/audit/Event.java
@@ -50,7 +50,14 @@ public class Event {
      * Type - Constant representing the type of this event.
      */
     public enum Type {
-        CREATED, MODIFIED, DELETED, EXPIRED
+        CREATED, MODIFIED, DELETED, EXPIRED,
+
+        /**
+         * Represents a deletion event for multiple entities of the given target. Note that because this
+         * event type represents many entities, certain event fields *should not* be populated,
+         * such as: targetName, or entityId
+         */
+        BULK_DELETION
     }
 
     /**

--- a/src/main/java/org/candlepin/audit/EventFactory.java
+++ b/src/main/java/org/candlepin/audit/EventFactory.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -208,6 +209,60 @@ public class EventFactory {
             .setEntityId(consumer.getUuid())
             .setOwnerKey(consumer.getOwnerKey())
             .setEventData(eventData);
+    }
+
+    /**
+     * Generates a bulk consumer deletion event for the given consumers in the specified owner.
+     *
+     * @param owner
+     *  The owner from which the consumers were deleted
+     *
+     * @param consumers
+     *  The consumers that were deleted
+     *
+     * @return
+     *  an event representing the bulk deletion of the given consumers
+     */
+    public Event bulkConsumerDeletion(Owner owner, Collection<Consumer> consumers) {
+        if (owner == null) {
+            throw new IllegalArgumentException("owner is null");
+        }
+
+        if (consumers == null) {
+            throw new IllegalArgumentException("consumers is null");
+        }
+
+        List<String> consumerUuids = consumers.stream()
+            .map(Consumer::getUuid)
+            .toList();
+
+        return this.bulkConsumerDeletion(owner.getKey(), consumerUuids);
+    }
+
+    /**
+     * Generates a bulk consumer deletion event for the given consumers in the specified owner.
+     *
+     * @param ownerKey
+     *  The key of the owner from which the consumers were deleted
+     *
+     * @param consumerUuids
+     *  The UUIDs of the consumers that were deleted
+     *
+     * @return
+     *  an event representing the bulk deletion of the given consumers
+     */
+    public Event bulkConsumerDeletion(String ownerKey, Collection<String> consumerUuids) {
+        if (ownerKey == null || ownerKey.isBlank()) {
+            throw new IllegalArgumentException("owner is null or empty");
+        }
+
+        if (consumerUuids == null || consumerUuids.isEmpty()) {
+            throw new IllegalArgumentException("consumerUuids is null or empty");
+        }
+
+        return new Event(Type.BULK_DELETION, Target.CONSUMER, principalProvider.get().getData())
+            .setOwnerKey(ownerKey)
+            .setEventData(Map.of("consumerUuids", consumerUuids));
     }
 
     public Event complianceCreated(Consumer consumer, SystemPurposeComplianceStatus compliance) {

--- a/src/main/java/org/candlepin/model/CertificateSerialCurator.java
+++ b/src/main/java/org/candlepin/model/CertificateSerialCurator.java
@@ -188,13 +188,15 @@ public class CertificateSerialCurator extends AbstractHibernateCurator<Certifica
             return 0;
         }
 
-        String query = "UPDATE CertificateSerial s SET s.revoked = true" +
-            " WHERE s.revoked = false AND s.id IN (:serials)";
+        String jpql = "UPDATE CertificateSerial s SET s.revoked = true " +
+            "WHERE s.revoked = false AND s.id IN (:serials)";
+
+        Query query = this.getEntityManager()
+            .createQuery(jpql);
 
         int updated = 0;
-        for (Collection<Long> serialsToRevokeBlock : this.partition(serialsToRevoke)) {
-            updated += this.getEntityManager().createQuery(query)
-                .setParameter("serials", serialsToRevokeBlock)
+        for (List<Long> block : this.partition(serialsToRevoke)) {
+            updated += query.setParameter("serials", block)
                 .executeUpdate();
         }
 

--- a/src/main/java/org/candlepin/model/Consumer.java
+++ b/src/main/java/org/candlepin/model/Consumer.java
@@ -227,7 +227,7 @@ public class Consumer extends AbstractHibernateObject<Consumer> implements Linka
     @JoinColumn(name = "consumer_idcert_id")
     private IdentityCertificate idCert;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     @JoinColumn(name = "cont_acc_cert_id")
     private SCACertificate contentAccessCert;
 

--- a/src/main/java/org/candlepin/model/DeletedConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/DeletedConsumerCurator.java
@@ -123,13 +123,12 @@ public class DeletedConsumerCurator extends AbstractHibernateCurator<DeletedCons
         }
 
         Principal principal = this.principalProvider.get();
-        String deletedConsumersStatement = "INSERT INTO DeletedConsumer " +
-            "(id, created, updated, consumerUuid, ownerId, " +
-            "ownerDisplayName, ownerKey, principalName, consumerName) " +
+        String deletedConsumersStatement = "INSERT INTO DeletedConsumer (id, created, updated, " +
+            "  consumerUuid, ownerId, ownerDisplayName, ownerKey, principalName, consumerName) " +
             "SELECT consumer.id, NOW(), NOW(), consumer.uuid, consumer.ownerId, owner.displayName, " +
-            "owner.key, :principalName, consumer.name " +
+            "  owner.key, :principalName, consumer.name " +
             "FROM Consumer consumer " +
-            "JOIN Owner owner on owner.id=consumer.ownerId " +
+            "  JOIN consumer.owner owner " +
             "WHERE consumer.id IN (:consumerIds)";
 
         return entityManager.get()

--- a/src/main/java/org/candlepin/model/InactiveConsumerRecord.java
+++ b/src/main/java/org/candlepin/model/InactiveConsumerRecord.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.model;
+
+
+
+/**
+ * A record containing the consumer UUID and owner key, representing an "inactive" consumer.
+ *
+ * @param consumerId
+ *  The ID of the inactive consumer
+ *
+ * @param consumerUuid
+ *  The UUID of the inactive consumer
+ *
+ * @param ownerKey
+ *  The key of the owner the inactive consumer belongs to
+ */
+public record InactiveConsumerRecord(String consumerId, String consumerUuid, String ownerKey) {
+    // intentionally left empty
+}

--- a/src/test/java/org/candlepin/async/tasks/InactiveConsumerCleanerJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/InactiveConsumerCleanerJobTest.java
@@ -14,6 +14,7 @@
  */
 package org.candlepin.async.tasks;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -22,12 +23,15 @@ import static org.mockito.Mockito.mock;
 
 import org.candlepin.async.JobExecutionContext;
 import org.candlepin.async.JobExecutionException;
+import org.candlepin.audit.Event;
+import org.candlepin.audit.EventFactory;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.model.Consumer;
 import org.candlepin.model.ConsumerType;
 import org.candlepin.model.DeletedConsumer;
 import org.candlepin.model.Owner;
 import org.candlepin.test.DatabaseTestFixture;
+import org.candlepin.test.TestEventSink;
 import org.candlepin.test.TestUtil;
 import org.candlepin.util.Util;
 
@@ -38,32 +42,45 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.stream.Stream;
 
 
 public class InactiveConsumerCleanerJobTest extends DatabaseTestFixture {
 
     private InactiveConsumerCleanerJob inactiveConsumerCleanerJob;
-    private Owner owner;
     private ConsumerType consumerType;
+    private TestEventSink eventSink;
 
+    @Override
     @BeforeEach
-    public void beforeEach() {
-        owner = this.createOwner(TestUtil.randomString(), TestUtil.randomString());
-        consumerType = this.createConsumerType(false);
+    public void init() throws Exception {
+        super.init(false);
+
+        this.consumerType = this.createConsumerType(false);
+
+        this.eventSink = this.injector.getInstance(TestEventSink.class);
+        EventFactory eventFactory = this.injector.getInstance(EventFactory.class);
+
         inactiveConsumerCleanerJob = new InactiveConsumerCleanerJob(this.config,
             this.consumerCurator,
             this.deletedConsumerCurator,
-            this.identityCertificateCurator,
-            this.caCertCurator,
-            this.certSerialCurator);
+            this.certSerialCurator,
+            this.eventSink,
+            eventFactory);
     }
 
     @Test
     public void testExecutionWithInactiveCheckedInTime() throws JobExecutionException {
-        Consumer inactiveConsumer =
-            createConsumer(InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS + 10);
-        Consumer activeConsumer =
-            createConsumer(InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS - 10);
+        Owner owner = this.createOwner(TestUtil.randomString(), TestUtil.randomString());
+
+        Consumer inactiveConsumer = this.createConsumer(owner,
+            InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS + 10);
+        Consumer activeConsumer = this.createConsumer(owner,
+            InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS - 10);
 
         JobExecutionContext context = mock(JobExecutionContext.class);
         inactiveConsumerCleanerJob.execute(context);
@@ -87,6 +104,127 @@ public class InactiveConsumerCleanerJobTest extends DatabaseTestFixture {
         assertNull(this.deletedConsumerCurator.findByConsumer(activeConsumer));
     }
 
+    @Test
+    public void testExecutionWithInactiveConsumersInSingleOrg() throws Exception {
+        Owner owner = this.createOwner(TestUtil.randomString(), TestUtil.randomString());
+        int activeLastCheckin = InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS - 10;
+        int inactiveLastCheckin = InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS + 10;
+
+        List<Consumer> activeConsumers = Stream.generate(() -> this.createConsumer(owner, activeLastCheckin))
+            .limit(10)
+            .toList();
+
+        List<Consumer> inactiveConsumers =
+            Stream.generate(() -> this.createConsumer(owner, inactiveLastCheckin))
+                .limit(10)
+                .toList();
+
+        consumerCurator.flush();
+        consumerCurator.clear();
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        inactiveConsumerCleanerJob.execute(context);
+
+        consumerCurator.flush();
+        consumerCurator.clear();
+
+        // Verify all of our inactive consumers were removed
+        for (Consumer consumer : inactiveConsumers) {
+            DeletedConsumer deleted = this.deletedConsumerCurator.findByConsumerUuid(consumer.getUuid());
+
+            assertNotNull(deleted);
+            assertEquals(consumer.getUuid(), deleted.getConsumerUuid());
+            assertEquals(consumer.getName(), deleted.getConsumerName());
+        }
+
+        // Verify the active consumers were not removed
+        for (Consumer consumer : activeConsumers) {
+            DeletedConsumer deleted = this.deletedConsumerCurator.findByConsumerUuid(consumer.getUuid());
+
+            assertNull(deleted);
+        }
+
+        // Verify an event was dispatched that contains all of the UUIDs of the inactive consumers
+        Queue<Event> dispatchedEvents = this.eventSink.getDispatchedEvents();
+        assertEquals(1, dispatchedEvents.size());
+
+        Event event = dispatchedEvents.poll();
+        this.validateBulkDeletionEvent(event, owner, inactiveConsumers);
+    }
+
+    @Test
+    public void testExecutionWithInactiveConsumersInMultipleOrgs() throws Exception {
+        int activeLastCheckin = InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS - 10;
+        int inactiveLastCheckin = InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS + 10;
+
+        Map<Owner, List<Consumer>> activeConsumersMap = new HashMap<>();
+        Map<Owner, List<Consumer>> inactiveConsumersMap = new HashMap<>();
+        Map<String, Owner> ownerMap = new HashMap<>();
+
+        for (int i = 0; i < 5; ++i) {
+            Owner owner = this.createOwner(TestUtil.randomString(), TestUtil.randomString());
+
+            List<Consumer> activeConsumers =
+                Stream.generate(() -> this.createConsumer(owner, activeLastCheckin))
+                    .limit(10)
+                    .toList();
+
+            List<Consumer> inactiveConsumers =
+                Stream.generate(() -> this.createConsumer(owner, inactiveLastCheckin))
+                    .limit(10)
+                    .toList();
+
+            ownerMap.put(owner.getKey(), owner);
+            activeConsumersMap.put(owner, activeConsumers);
+            inactiveConsumersMap.put(owner, inactiveConsumers);
+        }
+
+        consumerCurator.flush();
+        consumerCurator.clear();
+
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        inactiveConsumerCleanerJob.execute(context);
+
+        consumerCurator.flush();
+        consumerCurator.clear();
+
+        // Verify all of our inactive consumers were removed
+        for (List<Consumer> inactiveConsumers : inactiveConsumersMap.values()) {
+            for (Consumer consumer : inactiveConsumers) {
+                DeletedConsumer deleted = this.deletedConsumerCurator.findByConsumerUuid(consumer.getUuid());
+
+                assertNotNull(deleted);
+                assertEquals(consumer.getUuid(), deleted.getConsumerUuid());
+                assertEquals(consumer.getName(), deleted.getConsumerName());
+            }
+        }
+
+        // Verify the active consumers were not removed
+        for (List<Consumer> activeConsumers : activeConsumersMap.values()) {
+            for (Consumer consumer : activeConsumers) {
+                DeletedConsumer deleted = this.deletedConsumerCurator.findByConsumerUuid(consumer.getUuid());
+
+                assertNull(deleted);
+            }
+        }
+
+        // Verify an event was dispatched that contains all of the UUIDs of the inactive consumers
+        Queue<Event> dispatchedEvents = this.eventSink.getDispatchedEvents();
+        assertEquals(inactiveConsumersMap.size(), dispatchedEvents.size());
+
+        for (Event event = dispatchedEvents.poll(); event != null; event = dispatchedEvents.poll()) {
+            String ownerKey = event.getOwnerKey();
+            Owner owner = ownerMap.get(ownerKey);
+            List<Consumer> inactiveConsumers = inactiveConsumersMap.get(owner);
+
+            assertNotNull(owner);
+            assertNotNull(inactiveConsumers);
+
+            this.validateBulkDeletionEvent(event, owner, inactiveConsumers);
+        }
+    }
+
+
     @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(strings = { "0", "-50" })
     public void testExecutionWithInvalidCheckedInRetentionConfig(int rententionDays)
@@ -109,7 +247,7 @@ public class InactiveConsumerCleanerJobTest extends DatabaseTestFixture {
         assertThrows(JobExecutionException.class, () -> inactiveConsumerCleanerJob.execute(context));
     }
 
-    private Consumer createConsumer(Integer lastCheckedInDaysAgo) {
+    private Consumer createConsumer(Owner owner, Integer lastCheckedInDaysAgo) {
         Consumer newConsumer = new Consumer();
         newConsumer.setOwner(owner);
         newConsumer.setType(consumerType);
@@ -127,5 +265,30 @@ public class InactiveConsumerCleanerJobTest extends DatabaseTestFixture {
             InactiveConsumerCleanerJob.JOB_KEY,
             configurationName);
         this.config.setProperty(configuration, String.valueOf(retentionDays));
+    }
+
+    /**
+     * Validates that the event is a bulk deletion event for the target org with the given inactive consumers
+     */
+    private void validateBulkDeletionEvent(Event event, Owner owner, Collection<Consumer> inactiveConsumers) {
+        assertThat(event)
+            .isNotNull()
+            .returns(Event.Target.CONSUMER, Event::getTarget)
+            .returns(Event.Type.BULK_DELETION, Event::getType)
+            .returns(owner.getKey(), Event::getOwnerKey);
+
+        Map<String, Object> eventData = event.getEventData();
+        assertNotNull(eventData);
+
+        List<String> eventConsumerUuids = (List<String>) eventData.get("consumerUuids");
+        assertNotNull(eventConsumerUuids);
+
+        List<String> inactiveConsumerUuids = inactiveConsumers.stream()
+            .map(Consumer::getUuid)
+            .toList();
+
+        assertThat(eventConsumerUuids)
+            .isNotNull()
+            .containsExactlyInAnyOrderElementsOf(inactiveConsumerUuids);
     }
 }

--- a/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -1912,31 +1912,31 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
     }
 
     @Test
-    public void testGetInactiveConsumerIdsWithNullLastCheckedInRetentionDate() {
+    public void testGetInactiveConsumersWithNullLastCheckedInRetentionDate() {
         Instant nonCheckedInRetention = Instant.now()
             .minus(InactiveConsumerCleanerJob.DEFAULT_LAST_UPDATED_IN_RETENTION_IN_DAYS, ChronoUnit.DAYS);
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            consumerCurator.getInactiveConsumerIds(null, nonCheckedInRetention);
+            consumerCurator.getInactiveConsumers(null, nonCheckedInRetention);
         });
 
         assertEquals("Last checked-in retention date cannot be null.", exception.getMessage());
     }
 
     @Test
-    public void testGetInactiveConsumerIdsWithNullLastUpdatedRetentionDate() {
+    public void testGetInactiveConsumersWithNullLastUpdatedRetentionDate() {
         Instant lastCheckedInRetention = Instant.now()
             .minus(InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS, ChronoUnit.DAYS);
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            consumerCurator.getInactiveConsumerIds(lastCheckedInRetention, null);
+            consumerCurator.getInactiveConsumers(lastCheckedInRetention, null);
         });
 
         assertEquals("Last updated retention date cannot be null.", exception.getMessage());
     }
 
     @Test
-    public void testGetInactiveConsumerIdsWithExpiredLastCheckedInDate() {
+    public void testGetInactiveConsumersWithExpiredLastCheckedInDate() {
         Instant lastCheckedInRetention = Instant.now()
             .minus(InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS, ChronoUnit.DAYS);
         Instant nonCheckedInRetention = Instant.now()
@@ -1960,15 +1960,15 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         activeConsumer.setLastCheckin(Date.from(activeLastCheckedIn));
         consumerCurator.create(activeConsumer);
 
-        List<String> actual = consumerCurator.getInactiveConsumerIds(lastCheckedInRetention,
+        List<InactiveConsumerRecord> actual = consumerCurator.getInactiveConsumers(lastCheckedInRetention,
             nonCheckedInRetention);
 
         assertEquals(1, actual.size());
-        assertEquals(inactiveConsumer.getId(), actual.get(0));
+        assertEquals(inactiveConsumer.getId(), actual.get(0).consumerId());
     }
 
     @Test
-    public void testGetInactiveConsumerIdsWithTypeThatHasManifest() {
+    public void testGetInactiveConsumersWithTypeThatHasManifest() {
         Instant lastCheckedInRetention = Instant.now()
             .minus(InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS, ChronoUnit.DAYS);
 
@@ -1987,12 +1987,14 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         consumer.setLastCheckin(Date.from(lastCheckedIn));
         consumerCurator.create(consumer);
 
-        List<String> actual = consumerCurator.getInactiveConsumerIds(lastCheckedInRetention, Instant.now());
+        List<InactiveConsumerRecord> actual = this.consumerCurator
+            .getInactiveConsumers(lastCheckedInRetention, Instant.now());
+
         assertEquals(0, actual.size());
     }
 
     @Test
-    public void testGetInactiveConsumerIdsWithConsumerThatHasExistingEntitlements() {
+    public void testGetInactiveConsumersWithConsumerThatHasExistingEntitlements() {
         Instant lastCheckedInRetention = Instant.now()
             .minus(InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS, ChronoUnit.DAYS);
         Instant nonCheckedInRetention = Instant.now()
@@ -2012,7 +2014,7 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         ent1.setUpdatedOnStart(false);
         entitlementCurator.create(ent1);
 
-        List<String> actual = consumerCurator.getInactiveConsumerIds(lastCheckedInRetention,
+        List<InactiveConsumerRecord> actual = consumerCurator.getInactiveConsumers(lastCheckedInRetention,
             nonCheckedInRetention);
 
         assertEquals(0, actual.size());

--- a/src/test/java/org/candlepin/test/TestEventSink.java
+++ b/src/test/java/org/candlepin/test/TestEventSink.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.test;
+
+import org.candlepin.audit.ActiveMQContextListener;
+import org.candlepin.audit.Event;
+import org.candlepin.audit.EventFactory;
+import org.candlepin.audit.EventFilter;
+import org.candlepin.audit.EventSink;
+import org.candlepin.config.Configuration;
+import org.candlepin.controller.mode.CandlepinModeManager;
+import org.candlepin.controller.mode.CandlepinModeManager.Mode;
+import org.candlepin.dto.api.server.v1.QueueStatus;
+import org.candlepin.dto.manifest.v1.SubscriptionDTO;
+import org.candlepin.model.Consumer;
+import org.candlepin.model.Owner;
+import org.candlepin.model.Pool;
+import org.candlepin.model.Rules;
+import org.candlepin.model.activationkeys.ActivationKey;
+import org.candlepin.policy.SystemPurposeComplianceStatus;
+import org.candlepin.policy.js.compliance.ComplianceStatus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import javax.inject.Inject;
+
+
+
+/**
+ * The TestEventSink class provides an event sink implementation that captures events that are successfully
+ * dispatched for testing purposes without needing to rely on mocks that may or may not fully capture the
+ * eventing framework and configuration.
+ */
+public class TestEventSink implements EventSink {
+    private static Logger log = LoggerFactory.getLogger(TestEventSink.class);
+
+    private final Configuration config;
+    private final EventFactory eventFactory;
+    private final EventFilter eventFilter;
+    private final CandlepinModeManager modeManager;
+
+    private int dispatchedEventCount;
+    private final Queue<Event> dispatchedEvents;
+    private final Queue<Event> eventQueue;
+
+    /*
+     * needed cause guice needs public scope, default scope is package scope
+     */
+    @Inject
+    public TestEventSink(Configuration config, EventFilter eventFilter, CandlepinModeManager modeManager,
+        EventFactory eventFactory) {
+
+        this.config = Objects.requireNonNull(config);
+        this.eventFilter = Objects.requireNonNull(eventFilter);
+        this.eventFactory = Objects.requireNonNull(eventFactory);
+        this.modeManager = Objects.requireNonNull(modeManager);
+
+        this.dispatchedEvents = new ConcurrentLinkedQueue<>();
+        this.eventQueue = new ConcurrentLinkedQueue<>();
+    }
+
+    @Override
+    public void queueEvent(Event event) {
+        // This is technically not accurate to the base EventSinkImpl, as it doesn't test for nulls, but we
+        // should fix that rather than ignore it and hope for the best.
+        if (event == null) {
+            throw new IllegalArgumentException("event is null");
+        }
+
+        if (this.eventFilter.shouldFilter(event)) {
+            log.debug("Filtering event {}", event);
+            return;
+        }
+
+        if (this.modeManager.getCurrentMode() != Mode.NORMAL) {
+            throw new IllegalStateException("Candlepin is in suspend mode");
+        }
+
+        this.eventQueue.add(event);
+    }
+
+    @Override
+    public void sendEvents() {
+        this.dispatchedEventCount += this.eventQueue.size();
+        this.dispatchedEvents.addAll(this.eventQueue);
+        this.eventQueue.clear();
+    }
+
+    @Override
+    public void rollback() {
+        this.eventQueue.clear();
+    }
+
+    @Override
+    public List<QueueStatus> getQueueInfo() {
+        return ActiveMQContextListener.getActiveMQListeners(this.config)
+            .stream()
+            .map(listenerClassName -> "event." + listenerClassName)
+            .map(queueName -> new QueueStatus().queueName(queueName).pendingMessageCount(0L))
+            .toList();
+    }
+
+    /**
+     * Fetches the total number of events dispatched by this event sink; including those that have already
+     * been processed and removed from the dispatched event queue. Events which were queued but rolled back
+     * are not included in this count.
+     *
+     * @return
+     *  the number of events dispatched by this event sink
+     */
+    public int getDispatchedEventCount() {
+        return this.dispatchedEventCount;
+    }
+
+    /**
+     * Fetches a queue containing the events that were sent (or dispatched) after being queued. This queue
+     * will represent events that went through the flow of being queued via <code>queueEvent(...)</code> and
+     * then dispatched via successful call to <code>sendEvents()</code>. Events which were queued in the
+     * event sink but rolled back are not included in this queue.
+     * <p>
+     * This method returns the same queue used internally by this EventSink to queue messages. Its contents
+     * may be changed after it is returned.
+     *
+     * @return
+     *  a queue containing the events dispatched by this event sink
+     */
+    public Queue<Event> getDispatchedEvents() {
+        return this.dispatchedEvents;
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // EventSink utility function overrides
+    // These should all be one-liners that pass through to the event factory and then queue the event.
+
+    @Override
+    public void emitConsumerCreated(Consumer consumer) {
+        this.queueEvent(this.eventFactory.consumerCreated(consumer));
+    }
+
+    @Override
+    public void emitOwnerCreated(Owner owner) {
+        this.queueEvent(this.eventFactory.ownerCreated(owner));
+    }
+
+    @Override
+    public void emitOwnerMigrated(Owner owner) {
+        this.queueEvent(this.eventFactory.ownerModified(owner));
+    }
+
+    @Override
+    public void emitPoolCreated(Pool pool) {
+        this.queueEvent(this.eventFactory.poolCreated(pool));
+    }
+
+    @Override
+    public void emitExportCreated(Consumer consumer) {
+        this.queueEvent(this.eventFactory.exportCreated(consumer));
+    }
+
+    @Override
+    public void emitImportCreated(Owner owner) {
+        this.queueEvent(this.eventFactory.importCreated(owner));
+    }
+
+    @Override
+    public void emitActivationKeyCreated(ActivationKey key) {
+        this.queueEvent(this.eventFactory.activationKeyCreated(key));
+    }
+
+    @Override
+    public void emitSubscriptionExpired(SubscriptionDTO subscription) {
+        this.queueEvent(this.eventFactory.subscriptionExpired(subscription));
+    }
+
+    @Override
+    public void emitRulesModified(Rules oldRules, Rules newRules) {
+        this.queueEvent(this.eventFactory.rulesUpdated(oldRules, newRules));
+    }
+
+    @Override
+    public void emitRulesDeleted(Rules rules) {
+        this.queueEvent(this.eventFactory.rulesDeleted(rules));
+    }
+
+    @Override
+    public void emitCompliance(Consumer consumer, ComplianceStatus compliance) {
+        this.queueEvent(this.eventFactory.complianceCreated(consumer, compliance));
+    }
+
+    @Override
+    public void emitCompliance(Consumer consumer, SystemPurposeComplianceStatus compliance) {
+        this.queueEvent(this.eventFactory.complianceCreated(consumer, compliance));
+    }
+
+    @Override
+    public void emitOwnerContentAccessModeChanged(Owner owner) {
+        this.queueEvent(this.eventFactory.ownerContentAccessModeChanged(owner));
+    }
+
+}


### PR DESCRIPTION
- Updated the InactiveConsumerCleanerJob to generate an event for each org in which inactive consumers were removed
- Optimized several database operations
- Added a TestEventSink test utility for testing and validating events that are generated by various units