### PR TITLE
[M] CANDLEPIN-1199: Removed rsa default value from change set

### DIFF
--- a/src/main/resources/db/changelog/202601081203540-add-key-pair-algorithm.xml
+++ b/src/main/resources/db/changelog/202601081203540-add-key-pair-algorithm.xml
@@ -8,7 +8,7 @@
 
     <changeSet id="202601081203540-1" author="sbakaj">
         <addColumn tableName="cp_key_pair">
-            <column name="algorithm" type="VARCHAR(64)" value="rsa"/>
+            <column name="algorithm" type="VARCHAR(64)"/>
         </addColumn>
     </changeSet>
 


### PR DESCRIPTION
- Updated the 202601081203540-add-key-pair-algorithm.xml change set by removing the default 'rsa' value from the algorithm column as it is not needed because null algorithms are handled.