### PR TITLE
CANDLEPIN-1092: Added testing releases to test repos

### DIFF
--- a/bin/deployment/deploy
+++ b/bin/deployment/deploy
@@ -148,8 +148,8 @@ create_test_repos() {
         echo ""
         echo "Run following commands on registered system to use created repositories:"
         echo ""
-        echo "    subscription-manager config --rhsm.baseurl=http://<ip_of_this_server>:8080"
-        echo "    curl http://<ip_of_this_server>:8080/RPM-GPG-KEY-candlepin > /etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin"
+        echo "    subscription-manager config --rhsm.baseurl=https://<ip_of_this_server>:9443"
+        echo "    curl -k https://<ip_of_this_server>:9443/RPM-GPG-KEY-candlepin > /etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin"
         echo ""
     fi
 }

--- a/bin/deployment/test_data.json
+++ b/bin/deployment/test_data.json
@@ -419,6 +419,42 @@
             "content_url": "/path/to/fake-content",
             "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
             "packages": ["insights-client"]
+        },
+        {
+            "name": "release-content",
+            "id": 22222,
+            "label": "release-content",
+            "type": "yum",
+            "vendor": "Red Hat",
+            "content_url": "/foo/path/rhel10/$releasever/release-content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
+            "required_tags": "rhel-10",
+            "releases": ["10", "10.0", "10.1", "10.2"],
+            "packages": ["lazy-fox", "white-lion", "fluffy-snake"]
+        },
+        {
+            "name": "awesome-release-content",
+            "id": 33333,
+            "label": "awesome-release-content",
+            "type": "yum",
+            "vendor": "Red Hat",
+            "content_url": "/path/to/fake-content/rhel10/$releasever/awesome-release-content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
+            "required_tags": "rhel-10",
+            "releases": ["10", "10.1", "10.2", "10.4"],
+            "packages": ["awesome-sheep", "awesome-cow", "awesome-rabbit"]
+        },
+        {
+            "name": "another-release-content",
+            "id": 44444,
+            "label": "another-release-content",
+            "type": "yum",
+            "vendor": "Red Hat",
+            "content_url": "/path/to/fake-content/rhel10/$releasever/another-release-content",
+            "gpg_url": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
+            "required_tags": "rhel-10",
+            "releases": ["10", "10.1", "10.2", "10.4"],
+            "packages": ["awesome-sheep", "awesome-goat", "awesome-pig"]
         }
     ],
     "owners": [
@@ -1064,6 +1100,51 @@
             "type": "MKT",
             "provided_products": [
                 "38072"
+            ]
+        },
+        {
+            "name": "OS Bits with Releases",
+            "id": "38090",
+            "content": [
+                [22222, true]
+            ]
+        },
+        {
+            "name": "OS Bits with Releases",
+            "id": "release-bits",
+            "type": "MKT",
+            "provided_products": [
+                "38090"
+            ]
+        },
+        {
+            "name": "Awesome OS Bits with Releases",
+            "id": "38091",
+            "content": [
+                [33333, true]
+            ]
+        },
+        {
+            "name": "Awesome OS Bits with Releases",
+            "id": "awesome-release-bits",
+            "type": "MKT",
+            "provided_products": [
+                "38091"
+            ]
+        },
+        {
+            "name": "Another OS Bits with Releases",
+            "id": "38092",
+            "content": [
+                [44444, false]
+            ]
+        },
+        {
+            "name": "Another OS Bits with Releases",
+            "id": "another-release-bits",
+            "type": "MKT",
+            "provided_products": [
+                "38092"
             ]
         },
         {

--- a/bin/deployment/update-server-xml.py
+++ b/bin/deployment/update-server-xml.py
@@ -214,6 +214,11 @@ class LegacySSLContextEditor(AbstractBaseEditor):
         return connector
 
 
+class LegacySSLContextRepoEditor(LegacySSLContextEditor):
+    def __init__(self, *args, **kwargs):
+        self.port = "9443"
+        super(LegacySSLContextRepoEditor, self).__init__(*args, **kwargs)
+
 
 class CandlepinConnectorEditorV3(AbstractBaseEditor):
     def __init__(self, *args, **kwargs):
@@ -299,6 +304,11 @@ class CandlepinConnectorEditorV3(AbstractBaseEditor):
         # return
         return connector
 
+
+class CandlepinRepoConnectorEditorV3(CandlepinConnectorEditorV3):
+    def __init__(self, *args, **kwargs):
+        self.port = "9443"
+        super(CandlepinRepoConnectorEditorV3, self).__init__(*args, **kwargs)
 
 
 class AccessLogValveEditor(AbstractBaseEditor):
@@ -412,14 +422,17 @@ def main():
     tversion = parse_tc_version(options.tc_version)
     if not tversion or len(tversion) < 1 or tversion[0] > 8 or (tversion[0] == 8 and tversion[1] >= 5):
         ssl_editor_target = CandlepinConnectorEditorV3
+        ssl_repo_editor_target = CandlepinRepoConnectorEditorV3
     else:
         logger.warn("Using legacy Tomcat configuration")
         ssl_editor_target = LegacySSLContextEditor
+        ssl_repo_editor_target = LegacySSLContextRepoEditor
 
     xml_file = os.path.join(conf_dir, "server.xml")
     logger.debug("Opening %s" % xml_file)
     with open_xml(xml_file) as doc:
         ssl_editor_target(doc).insert()
+        ssl_repo_editor_target(doc).insert()
         AccessLogValveEditor(doc).insert()
         AprListenerDeleter(doc).remove()
 


### PR DESCRIPTION
* Extended deployment script to be able to define
  releases for testing repositories
* The definition of repository can contain `releases`
  attribute with list of releases like this:
    `"releases": ["10", "10.0", "10.1", "10.2"]`
  This list will be used for generating listing
  file in testing RPM repository and the repository
  will contain copy for each release (each copy
  contains same versions of RPMs).
* Extended testing data. One new testing repository
  is also enabled by default and it contains listing
  file (with some releases) and the content URL of
  the repository contains `"$releasever"` in the path
* Modified configuration file of tomcat. Tomcat also
  listens on 9443 port now, because
  subscription-manager access repository only
  using HTTPs (not HTTP) protocol. The
  subscription-manager cannot use existing 8080
  port (HTTP).
* Modified final message with hints to use https
  and port 9443
* When `/etc/pki/product-default/` contains at least
  one product certificate with tag `"rhel-10"`, then
  you can use "subscription-manager release" command
  with testing