### PR TITLE
[M] CANDLEPIN-1028: Added event generation to environment deletion

### DIFF
--- a/src/test/java/org/candlepin/resource/EnvironmentContentOverrideResourceTest.java
+++ b/src/test/java/org/candlepin/resource/EnvironmentContentOverrideResourceTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.async.JobManager;
+import org.candlepin.audit.EventFactory;
+import org.candlepin.audit.EventSink;
 import org.candlepin.controller.ContentAccessManager;
 import org.candlepin.controller.EntitlementCertificateService;
 import org.candlepin.controller.PoolService;
@@ -80,6 +82,9 @@ public class EnvironmentContentOverrideResourceTest extends DatabaseTestFixture 
     }
 
     private EnvironmentResource buildResource() {
+        EventFactory eventFactory = injector.getInstance(EventFactory.class);
+        EventSink eventSink = injector.getInstance(EventSink.class);
+
         return new EnvironmentResource(
             this.environmentCurator,
             this.i18n,
@@ -99,7 +104,9 @@ public class EnvironmentContentOverrideResourceTest extends DatabaseTestFixture 
             this.caCertCurator,
             this.entitlementCurator,
             this.mockEntitlementCertService,
-            this.environmentContentOverrideCurator);
+            this.environmentContentOverrideCurator,
+            eventFactory,
+            eventSink);
     }
 
     private Environment createEnvironment() {

--- a/src/test/java/org/candlepin/test/TestEventSink.java
+++ b/src/test/java/org/candlepin/test/TestEventSink.java
@@ -35,6 +35,7 @@ import org.candlepin.policy.js.compliance.ComplianceStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
@@ -61,9 +62,6 @@ public class TestEventSink implements EventSink {
     private final Queue<Event> dispatchedEvents;
     private final Queue<Event> eventQueue;
 
-    /*
-     * needed cause guice needs public scope, default scope is package scope
-     */
     @Inject
     public TestEventSink(Configuration config, EventFilter eventFilter, CandlepinModeManager modeManager,
         EventFactory eventFactory) {
@@ -135,15 +133,24 @@ public class TestEventSink implements EventSink {
      * will represent events that went through the flow of being queued via <code>queueEvent(...)</code> and
      * then dispatched via successful call to <code>sendEvents()</code>. Events which were queued in the
      * event sink but rolled back are not included in this queue.
-     * <p>
-     * This method returns the same queue used internally by this EventSink to queue messages. Its contents
-     * may be changed after it is returned.
      *
      * @return
      *  a queue containing the events dispatched by this event sink
      */
     public Queue<Event> getDispatchedEvents() {
-        return this.dispatchedEvents;
+        return new LinkedList<>(this.dispatchedEvents);
+    }
+
+    /**
+     * Fetches a queue containing the events that are currently in queue, but not yet dispatched. This queue
+     * will represent events that have been received via <code>queueEvent(...)</code>, but have not yet been
+     * commited and dispatched during a call to <code>sendEvents()</code>.
+     *
+     * @return
+     *  a queue containing the events queued in this event sink
+     */
+    public Queue<Event> getQueuedEvents() {
+        return new LinkedList<>(this.eventQueue);
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Environment deletion will now generate bulk consumer deletion events when consumers are cleaned up as a result of an environment being removed