### PR TITLE
[M] CANDLEPIN-1028: Restored cert deletion during inactive consumer cleanup

### DIFF
--- a/src/test/java/org/candlepin/async/tasks/InactiveConsumerCleanerJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/InactiveConsumerCleanerJobTest.java
@@ -68,6 +68,8 @@ public class InactiveConsumerCleanerJobTest extends DatabaseTestFixture {
         inactiveConsumerCleanerJob = new InactiveConsumerCleanerJob(this.config,
             this.consumerCurator,
             this.deletedConsumerCurator,
+            this.identityCertificateCurator,
+            this.caCertCurator,
             this.certSerialCurator,
             this.eventSink,
             eventFactory);


### PR DESCRIPTION
- Restored the explicit certificate deletion during inactive consumer cleanup that was erroneously removed in a previous commit