### PR TITLE
[M] Fix intermittent failure in spec_tests.yml

### DIFF
--- a/.github/workflows/spec_tests.yml
+++ b/.github/workflows/spec_tests.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Create Candlepin and database containers
         shell: bash
         run: |
-          WAR_FILE=$(find ./build/libs -name 'candlepin*.war' | head -n 1)
+          WAR_FILE=build/libs/candlepin.war
           echo "WAR_FILE=$WAR_FILE" > ./.github/containers/.env
           docker compose -f ./.github/containers/${{ matrix.database }}.docker-compose.yml --env-file ./.github/containers/.env up --build -d --wait
 


### PR DESCRIPTION
- Fixed an intermittent failure in spec_tests.yml where a 'find' command would sometimes pick the unversioned candlepin.war file and sometimes the versioned (e.g. candlepin-4.8.1.war) file, while .dockerignore ignores the versioned .war files (resulting in a 'file not found' error.