### PR TITLE
[M] Use version refs in libs.versions.toml for bouncycastle

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 artemis = "2.53.0"
+bouncycastle = "1.83"
 guice = "6.0.0"
 hibernate = "5.6.15.Final"
 hibernate-validator = "6.2.5.Final"
@@ -24,9 +25,9 @@ test-logger = { id = "com.adarshr.test-logger", version.ref = "test-logger" }
 artemis-server = { module = "org.apache.artemis:artemis-server", version.ref = "artemis" }
 artemis-stomp = { module = "org.apache.artemis:artemis-stomp-protocol", version.ref = "artemis" }
 assertj = { module = "org.assertj:assertj-core", version = "3.27.7" }
-bouncycastle-prov = { module = "org.bouncycastle:bcprov-jdk18on", version = "1.83"}
-bouncycastle-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version = "1.83"}
-bouncycastle-tls = { module = "org.bouncycastle:bctls-jdk18on", version = "1.83"}
+bouncycastle-prov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-tls = { module = "org.bouncycastle:bctls-jdk18on", version.ref = "bouncycastle" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.2.3" }
 checkstyle = { module = "com.puppycrawl.tools:checkstyle", version = "12.3.1" }
 checkstyle-sevntu = { module = "com.github.sevntu-checkstyle:sevntu-checks", version = "1.44.1" }


### PR DESCRIPTION
- Added a version.ref for the three bouncycastle libraries we pull so that dependabot will open one PR instead of three.