### PR TITLE
[M] CANDLEPIN-1193: Fixed ML-DSA signature verification failure with BC 1.84

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 artemis = "2.53.0"
-bouncycastle = "1.83"
+bouncycastle = "1.84"
 guice = "6.0.0"
 hibernate = "5.6.15.Final"
 hibernate-validator = "6.2.5.Final"

--- a/src/main/java/org/candlepin/sync/Importer.java
+++ b/src/main/java/org/candlepin/sync/Importer.java
@@ -39,6 +39,7 @@ import org.candlepin.model.ImportUpstreamConsumer;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.UpstreamConsumer;
+import org.candlepin.pki.CertificateReader;
 import org.candlepin.pki.CryptoManager;
 import org.candlepin.pki.Scheme;
 import org.candlepin.service.SubscriptionServiceAdapter;
@@ -58,6 +59,7 @@ import org.xnap.commons.i18n.I18n;
 
 import tools.jackson.databind.ObjectMapper;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -69,6 +71,7 @@ import java.io.Reader;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -145,6 +148,7 @@ public class Importer {
     private final ImportRecordCurator importRecordCurator;
     private final SubscriptionReconciler subscriptionReconciler;
     private final ModelTranslator translator;
+    private final CertificateReader certificateReader;
 
     @Inject
     public Importer(
@@ -164,7 +168,8 @@ public class Importer {
         @Named("ImportObjectMapper") ObjectMapper mapper,
         ImportRecordCurator importRecordCurator,
         SubscriptionReconciler subscriptionReconciler,
-        ModelTranslator translator) {
+        ModelTranslator translator,
+        CertificateReader certificateReader) {
 
         this.consumerTypeCurator = Objects.requireNonNull(consumerTypeCurator);
         this.rulesImporter = Objects.requireNonNull(rulesImporter);
@@ -183,6 +188,7 @@ public class Importer {
         this.subscriptionReconciler = Objects.requireNonNull(subscriptionReconciler);
         this.translator = Objects.requireNonNull(translator);
         this.cryptoManager = Objects.requireNonNull(cryptoManager);
+        this.certificateReader = Objects.requireNonNull(certificateReader);
     }
 
     /**
@@ -501,7 +507,15 @@ public class Importer {
             SchemeFile schemeFile = this.mapper
                 .readValue(zipFile.getInputStream(schemeEntry), SchemeFile.class);
 
-            return Optional.of(SchemeFile.toScheme(schemeFile));
+            byte[] decoded = Base64.getDecoder().decode(schemeFile.certificate());
+            X509Certificate certificate = certificateReader.read(new ByteArrayInputStream(decoded));
+
+            return Optional.of(new Scheme.Builder()
+                .setCertificate(certificate)
+                .setName(schemeFile.name())
+                .setKeyAlgorithm(schemeFile.keyAlgorithm())
+                .setSignatureAlgorithm(schemeFile.signatureAlgorithm())
+                .build());
         }
     }
 

--- a/src/main/java/org/candlepin/sync/SchemeFile.java
+++ b/src/main/java/org/candlepin/sync/SchemeFile.java
@@ -18,11 +18,7 @@ import org.candlepin.pki.Scheme;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Base64.Encoder;
@@ -97,42 +93,4 @@ public record SchemeFile(
             scheme.signatureAlgorithm(),
             scheme.keyAlgorithm());
     }
-
-    /**
-     * Create a {@link Scheme} using the provided scheme file.
-     *
-     * @param schemeFile
-     *  the scheme file used to create a scheme instance
-     *
-     * @throws IllegalArgumentException
-     *  if the provided scheme file is null or the certificate in the scheme file is not in a valid Base64
-     *  scheme
-     *
-     * @throws CertificateException
-     *  if unable to create a X.509 certificate
-     *
-     * @return the created scheme
-     */
-    public static Scheme toScheme(SchemeFile schemeFile) throws CertificateException {
-        if (schemeFile == null) {
-            throw new IllegalArgumentException("scheme file is null");
-        }
-
-        byte[] decoded = Base64.getDecoder().decode(schemeFile.certificate());
-        try (ByteArrayInputStream is = new ByteArrayInputStream(decoded)) {
-            X509Certificate certificate = (X509Certificate) CertificateFactory.getInstance("X.509")
-                .generateCertificate(is);
-
-            return new Scheme.Builder()
-                .setName(schemeFile.name())
-                .setCertificate(certificate)
-                .setKeyAlgorithm(schemeFile.keyAlgorithm())
-                .setSignatureAlgorithm(schemeFile.signatureAlgorithm())
-                .build();
-        }
-        catch (IOException e) {
-            throw new CertificateException(e);
-        }
-    }
-
 }

--- a/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -73,6 +73,7 @@ import org.candlepin.model.Pool;
 import org.candlepin.model.Product;
 import org.candlepin.model.UpstreamConsumer;
 import org.candlepin.model.dto.Subscription;
+import org.candlepin.pki.CertificateReader;
 import org.candlepin.pki.CryptoManager;
 import org.candlepin.pki.Scheme;
 import org.candlepin.pki.SignatureValidator;
@@ -187,6 +188,8 @@ public class ImporterTest extends DatabaseTestFixture {
     @Mock
     private EntitlementCertServiceAdapter mockEntitlementCertServiceAdapter;
 
+    private CertificateReader certificateReader;
+
     private ObjectMapper mapper;
     private ClassLoader classLoader = getClass().getClassLoader();
     private String mockJsPath;
@@ -212,6 +215,7 @@ public class ImporterTest extends DatabaseTestFixture {
         this.updateReleaseVersion("0.0.3", "1");
 
         this.cryptoManager = spy(CryptoUtil.getCryptoManager(this.config));
+        this.certificateReader = CryptoUtil.getCertificateReader();
 
         Principal principal = mock(Principal.class);
         doReturn(principal).when(mockPrincipalProvider).get();
@@ -247,7 +251,8 @@ public class ImporterTest extends DatabaseTestFixture {
             this.mockIdentityCertCurator, this.refresherFactory, this.cryptoManager,
             this.mockExporterMetadataCurator, this.mockCertSerialCurator, this.mockEventSink, this.i18n,
             this.mockDistributorVersionCurator, this.mockCdnCurator, this.syncUtils, this.mapper,
-            this.mockImportRecordCurator, this.mockSubscriptionReconciler, this.modelTranslator);
+            this.mockImportRecordCurator, this.mockSubscriptionReconciler, this.modelTranslator,
+            this.certificateReader);
     }
 
     private File createTempDirectory(String prefix) throws IOException {

--- a/src/test/java/org/candlepin/sync/SchemeFileTest.java
+++ b/src/test/java/org/candlepin/sync/SchemeFileTest.java
@@ -19,14 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.candlepin.pki.Scheme;
 import org.candlepin.test.CryptoUtil;
-import org.candlepin.test.TestUtil;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.security.cert.CertificateException;
 import java.util.Base64;
 import java.util.stream.Stream;
 
@@ -57,51 +55,4 @@ public class SchemeFileTest {
             .returns(scheme.signatureAlgorithm(), SchemeFile::signatureAlgorithm)
             .returns(scheme.keyAlgorithm(), SchemeFile::keyAlgorithm);
     }
-
-    @Test
-    public void testToSchemeWithNullSchemeFile() {
-        assertThrows(IllegalArgumentException.class, () -> SchemeFile.toScheme(null));
-    }
-
-    @Test
-    public void testToScheme() throws Exception {
-        Scheme expected = CryptoUtil.getCryptoManager().getDefaultCryptoScheme();
-        String encodedCert = Base64.getEncoder().encodeToString(expected.certificate().getEncoded());
-
-        SchemeFile schemeFile = new SchemeFile(expected.name(), encodedCert, expected.signatureAlgorithm(),
-            expected.keyAlgorithm());
-
-        Scheme actual = SchemeFile.toScheme(schemeFile);
-
-        assertThat(actual)
-            .isNotNull()
-            .returns(expected.name(), Scheme::name)
-            .returns(expected.certificate(), Scheme::certificate)
-            .returns(expected.signatureAlgorithm(), Scheme::signatureAlgorithm)
-            .returns(expected.keyAlgorithm(), Scheme::keyAlgorithm);
-    }
-
-    @Test
-    public void testToSchemeWithNonB64Cert() throws Exception {
-        SchemeFile schemeFile = new SchemeFile("name", "bad-cert", "sig-algo", "key-algo");
-
-        assertThrows(IllegalArgumentException.class, () -> SchemeFile.toScheme(schemeFile));
-    }
-
-    @Test
-    public void testToSchemeWithEmptyCert() throws Exception {
-        SchemeFile schemeFile = new SchemeFile("name", "", "sig-algo", "key-algo");
-
-        assertThrows(CertificateException.class, () -> SchemeFile.toScheme(schemeFile));
-    }
-
-    @Test
-    public void testToSchemeWithBadCertEncoding() throws Exception {
-        byte[] badEncoded = Base64.getEncoder().encode(TestUtil.randomString().getBytes());
-
-        SchemeFile schemeFile = new SchemeFile("name", new String(badEncoded), "sig-algo", "key-algo");
-
-        assertThrows(CertificateException.class, () -> SchemeFile.toScheme(schemeFile));
-    }
-
 }


### PR DESCRIPTION
- SchemeFile.toScheme() was using CertificateFactory.getInstance("X.509") without specifying a security provider. On JDK 25, this defaults to the SUN provider which creates JDK-native ML-DSA public keys. These keys trigger a type mismatch bug in BC 1.84's SignatureSpi.verifyInit() where pqc.crypto.util.PublicKeyFactory returns the old MLDSAPublicKeyParameters type but the code casts to the new crypto.params.MLDSAPublicKeyParameters, causing a ClassCastException that silently fails signature verification.
- Using BC's provider explicitly ensures certificates produce BCMLDSAPublicKey objects, which take the direct code path and bypass the buggy branch.