### PR TITLE
[M] CANDLEPIN-1059: Reduced 429s while fetching content access payloads

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -1227,6 +1227,9 @@ paths:
       tags:
         - consumer
       operationId: exportCertificates
+      x-java-response:
+        type: javax.ws.rs.core.Response
+        isContainer: false
       security: [ ]
       parameters:
         - name: consumer_uuid
@@ -1259,18 +1262,15 @@ paths:
                 format: binary
             application/json:
               schema:
-                $ref: '#/components/schemas/CertificateDTO'
+                type: array
+                items:
+                  $ref: '#/components/schemas/CertificateDTO'
         400:
-          description: Consumer is null or does not have a defined type ID or Consumer is not associated
-            with a valid type.
+          description: if the provided list of serials are invalid or malformed
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExceptionMessage'
-              example:
-                displayMessage: Consumer is null or does not have a defined type ID or Consumer is
-                  not associated with a valid type.
-                requestUuid: c4347004-8792-41fe-a4d8-fccaa0d3898a
         404:
           description: Consumer with this UUID could not be found.
           content:

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/ExportUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/ExportUtil.java
@@ -157,4 +157,37 @@ public final class ExportUtil {
         }
     }
 
+    /**
+     * Extracts the given entry from the provided archive. If the entry does not exist or otherwise cannot be
+     * read, this method throws an IOException.
+     *
+     * @param archive
+     *  the archive from which to read an entry
+     *
+     * @param entry
+     *  the entry to read
+     *
+     * @throws IllegalArgumentException
+     *  if either archive or entry are null
+     *
+     * @throws IOException
+     *  if the entry does not exist or otherwise cannot be read
+     *
+     * @return
+     *  the contents of the entry as a byte array
+     */
+    public static byte[] extractEntry(ZipFile archive, ZipEntry entry) throws IOException {
+        if (archive == null) {
+            throw new IllegalArgumentException("archive is null");
+        }
+
+        if (entry == null) {
+            throw new IllegalArgumentException("entry is null");
+        }
+
+        try (InputStream istream = archive.getInputStream(entry)) {
+            return istream.readAllBytes();
+        }
+    }
+
 }

--- a/src/main/java/org/candlepin/pki/certs/AnonymousCertificateGenerator.java
+++ b/src/main/java/org/candlepin/pki/certs/AnonymousCertificateGenerator.java
@@ -46,8 +46,6 @@ import org.candlepin.service.model.ProductInfo;
 import org.candlepin.util.Util;
 import org.candlepin.util.X509V3ExtensionUtil;
 
-import com.google.inject.persist.Transactional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,7 +140,6 @@ public class AnonymousCertificateGenerator {
      * @return
      *  the retrieved or generated certificate
      */
-    @Transactional
     public AnonymousContentAccessCertificate generate(AnonymousCloudConsumer consumer) {
         if (this.isStandalone()) {
             String msg = "cannot retrieve or create content access certificate in standalone mode";


### PR DESCRIPTION
- Updated the handling of concurrent content payload exceptions such that content access payload generation is retried at least once before returning returning a 429 to the user
- Refactored several methods in ConsumerResource surrounding content access certificate and payload generation
- Fixed a bug causing serial filtering to exclude matching certificates rather than include while fetching anonymous consumer certificates