### PR TITLE
[M] CANDLEPIN-1189: Fix .dockerignore for release.Containerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,11 @@
 *
 !apache-tomcat-*.tar.gz
 !build/libs/candlepin.war
+!build/libs/candlepin-*.war
 !build/candlepin.conf
 !bin/deployment/gen_certs.sh
 !.github/containers/server.xml
 !.github/containers/logback.xml
-!candlepin-*-redhat-*.war
-!build/libs/candlepin-*-redhat-*.war
+!candlepin-*.war
 !containers/server.xml
 !containers/logback.xml


### PR DESCRIPTION
- Made sure dockerignore allows all the kinds of .war name formats that release pipeline expects.