### PR TITLE
[PQC] CANDLEPIN-1175: Enforce RHEL crypto policy for primitive crypto operations

### DIFF
--- a/src/main/java/org/candlepin/guice/CandlepinModule.java
+++ b/src/main/java/org/candlepin/guice/CandlepinModule.java
@@ -96,6 +96,7 @@ import org.candlepin.messaging.impl.noop.NoopContextListener;
 import org.candlepin.messaging.impl.noop.NoopSessionFactory;
 import org.candlepin.pki.CertificateReader;
 import org.candlepin.pki.CryptoManager;
+import org.candlepin.pki.CryptoPolicyValidator;
 import org.candlepin.pki.OidUtil;
 import org.candlepin.pki.PemEncoder;
 import org.candlepin.pki.PrivateKeyReader;
@@ -319,6 +320,9 @@ public class CandlepinModule extends AbstractModule {
         bind(PrivateKeyReader.class).to(BouncyCastlePrivateKeyReader.class).asEagerSingleton();
         bind(PemEncoder.class).to(BouncyCastlePemEncoder.class).asEagerSingleton();
         // Impl note: SubjectKeyIdentifier is bound in the DefaultConfig pseudo-module
+
+        // Crypto policy validator
+        bind(CryptoPolicyValidator.class).asEagerSingleton();
 
         // CryptoManager
         bind(CryptoManager.class).to(BouncyCastleCryptoManager.class).asEagerSingleton();

--- a/src/main/java/org/candlepin/pki/CryptoPolicyValidator.java
+++ b/src/main/java/org/candlepin/pki/CryptoPolicyValidator.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2009 - 2026 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pki;
+
+import org.candlepin.config.ConfigurationException;
+import org.candlepin.sync.SchemeFile;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.security.Security;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.DSAPublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+
+
+/**
+ * Validates cryptographic schemes against the system's crypto policy as defined by the JVM security
+ * property {@code jdk.certpath.disabledAlgorithms}.
+ *
+ * <p>RHEL crypto policy restrictions are loaded into JVM security properties but are not enforced by
+ * Java during primitive cryptographic operations (key/cert generation) or when using BouncyCastle as
+ * the TLS provider. This class reads those restrictions and enforces them for Candlepin's configured
+ * schemes.
+ *
+ * <p>The parser handles the JDK disabled algorithms format:
+ * <ul>
+ *   <li>Plain algorithm name: {@code MD2} (fully disabled)</li>
+ *   <li>Key size constraint: {@code RSA keySize < 2048}</li>
+ *   <li>Conditional constraints ({@code jdkCA}, {@code denyAfter}, {@code usage}): ignored, as they
+ *       are certpath/TLS-context-specific and not relevant to primitive operations</li>
+ *   <li>{@code include <property>}: resolved recursively</li>
+ * </ul>
+ */
+@Singleton
+public class CryptoPolicyValidator {
+    private static final Logger log = LoggerFactory.getLogger(CryptoPolicyValidator.class);
+
+    static final String CERTPATH_DISABLED_ALGORITHMS_PROPERTY = "jdk.certpath.disabledAlgorithms";
+
+    private static final Pattern KEY_SIZE_PATTERN = Pattern.compile(
+        "keySize\\s*(<=|<|==|!=|>=|>)\\s*(\\d+)", Pattern.CASE_INSENSITIVE);
+
+    private final List<DisabledAlgorithm> disabledAlgorithms;
+
+    @Inject
+    public CryptoPolicyValidator() {
+        this(Security.getProperty(CERTPATH_DISABLED_ALGORITHMS_PROPERTY));
+    }
+
+    /**
+     * Constructs a validator from a raw disabled algorithms string (the format used by
+     * {@code jdk.certpath.disabledAlgorithms}). Useful for testing with controlled policy values.
+     *
+     * @param disabledAlgorithmsProperty
+     *  the raw comma-separated disabled algorithms string, or null/empty for no restrictions
+     */
+    public CryptoPolicyValidator(String disabledAlgorithmsProperty) {
+        this.disabledAlgorithms = Collections.unmodifiableList(parse(disabledAlgorithmsProperty));
+
+        if (this.disabledAlgorithms.isEmpty()) {
+            log.info("No crypto policy restrictions found in {}", CERTPATH_DISABLED_ALGORITHMS_PROPERTY);
+        }
+        else {
+            log.info("Loaded {} crypto policy restriction(s) from {}: {}",
+                this.disabledAlgorithms.size(), CERTPATH_DISABLED_ALGORITHMS_PROPERTY,
+                this.disabledAlgorithms);
+        }
+    }
+
+    /**
+     * Validates the given scheme against the system crypto policy. Throws a
+     * {@link ConfigurationException} if the scheme's algorithms or key size violate the policy.
+     *
+     * @param scheme
+     *  the scheme to validate
+     *
+     * @throws ConfigurationException
+     *  if the scheme violates the crypto policy
+     */
+    public void validateScheme(Scheme scheme) {
+        if (scheme == null) {
+            throw new IllegalArgumentException("scheme is null");
+        }
+
+        List<String> violations = checkAlgorithms(
+            scheme.signatureAlgorithm(),
+            scheme.keyAlgorithm(),
+            scheme.keySize().orElse(null));
+
+        if (!violations.isEmpty()) {
+            throw new ConfigurationException(String.format(
+                "Scheme \"%s\" violates the system crypto policy (%s): %s",
+                scheme.name(), CERTPATH_DISABLED_ALGORITHMS_PROPERTY, String.join("; ", violations)));
+        }
+    }
+
+    /**
+     * Validates algorithms from a manifest's {@link SchemeFile} against the system crypto policy.
+     * The key size is extracted from the embedded X.509 certificate if present.
+     *
+     * @param schemeFile
+     *  the scheme file from a manifest to validate
+     *
+     * @throws ConfigurationException
+     *  if the scheme file's algorithms violate the crypto policy
+     */
+    public void validateSchemeFile(SchemeFile schemeFile) {
+        if (schemeFile == null) {
+            throw new IllegalArgumentException("schemeFile is null");
+        }
+
+        Integer keySize = extractKeySizeFromCertificate(schemeFile.certificate());
+
+        List<String> violations = checkAlgorithms(
+            schemeFile.signatureAlgorithm(),
+            schemeFile.keyAlgorithm(),
+            keySize);
+
+        if (!violations.isEmpty()) {
+            throw new ConfigurationException(String.format(
+                "Manifest scheme \"%s\" violates the system crypto policy (%s): %s",
+                schemeFile.name(), CERTPATH_DISABLED_ALGORITHMS_PROPERTY,
+                String.join("; ", violations)));
+        }
+    }
+
+    /**
+     * Checks the given algorithms and key size against the loaded crypto policy restrictions, returning
+     * a list of human-readable violation descriptions. An empty list means no violations.
+     *
+     * @param signatureAlgorithm
+     *  the signature algorithm (e.g. "SHA256withRSA")
+     *
+     * @param keyAlgorithm
+     *  the key algorithm (e.g. "RSA")
+     *
+     * @param keySize
+     *  the key size in bits, or null if not specified
+     *
+     * @return
+     *  a list of violation descriptions, empty if compliant
+     */
+    List<String> checkAlgorithms(String signatureAlgorithm, String keyAlgorithm, Integer keySize) {
+        List<String> violations = new ArrayList<>();
+
+        for (DisabledAlgorithm disabled : this.disabledAlgorithms) {
+            if (disabled.keySizeConstraint() != null) {
+                if (matchesAlgorithmName(disabled.name(), keyAlgorithm) && keySize != null) {
+                    if (disabled.keySizeConstraint().isViolatedBy(keySize)) {
+                        violations.add(String.format(
+                            "key algorithm \"%s\" with key size %d violates constraint \"%s keySize %s %d\"",
+                            keyAlgorithm, keySize, disabled.name(),
+                            disabled.keySizeConstraint().operator(), disabled.keySizeConstraint().value()));
+                    }
+                }
+            }
+            else {
+                if (matchesAlgorithmName(disabled.name(), keyAlgorithm)) {
+                    violations.add(String.format(
+                        "key algorithm \"%s\" is disabled by crypto policy (disabled: \"%s\")",
+                        keyAlgorithm, disabled.name()));
+                }
+
+                if (signatureAlgorithm != null &&
+                    isSignatureAlgorithmAffected(disabled.name(), signatureAlgorithm)) {
+                    violations.add(String.format(
+                        "signature algorithm \"%s\" contains disabled sub-element \"%s\"",
+                        signatureAlgorithm, disabled.name()));
+                }
+            }
+        }
+
+        return violations;
+    }
+
+    /**
+     * Returns the parsed list of disabled algorithm entries. Visible for testing.
+     *
+     * @return an unmodifiable list of disabled algorithm entries
+     */
+    List<DisabledAlgorithm> getDisabledAlgorithms() {
+        return this.disabledAlgorithms;
+    }
+
+    /**
+     * Parses the {@code jdk.certpath.disabledAlgorithms} property value into structured entries.
+     * Entries with non-keySize constraints (jdkCA, denyAfter, usage) are skipped, as they are
+     * context-specific and not applicable to primitive crypto operations.
+     */
+    private static List<DisabledAlgorithm> parse(String property) {
+        if (property == null || property.isBlank()) {
+            return List.of();
+        }
+
+        List<DisabledAlgorithm> result = new ArrayList<>();
+        String[] entries = property.split(",");
+
+        for (String entry : entries) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+
+            // Handle "include <property>" directives by resolving them recursively
+            if (trimmed.toLowerCase(Locale.ROOT).startsWith("include ")) {
+                String includedProperty = trimmed.substring("include ".length()).trim();
+                String includedValue = Security.getProperty(includedProperty);
+                result.addAll(parse(includedValue));
+                continue;
+            }
+
+            // Skip entries with conditional constraints that don't apply to primitive operations
+            String lowerTrimmed = trimmed.toLowerCase(Locale.ROOT);
+            if (lowerTrimmed.contains("jdkca") || lowerTrimmed.contains("denyafter") ||
+                lowerTrimmed.contains("usage ")) {
+                log.debug("Skipping context-specific crypto policy entry: {}", trimmed);
+                continue;
+            }
+
+            Matcher keySizeMatcher = KEY_SIZE_PATTERN.matcher(trimmed);
+            if (keySizeMatcher.find()) {
+                String algorithmName = trimmed.substring(0, keySizeMatcher.start()).trim();
+                String operator = keySizeMatcher.group(1);
+                int value = Integer.parseInt(keySizeMatcher.group(2));
+                result.add(new DisabledAlgorithm(algorithmName, new KeySizeConstraint(operator, value)));
+            }
+            else {
+                // Plain disabled algorithm with no constraints
+                result.add(new DisabledAlgorithm(trimmed, null));
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Checks if a disabled algorithm name matches a given algorithm name (case-insensitive, exact match).
+     */
+    private static boolean matchesAlgorithmName(String disabledName, String algorithmName) {
+        return disabledName.equalsIgnoreCase(algorithmName);
+    }
+
+    /**
+     * Checks if a disabled algorithm name affects a composite signature algorithm using JDK sub-element
+     * matching rules. The signature algorithm is split on "with" (case-insensitive) into its hash and
+     * signing components. A match occurs if either component equals the disabled name (case-insensitive).
+     *
+     * <p>For example, if "SHA1" is disabled, then "SHA1withRSA" and "SHA1withECDSA" are both affected.
+     * If "DSA" is disabled, then "SHA1withDSA" is affected, but "SHA1withECDSA" is not (because "DSA"
+     * is not equal to "ECDSA").
+     */
+    private static boolean isSignatureAlgorithmAffected(String disabledName, String signatureAlgorithm) {
+        // Direct match on the full algorithm name
+        if (disabledName.equalsIgnoreCase(signatureAlgorithm)) {
+            return true;
+        }
+
+        // Sub-element matching: split on "with" (case-insensitive)
+        String lower = signatureAlgorithm.toLowerCase(Locale.ROOT);
+        int withIdx = lower.indexOf("with");
+        if (withIdx > 0) {
+            String hashPart = signatureAlgorithm.substring(0, withIdx);
+            String sigPart = signatureAlgorithm.substring(withIdx + 4);
+            return disabledName.equalsIgnoreCase(hashPart) || disabledName.equalsIgnoreCase(sigPart);
+        }
+
+        return false;
+    }
+
+    /**
+     * Attempts to extract the key size (in bits) from a Base64-encoded X.509 certificate. Returns null
+     * if the certificate cannot be parsed or the key type is unrecognized.
+     */
+    private static Integer extractKeySizeFromCertificate(String base64Certificate) {
+        if (base64Certificate == null || base64Certificate.isBlank()) {
+            return null;
+        }
+
+        try {
+            byte[] certBytes = Base64.getDecoder().decode(base64Certificate);
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            X509Certificate cert = (X509Certificate) cf.generateCertificate(
+                new ByteArrayInputStream(certBytes));
+
+            java.security.PublicKey publicKey = cert.getPublicKey();
+            if (publicKey instanceof RSAPublicKey rsaKey) {
+                return rsaKey.getModulus().bitLength();
+            }
+            else if (publicKey instanceof ECPublicKey ecKey) {
+                return ecKey.getParams().getOrder().bitLength();
+            }
+            else if (publicKey instanceof DSAPublicKey dsaKey) {
+                return dsaKey.getParams().getP().bitLength();
+            }
+
+            return null;
+        }
+        catch (CertificateException | IllegalArgumentException e) {
+            log.warn("Unable to extract key size from manifest certificate", e);
+            return null;
+        }
+    }
+
+    /**
+     * Represents a single disabled algorithm entry parsed from the crypto policy.
+     *
+     * @param name
+     *  the algorithm name (e.g. "RSA", "MD2")
+     * @param keySizeConstraint
+     *  the optional key size constraint, or null if the algorithm is fully disabled
+     */
+    record DisabledAlgorithm(String name, KeySizeConstraint keySizeConstraint) {
+        @Override
+        public String toString() {
+            if (keySizeConstraint != null) {
+                return String.format("%s keySize %s %d", name,
+                    keySizeConstraint.operator(), keySizeConstraint.value());
+            }
+            return name;
+        }
+    }
+
+    /**
+     * Represents a key size constraint from the crypto policy (e.g. "keySize < 2048").
+     *
+     * @param operator
+     *  the comparison operator as a string
+     * @param value
+     *  the key size threshold in bits
+     */
+    record KeySizeConstraint(String operator, int value) {
+        boolean isViolatedBy(int keySize) {
+            return switch (operator) {
+                case "<" -> keySize < value;
+                case "<=" -> keySize <= value;
+                case "==" -> keySize == value;
+                case "!=" -> keySize != value;
+                case ">=" -> keySize >= value;
+                case ">" -> keySize > value;
+                default -> false;
+            };
+        }
+    }
+}

--- a/src/main/java/org/candlepin/pki/impl/bc/BouncyCastleCryptoManager.java
+++ b/src/main/java/org/candlepin/pki/impl/bc/BouncyCastleCryptoManager.java
@@ -22,6 +22,7 @@ import org.candlepin.model.ConsumerType;
 import org.candlepin.pki.CertificateReader;
 import org.candlepin.pki.CryptoCapabilitiesException;
 import org.candlepin.pki.CryptoManager;
+import org.candlepin.pki.CryptoPolicyValidator;
 import org.candlepin.pki.DistinguishedName;
 import org.candlepin.pki.KeyPairGenerator;
 import org.candlepin.pki.OidUtil;
@@ -88,10 +89,11 @@ public class BouncyCastleCryptoManager implements CryptoManager {
     @Inject
     public BouncyCastleCryptoManager(Configuration config, BouncyCastleProvider securityProvider,
         SchemeReader schemeReader, CertificateReader certreader, SubjectKeyIdentifierWriter skiWriter,
-        OidUtil oidUtil) {
+        OidUtil oidUtil, CryptoPolicyValidator cryptoPolicyValidator) {
 
         Objects.requireNonNull(config);
         Objects.requireNonNull(schemeReader);
+        Objects.requireNonNull(cryptoPolicyValidator);
 
         this.securityProvider = Objects.requireNonNull(securityProvider);
         this.certreader = Objects.requireNonNull(certreader);
@@ -105,6 +107,10 @@ public class BouncyCastleCryptoManager implements CryptoManager {
         // Validate the schemes we've loaded
         Stream.concat(this.schemes.stream(), Stream.of(this.defaultScheme))
             .forEach(this::validateScheme);
+
+        // Validate schemes against the system crypto policy
+        Stream.concat(this.schemes.stream(), Stream.of(this.defaultScheme))
+            .forEach(cryptoPolicyValidator::validateScheme);
 
         // Temporary feature flag
         this.enableSchemeNegotiation = config.getBoolean(ConfigProperties.CRYPTO_CLIENT_NEGOTIATION_ENABLED);

--- a/src/main/java/org/candlepin/sync/Importer.java
+++ b/src/main/java/org/candlepin/sync/Importer.java
@@ -15,6 +15,7 @@
 package org.candlepin.sync;
 
 import org.candlepin.audit.EventSink;
+import org.candlepin.config.ConfigurationException;
 import org.candlepin.controller.RefresherFactory;
 import org.candlepin.dto.ModelTranslator;
 import org.candlepin.dto.manifest.v1.CdnDTO;
@@ -40,6 +41,7 @@ import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.UpstreamConsumer;
 import org.candlepin.pki.CryptoManager;
+import org.candlepin.pki.CryptoPolicyValidator;
 import org.candlepin.pki.Scheme;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.service.impl.ImportSubscriptionServiceAdapter;
@@ -128,6 +130,7 @@ public class Importer {
     private final IdentityCertificateCurator idCertCurator;
     private final RefresherFactory refresherFactory;
     private final CryptoManager cryptoManager;
+    private final CryptoPolicyValidator cryptoPolicyValidator;
     private final ExporterMetadataCurator expMetaCurator;
     private final CertificateSerialCurator csCurator;
     private final CdnCurator cdnCurator;
@@ -150,6 +153,7 @@ public class Importer {
         IdentityCertificateCurator idCertCurator,
         RefresherFactory refresherFactory,
         CryptoManager cryptoManager,
+        CryptoPolicyValidator cryptoPolicyValidator,
         ExporterMetadataCurator emc,
         CertificateSerialCurator csc,
         EventSink sink,
@@ -180,6 +184,7 @@ public class Importer {
         this.translator = Objects.requireNonNull(translator);
 
         this.cryptoManager = Objects.requireNonNull(cryptoManager);
+        this.cryptoPolicyValidator = Objects.requireNonNull(cryptoPolicyValidator);
 
         // Temporary measure to get a scheme; this should be determined on a per-op basis
         this.scheme = this.cryptoManager.getDefaultCryptoScheme();
@@ -437,6 +442,20 @@ public class Importer {
             // Need the rules file as well which is in a nested dir:
             File rulesFile = new File(consumerExportDir, ImportFile.RULES_FILE.fileName());
             importFiles.put(ImportFile.RULES_FILE.fileName(), rulesFile);
+
+            // Validate the manifest's scheme against the system crypto policy if scheme.json is present
+            File schemeJsonFile = importFiles.get(SchemeFile.FILENAME);
+            if (schemeJsonFile != null && schemeJsonFile.isFile()) {
+                try {
+                    SchemeFile manifestScheme = mapper.readValue(schemeJsonFile, SchemeFile.class);
+                    this.cryptoPolicyValidator.validateSchemeFile(manifestScheme);
+                }
+                catch (ConfigurationException e) {
+                    throw new ImporterException(
+                        i18n.tr("Manifest scheme violates the system crypto policy: {0}",
+                            e.getMessage()), e);
+                }
+            }
 
             List<SubscriptionDTO> importSubs = importObjects(owner, importFiles, overrides);
             Meta m = mapper.readValue(importFiles.get(ImportFile.META.fileName()), Meta.class);

--- a/src/test/java/org/candlepin/pki/CryptoManagerTest.java
+++ b/src/test/java/org/candlepin/pki/CryptoManagerTest.java
@@ -15,6 +15,7 @@
 package org.candlepin.pki;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -77,6 +78,22 @@ public abstract class CryptoManagerTest {
      *  a new CryptoManager instance to test
      */
     protected abstract CryptoManager buildCryptoManager(Configuration config);
+
+    /**
+     * Builds a new CryptoManager instance to test, using the given system configuration and crypto policy
+     * validator. Each invocation should return a new instance.
+     *
+     * @param config
+     *  the configuration to use for the crypto manager
+     *
+     * @param cryptoPolicyValidator
+     *  the crypto policy validator to use
+     *
+     * @return
+     *  a new CryptoManager instance to test
+     */
+    protected abstract CryptoManager buildCryptoManager(Configuration config,
+        CryptoPolicyValidator cryptoPolicyValidator);
 
     private static Stream<Arguments> schemeSource() {
         return CryptoUtil.SUPPORTED_SCHEMES.values()
@@ -196,6 +213,46 @@ public abstract class CryptoManagerTest {
         DevConfig config = addSchemeConfig(TestConfig.defaults(), List.of(scheme, malformed));
 
         assertThrows(ConfigurationException.class, () -> this.buildCryptoManager(config));
+    }
+
+    @ParameterizedTest
+    @MethodSource("schemeSource")
+    public void testCryptoManagerThrowsExceptionWhenKeyAlgorithmViolatesCryptoPolicy(Scheme scheme)
+        throws Exception {
+
+        DevConfig config = addSchemeConfig(TestConfig.defaults(), List.of(scheme));
+        CryptoPolicyValidator validator = new CryptoPolicyValidator(scheme.keyAlgorithm());
+
+        assertThrows(ConfigurationException.class, () -> this.buildCryptoManager(config, validator));
+    }
+
+    @Test
+    public void testCryptoManagerThrowsExceptionWhenKeySizeViolatesCryptoPolicy() throws Exception {
+        Scheme rsaScheme = CryptoUtil.SUPPORTED_SCHEMES.values().stream()
+            .filter(s -> s.keyAlgorithm().equalsIgnoreCase("RSA") && s.keySize().isPresent())
+            .findFirst()
+            .orElse(null);
+
+        if (rsaScheme == null) {
+            return;
+        }
+
+        int disallowBelow = rsaScheme.keySize().get() + 1;
+        DevConfig config = addSchemeConfig(TestConfig.defaults(), List.of(rsaScheme));
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA keySize < " + disallowBelow);
+
+        assertThrows(ConfigurationException.class, () -> this.buildCryptoManager(config, validator));
+    }
+
+    @ParameterizedTest
+    @MethodSource("schemeSource")
+    public void testCryptoManagerStartsSuccessfullyWithPermissiveCryptoPolicy(Scheme scheme)
+        throws Exception {
+
+        DevConfig config = addSchemeConfig(TestConfig.defaults(), List.of(scheme));
+        CryptoPolicyValidator validator = new CryptoPolicyValidator((String) null);
+
+        assertDoesNotThrow(() -> this.buildCryptoManager(config, validator));
     }
 
     @Test

--- a/src/test/java/org/candlepin/pki/CryptoPolicyValidatorTest.java
+++ b/src/test/java/org/candlepin/pki/CryptoPolicyValidatorTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2009 - 2026 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.pki;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.candlepin.config.ConfigurationException;
+import org.candlepin.sync.SchemeFile;
+import org.candlepin.test.CryptoUtil;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.List;
+
+public class CryptoPolicyValidatorTest {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "   ", "\t" })
+    public void testNoPolicyMeansNoRestrictions(String policy) {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator(policy);
+
+        assertThat(validator.getDisabledAlgorithms()).isEmpty();
+        assertThat(validator.checkAlgorithms("SHA256withRSA", "RSA", 4096)).isEmpty();
+    }
+
+    @Test
+    public void testParsesPlainDisabledAlgorithm() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("MD2, MD5");
+
+        assertThat(validator.getDisabledAlgorithms()).hasSize(2)
+            .extracting(CryptoPolicyValidator.DisabledAlgorithm::name)
+            .containsExactlyInAnyOrder("MD2", "MD5");
+    }
+
+    @Test
+    public void testParsesKeySizeConstraintLessThan() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA keySize < 2048");
+
+        assertThat(validator.getDisabledAlgorithms()).singleElement()
+            .extracting(CryptoPolicyValidator.DisabledAlgorithm::name,
+                entry -> entry.keySizeConstraint().operator(), entry -> entry.keySizeConstraint().value())
+            .containsExactly("RSA", "<", 2048);
+    }
+
+    @Test
+    public void testParsesKeySizeConstraintLessThanOrEqual() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA keySize <= 1024");
+
+        assertThat(validator.getDisabledAlgorithms()).singleElement()
+            .extracting(entry -> entry.keySizeConstraint().operator(),
+                entry -> entry.keySizeConstraint().value()).containsExactly("<=", 1024);
+    }
+
+    @Test
+    public void testParsesMultipleEntriesIncludingKeySizeConstraints() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator(
+            "MD2, RSA keySize < 2048, DSA keySize < 2048, EC keySize < 224");
+
+        assertThat(validator.getDisabledAlgorithms()).hasSize(4);
+
+        assertThat(validator.getDisabledAlgorithms()).element(0).satisfies(entry -> {
+            assertThat(entry.name()).isEqualTo("MD2");
+            assertThat(entry.keySizeConstraint()).isNull();
+        });
+
+        assertThat(validator.getDisabledAlgorithms()).element(1).satisfies(entry -> {
+            assertThat(entry.name()).isEqualTo("RSA");
+            assertThat(entry.keySizeConstraint()).isNotNull();
+            assertThat(entry.keySizeConstraint().value()).isEqualTo(2048);
+        });
+    }
+
+    @Test
+    public void testSkipsJdkCAConstraint() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("SHA1 jdkCA & usage TLSServer, MD2");
+
+        assertThat(validator.getDisabledAlgorithms()).singleElement()
+            .extracting(CryptoPolicyValidator.DisabledAlgorithm::name).isEqualTo("MD2");
+    }
+
+    @Test
+    public void testSkipsDenyAfterConstraint() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("SHA1 denyAfter 2020-01-01, MD5");
+
+        assertThat(validator.getDisabledAlgorithms()).singleElement()
+            .extracting(CryptoPolicyValidator.DisabledAlgorithm::name).isEqualTo("MD5");
+    }
+
+    @Test
+    public void testSkipsUsageConstraint() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator(
+            "SHA1 usage TLSServer, RSA keySize < 2048");
+
+        assertThat(validator.getDisabledAlgorithms()).singleElement()
+            .extracting(CryptoPolicyValidator.DisabledAlgorithm::name).isEqualTo("RSA");
+    }
+
+    @Test
+    public void testDetectsDisabledKeyAlgorithm() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("DSA");
+
+        List<String> violations = validator.checkAlgorithms("SHA256withDSA", "DSA", 2048);
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(v -> v.contains("key algorithm") && v.contains("disabled"));
+    }
+
+    @Test
+    public void testDetectsDisabledSignatureSubElement() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("MD5");
+
+        List<String> violations = validator.checkAlgorithms("MD5withRSA", "RSA", 4096);
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(v -> v.contains("signature algorithm") && v.contains("MD5"));
+    }
+
+    @Test
+    public void testDetectsDisabledSignatureSubElementInSigningPart() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("DSA");
+
+        List<String> violations = validator.checkAlgorithms("SHA256withDSA", "DSA", 2048);
+        assertThat(violations).anyMatch(v -> v.contains("signature algorithm") && v.contains("DSA"));
+    }
+
+    @Test
+    public void testDoesNotFalsePositiveOnSubstring() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("DSA");
+
+        List<String> violations = validator.checkAlgorithms("SHA256withECDSA", "EC", 256);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testAllowsAlgorithmNotInDisabledList() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("MD2, MD5, DSA");
+
+        List<String> violations = validator.checkAlgorithms("SHA256withRSA", "RSA", 4096);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testCaseInsensitiveMatching() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("rsa");
+
+        List<String> violations = validator.checkAlgorithms("SHA256withRSA", "RSA", 4096);
+        assertThat(violations).isNotEmpty();
+    }
+
+    // --- Validation: key size constraints ---
+
+    @Test
+    public void testKeySizeConstraintViolated() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA keySize < 2048");
+
+        List<String> violations = validator.checkAlgorithms("SHA256withRSA", "RSA", 1024);
+        assertThat(violations).singleElement().asString().contains("key size 1024");
+    }
+
+    @Test
+    public void testKeySizeConstraintNotViolated() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA keySize < 2048");
+
+        assertThat(validator.checkAlgorithms("SHA256withRSA", "RSA", 4096)).isEmpty();
+    }
+
+    @Test
+    public void testKeySizeConstraintBoundary() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA keySize < 2048");
+
+        assertThat(validator.checkAlgorithms("SHA256withRSA", "RSA", 2048)).isEmpty();
+        assertThat(validator.checkAlgorithms("SHA256withRSA", "RSA", 2047)).hasSize(1);
+    }
+
+    @Test
+    public void testKeySizeConstraintLessThanOrEqualBoundary() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA keySize <= 1024");
+
+        assertThat(validator.checkAlgorithms("SHA256withRSA", "RSA", 1024)).hasSize(1);
+        assertThat(validator.checkAlgorithms("SHA256withRSA", "RSA", 1025)).isEmpty();
+    }
+
+    @Test
+    public void testKeySizeConstraintDoesNotApplyToOtherAlgorithms() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA keySize < 2048");
+
+        assertThat(validator.checkAlgorithms("SHA256withECDSA", "EC", 256)).isEmpty();
+    }
+
+    @Test
+    public void testKeySizeConstraintSkippedWhenKeySizeNull() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA keySize < 2048");
+
+        assertThat(validator.checkAlgorithms("SHA256withRSA", "RSA", null)).isEmpty();
+    }
+
+    @Test
+    public void testValidateSchemePassesForCompliantScheme() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("MD2, DSA keySize < 1024");
+
+        for (Scheme scheme : CryptoUtil.SUPPORTED_SCHEMES.values()) {
+            assertDoesNotThrow(() -> validator.validateScheme(scheme));
+        }
+    }
+
+    @Test
+    public void testValidateSchemeThrowsForDisabledKeyAlgorithm() {
+        Scheme scheme = CryptoUtil.SUPPORTED_SCHEMES.values().iterator().next();
+        String keyAlgorithm = scheme.keyAlgorithm();
+
+        CryptoPolicyValidator validator = new CryptoPolicyValidator(keyAlgorithm);
+
+        assertThatThrownBy(() -> validator.validateScheme(scheme)).isInstanceOf(ConfigurationException.class)
+            .hasMessageContaining(scheme.name()).hasMessageContaining("violates the system crypto policy");
+    }
+
+    @Test
+    public void testValidateSchemeThrowsForKeySizeViolation() {
+        Scheme rsaScheme = CryptoUtil.SUPPORTED_SCHEMES.values().stream()
+            .filter(s -> s.keyAlgorithm().equalsIgnoreCase("RSA")).findFirst().orElse(null);
+
+        if (rsaScheme == null) {
+            return;
+        }
+
+        // Disallow RSA keys smaller than a size larger than our test scheme's key
+        int disallowBelow = rsaScheme.keySize().orElse(0) + 1;
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA keySize < " + disallowBelow);
+
+        assertThatThrownBy(() -> validator.validateScheme(rsaScheme)).isInstanceOf(
+            ConfigurationException.class).hasMessageContaining("violates the system crypto policy");
+    }
+
+    @Test
+    public void testValidateSchemeThrowsForNullScheme() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator((String) null);
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validateScheme(null));
+    }
+
+    @Test
+    public void testValidateSchemeFilePassesForCompliantScheme() throws Exception {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("MD2, DSA keySize < 1024");
+
+        SchemeFile schemeFile = createSchemeFile("SHA256withRSA", "RSA");
+
+        assertDoesNotThrow(() -> validator.validateSchemeFile(schemeFile));
+    }
+
+    @Test
+    public void testValidateSchemeFileThrowsForDisabledAlgorithm() throws Exception {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator("RSA");
+
+        SchemeFile schemeFile = createSchemeFile("SHA256withRSA", "RSA");
+        assertThatThrownBy(() -> validator.validateSchemeFile(schemeFile)).isInstanceOf(
+            ConfigurationException.class).hasMessageContaining("Manifest scheme");
+    }
+
+    @Test
+    public void testValidateSchemeFileThrowsForNullSchemeFile() {
+        CryptoPolicyValidator validator = new CryptoPolicyValidator(null);
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validateSchemeFile(null));
+    }
+
+    @Test
+    public void testRealisticDefaultPolicy() {
+        String policy = "MD2, MD5, SHA1 jdkCA & usage TLSServer, RSA keySize < 2048, " +
+            "DSA keySize < 2048, EC keySize < 224";
+
+        CryptoPolicyValidator validator = new CryptoPolicyValidator(policy);
+
+        assertThat(validator.checkAlgorithms("SHA256withRSA", "RSA", 4096)).isEmpty();
+        assertThat(validator.checkAlgorithms("MD5withRSA", "RSA", 4096)).isNotEmpty();
+        assertThat(validator.checkAlgorithms("SHA256withRSA", "RSA", 1024)).isNotEmpty();
+        assertThat(validator.checkAlgorithms("ML-DSA-65", "ML-DSA-65", null)).isEmpty();
+        assertThat(validator.checkAlgorithms("SHA1withRSA", "RSA", 4096)).isEmpty();
+    }
+
+    private SchemeFile createSchemeFile(String signatureAlgorithm, String keyAlgorithm) throws Exception {
+
+        KeyPair keyPair = CryptoUtil.generateKeyPair(keyAlgorithm, 4096);
+        X509Certificate cert = CryptoUtil.generateX509Certificate(keyPair, signatureAlgorithm);
+
+        return new SchemeFile("test_scheme", Base64.getEncoder().encodeToString(cert.getEncoded()),
+            signatureAlgorithm, keyAlgorithm);
+    }
+}

--- a/src/test/java/org/candlepin/pki/impl/bc/BouncyCastleCryptoManagerTest.java
+++ b/src/test/java/org/candlepin/pki/impl/bc/BouncyCastleCryptoManagerTest.java
@@ -18,6 +18,7 @@ import org.candlepin.config.Configuration;
 import org.candlepin.pki.CertificateReader;
 import org.candlepin.pki.CryptoManager;
 import org.candlepin.pki.CryptoManagerTest;
+import org.candlepin.pki.CryptoPolicyValidator;
 import org.candlepin.pki.OidUtil;
 import org.candlepin.pki.PrivateKeyReader;
 import org.candlepin.pki.SchemeReader;
@@ -36,6 +37,13 @@ public class BouncyCastleCryptoManagerTest extends CryptoManagerTest {
 
     @Override
     protected CryptoManager buildCryptoManager(Configuration config) {
+        return buildCryptoManager(config, new CryptoPolicyValidator((String) null));
+    }
+
+    @Override
+    protected CryptoManager buildCryptoManager(Configuration config,
+        CryptoPolicyValidator cryptoPolicyValidator) {
+
         CertificateReader certReader = CryptoUtil.getCertificateReader();
         PrivateKeyReader keyReader = CryptoUtil.getPrivateKeyReader();
         SchemeReader schemeReader = new SchemeReader(config, keyReader, certReader);
@@ -43,7 +51,7 @@ public class BouncyCastleCryptoManagerTest extends CryptoManagerTest {
         OidUtil oidUtil = CryptoUtil.getOidUtil();
 
         return new BouncyCastleCryptoManager(config, SECURITY_PROVIDER_PROVIDER.get(), schemeReader,
-            certReader, skiWriter, oidUtil);
+            certReader, skiWriter, oidUtil, cryptoPolicyValidator);
     }
 
 }

--- a/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -69,6 +69,7 @@ import org.candlepin.model.Product;
 import org.candlepin.model.UpstreamConsumer;
 import org.candlepin.model.dto.Subscription;
 import org.candlepin.pki.CryptoManager;
+import org.candlepin.pki.CryptoPolicyValidator;
 import org.candlepin.pki.Scheme;
 import org.candlepin.pki.SignatureValidator;
 import org.candlepin.service.SubscriptionServiceAdapter;
@@ -157,6 +158,7 @@ public class ImporterTest {
     private String mockJsPath;
 
     private CryptoManager cryptoManager;
+    private CryptoPolicyValidator cryptoPolicyValidator;
 
 
     @BeforeEach
@@ -175,6 +177,7 @@ public class ImporterTest {
         this.updateReleaseVersion("0.0.3", "1");
 
         this.cryptoManager = spy(CryptoUtil.getCryptoManager(this.config));
+        this.cryptoPolicyValidator = new CryptoPolicyValidator((String) null);
     }
 
     @AfterEach
@@ -195,8 +198,13 @@ public class ImporterTest {
     }
 
     private Importer buildImporter() {
+        return buildImporter(this.cryptoPolicyValidator);
+    }
+
+    private Importer buildImporter(CryptoPolicyValidator cryptoPolicyValidator) {
         return new Importer(this.mockConsumerTypeCurator, this.mockRulesImporter, this.mockOwnerCurator,
             this.mockIdentityCertCurator, this.refresherFactory, this.cryptoManager,
+            cryptoPolicyValidator,
             this.mockExporterMetadataCurator, this.mockCertSerialCurator, this.mockEventSink, this.i18n,
             this.mockDistributorVersionCurator, this.mockCdnCurator, this.syncUtils, this.mapper,
             this.mockImportRecordCurator, this.mockSubscriptionReconciler, this.modelTranslator);
@@ -1061,6 +1069,122 @@ public class ImporterTest {
 
         verify(this.mockEventSink, never()).emitSubscriptionExpired(any(SubscriptionDTO.class));
         verify(this.mockImportRecordCurator).create(record);
+    }
+
+    @Test
+    public void testImportThrowsExceptionWhenManifestSchemeViolatesCryptoPolicy() throws Exception {
+        SignatureValidator mockSignatureValidator = mock(SignatureValidator.class, Answers.RETURNS_SELF);
+        doReturn(true).when(mockSignatureValidator).validate(any(File.class));
+        doReturn(mockSignatureValidator).when(this.cryptoManager).getSignatureValidator(any(Scheme.class));
+
+        Owner owner = mock(Owner.class);
+        ConflictOverrides co = mock(ConflictOverrides.class);
+
+        String schemeJson = "{\"name\":\"legacy\",\"certificate\":\"AAAA\"," +
+            "\"signature_algorithm\":\"SHA256withRSA\",\"key_algorithm\":\"RSA\"}";
+
+        // entries must be under "export/" to match extractArchive's expected layout
+        File ceArchive = new File(this.tmpFolder, "consumer_export.zip");
+        try (ZipOutputStream cezip = new ZipOutputStream(new FileOutputStream(ceArchive))) {
+            cezip.putNextEntry(new ZipEntry("export/" + SchemeFile.FILENAME));
+            cezip.write(schemeJson.getBytes());
+            cezip.closeEntry();
+            cezip.putNextEntry(new ZipEntry("export/dummy.txt"));
+            cezip.write("placeholder".getBytes());
+            cezip.closeEntry();
+        }
+
+        File archive = new File(this.tmpFolder, "file.zip");
+        try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(archive))) {
+            out.putNextEntry(new ZipEntry("signature"));
+            out.write("signature placeholder".getBytes());
+            out.closeEntry();
+            addFileToArchive(out, ceArchive);
+        }
+
+        CryptoPolicyValidator restrictiveValidator = new CryptoPolicyValidator("RSA");
+        Importer importer = this.buildImporter(restrictiveValidator);
+
+        Throwable throwable = assertThrows(ImporterException.class,
+            () -> importer.loadExport(owner, archive, co, "original_file.zip"));
+        assertThat(throwable.getMessage(),
+            StringContains.containsString("Manifest scheme violates the system crypto policy"));
+    }
+
+    @Test
+    public void testImportSucceedsWhenManifestSchemeCompliesWithCryptoPolicy() throws Exception {
+        SignatureValidator mockSignatureValidator = mock(SignatureValidator.class, Answers.RETURNS_SELF);
+        doReturn(true).when(mockSignatureValidator).validate(any(File.class));
+        doReturn(mockSignatureValidator).when(this.cryptoManager).getSignatureValidator(any(Scheme.class));
+
+        Owner owner = mock(Owner.class);
+        ConflictOverrides co = mock(ConflictOverrides.class);
+
+        String schemeJson = "{\"name\":\"legacy\",\"certificate\":\"AAAA\"," +
+            "\"signature_algorithm\":\"SHA256withRSA\",\"key_algorithm\":\"RSA\"}";
+
+        File ceArchive = new File(this.tmpFolder, "consumer_export.zip");
+        try (ZipOutputStream cezip = new ZipOutputStream(new FileOutputStream(ceArchive))) {
+            cezip.putNextEntry(new ZipEntry("export/" + SchemeFile.FILENAME));
+            cezip.write(schemeJson.getBytes());
+            cezip.closeEntry();
+            cezip.putNextEntry(new ZipEntry("export/dummy.txt"));
+            cezip.write("placeholder".getBytes());
+            cezip.closeEntry();
+        }
+
+        File archive = new File(this.tmpFolder, "file.zip");
+        try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(archive))) {
+            out.putNextEntry(new ZipEntry("signature"));
+            out.write("signature placeholder".getBytes());
+            out.closeEntry();
+            addFileToArchive(out, ceArchive);
+        }
+
+        CryptoPolicyValidator permissiveValidator = new CryptoPolicyValidator("MD2");
+        Importer importer = this.buildImporter(permissiveValidator);
+
+        // The import will fail further down (missing meta.json) but should NOT fail on crypto policy
+        Throwable throwable = assertThrows(ImporterException.class,
+            () -> importer.loadExport(owner, archive, co, "original_file.zip"));
+        assertThat(throwable.getMessage(),
+            org.hamcrest.Matchers.not(
+                StringContains.containsString("Manifest scheme violates the system crypto policy")));
+    }
+
+    @Test
+    public void testImportSucceedsWithoutSchemeJson() throws Exception {
+        SignatureValidator mockSignatureValidator = mock(SignatureValidator.class, Answers.RETURNS_SELF);
+        doReturn(true).when(mockSignatureValidator).validate(any(File.class));
+        doReturn(mockSignatureValidator).when(this.cryptoManager).getSignatureValidator(any(Scheme.class));
+
+        Owner owner = mock(Owner.class);
+        ConflictOverrides co = mock(ConflictOverrides.class);
+
+        File ceArchive = new File(this.tmpFolder, "consumer_export.zip");
+        try (ZipOutputStream cezip = new ZipOutputStream(new FileOutputStream(ceArchive))) {
+            cezip.putNextEntry(new ZipEntry("export/dummy.txt"));
+            cezip.write("placeholder".getBytes());
+            cezip.closeEntry();
+        }
+
+        File archive = new File(this.tmpFolder, "file.zip");
+        try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(archive))) {
+            out.putNextEntry(new ZipEntry("signature"));
+            out.write("signature placeholder".getBytes());
+            out.closeEntry();
+            addFileToArchive(out, ceArchive);
+        }
+
+        CryptoPolicyValidator restrictiveValidator = new CryptoPolicyValidator("RSA");
+        Importer importer = this.buildImporter(restrictiveValidator);
+
+        // No scheme.json -> no crypto policy violation, will fail later on missing meta.json
+        Throwable throwable = assertThrows(ImporterException.class,
+            () -> importer.loadExport(owner, archive, co, "original_file.zip"));
+        assertThat(throwable.getMessage(),
+            org.hamcrest.Matchers.not(
+                StringContains.containsString("Manifest scheme violates the system crypto policy")));
     }
 
 }

--- a/src/test/java/org/candlepin/test/CryptoUtil.java
+++ b/src/test/java/org/candlepin/test/CryptoUtil.java
@@ -23,6 +23,7 @@ import org.candlepin.model.AbstractCertificate;
 import org.candlepin.model.Consumer;
 import org.candlepin.pki.CertificateReader;
 import org.candlepin.pki.CryptoManager;
+import org.candlepin.pki.CryptoPolicyValidator;
 import org.candlepin.pki.OidUtil;
 import org.candlepin.pki.PemEncoder;
 import org.candlepin.pki.PrivateKeyReader;
@@ -213,9 +214,10 @@ public class CryptoUtil {
 
         SchemeReader schemeReader = new SchemeReader(config, keyReader, certReader);
 
-        // Build & return crypto manager
+        // Build & return crypto manager (no crypto policy restrictions for test environments)
+        CryptoPolicyValidator cryptoPolicyValidator = new CryptoPolicyValidator((String) null);
         return new BouncyCastleCryptoManager(config, SECURITY_PROVIDER_PROVIDER.get(), schemeReader,
-            certReader, skiWriter, oidUtil);
+            certReader, skiWriter, oidUtil, cryptoPolicyValidator);
     }
 
     /**


### PR DESCRIPTION
RHEL crypto policy restrictions (jdk.certpath.disabledAlgorithms) are not enforced by Java during primitive operations or when using BouncyCastle. Added CryptoPolicyValidator that reads the JVM security property at startup and validates configured schemes against it, throwing an error if any scheme uses forbidden algorithms or key sizes. The same validation is applied during manifest import if the manifest contains a scheme.json.