### PR TITLE
CANDLEPIN-1050: Fixed constraint violation in InactiveConsumerCleanerJob

### DIFF
--- a/src/main/java/org/candlepin/async/tasks/InactiveConsumerCleanerJob.java
+++ b/src/main/java/org/candlepin/async/tasks/InactiveConsumerCleanerJob.java
@@ -26,7 +26,6 @@ import org.candlepin.model.CertificateSerialCurator;
 import org.candlepin.model.ConsumerCurator;
 import org.candlepin.model.ContentAccessCertificateCurator;
 import org.candlepin.model.DeletedConsumer;
-import org.candlepin.model.DeletedConsumerCurator;
 import org.candlepin.model.IdentityCertificateCurator;
 import org.candlepin.model.InactiveConsumerRecord;
 import org.candlepin.util.Transactional;
@@ -70,7 +69,6 @@ public class InactiveConsumerCleanerJob implements AsyncJob {
 
     private final Configuration config;
     private final ConsumerCurator consumerCurator;
-    private final DeletedConsumerCurator deletedConsumerCurator;
     private final IdentityCertificateCurator identityCertificateCurator;
     private final ContentAccessCertificateCurator contentAccessCertificateCurator;
     private final CertificateSerialCurator certificateSerialCurator;
@@ -81,7 +79,6 @@ public class InactiveConsumerCleanerJob implements AsyncJob {
     @Inject
     public InactiveConsumerCleanerJob(Configuration config,
         ConsumerCurator consumerCurator,
-        DeletedConsumerCurator deletedConsumerCurator,
         IdentityCertificateCurator identityCertificateCurator,
         ContentAccessCertificateCurator contentAccessCertificateCurator,
         CertificateSerialCurator certificateSerialCurator,
@@ -90,7 +87,6 @@ public class InactiveConsumerCleanerJob implements AsyncJob {
 
         this.config = Objects.requireNonNull(config);
         this.consumerCurator = Objects.requireNonNull(consumerCurator);
-        this.deletedConsumerCurator = Objects.requireNonNull(deletedConsumerCurator);
         this.identityCertificateCurator = Objects.requireNonNull(identityCertificateCurator);
         this.contentAccessCertificateCurator = Objects.requireNonNull(contentAccessCertificateCurator);
         this.certificateSerialCurator = Objects.requireNonNull(certificateSerialCurator);
@@ -141,7 +137,6 @@ public class InactiveConsumerCleanerJob implements AsyncJob {
         List<String> scaCertsToRemove = consumerCurator.getContentAccessCertIds(consumerIds);
         List<Long> serialIdsToRevoke = this.consumerCurator.getConsumerCertSerialIds(consumerIds);
 
-        this.deletedConsumerCurator.createDeletedConsumers(consumerIds);
         int deletedConsumers = this.consumerCurator.deleteConsumers(consumerIds);
 
         // Delete the certificates and revoke their serials.

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -1028,7 +1028,15 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
     }
 
     /**
-     * Deletes {@link Consumer}s based on the provided consumer ids.
+     * Deletes {@link Consumer}s based on the provided consumer ids and
+     * creates corresponding records in {@link DeletedConsumer}.
+     *
+     * <p>For each consumer id in the input collection:</p>
+     * <ul>
+     *   <li>The consumer entry is removed from the {@code Consumer} table.</li>
+     *   <li>A record is created in the {@code DeletedConsumer} table
+     *       to track the deletion.</li>
+     * </ul>
      *
      * @param consumerIds
      *  ids of the consumers to delete
@@ -1040,6 +1048,8 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
         if (consumerIds == null || consumerIds.isEmpty()) {
             return 0;
         }
+
+        this.deletedConsumerCurator.createDeletedConsumers(consumerIds);
 
         int deleted = 0;
 

--- a/src/test/java/org/candlepin/async/tasks/InactiveConsumerCleanerJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/InactiveConsumerCleanerJobTest.java
@@ -67,7 +67,6 @@ public class InactiveConsumerCleanerJobTest extends DatabaseTestFixture {
 
         inactiveConsumerCleanerJob = new InactiveConsumerCleanerJob(this.config,
             this.consumerCurator,
-            this.deletedConsumerCurator,
             this.identityCertificateCurator,
             this.caCertCurator,
             this.certSerialCurator,


### PR DESCRIPTION
- Previously, when the job attempted to delete a consumer whose UUID already existed in `cp_deleted_consumers`, it failed with a unique constraint violation. The logic now uses an upsert to handle already-deleted consumers safely.