### PR TITLE
[M] CANDLEPIN-1197: Do not persist GH action bot git credentials

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -40,12 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
-          fetch-depth: 0
           persist-credentials: false
-
-      - name: Override i18n files from feature branch
-        run: |
-          git checkout origin/nikos/fix_i18n_v2 -- .github/workflows/i18n.yml
 
       - name: Set up Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
- When the checkout github action runs, it should not persist git credentials of the github action bot itself, because otherwise the candlepin-bot token is ignored during git push.
- Also, remove accidentally pushed debug code from i18n.yml that was overwritting the i18n.yml file from a feature branch.