### PR TITLE
[M] CANDLEPIN-1229: Update docs on docker-compose for dev setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,9 @@ Gradle wrapper (`./gradlew`) is the build tool. Assumes JDK 25 is installed.
 ./gradlew checkstyle                                        # Checkstyle on all code
 ```
 
-## Running Locally (Dev Container)
+## Development Setup (Dev Container)
 
-Assumes `podman` & either of `docker-compose` or `podman-compose` are installed.
+Assumes `podman` & `docker-compose` are installed.
 ```bash
 ./bin/deployment/deploy-container -HMag         # redeploy Candlepin & Postgres in Hosted mode
 ./bin/deployment/deploy-container -Ma           # redeploy Candlepin & Postgres in Standalone mode
@@ -42,12 +42,6 @@ Assumes `podman` & either of `docker-compose` or `podman-compose` are installed.
 ./bin/deployment/deploy-container -HMag -p 2    # ports offset by 2: https://localhost:8445, debug 8002, db 5434
 ```
 Access at `https://localhost:8443/candlepin` (default, with `-p 0` or no `-p`).
-
-## Development Setup (Vagrant VM)
-
-Uses vagrant & ansible.
-Do NOT run vagrant commands, unless asked (humans only).
-Use [Running Locally](#running-locally-dev-container) instead.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,11 +88,16 @@ For code style, see: [CLAUDE.md#code-style](CLAUDE.md#code-style)
 If you have not done so on this machine, you need to:
 
 - Install Git and configure your GitHub access
-- Development environment instructions can be found in [candlepinproject.org](https://www.candlepinproject.org/docs/candlepin/developer_deployment.html#developer-deployment)
-  which include a vagrant/ansible VM setup (with `vagrant up el9`). Alternatively see [Active Development Container](#run-active-development-container).
+- Install the following packages: podman, docker-compose, java-25-openjdk-devel gettext
+- Make sure java 25 is the default with 'alternatives': `sudo alternatives --config java` & `sudo alternatives --config javac`
+- The `./bin/deployment/deploy-container` script is used for development (see [Active Development Container](#run-active-development-container)).
+
+### Deprecated/Legacy setup (vagrant/ansible)
+For working with older candlepin versions (before 5.0.0), you must use the legacy vagrant/ansible setup which is now
+deprecated. Instructions for setting that up can be found in [candlepinproject.org](https://www.candlepinproject.org/docs/candlepin/developer_deployment.html#vagrant)
 
 ### Run Active Development Container
-Assuming `podman` & either of `docker-compose` or `podman-compose` are installed, the following script can be
+Assuming `podman` & `docker-compose` are installed, the following script can be
 used to deploy a Candlepin and MariaDB/Postgres container. It uses the Containerfile and compose files used
 by the GitHub Actions spec-test setup.
 ```bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,8 @@
 VAGRANTFILE_API_VERSION = "2"
 
+# IMPORTANT: THIS FILE IS NOW CONSIDERED DEPRECATED, AND WILL BE REMOVED IN THE FUTURE.
+# The only reason it is not deleted yet is to allow users to work with older candlepin versions/branches (before 5.0.0).
+
 ANSIBLE_TAGS_VAR = "ansible_tags"
 ANSIBLE_SKIP_TAGS_VAR = "ansible_skip_tags"
 ANSIBLE_VAR_PREFIX = "cp_"

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -2,6 +2,9 @@
 The Vagrantfile included with Candlepin is designed to provide a standardized testing and
 development environment, based on various versions of CentOS.
 
+**IMPORTANT: THE VAGRANT/ANSIBLE SETUP IS CONSIDERED DEPRECATED, AND WILL BE REMOVED IN THE FUTURE.
+The only reason it is not deleted yet is to allow users to work with older candlepin versions/branches (before 5.0.0).**
+
 By default, it will map in the Candlepin repo from which the Vagrant box is built, update the
 system packages, install any Candlepin dependencies (including PostgreSQL and MariaDB), and
 set up the user environment to be immediately usable.


### PR DESCRIPTION
- Updated docs on our dev setup standardized on usage of podman and docker-compose.
- Added instructions for setup (packages required and java config).
- Added deprecation notes about vagrant & ansible.