### PR TITLE
[PoC - Do not merge] Use FFM OpenSSL listener instead of tomcat-native+apr

### DIFF
--- a/.github/containers/cs9.Containerfile
+++ b/.github/containers/cs9.Containerfile
@@ -10,7 +10,7 @@ RUN dnf -y --setopt install_weak_deps=False update && \
     dnf clean all
 
 # Prepare Tomcat
-ARG TOMCAT_VERSION=9.0.110
+ARG TOMCAT_VERSION=9.0.111
 COPY apache-tomcat-${TOMCAT_VERSION}.tar.gz /tmp/
 RUN tar xzf /tmp/apache-tomcat-${TOMCAT_VERSION}.tar.gz -C /tmp && \
     mkdir /opt/tomcat && \
@@ -37,7 +37,7 @@ USER root
 RUN dnf -y update && \
     dnf -y update ca-certificates && \
     dnf install -y epel-release && \
-    dnf install -y java-25-openjdk-headless tomcat-native openssl initscripts && \
+    dnf install -y java-25-openjdk-headless openssl openssl-devel initscripts && \
     dnf clean all
 
 # Enable post-quantum algorithms (ML-DSA, ML-KEM) for OpenSSL/TLS

--- a/.github/containers/server.xml
+++ b/.github/containers/server.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Server port="8005" shutdown="SHUTDOWN">
   <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
-  <Listener className="org.apache.catalina.core.AprLifecycleListener" />
+  <Listener className="org.apache.catalina.core.OpenSSLLifecycleListener" />
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
   <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
@@ -16,7 +16,7 @@
   <Service name="Catalina">
 
     <Connector port="8443"
-        protocol="org.apache.coyote.http11.Http11AprProtocol"
+        protocol="org.apache.coyote.http11.Http11NioProtocol"
         scheme="https"
         secure="true"
         SSLEnabled="true"
@@ -26,7 +26,6 @@
 
             <SSLHostConfig certificateVerification="optional"
                 protocols="+TLSv1.2,+TLSv1.3"
-                sslProtocol="TLS"
                 caCertificateFile="/etc/candlepin/certs/candlepin-ca-bundle.crt">
 
                 <Certificate certificateFile="/etc/candlepin/certs/candlepin-mldsa-65-ca.crt"

--- a/.github/workflows/spec_tests.yml
+++ b/.github/workflows/spec_tests.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  TOMCAT_VERSION: 9.0.111
+
 jobs:
   spec_tests:
     name: spec tests
@@ -73,21 +76,22 @@ jobs:
       - uses: actions/cache/restore@v4
         id: restore-tomcat
         with:
-          path: apache-tomcat-9.0.110.tar.gz
-          key: tomcat-9.0.110
+          path: apache-tomcat-${{ env.TOMCAT_VERSION }}.tar.gz
+          key: tomcat-${{ env.TOMCAT_VERSION }}
 
       - name: Ensure Tomcat Artifact
         run: |
-          if [ ! -f apache-tomcat-9.0.110.tar.gz ]; then
-            wget --max-redirect=0 https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.110/bin/apache-tomcat-9.0.110.tar.gz \
-                -O apache-tomcat-9.0.110.tar.gz
+          TOMCAT_FILE="apache-tomcat-${{ env.TOMCAT_VERSION }}.tar.gz"
+          if [ ! -f "$TOMCAT_FILE" ]; then
+            wget --max-redirect=0 https://archive.apache.org/dist/tomcat/tomcat-9/v${{ env.TOMCAT_VERSION }}/bin/apache-tomcat-${{ env.TOMCAT_VERSION }}.tar.gz \
+                -O "$TOMCAT_FILE"
           fi
 
       - uses: actions/cache/save@v4
         if: steps.restore-tomcat.outputs.cache-matched-key == '' # If cache is not present save tomcat to cache
         with:
-          path: apache-tomcat-9.0.110.tar.gz
-          key: tomcat-9.0.110
+          path: apache-tomcat-${{ env.TOMCAT_VERSION }}.tar.gz
+          key: tomcat-${{ env.TOMCAT_VERSION }}
 
       - name: Create Candlepin and database containers
         shell: bash

--- a/bin/deployment/deploy
+++ b/bin/deployment/deploy
@@ -115,7 +115,7 @@ configure_tomcat() {
     $SUDO "${PROJECT_DIR}/bin/deployment/gen_certs.sh" --pq --trust $GEN_CERTS_ARGS
 
     # update server.xml
-    $SUDO python $PROJECT_DIR/bin/deployment/update-server-xml.py --tomcat-version $TC_VERSION --use-apr $CONTAINER_CONF_DIR
+    $SUDO python $PROJECT_DIR/bin/deployment/update-server-xml.py --tomcat-version $TC_VERSION --use-ffm-openssl $CONTAINER_CONF_DIR
 
     # create conf.d file to disable FIPS for our TC instance
     local CONTAINER_CONFD_DIR="${CONTAINER_CONF_DIR}/conf.d"

--- a/bin/deployment/update-server-xml.py
+++ b/bin/deployment/update-server-xml.py
@@ -161,60 +161,6 @@ class AbstractBaseEditor(object):
                 self._delete(existing_nodes, parent)
 
 
-class LegacySSLContextEditor(AbstractBaseEditor):
-    def __init__(self, *args, **kwargs):
-        super(LegacySSLContextEditor, self).__init__(*args, **kwargs)
-        self.port = "8443"
-        self._element = self._build_node()
-
-    @property
-    def parent_xpath(self):
-        return "/Server/Service"
-
-    @property
-    def search_xpath(self):
-        return "./Connector[@port='%s']" % self.port
-
-    @property
-    def new_node(self):
-        return self._element
-
-    @property
-    def attributes(self):
-        # We manually add the attributes below, so we don't want to return anything here.
-        return []
-
-    def _build_node(self):
-        # Setup our node configuration
-        connector = libxml2.newNode("Connector")
-        self._add_attributes(connector, [
-            ("port", self.port),
-            ("protocol", "HTTP/1.1"),
-            ("SSLEnabled", "true"),
-            ("maxThreads", "150"),
-            ("scheme", "https"),
-            ("secure", "true"),
-            ("clientAuth", "want"),
-            # Note SSLv3 is not included, to avoid poodle
-            # For the time being, TLSv1 needs to stay enabled in Satellite deployments to support
-            # existing python-rhsm based clients (RHEL5).
-            ("sslEnabledProtocols", "TLSv1.2,TLSv1.1,TLSv1"),
-            ("SSLProtocol", "TLSv1.2,TLSv1.1,TLSv1"),
-            ("truststoreFile", "conf/keystore"),
-            ("truststorePass", "password"),
-            ("keystoreFile", "conf/keystore"),
-            ("keystorePass", "password"),
-            ("keystoreType", "PKCS12"),
-            ("compression", "on"),
-            ("compressionMinSize", "11"),
-            ("compressableMimeType", "application/json,text/html,text/xml"),
-        ])
-
-        # Return our top-level node
-        return connector
-
-
-
 class CandlepinConnectorEditorV3(AbstractBaseEditor):
     def __init__(self, *args, **kwargs):
         super(CandlepinConnectorEditorV3, self).__init__(*args, **kwargs)
@@ -334,15 +280,15 @@ class AccessLogValveEditor(AbstractBaseEditor):
         ]
 
 
-class CandlepinConnectorAPR(AbstractBaseEditor):
-    """APR (Apache Portable Runtime) connector that uses OpenSSL directly.
+class CandlepinConnectorOpenSSL(AbstractBaseEditor):
+    """Java FFM (Foreign Function and Memory) API connector that uses OpenSSL directly.
     This works with ML-DSA certificates since OpenSSL 3.5+ supports them,
     bypassing Java JSSE KeyManager limitations.
 
     Supports multiple certificates (RSA + ML-DSA) for hybrid deployment."""
 
     def __init__(self, *args, **kwargs):
-        super(CandlepinConnectorAPR, self).__init__(*args, **kwargs)
+        super(CandlepinConnectorOpenSSL, self).__init__(*args, **kwargs)
         self.port = "8443"
         self._node = self._build_node()
 
@@ -362,7 +308,7 @@ class CandlepinConnectorAPR(AbstractBaseEditor):
     def attributes(self):
         return [
             ('port', self.port),
-            ('protocol', 'org.apache.coyote.http11.Http11AprProtocol'),
+            ('protocol', 'org.apache.coyote.http11.Http11NioProtocol'),
             ('scheme', 'https'),
             ('secure', 'true'),
             ('SSLEnabled', 'true'),
@@ -372,7 +318,7 @@ class CandlepinConnectorAPR(AbstractBaseEditor):
         ]
 
     def _build_node(self):
-        # <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+        # <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
         #     scheme="https"
         #     secure="true"
         #     SSLEnabled="true"
@@ -382,7 +328,6 @@ class CandlepinConnectorAPR(AbstractBaseEditor):
         #
         #     <SSLHostConfig certificateVerification="optional"
         #         protocols="+TLSv1.2,+TLSv1.3"
-        #         sslProtocol="TLS"
         #         caCertificateFile="/etc/candlepin/certs/candlepin-ca-bundle.crt">
         #
         #         <Certificate certificateFile="/etc/candlepin/certs/candlepin-mldsa-65-ca.crt"
@@ -402,7 +347,6 @@ class CandlepinConnectorAPR(AbstractBaseEditor):
             ("certificateVerification", "optional"),
             # Support TLS 1.2 and 1.3 for both legacy and PQC clients
             ("protocols", "+TLSv1.2,+TLSv1.3"),
-            ("sslProtocol", "TLS"),
             # Use combined CA bundle for client certificate verification
             # Contains both RSA and ML-DSA CAs to verify both types of client certificates
             ("caCertificateFile", "/etc/candlepin/certs/candlepin-ca-bundle.crt"),
@@ -437,13 +381,13 @@ class CandlepinConnectorAPR(AbstractBaseEditor):
         return connector
 
 
-class AprListenerAdder(AbstractBaseEditor):
-    """Adds the AprLifecycleListener required for APR connector.
-    This listener loads the Apache Portable Runtime (APR) native library."""
+class OpenSSLListenerAdder(AbstractBaseEditor):
+    """Adds the OpenSSLLifecycleListener required for FFM openssl connector.
+    This listener uses the Java FFM API to utilize the underlying openssl library for TLS."""
 
     def __init__(self, *args, **kwargs):
-        super(AprListenerAdder, self).__init__(*args, **kwargs)
-        self.listener_class = "org.apache.catalina.core.AprLifecycleListener"
+        super(OpenSSLListenerAdder, self).__init__(*args, **kwargs)
+        self.listener_class = "org.apache.catalina.core.OpenSSLLifecycleListener"
         self._element = libxml2.newNode("Listener")
         self._add_attributes(self._element, self.attributes)
 
@@ -463,6 +407,29 @@ class AprListenerAdder(AbstractBaseEditor):
     def attributes(self):
         return [("className", self.listener_class)]
 
+class OpenSSLListenerDeleter(AbstractBaseEditor):
+    """The OpenSSLLifecycleListener uses the Java FFM API to utilize the underlying openssl library for TLS.
+    We want to remove it from the configuration if a different listener is being used."""
+
+    def __init__(self, *args, **kwargs):
+        super(OpenSSLListenerDeleter, self).__init__(*args, **kwargs)
+        self.listener_class = "org.apache.catalina.core.OpenSSLLifecycleListener"
+
+    @property
+    def parent_xpath(self):
+        return "/Server"
+
+    @property
+    def search_xpath(self):
+        return "./Listener[@className='%s']" % self.listener_class
+
+    @property
+    def new_node(self):
+        raise NotImplementedError
+
+    @property
+    def attributes(self):
+        raise NotImplementedError
 
 class AprListenerDeleter(AbstractBaseEditor):
     """The AprLifecycleListener attempts to load the Apache Portable Runtime (APR).  The
@@ -505,8 +472,8 @@ def parse_options():
             help="print debug output")
     parser.add_option("--tomcat-version", action="store", default=None, type=str, dest="tc_version",
             help="specify a Tomcat version to target")
-    parser.add_option("--use-apr", action="store_true", default=False,
-            help="use APR connector with OpenSSL and dual RSA/ML-DSA certificates")
+    parser.add_option("--use-ffm-openssl", action="store_true", default=False,
+            help="use FFM connector with OpenSSL and dual RSA/ML-DSA certificates")
 
     (options, args) = parser.parse_args()
     if len(args) != 1:
@@ -541,19 +508,13 @@ def main():
     make_backup_config(conf_dir)
 
     # Determine which connector to use...
-    if options.use_apr:
-        logger.info("Using APR connector and dual RSA/ML-DSA certificate support")
-        ssl_editor_target = CandlepinConnectorAPR
-        use_apr = True
+    if options.use_ffm_openssl:
+        logger.info("Using FFM OpenSSL connector and dual RSA/ML-DSA certificate support")
+        ssl_editor_target = CandlepinConnectorOpenSSL
+        use_ffm_openssl = True
     else:
-        # Determine which SSLContextEditor we need...
-        tversion = parse_tc_version(options.tc_version)
-        if not tversion or len(tversion) < 1 or tversion[0] > 8 or (tversion[0] == 8 and tversion[1] >= 5):
-            ssl_editor_target = CandlepinConnectorEditorV3
-        else:
-            logger.warn("Using legacy Tomcat configuration")
-            ssl_editor_target = LegacySSLContextEditor
-        use_apr = False
+        ssl_editor_target = CandlepinConnectorEditorV3
+        use_ffm_openssl = False
 
     xml_file = os.path.join(conf_dir, "server.xml")
     logger.debug("Opening %s" % xml_file)
@@ -561,12 +522,14 @@ def main():
         ssl_editor_target(doc).insert()
         AccessLogValveEditor(doc).insert()
 
-        if use_apr:
-            # Add APR listener (required for APR connector)
-            AprListenerAdder(doc).insert()
+        if use_ffm_openssl:
+            # Add OpenSSL listener (required for FFM openssl connector)
+            OpenSSLListenerAdder(doc).insert()
         else:
-            # Remove APR listener (causes issues with JSSE connector)
-            AprListenerDeleter(doc).remove()
+            OpenSSLListenerDeleter(doc).remove()
+
+        # Always Remove APR listener (causes issues when using other connectors)
+        AprListenerDeleter(doc).remove()
 
         if options.stdout:
             print(doc.serialize())


### PR DESCRIPTION
- To remove our dependency on tomcat-native (which is only available on EPEL repo), this changes tomcat's TLS configuration to use the OpenSSLLifecycleListener, which is tomcat's FFM bridge to openssl.
- This requires a dependency on openssl-devel instead (which is available on the RHEL AppStream repo).
- This requires tomcat version 9.0.111 or newer to work (or 10.1.48 and newer), due to a tomcat FFM bug on 9.0.110 or earlier that caused the server to reject client certificates signed by its own CA.
- Removed 'sslProtocol' property (it caused empty replies with FFM).
- Removed the 'LegacySSLContextEditor' from update-server-xml.py.