### PR TITLE
Fixed malformed $ref in getConsumer operation

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -968,7 +968,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - '#/components/schemas/ExceptionMessage'
+                  - $ref: '#/components/schemas/ExceptionMessage'
                 properties:
                   deletedId:
                     type: string


### PR DESCRIPTION
When I documented the 410: GONE in getConsumer, I unfortunately left out the `$ref:` keyword. This PR fixes that mistake.

I don't think this impacts OpenAPI generator, which will create the class for the referenced type when it iterates over the `#/components/schemas` section regardless of any references to it.