### PR TITLE
[PQC] Renamed the ConsumerClient.exportCertificates utility function

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/ConsumerClient.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/api/ConsumerClient.java
@@ -156,8 +156,7 @@ public class ConsumerClient extends ConsumerApi {
             "", "", false, null, new ArrayList<>()));
     }
 
-    @Override
-    public List<JsonNode> exportCertificates(String consumerUuid, String serials) {
+    public List<JsonNode> exportCertificatePayloads(String consumerUuid, String serials) {
         Object jsonPayload = super.exportCertificates(consumerUuid, serials);
         try {
             return CertificateUtil.extractEntitlementCertificatesFromPayload(jsonPayload, mapper);

--- a/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
@@ -593,7 +593,7 @@ class CloudRegistrationSpecTest {
             .returns(ANON_TOKEN_TYPE, CloudAuthenticationResultDTO::getTokenType);
 
         List<JsonNode> certs = ApiClients.bearerToken(result.getToken()).consumers()
-            .exportCertificates(result.getAnonymousConsumerUuid(), null);
+            .exportCertificatePayloads(result.getAnonymousConsumerUuid(), null);
 
         assertThat(certs).singleElement();
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));

--- a/spec-tests/src/test/java/org/candlepin/spec/ContentResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/ContentResourceSpecTest.java
@@ -158,7 +158,7 @@ public class ContentResourceSpecTest {
         consumer = consumerApi.createConsumer(consumer, null, owner.getKey(), null, false);
         consumerApi.bindPool(consumer.getUuid(), pool.getId(), null);
 
-        List<JsonNode> jsonNodes = consumerApi.exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> jsonNodes = consumerApi.exportCertificatePayloads(consumer.getUuid(), null);
 
         assertEquals(1, jsonNodes.size());
         JsonNode jsonBody = jsonNodes.get(0);
@@ -232,7 +232,7 @@ public class ContentResourceSpecTest {
         consumerApi.bindPool(consumer.getUuid(), pool1.getId(), null);
         consumerApi.bindPool(consumer.getUuid(), pool2.getId(), null);
 
-        List<JsonNode> jsonNodes = consumerApi.exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> jsonNodes = consumerApi.exportCertificatePayloads(consumer.getUuid(), null);
         assertEquals(2, jsonNodes.size());
         JsonNode jsonBody1 = jsonNodes.get(0);
         assertEquals(1, jsonBody1.get("products").size());

--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
@@ -166,7 +166,7 @@ public class ContentAccessSpecTest {
             .facts(Map.of("system.certificate_version", "3.3", "uname.machine", "ppc64")));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
-        List<JsonNode> certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).singleElement();
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));
         assertThat(prodIdToContentIds)
@@ -390,7 +390,7 @@ public class ContentAccessSpecTest {
             .createConsumer(Consumers.random(owner).facts(Map.of("system.certificate_version", "1.0")));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
-        List<JsonNode> certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).isEmpty();
     }
 
@@ -558,7 +558,7 @@ public class ContentAccessSpecTest {
             .createConsumer(Consumers.random(owner).addEnvironmentsItem(env));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
-        List<JsonNode> certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).singleElement();
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));
         assertThat(prodIdToContentIds)
@@ -578,7 +578,7 @@ public class ContentAccessSpecTest {
             .singleElement()
             .returns(content.getId(), EnvironmentContentDTO::getContentId);
 
-        certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).singleElement();
         prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));
         assertThat(prodIdToContentIds)
@@ -593,7 +593,7 @@ public class ContentAccessSpecTest {
 
         env = adminClient.environments().getEnvironment(env.getId());
         assertThat(env.getEnvironmentContent()).isEmpty();
-        certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).singleElement();
         prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));
         assertThat(prodIdToContentIds)
@@ -723,7 +723,7 @@ public class ContentAccessSpecTest {
 
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
-        List<JsonNode> certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).singleElement();
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));
         assertThat(prodIdToContentIds)
@@ -734,7 +734,7 @@ public class ContentAccessSpecTest {
         owner.contentAccessMode(Owners.ENTITLEMENT_ACCESS_MODE);
         adminClient.owners().updateOwner(ownerKey, owner);
 
-        certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).isEmpty();
     }
 
@@ -754,12 +754,12 @@ public class ContentAccessSpecTest {
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
-        List<JsonNode> certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).isEmpty();
 
         owner.contentAccessMode(Owners.SCA_ACCESS_MODE);
         adminClient.owners().updateOwner(ownerKey, owner);
-        certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).singleElement();
     }
 
@@ -1148,11 +1148,11 @@ public class ContentAccessSpecTest {
             }
 
             List<Callable<List<JsonNode>>> tasks = List.of(
-                () -> adminClient.consumers().exportCertificates(consumer1.getUuid(), null),
-                () -> adminClient.consumers().exportCertificates(consumer2.getUuid(), null),
-                () -> adminClient.consumers().exportCertificates(consumer3.getUuid(), null),
-                () -> adminClient.consumers().exportCertificates(consumer4.getUuid(), null),
-                () -> adminClient.consumers().exportCertificates(consumer5.getUuid(), null));
+                () -> adminClient.consumers().exportCertificatePayloads(consumer1.getUuid(), null),
+                () -> adminClient.consumers().exportCertificatePayloads(consumer2.getUuid(), null),
+                () -> adminClient.consumers().exportCertificatePayloads(consumer3.getUuid(), null),
+                () -> adminClient.consumers().exportCertificatePayloads(consumer4.getUuid(), null),
+                () -> adminClient.consumers().exportCertificatePayloads(consumer5.getUuid(), null));
 
             ExecutorService execService = Executors.newFixedThreadPool(consumers.size());
             List<Future<List<JsonNode>>> futures = execService.invokeAll(tasks);
@@ -1186,13 +1186,13 @@ public class ContentAccessSpecTest {
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
-        assertThat(consumerClient.consumers().exportCertificates(consumer.getUuid(), null))
+        assertThat(consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null))
             .singleElement();
 
         content.setName(StringUtil.random("name-"));
         adminClient.ownerContent().updateContent(ownerKey, content.getId(), content);
 
-        List<JsonNode> certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));
         assertThat(prodIdToContentIds)
             .hasSize(1)
@@ -1269,7 +1269,7 @@ public class ContentAccessSpecTest {
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
-        assertThat(consumerClient.consumers().exportCertificates(consumer.getUuid(), null))
+        assertThat(consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null))
             .singleElement();
 
         // Update the content prefix on the org, which should trigger a refresh of at least the
@@ -1277,7 +1277,7 @@ public class ContentAccessSpecTest {
         owner.setContentPrefix("content_prefix");
         adminClient.owners().updateOwner(owner.getKey(), owner);
 
-        List<JsonNode> certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));
         assertThat(prodIdToContentIds)
             .hasSize(1)
@@ -1476,7 +1476,7 @@ public class ContentAccessSpecTest {
 
         // confirm that there is a content access cert
         // and only a content access cert
-        List<JsonNode> certs = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certs = consumerClient.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).singleElement();
         JsonNode certContent = certs.get(0).get("products").get(0).get("content");
         assertThat(certContent).singleElement();
@@ -1538,7 +1538,9 @@ public class ContentAccessSpecTest {
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
-        List<JsonNode> entCerts = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> entCerts = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
+
         assertThat(entCerts).singleElement();
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(entCerts.get(0));
         assertThat(prodIdToContentIds)
@@ -1629,7 +1631,8 @@ public class ContentAccessSpecTest {
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
 
-        List<JsonNode> entCerts = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> entCerts = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(entCerts).singleElement();
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(entCerts.get(0));
         assertThat(prodIdToContentIds)
@@ -1677,7 +1680,9 @@ public class ContentAccessSpecTest {
 
         // Make sure that content cont1 is not present in cert,
         // since pro1 does not have active pool
-        List<JsonNode> entCerts = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> entCerts = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
+
         assertThat(entCerts).singleElement();
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(entCerts.get(0));
         assertThat(prodIdToContentIds)
@@ -1721,7 +1726,8 @@ public class ContentAccessSpecTest {
 
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient consumerClient = ApiClients.ssl(consumer);
-        List<JsonNode> entCerts = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> entCerts = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(entCerts).singleElement();
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(entCerts.get(0));
         assertThat(prodIdToContentIds)

--- a/spec-tests/src/test/java/org/candlepin/spec/content/SkuLevelEnableOverrideSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/SkuLevelEnableOverrideSpecTest.java
@@ -90,7 +90,9 @@ public class SkuLevelEnableOverrideSpecTest {
         PoolDTO pool = ownerClient.createPool(owner.getKey(), Pools.random(product));
         consumerClient.consumers().bindPool(consumer.getUuid(), pool.getId(), 1);
 
-        List<JsonNode> result = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> result = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
+
         JsonNode products = result.get(0).get("products");
         assertThat(products)
             .hasSize(2);
@@ -121,7 +123,9 @@ public class SkuLevelEnableOverrideSpecTest {
         PoolDTO pool = ownerClient.createPool(owner.getKey(), Pools.random(product));
         consumerClient.consumers().bindPool(consumer.getUuid(), pool.getId(), 1);
 
-        List<JsonNode> result = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> result = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
+
         JsonNode products = result.get(0).get("products");
         assertThat(products)
             .hasSize(2);
@@ -166,7 +170,9 @@ public class SkuLevelEnableOverrideSpecTest {
         assertThatJob(job).isFinished();
 
         consumerClient.consumers().bindPool(consumer.getUuid(), pool.getId(), 1);
-        List<JsonNode> result = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> result = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
+
         JsonNode products = result.get(0).get("products");
         assertThat(products)
             .hasSize(2);

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/DerivedProductSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/DerivedProductSpecTest.java
@@ -284,7 +284,8 @@ public class DerivedProductSpecTest {
         assertThat(distributorClient.consumers().bindPool(distributor.getUuid(), mainPool.getId(), 1))
             .isNotEmpty();
 
-        List<JsonNode> certs = distributorClient.consumers().exportCertificates(distributor.getUuid(), null);
+        List<JsonNode> certs = distributorClient.consumers()
+            .exportCertificatePayloads(distributor.getUuid(), null);
         assertThat(certs)
             .singleElement()
             .returns(3, x -> x.get("products").size());
@@ -322,7 +323,10 @@ public class DerivedProductSpecTest {
 
         assertThat(distributorClient.consumers().bindPool(distributor.getUuid(), modifiedPool.getId(), 1))
             .isNotEmpty();
-        List<JsonNode> certs = distributorClient.consumers().exportCertificates(distributor.getUuid(), null);
+
+        List<JsonNode> certs = distributorClient.consumers()
+            .exportCertificatePayloads(distributor.getUuid(), null);
+
         assertThat(certs)
             .singleElement()
             .returns(4, x -> x.get("products").size());
@@ -344,7 +348,9 @@ public class DerivedProductSpecTest {
         // Unbind the base entitlement. This should trigger the removal of the modifier content since the
         // distributor no longer has an entitlement that provides @modified_product.
         distributorClient.consumers().unbindByEntitlementId(distributor.getUuid(), vdcPoolEnt.getId());
-        List<JsonNode> certs = distributorClient.consumers().exportCertificates(distributor.getUuid(), null);
+        List<JsonNode> certs = distributorClient.consumers()
+            .exportCertificatePayloads(distributor.getUuid(), null);
+
         assertThat(certs)
             .singleElement();
         verifyModifierContent(certs, false, setupData);
@@ -364,7 +370,8 @@ public class DerivedProductSpecTest {
         // Delete the base pool. This should trigger the removal of the modifier content since the
         // distributor no longer has an entitlement that provides @modified_product.
         client.pools().deletePool(vdcPool.getId());
-        List<JsonNode> certs = distributorClient.consumers().exportCertificates(distributor.getUuid(), null);
+        List<JsonNode> certs = distributorClient.consumers()
+            .exportCertificatePayloads(distributor.getUuid(), null);
         assertThat(certs)
             .singleElement();
         verifyModifierContent(certs, false, setupData);
@@ -385,7 +392,8 @@ public class DerivedProductSpecTest {
 
         assertThat(physicalClient.consumers().bindPool(physicalSystem.getUuid(), mainPool.getId(), 1))
             .isNotNull();
-        List<JsonNode> certs = physicalClient.consumers().exportCertificates(physicalSystem.getUuid(), null);
+        List<JsonNode> certs = physicalClient.consumers()
+            .exportCertificatePayloads(physicalSystem.getUuid(), null);
         assertThat(certs)
             .singleElement()
             .returns(1, x -> x.get("products").size());
@@ -487,7 +495,9 @@ public class DerivedProductSpecTest {
             .bindPoolSync(distributor.getUuid(), mainPools.get(0).getId(), 1)
             .get(0);
 
-        List<JsonNode> certs = distributorClient.consumers().exportCertificates(distributor.getUuid(), null);
+        List<JsonNode> certs = distributorClient.consumers()
+            .exportCertificatePayloads(distributor.getUuid(), null);
+
         assertThat(certs)
             .singleElement()
             .extracting(node -> node.get("products"))
@@ -514,7 +524,7 @@ public class DerivedProductSpecTest {
 
         // Export the certs again and verify the product on the certificate has changed to reflect
         // the new content
-        certs = distributorClient.consumers().exportCertificates(distributor.getUuid(), null);
+        certs = distributorClient.consumers().exportCertificatePayloads(distributor.getUuid(), null);
         assertThat(certs)
             .singleElement()
             .extracting(node -> node.get("products"))
@@ -530,7 +540,7 @@ public class DerivedProductSpecTest {
             .bindPoolSync(distributor.getUuid(), mainPools.get(0).getId(), 1)
             .get(0);
 
-        certs = distributorClient.consumers().exportCertificates(distributor.getUuid(), null);
+        certs = distributorClient.consumers().exportCertificatePayloads(distributor.getUuid(), null);
         assertThat(certs)
             .singleElement()
             .extracting(node -> node.get("products"))

--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementCertificateV3SpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementCertificateV3SpecTest.java
@@ -265,7 +265,7 @@ public class EntitlementCertificateV3SpecTest {
     @Test
     public void shouldGenerateCorrectBodyInTheBlob() {
         consumerApi.bindProduct(system.getUuid(), product.getId());
-        List<JsonNode> jsonNodes = consumerApi.exportCertificates(system.getUuid(), null);
+        List<JsonNode> jsonNodes = consumerApi.exportCertificatePayloads(system.getUuid(), null);
         assertEquals(1, jsonNodes.size());
         JsonNode jsonBody = jsonNodes.get(0);
         assertEquals(system.getUuid(), jsonBody.get("consumer").asText());
@@ -364,7 +364,7 @@ public class EntitlementCertificateV3SpecTest {
 
         assertThat(pool.getBranding()).hasSize(1);
         consumerApi.bindProduct(system.getUuid(), engProduct.getId());
-        List<JsonNode> jsonNodes = consumerApi.exportCertificates(system.getUuid(), null);
+        List<JsonNode> jsonNodes = consumerApi.exportCertificatePayloads(system.getUuid(), null);
         assertEquals(1, jsonNodes.size());
         JsonNode jsonBody = jsonNodes.get(0);
         assertEquals(mktProduct.getName(), jsonBody.get("subscription").get("name").asText());
@@ -409,7 +409,7 @@ public class EntitlementCertificateV3SpecTest {
         ConsumerClient consumers = consumerClient.consumers();
         JsonNode bindResult = consumers.bindProduct(system.getUuid(), product.getId());
 
-        List<JsonNode> jsonNodes = consumers.exportCertificates(system.getUuid(), null);
+        List<JsonNode> jsonNodes = consumers.exportCertificatePayloads(system.getUuid(), null);
         assertEquals(1, jsonNodes.size());
         JsonNode jsonBody = jsonNodes.get(0);
         assertThat(jsonBody.get("products").get(0).get("content")).hasSize(4);
@@ -459,7 +459,7 @@ public class EntitlementCertificateV3SpecTest {
         JsonNode bindResult = consumers.bindProduct(system.getUuid(), product.getId());
 
         // confirm content count to cross-check
-        List<JsonNode> jsonNodes = consumers.exportCertificates(system.getUuid(), null);
+        List<JsonNode> jsonNodes = consumers.exportCertificatePayloads(system.getUuid(), null);
         assertEquals(1, jsonNodes.size());
         JsonNode jsonBody = jsonNodes.get(0);
         assertThat(jsonBody.get("products")).hasSize(1);

--- a/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentSpecTest.java
@@ -577,7 +577,8 @@ public class EnvironmentSpecTest {
         ApiClient consumerClient = ApiClients.ssl(consumer);
         consumerClient.consumers().bindPool(consumer.getUuid(), pool.getId(), 1);
 
-        List<JsonNode> certificates = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certificates = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certificates).hasSize(1);
 
         assertThat(certificates.get(0).get("products")).hasSize(1);
@@ -619,7 +620,8 @@ public class EnvironmentSpecTest {
         ApiClient consumerClient = ApiClients.ssl(consumer);
         consumerClient.consumers().bindPool(consumer.getUuid(), pool.getId(), 1);
 
-        List<JsonNode> certificates = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certificates = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certificates).hasSize(1);
 
         assertThat(certificates.get(0).get("products")).hasSize(1);
@@ -657,7 +659,8 @@ public class EnvironmentSpecTest {
         ApiClient consumerClient = ApiClients.ssl(consumer);
         consumerClient.consumers().bindPool(consumer.getUuid(), pool.getId(), 1);
 
-        List<JsonNode> certificates = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certificates = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certificates).hasSize(1);
 
         assertThat(certificates.get(0).get("products")).hasSize(1);
@@ -699,7 +702,8 @@ public class EnvironmentSpecTest {
         ApiClient consumerClient = ApiClients.ssl(consumer);
         consumerClient.consumers().bindPool(consumer.getUuid(), pool.getId(), 1);
 
-        List<JsonNode> certificates = consumerClient.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certificates = consumerClient.consumers()
+            .exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certificates).hasSize(1);
 
         assertThat(certificates.get(0).get("products")).hasSize(1);
@@ -788,7 +792,7 @@ public class EnvironmentSpecTest {
         Long pool2Serial = serialOf(entitlement2);
 
         List<JsonNode> certificatesBeforeDelete = consumerClient.consumers()
-            .exportCertificates(consumer.getUuid(), null);
+            .exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certificatesBeforeDelete).hasSize(2);
 
         ownerClient.environments().deleteEnvironment(env1.getId());

--- a/spec-tests/src/test/java/org/candlepin/spec/hypervisors/HypervisorCheckInSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/hypervisors/HypervisorCheckInSpecTest.java
@@ -1430,7 +1430,8 @@ public class HypervisorCheckInSpecTest {
         assertEquals(hypervisor1StackDerivedPool1, guestRH00271Entitlement.getPool().getId());
 
         // Verify guest's entitlement certs each contain the appropriate content set
-        List<JsonNode> jsonNodes = guestClient.consumers().exportCertificates(guest.getUuid(), null);
+        List<JsonNode> jsonNodes = guestClient.consumers()
+            .exportCertificatePayloads(guest.getUuid(), null);
         assertEquals(2, jsonNodes.size());
         JsonNode rh00051Cert = jsonNodes.stream().filter(x ->
             guestRH00051Entitlement.getPool().getId().equals(x.get("pool").get("id").asText()))
@@ -1451,7 +1452,8 @@ public class HypervisorCheckInSpecTest {
         executeMigration(owner, data1, data2, virtwho, guestUuid);
         //  At this point, the guest will have the entitlements from the old hypervisor revoked, and
         //  it will get the entitlements from the new hypervisor auto-attached
-        List<JsonNode> newJsonNodes = guestClient.consumers().exportCertificates(guest.getUuid(), null);
+        List<JsonNode> newJsonNodes = guestClient.consumers()
+            .exportCertificatePayloads(guest.getUuid(), null);
         assertEquals(2, jsonNodes.size());
         // Verify guest's entitlement certs each contain the appropriate content set
         List<EntitlementDTO> newEnts = guestClient.consumers().listEntitlements(guest.getUuid());

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
@@ -1777,7 +1777,7 @@ public class OwnerResourceSpecTest {
             .environments(List.of(env1));
         consumer = admin.consumers().createConsumer(consumer);
 
-        List<JsonNode> certs = admin.consumers().exportCertificates(consumer.getUuid(), null);
+        List<JsonNode> certs = admin.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));
         assertThat(prodIdToContentIds)
             .hasSize(1)
@@ -1792,7 +1792,7 @@ public class OwnerResourceSpecTest {
         admin.owners().setConsumersToEnvironments(ownerKey, req);
 
         // Verify that the certificate content was updated
-        certs = admin.consumers().exportCertificates(consumer.getUuid(), null);
+        certs = admin.consumers().exportCertificatePayloads(consumer.getUuid(), null);
         assertThat(certs).singleElement();
         prodIdToContentIds = CertificateUtil.toProductContentIdMap(certs.get(0));
         assertThat(prodIdToContentIds)

--- a/spec-tests/src/test/java/org/candlepin/spec/pools/RefreshPoolsSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/pools/RefreshPoolsSpecTest.java
@@ -501,7 +501,8 @@ public class RefreshPoolsSpecTest {
         scaOwnerKey, null, true);
         ApiClient consumerClient = ApiClients.ssl(user);
 
-        List<JsonNode> certificates = consumerClient.consumers().exportCertificates(user.getUuid(), null);
+        List<JsonNode> certificates = consumerClient.consumers()
+            .exportCertificatePayloads(user.getUuid(), null);
         assertEquals(1, certificates.size());
         JsonNode body = certificates.get(0);
         Map<String, List<String>> prodIdToContentIds = CertificateUtil.toProductContentIdMap(body);
@@ -531,7 +532,7 @@ public class RefreshPoolsSpecTest {
         assertEquals(updatedContent.getContentUrl(), actualContent.getContentUrl());
 
         // Verify the SCA cert has changed as a result
-        certificates = consumerClient.consumers().exportCertificates(user.getUuid(), null);
+        certificates = consumerClient.consumers().exportCertificatePayloads(user.getUuid(), null);
         assertEquals(1, certificates.size());
         body = certificates.get(0);
         prodIdToContentIds = CertificateUtil.toProductContentIdMap(body);


### PR DESCRIPTION
- Renamed the ConsumerClient.exportCertificates to exportCertificatePayloads to better indicate its actual behavior
- Updated several call sites to use the new method name