### PR TITLE
[M] CANDLEPIN-1194: Added ML-DSA certs to dev image

### DIFF
--- a/containers/release.Containerfile
+++ b/containers/release.Containerfile
@@ -24,7 +24,7 @@ COPY ${WAR_FILE} ./candlepin.war
 RUN mkdir -p /app/certs
 WORKDIR /app/certs
 COPY ./bin/deployment/gen_certs.sh .
-RUN ./gen_certs.sh --cert_dir /app/certs --hostname candlepin --force && \
+RUN ./gen_certs.sh --pq --cert_dir /app/certs --hostname candlepin --force && \
     rm gen_certs.sh
 
 ################################# Production Image #################################


### PR DESCRIPTION
- In release.Containerfile, I added the '--pq' flag to generate certificates using ML-DSA algorithms for the dev container image. This is needed because candlepin.crypto.scheme.mldsa65.* configs in the candlepin.conf file require the ML_DSA certs to exist.

### Testing

1. Build the WAR: `./gradlew war -Ptest_extensions=hostedtest,manifestgen`
2. Generate the config: `./gradlew generateConfig -Pdb_host=postgres -Phostedtest=true -Pmanifestgen=true -Pcpdb_password=candlepin`
3. Run the containers using the compose file in `/dev-container`: `podman-compose up -d --build`

Your Candlepin container should come up healthy and you should be able to hit the status endpoint successfully:

`curl -k https://localhost:8443/candlepin/status`