### PR TITLE
[M] CANDLEPIN-1195: Added catch for EntityNotFoundException

### DIFF
--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -59,6 +59,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
 import javax.persistence.LockModeType;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceException;
@@ -541,6 +542,10 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             return em.createQuery(query).getSingleResult();
         }
         catch (NoResultException e) {
+            return null;
+        }
+        catch (EntityNotFoundException e) {
+            // Handle concurrently deleted entities that are eagerly fetched
             return null;
         }
     }

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -59,6 +59,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
 import javax.persistence.LockModeType;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceException;
@@ -541,6 +542,11 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             return em.createQuery(query).getSingleResult();
         }
         catch (NoResultException e) {
+            return null;
+        }
+        catch (EntityNotFoundException e) {
+            // Concurrent deletions of eagerly fetched relationships can cause this error.
+            log.error("Unable to retrieve consumer", e);
             return null;
         }
     }

--- a/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -22,6 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,6 +46,7 @@ import org.candlepin.util.PropertyValidationException;
 import org.candlepin.util.Util;
 
 import org.assertj.core.api.Assertions;
+import org.hibernate.query.spi.QueryImplementor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -69,6 +73,8 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
+import javax.persistence.criteria.CriteriaQuery;
 
 public class ConsumerCuratorTest extends DatabaseTestFixture {
 
@@ -330,6 +336,22 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         for (Consumer consumer : expected) {
             assertTrue(output.contains(consumer));
         }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetConsumerReturnsNullWhenEntityNotFoundExceptionIsThrown() {
+        ConsumerCurator spyCurator = Mockito.spy(this.consumerCurator);
+        EntityManager spyEntityManager = Mockito.spy(this.getEntityManager());
+        doReturn(spyEntityManager).when(spyCurator).getEntityManager();
+
+        QueryImplementor<Consumer> mockQuery = Mockito.mock(QueryImplementor.class);
+        doReturn(mockQuery).when(spyEntityManager).createQuery(any(CriteriaQuery.class));
+        doThrow(EntityNotFoundException.class).when(mockQuery).getSingleResult();
+
+        Consumer actual = spyCurator.getConsumer("uuid");
+
+        assertNull(actual);
     }
 
     @Test


### PR DESCRIPTION
- Added a catch block for ConsumerCurator.getConsumer() so that concurrently deleted entities that are eagerly fetched for Consumer does not cause a 500 error.

This change fixes the following spec test that intermittently fails:
`ConsumerResourceSpecTest.shouldReturn404Or410WhenConcurrentRegisterIsDeletedByAnotherRequest`

### Testing

You can add the `@RepeatedTest(100)` to the problematic `ConsumerResourceSpecTest.shouldReturn404Or410WhenConcurrentRegisterIsDeletedByAnotherRequest` spec test and compare before and after the changes.