### PR TITLE
[M] Fix debugging with containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!apache-tomcat-*.tar.gz
+!build/libs/candlepin.war
+!build/candlepin.conf
+!bin/deployment/gen_certs.sh
+!.github/containers/server.xml

--- a/.github/containers/cs10.Containerfile
+++ b/.github/containers/cs10.Containerfile
@@ -85,6 +85,6 @@ WORKDIR /opt/tomcat/bin
 USER root
 
 # Expose ports for tomcat, candlepin, postgres and mariadb
-EXPOSE 8080 8443 5432 3306
+EXPOSE 8000 8443 5432 3306
 
 ENTRYPOINT ["/opt/tomcat/bin/catalina.sh", "run"]

--- a/.github/containers/cs9.Containerfile
+++ b/.github/containers/cs9.Containerfile
@@ -84,6 +84,6 @@ WORKDIR /opt/tomcat/bin
 USER tomcat
 
 # Expose ports for tomcat, candlepin, postgres and mariadb
-EXPOSE 8080 8443 5432 3306
+EXPOSE 8000 8443 5432 3306
 
 ENTRYPOINT ["/opt/tomcat/bin/catalina.sh", "run"]

--- a/.github/containers/mariadb.docker-compose.yml
+++ b/.github/containers/mariadb.docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mariadb:
     image: mariadb:10.6.14

--- a/.github/containers/postgres.docker-compose.yml
+++ b/.github/containers/postgres.docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:latest

--- a/dev-container/docker-compose.yml
+++ b/dev-container/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:latest


### PR DESCRIPTION
- Also remove deprecated 'version:' field in compose files to avoid the warning displayed.
- Additionally, add a .dockerignore in order to reduce the amount of
  data sent to the docker daemon to the minimum required by our
  container.