### PR TITLE
[4.6] CANDLEPIN-1059: Reduce 429s while fetching content access payloads

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -1227,6 +1227,9 @@ paths:
       tags:
         - consumer
       operationId: exportCertificates
+      x-java-response:
+        type: javax.ws.rs.core.Response
+        isContainer: false
       security: [ ]
       parameters:
         - name: consumer_uuid
@@ -1259,18 +1262,15 @@ paths:
                 format: binary
             application/json:
               schema:
-                $ref: '#/components/schemas/CertificateDTO'
+                type: array
+                items:
+                  $ref: '#/components/schemas/CertificateDTO'
         400:
-          description: Consumer is null or does not have a defined type ID or Consumer is not associated
-            with a valid type.
+          description: if the provided list of serials are invalid or malformed
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExceptionMessage'
-              example:
-                displayMessage: Consumer is null or does not have a defined type ID or Consumer is
-                  not associated with a valid type.
-                requestUuid: c4347004-8792-41fe-a4d8-fccaa0d3898a
         404:
           description: Consumer with this UUID could not be found.
           content:

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/ExportUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/ExportUtil.java
@@ -157,4 +157,37 @@ public final class ExportUtil {
         }
     }
 
+    /**
+     * Extracts the given entry from the provided archive. If the entry does not exist or otherwise cannot be
+     * read, this method throws an IOException.
+     *
+     * @param archive
+     *  the archive from which to read an entry
+     *
+     * @param entry
+     *  the entry to read
+     *
+     * @throws IllegalArgumentException
+     *  if either archive or entry are null
+     *
+     * @throws IOException
+     *  if the entry does not exist or otherwise cannot be read
+     *
+     * @return
+     *  the contents of the entry as a byte array
+     */
+    public static byte[] extractEntry(ZipFile archive, ZipEntry entry) throws IOException {
+        if (archive == null) {
+            throw new IllegalArgumentException("archive is null");
+        }
+
+        if (entry == null) {
+            throw new IllegalArgumentException("entry is null");
+        }
+
+        try (InputStream istream = archive.getInputStream(entry)) {
+            return istream.readAllBytes();
+        }
+    }
+
 }

--- a/src/main/java/org/candlepin/async/tasks/InactiveConsumerCleanerJob.java
+++ b/src/main/java/org/candlepin/async/tasks/InactiveConsumerCleanerJob.java
@@ -164,8 +164,7 @@ public class InactiveConsumerCleanerJob implements AsyncJob {
         Instant nonCheckedInRetention = getRetentionDate(CFG_LAST_UPDATED_IN_RETENTION_IN_DAYS);
         int batchSize = this.getBatchSize();
 
-        Transactional<Integer> transactional = this.consumerCurator
-            .transactional(this::deleteInactiveConsumers)
+        Transactional transaction = this.consumerCurator.transactional()
             .onCommit(status -> this.eventSink.sendEvents())
             .onRollback(status -> this.eventSink.rollback());
 
@@ -174,7 +173,7 @@ public class InactiveConsumerCleanerJob implements AsyncJob {
 
         int deletedCount = 0;
         for (List<InactiveConsumerRecord> batch : Iterables.partition(inactiveConsumers, batchSize)) {
-            deletedCount += transactional.execute(batch);
+            deletedCount += transaction.execute(() -> this.deleteInactiveConsumers(batch));
         }
 
         log.info("InactiveConsumerCleanerJob has run! {} consumers removed.", deletedCount);

--- a/src/main/java/org/candlepin/controller/ConsumerMigration.java
+++ b/src/main/java/org/candlepin/controller/ConsumerMigration.java
@@ -80,10 +80,7 @@ public class ConsumerMigration {
         boolean failed = false;
         for (List<String> consumerIdsBlock : Iterables.partition(consumerIds, this.batchSize)) {
             try {
-                this.ownerCurator.transactional(args -> {
-                    migrateBatch(consumerIdsBlock, destinationOwner);
-                    return null;
-                }).execute();
+                this.ownerCurator.transactional(() -> this.migrateBatch(consumerIdsBlock, destinationOwner));
             }
             catch (Exception e) {
                 log.warn("Failed to migrate a batch of consumers.", e);

--- a/src/main/java/org/candlepin/controller/Refresher.java
+++ b/src/main/java/org/candlepin/controller/Refresher.java
@@ -181,9 +181,9 @@ public class Refresher {
 
         for (Owner owner : this.owners.values()) {
             try {
-                poolManager.refreshPoolsWithRegeneration(this.subAdapter, owner, this.lazy);
-                recalculatePoolQuantitiesForOwner(owner);
-                updateRefreshDate(owner);
+                this.poolManager.refreshPoolsWithRegeneration(this.subAdapter, owner, this.lazy);
+                this.recalculatePoolQuantitiesForOwner(owner);
+                this.updateRefreshDate(owner);
             }
             catch (SubscriptionServiceException e) {
                 throw new RuntimeException(
@@ -201,12 +201,14 @@ public class Refresher {
     }
 
     private void recalculatePoolQuantitiesForOwner(Owner owner) {
-        this.poolCurator.transactional().allowExistingTransactions().execute((args -> {
-            this.poolCurator.calculateConsumedForOwnersPools(owner);
-            this.poolCurator.calculateExportedForOwnersPools(owner);
+        this.poolCurator.transactional()
+            .allowExistingTransactions()
+            .execute(() -> {
+                this.poolCurator.calculateConsumedForOwnersPools(owner);
+                this.poolCurator.calculateExportedForOwnersPools(owner);
 
-            return String.format("Successfully recalculated quantities for owner: %s %n", owner.getKey());
-        }));
+                log.info("Successfully recalculated quantities for owner: {}", owner.getKey());
+            });
     }
 
 }

--- a/src/main/java/org/candlepin/pki/certs/AnonymousCertificateGenerator.java
+++ b/src/main/java/org/candlepin/pki/certs/AnonymousCertificateGenerator.java
@@ -46,8 +46,6 @@ import org.candlepin.service.model.ProductInfo;
 import org.candlepin.util.Util;
 import org.candlepin.util.X509V3ExtensionUtil;
 
-import com.google.inject.persist.Transactional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,7 +140,6 @@ public class AnonymousCertificateGenerator {
      * @return
      *  the retrieved or generated certificate
      */
-    @Transactional
     public AnonymousContentAccessCertificate generate(AnonymousCloudConsumer consumer) {
         if (this.isStandalone()) {
             String msg = "cannot retrieve or create content access certificate in standalone mode";

--- a/src/main/java/org/candlepin/util/function/CheckedRunnable.java
+++ b/src/main/java/org/candlepin/util/function/CheckedRunnable.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util.function;
+
+
+
+/**
+ * The CheckedRunnable is a functional interface for a block or function that may throw a checked exception,
+ * which is to be passed through to the caller.
+ *
+ * @param <E>
+ *  the type of checked exception, or class of exceptions, this runnable may throw
+ */
+@FunctionalInterface
+public interface CheckedRunnable<E extends Exception> {
+
+    /**
+     * Executes the action represented by this runnable.
+     */
+    void run() throws E;
+}

--- a/src/main/java/org/candlepin/util/function/CheckedSupplier.java
+++ b/src/main/java/org/candlepin/util/function/CheckedSupplier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.util.function;
+
+
+
+/**
+ * The CheckedSupplier is a functional interface for a block or function that may throw a checked exception,
+ * which is to be passed through to the caller.
+ *
+ * @param <T>
+ *  the type of value returned by this supplier
+ *
+ * @param <E>
+ *  the type of checked exception, or class of exceptions, this supplier may throw
+ */
+@FunctionalInterface
+public interface CheckedSupplier<T, E extends Exception> {
+
+    /**
+     * Fetches a value or result from this supplier. The output of this method may change from invocation to
+     * invocation.
+     *
+     * @return
+     *  the value or result of this checked supplier
+     */
+    T get() throws E;
+}

--- a/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
+++ b/src/test/java/org/candlepin/controller/refresher/RefreshWorkerTest.java
@@ -46,7 +46,6 @@ import org.candlepin.service.model.ProductContentInfo;
 import org.candlepin.service.model.ProductInfo;
 import org.candlepin.service.model.SubscriptionInfo;
 import org.candlepin.test.TestUtil;
-import org.candlepin.util.TransactionExecutionException;
 import org.candlepin.util.Util;
 
 import org.hibernate.exception.ConstraintViolationException;
@@ -1267,7 +1266,8 @@ public class RefreshWorkerTest {
 
         // Impl note: this only works because of the call to mockTransactionalFunctionality done in setup
         this.mockEntityManager.getTransaction().begin();
-        assertThrows(TransactionExecutionException.class, () -> worker.execute(owner));
+        Throwable thrown = assertThrows(Exception.class, () -> worker.execute(owner));
+        assertEquals(exception, thrown);
 
         verify(mockProductCurator, times(1)).getProductsByIds(eq(null), any(Collection.class));
         verify(mockProductCurator, times(1)).create(Mockito.any(Product.class), anyBoolean());


### PR DESCRIPTION
This PR includes two commits:

CANDLEPIN-1059: Refactored Transactional and EERetry utility classes
- Refactored the Transactional wrapper utility class to use standard
  functional interfaces instead of a custom actions
- Added the CheckedRunnable and CheckedSupplier interfaces to permit
  passing through checked exceptions through functional blocks
- Updated the ExpectedExceptionRetryWrapper class to allow use of
  the CheckedSupplier in addition to the standard Supplier
- Updated affected areas of code to use the new APIs where applicable

CANDLEPIN-1059: Reduced 429s while fetching content access payloads
- Updated the handling of concurrent content payload exceptions such
  that content access payload generation is retried at least once
  before returning returning a 429 to the user
- Refactored several methods in ConsumerResource surrounding content
  access certificate and payload generation
- Fixed a bug causing serial filtering to exclude matching
  certificates rather than include while fetching anonymous consumer
  certificates