### PR TITLE
[M] CANDLEPIN-1039: Fixed dangling Liquibase connections

### DIFF
--- a/src/main/java/org/candlepin/guice/CandlepinContextListener.java
+++ b/src/main/java/org/candlepin/guice/CandlepinContextListener.java
@@ -22,8 +22,8 @@ import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.Configuration;
 import org.candlepin.config.RyeConfig;
 import org.candlepin.config.validation.ConfigurationValidatorUtil;
-import org.candlepin.database.DatabaseConnectionManager;
 import org.candlepin.database.MigrationManager;
+import org.candlepin.liquibase.LiquibaseConnectionGenerator;
 import org.candlepin.logging.LoggerContextListener;
 import org.candlepin.logging.LoggingConfigurator;
 import org.candlepin.messaging.CPMContextListener;
@@ -321,7 +321,7 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
 
         RyeConfig ryeConfig = new RyeConfig(configBuilder.build());
 
-        log.info("Validating configurations.");
+        log.info("Validating configuration...");
         ConfigurationValidatorUtil.validateConfigurations(ConfigProperties.CONFIGURATION_VALIDATORS,
             ryeConfig);
 
@@ -330,12 +330,13 @@ public class CandlepinContextListener extends GuiceResteasyBootstrapServletConte
 
     protected void initializeDatabase() {
         try {
-            DatabaseConnectionManager connectionManager = new DatabaseConnectionManager(config);
-            MigrationManager migrationManager = new MigrationManager(config, connectionManager);
+            LiquibaseConnectionGenerator connectionGenerator = new LiquibaseConnectionGenerator(this.config);
+            MigrationManager migrationManager = new MigrationManager(this.config, connectionGenerator);
+
             migrationManager.migrate();
         }
         catch (Exception e) {
-            log.error("Error initializing database: " + e.getMessage(), e);
+            log.error("Error initializing database: {}", e.getMessage(), e);
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/org/candlepin/database/MigrationManagerTest.java
+++ b/src/test/java/org/candlepin/database/MigrationManagerTest.java
@@ -15,14 +15,19 @@
 package org.candlepin.database;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.DevConfig;
 import org.candlepin.config.TestConfig;
+import org.candlepin.liquibase.LiquibaseConnectionGenerator;
 import org.candlepin.test.TestUtil;
 
 import liquibase.changelog.ChangeSet;
@@ -44,142 +49,134 @@ import java.util.List;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class MigrationManagerTest {
     @Mock
-    private DatabaseConnectionManager connectionManager;
+    private LiquibaseConnectionGenerator connectionGenerator;
+
     @Mock
     private Database database;
 
     private DevConfig config;
 
     @BeforeEach
-    public void beforeEach() {
-        config = TestConfig.defaults();
+    public void beforeEach() throws Exception {
+        this.config = TestConfig.defaults();
+
+        doReturn(this.database).when(this.connectionGenerator).getDatabase();
+    }
+
+    private MigrationManager buildMigrationManager() {
+        return new MigrationManager(this.config, this.connectionGenerator);
+    }
+
+    private ChangeSet generateChangeSet() {
+        String id = TestUtil.randomString(14, TestUtil.CHARSET_NUMERIC);
+
+        return new ChangeSet(id, "test_changeset", true, true, "db/changelog/" + id + "-test.xml", null, null,
+            Mockito.mock(DatabaseChangeLog.class));
     }
 
     @Test
-    public void testMigrateWithUnknownMigrationLevel() {
+    public void testMigrateWithUnknownMigrationLevel() throws Exception {
         config.setProperty(ConfigProperties.DB_MANAGE_ON_START, TestUtil.randomString());
 
-        MigrationManager migrationManager = new MigrationManager(config, connectionManager);
+        MigrationManager migrationManager = this.buildMigrationManager();
 
         assertThrows(RuntimeException.class, () -> migrationManager.migrate());
+
+        // verify we never even open a connection that has to be closed later
+        verify(this.connectionGenerator, never()).getDatabase();
     }
 
     @Test
     public void testMigrateWithNoneMigrationLevel() throws Exception {
         config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.NONE.toString());
-        doReturn(database).when(connectionManager).getDatabase();
 
-        MigrationManager migrationManager = spy(new MigrationManager(config, connectionManager));
+        MigrationManager migrationManager = spy(this.buildMigrationManager());
 
         migrationManager.migrate();
 
         verify(migrationManager, never()).getUnrunChangeSets(database);
         verify(migrationManager, never()).executeUpdate(database);
+
+        // verify we never even open a connection that has to be closed later
+        verify(this.connectionGenerator, never()).getDatabase();
     }
 
     @Test
     public void testMigrateWithReportMigrationLevel() throws Exception {
         config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.REPORT.toString());
-        doReturn(database).when(connectionManager).getDatabase();
 
-        MigrationManager migrationManager = spy(new MigrationManager(config, connectionManager) {
-            @Override
-            protected List<ChangeSet> getUnrunChangeSets(Database database) {
-                ChangeSet changeSet = new ChangeSet("21220101",
-                    "tester",
-                    true,
-                    true,
-                    "db/changelog/21220101-test.xml",
-                    null,
-                    null,
-                    Mockito.mock(DatabaseChangeLog.class));
-
-                return List.of(changeSet);
-            }
-        });
+        MigrationManager migrationManager = spy(this.buildMigrationManager());
+        doReturn(List.of(this.generateChangeSet()))
+            .when(migrationManager)
+            .getUnrunChangeSets(any(Database.class));
 
         migrationManager.migrate();
 
         verify(migrationManager).getUnrunChangeSets(database);
         verify(migrationManager, never()).executeUpdate(database);
+
+        // Verify we only open a single connection and closed it properly
+        verify(this.connectionGenerator, times(1)).getDatabase();
+        verify(this.database, atLeastOnce()).close();
     }
 
     @Test
     public void testMigrateWithHaltMigrationLevel() throws Exception {
         config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.HALT.toString());
-        doReturn(database).when(connectionManager).getDatabase();
 
-        MigrationManager migrationManager = spy(new MigrationManager(config, connectionManager) {
-            @Override
-            protected List<ChangeSet> getUnrunChangeSets(Database database) {
-                ChangeSet changeSet = new ChangeSet("21220101",
-                    "tester",
-                    true,
-                    true,
-                    "db/changelog/21220101-test.xml",
-                    null,
-                    null,
-                    Mockito.mock(DatabaseChangeLog.class));
-
-                return List.of(changeSet);
-            }
-        });
+        MigrationManager migrationManager = spy(this.buildMigrationManager());
+        doReturn(List.of(this.generateChangeSet()))
+            .when(migrationManager)
+            .getUnrunChangeSets(any(Database.class));
 
         assertThrows(RuntimeException.class, () -> migrationManager.migrate());
+
+        // Verify we only open a single connection and closed it properly
+        verify(this.connectionGenerator, times(1)).getDatabase();
+        verify(this.database, atLeastOnce()).close();
     }
 
     @Test
     public void testMigrateWithManageMigrationLevelAndNoUnrunChanges() throws Exception {
         config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.MANAGE.toString());
-        doReturn(database).when(connectionManager).getDatabase();
 
-        MigrationManager migrationManager = spy(new MigrationManager(config, connectionManager) {
-            @Override
-            protected List<ChangeSet> getUnrunChangeSets(Database database) {
-                return List.of();
-            }
-
-            @Override
-            protected void executeUpdate(Database database) {
-                // Intentionally left blank
-            }
-        });
+        MigrationManager migrationManager = spy(this.buildMigrationManager());
+        doReturn(List.of())
+            .when(migrationManager)
+            .getUnrunChangeSets(any(Database.class));
+        doNothing()
+            .when(migrationManager)
+            .executeUpdate(any(Database.class));
 
         migrationManager.migrate();
 
         verify(migrationManager).getUnrunChangeSets(database);
         verify(migrationManager, never()).executeUpdate(database);
+
+        // Verify we only open a single connection and closed it properly
+        verify(this.connectionGenerator, times(1)).getDatabase();
+        verify(this.database, atLeastOnce()).close();
     }
 
     @Test
     public void testMigrateWithManageMigrationLevelAndUnrunChanges() throws Exception {
         config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.MANAGE.toString());
-        doReturn(database).when(connectionManager).getDatabase();
 
-        MigrationManager migrationManager = spy(new MigrationManager(config, connectionManager) {
-            @Override
-            protected List<ChangeSet> getUnrunChangeSets(Database database) {
-                ChangeSet changeSet = new ChangeSet("21220101",
-                    "tester",
-                    true,
-                    true,
-                    "db/changelog/21220101-test.xml",
-                    null,
-                    null,
-                    Mockito.mock(DatabaseChangeLog.class));
-
-                return List.of(changeSet);
-            }
-
-            @Override
-            protected void executeUpdate(Database database) {
-                // Intentionally left blank
-            }
-        });
+        MigrationManager migrationManager = spy(this.buildMigrationManager());
+        doReturn(List.of(this.generateChangeSet()))
+            .when(migrationManager)
+            .getUnrunChangeSets(any(Database.class));
+        doNothing()
+            .when(migrationManager)
+            .executeUpdate(any(Database.class));
 
         migrationManager.migrate();
 
         verify(migrationManager).getUnrunChangeSets(database);
         verify(migrationManager).executeUpdate(database);
+
+        // Verify we only open a single connection and closed it properly
+        verify(this.connectionGenerator, times(1)).getDatabase();
+        verify(this.database, atLeastOnce()).close();
     }
 }

--- a/src/test/java/org/candlepin/liquibase/LiquibaseConnectionGeneratorTest.java
+++ b/src/test/java/org/candlepin/liquibase/LiquibaseConnectionGeneratorTest.java
@@ -12,9 +12,11 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.database;
+package org.candlepin.liquibase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -24,6 +26,7 @@ import static org.mockito.Mockito.times;
 import org.candlepin.config.ConfigProperties;
 import org.candlepin.config.DevConfig;
 import org.candlepin.config.TestConfig;
+import org.candlepin.database.MigrationManagementLevel;
 import org.candlepin.test.TestUtil;
 
 import liquibase.database.Database;
@@ -31,35 +34,114 @@ import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
 
-public class DatabaseConnectionManagerTest {
+
+public class LiquibaseConnectionGeneratorTest {
+
+    /**
+     * A null driver to use in place of an actual jdbc driver
+     */
+    private static class NullJdbcDriver implements Driver {
+
+        public static final Driver INSTANCE = new NullJdbcDriver();
+
+        @Override
+        public boolean acceptsURL(String url) {
+            return url != null && url.startsWith("jdbc:null:");
+        }
+
+        @Override
+        public Connection connect(String url, Properties props) throws SQLException {
+            if (!this.acceptsURL(url)) {
+                return null;
+            }
+
+            return mock(Connection.class);
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String url, Properties props) {
+            return new DriverPropertyInfo[0];
+        }
+
+        @Override
+        public int getMajorVersion() {
+            return 1;
+        }
+
+        @Override
+        public int getMinorVersion() {
+            return 0;
+        }
+
+        @Override
+        public boolean jdbcCompliant() {
+            return false;
+        }
+
+        @Override
+        public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+            throw new SQLFeatureNotSupportedException();
+        }
+    }
 
     private DevConfig config;
 
     @BeforeEach
     public void init() {
         this.config = TestConfig.defaults();
+
+        this.config.setProperty(ConfigProperties.DB_DRIVER_CLASS, NullJdbcDriver.class.getName());
+        this.config.setProperty(ConfigProperties.DB_URL, "jdbc:null:" + TestUtil.randomString());
+    }
+
+    @BeforeAll
+    public static void beforeAll() {
+        try {
+            DriverManager.registerDriver(NullJdbcDriver.INSTANCE);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        try {
+            DriverManager.deregisterDriver(NullJdbcDriver.INSTANCE);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
     public void testConstructorWithNullConfiguration() {
-        assertThrows(NullPointerException.class, () -> new DatabaseConnectionManager(null));
+        assertThrows(NullPointerException.class, () -> new LiquibaseConnectionGenerator(null));
     }
 
     @Test
     public void testGetConnectionWithValidConnection() throws Exception {
-        String url = TestUtil.randomString();
+        String url = this.config.getString(ConfigProperties.DB_URL);
         String username = TestUtil.randomString();
         String password = TestUtil.randomString();
-        config.setProperty(ConfigProperties.DB_URL, url);
+
         config.setProperty(ConfigProperties.DB_USERNAME, username);
         config.setProperty(ConfigProperties.DB_PASSWORD, password);
         config.setProperty(ConfigProperties.DB_CONNECTION_RETRY_INTERVAL, "1");
@@ -69,32 +151,37 @@ public class DatabaseConnectionManagerTest {
         try (MockedStatic<DriverManager> manager = Mockito.mockStatic(DriverManager.class);
             MockedStatic<DatabaseFactory> dbFactory = Mockito.mockStatic(DatabaseFactory.class)) {
 
+            DatabaseFactory mockFactory = mock(DatabaseFactory.class);
+            dbFactory.when(DatabaseFactory::getInstance).thenReturn(mockFactory);
+
             Connection mockConnection = Mockito.mock(Connection.class);
             manager.when(() -> DriverManager.getConnection(url, username, password))
                 .thenReturn(mockConnection);
 
-            DatabaseConnectionManager conManager = new DatabaseConnectionManager(config) {
-                @Override
-                protected void loadDatabaseDriver() {
-                    // Intentionally left blank
-                }
-            };
+            Database mockDatabase = mock(Database.class);
+            ArgumentCaptor<JdbcConnection> captor = ArgumentCaptor.forClass(JdbcConnection.class);
+            doReturn(mockDatabase).when(mockFactory)
+                .findCorrectDatabaseImplementation(captor.capture());
 
-            Connection actual = conManager.getConnection();
+            LiquibaseConnectionGenerator connGenerator = new LiquibaseConnectionGenerator(this.config);
 
-            assertThat(actual)
-                .isEqualTo(mockConnection);
+            Database database = connGenerator.getDatabase();
+            assertNotNull(database);
 
             manager.verify(() -> DriverManager.getConnection(url, username, password));
+
+            // Verify the underlying connection is the one we created
+            JdbcConnection jdbcConnection = captor.getValue();
+            assertEquals(mockConnection, jdbcConnection.getWrappedConnection());
         }
     }
 
     @Test
     public void testGetConnectionWithUnsuccesfulConnection() throws Exception {
-        String url = TestUtil.randomString();
+        String url = this.config.getString(ConfigProperties.DB_URL);
         String username = TestUtil.randomString();
         String password = TestUtil.randomString();
-        config.setProperty(ConfigProperties.DB_URL, url);
+
         config.setProperty(ConfigProperties.DB_USERNAME, username);
         config.setProperty(ConfigProperties.DB_PASSWORD, password);
         config.setProperty(ConfigProperties.DB_CONNECTION_RETRY_INTERVAL, "1");
@@ -108,12 +195,8 @@ public class DatabaseConnectionManagerTest {
             manager.when(() -> DriverManager.getConnection(url, username, password))
                 .thenThrow(SQLException.class);
 
-            assertThrows(LiquibaseException.class, () -> new DatabaseConnectionManager(config) {
-                @Override
-                protected void loadDatabaseDriver() {
-                    // Intentionally left blank
-                }
-            });
+            LiquibaseConnectionGenerator generator = new LiquibaseConnectionGenerator(this.config);
+            assertThrows(LiquibaseException.class, () -> generator.getDatabase());
 
             manager.verify(() -> DriverManager.getConnection(url, username, password),
                 times(maxRetryAttempts));
@@ -122,19 +205,22 @@ public class DatabaseConnectionManagerTest {
 
     @Test
     public void testGetConnectionWithEventualValidConnection() throws Exception {
-        String url = TestUtil.randomString();
+        String url = this.config.getString(ConfigProperties.DB_URL);
         String username = TestUtil.randomString();
         String password = TestUtil.randomString();
-        config.setProperty(ConfigProperties.DB_URL, url);
+        int maxRetryAttempts = 3;
+
         config.setProperty(ConfigProperties.DB_USERNAME, username);
         config.setProperty(ConfigProperties.DB_PASSWORD, password);
         config.setProperty(ConfigProperties.DB_CONNECTION_RETRY_INTERVAL, "1");
-        int maxRetryAttempts = 3;
         config.setProperty(ConfigProperties.DB_MAX_CONNECTION_ATTEMPTS, String.valueOf(maxRetryAttempts));
         config.setProperty(ConfigProperties.DB_MANAGE_ON_START, MigrationManagementLevel.HALT.getName());
 
         try (MockedStatic<DriverManager> manager = Mockito.mockStatic(DriverManager.class);
             MockedStatic<DatabaseFactory> dbFactory = Mockito.mockStatic(DatabaseFactory.class)) {
+
+            DatabaseFactory mockFactory = mock(DatabaseFactory.class);
+            dbFactory.when(DatabaseFactory::getInstance).thenReturn(mockFactory);
 
             // Fail to connect the first two times and connect on the third and final attempt
             Connection mockConnection = Mockito.mock(Connection.class);
@@ -142,29 +228,31 @@ public class DatabaseConnectionManagerTest {
                 .thenThrow(SQLException.class, SQLException.class)
                 .thenReturn(mockConnection);
 
-            DatabaseConnectionManager conManager = new DatabaseConnectionManager(config) {
-                @Override
-                protected void loadDatabaseDriver() {
-                    // Intentionally left blank
-                }
-            };
+            Database mockDatabase = mock(Database.class);
+            ArgumentCaptor<JdbcConnection> captor = ArgumentCaptor.forClass(JdbcConnection.class);
+            doReturn(mockDatabase).when(mockFactory)
+                .findCorrectDatabaseImplementation(captor.capture());
 
-            Connection actual = conManager.getConnection();
+            LiquibaseConnectionGenerator conManager = new LiquibaseConnectionGenerator(config);
 
-            assertThat(actual)
-                .isEqualTo(mockConnection);
+            Database database = conManager.getDatabase();
+            assertNotNull(database);
 
             manager.verify(() -> DriverManager.getConnection(url, username, password),
                 times(maxRetryAttempts));
+
+            // Verify the underlying connection is the one we created after a delay
+            JdbcConnection jdbcConnection = captor.getValue();
+            assertEquals(mockConnection, jdbcConnection.getWrappedConnection());
         }
     }
 
     @Test
     public void testGetDatabase() throws Exception {
-        String url = TestUtil.randomString();
+        String url = this.config.getString(ConfigProperties.DB_URL);
         String username = TestUtil.randomString();
         String password = TestUtil.randomString();
-        config.setProperty(ConfigProperties.DB_URL, url);
+
         config.setProperty(ConfigProperties.DB_USERNAME, username);
         config.setProperty(ConfigProperties.DB_PASSWORD, password);
         config.setProperty(ConfigProperties.DB_CONNECTION_RETRY_INTERVAL, "1");
@@ -184,12 +272,7 @@ public class DatabaseConnectionManagerTest {
                 .findCorrectDatabaseImplementation(any(JdbcConnection.class));
             dbFactory.when(DatabaseFactory::getInstance).thenReturn(mockFactory);
 
-            DatabaseConnectionManager conManager = new DatabaseConnectionManager(config) {
-                @Override
-                protected void loadDatabaseDriver() {
-                    // Intentionally left blank
-                }
-            };
+            LiquibaseConnectionGenerator conManager = new LiquibaseConnectionGenerator(config);
 
             Database actual = conManager.getDatabase();
 
@@ -200,6 +283,8 @@ public class DatabaseConnectionManagerTest {
 
     @Test
     void testMissingDbDriverClass() {
-        assertThrows(RuntimeException.class, () -> new DatabaseConnectionManager(config));
+        this.config.setProperty(ConfigProperties.DB_DRIVER_CLASS, TestUtil.randomString("random_driver-"));
+
+        assertThrows(ReflectiveOperationException.class, () -> new LiquibaseConnectionGenerator(this.config));
     }
 }


### PR DESCRIPTION
- Updated the migration manager to use try-with-resources for its database connection to ensure it's closed when the migration operation is completed
- Renamed and moved the not-generic "DatabaseConnectionManager" to the Liquibase-specific "LiquibaseConnectionGenerator"