### PR TITLE
[M] CANDLEPIN-1172: Removed extraneous key usage from generated certs

### DIFF
--- a/src/main/java/org/candlepin/pki/impl/bc/BouncyCastleX509CertificateBuilder.java
+++ b/src/main/java/org/candlepin/pki/impl/bc/BouncyCastleX509CertificateBuilder.java
@@ -237,8 +237,7 @@ public class BouncyCastleX509CertificateBuilder implements X509CertificateBuilde
     }
 
     private void addKeyUsage(X509v3CertificateBuilder builder) {
-        KeyUsage usage = new KeyUsage(KeyUsage.digitalSignature |
-            KeyUsage.keyEncipherment | KeyUsage.dataEncipherment);
+        KeyUsage usage = new KeyUsage(KeyUsage.digitalSignature);
         this.addExtension(builder, Extension.keyUsage, true, usage);
 
         ExtendedKeyUsage exUsage = new ExtendedKeyUsage(KeyPurposeId.id_kp_clientAuth);

--- a/src/test/java/org/candlepin/pki/impl/bc/BouncyCastleX509CertificateBuilderTest.java
+++ b/src/test/java/org/candlepin/pki/impl/bc/BouncyCastleX509CertificateBuilderTest.java
@@ -138,9 +138,19 @@ public class BouncyCastleX509CertificateBuilderTest {
 
         KeyUsage keyUsage = KeyUsage.fromExtensions(bcExtensions);
 
+        // The key usage extension should only set the digital signature bit
         assertTrue(keyUsage.hasUsages(KeyUsage.digitalSignature));
-        assertTrue(keyUsage.hasUsages(KeyUsage.keyEncipherment));
-        assertTrue(keyUsage.hasUsages(KeyUsage.dataEncipherment));
+
+        // Impl note: these *could* be OR'd together to do this check in a single call, but this is probably
+        // clearer, and will be easier to port away from BC-specific test logic.
+        assertFalse(keyUsage.hasUsages(KeyUsage.cRLSign));
+        assertFalse(keyUsage.hasUsages(KeyUsage.dataEncipherment));
+        assertFalse(keyUsage.hasUsages(KeyUsage.decipherOnly));
+        assertFalse(keyUsage.hasUsages(KeyUsage.encipherOnly));
+        assertFalse(keyUsage.hasUsages(KeyUsage.keyAgreement));
+        assertFalse(keyUsage.hasUsages(KeyUsage.keyCertSign));
+        assertFalse(keyUsage.hasUsages(KeyUsage.keyEncipherment));
+        assertFalse(keyUsage.hasUsages(KeyUsage.nonRepudiation));
 
         // Verify the extended key usage is present, non-critical, and is configured correctly
         Extension exKeyUsageExt = bcExtensions.getExtension(Extension.extendedKeyUsage);


### PR DESCRIPTION
- Certs generated by the X509CertificateBuilder will no longer include key usage flags for key or data encipherment