### PR TITLE
[M] CANDLEPIN-1234: Updated lockAndLoad method to use JPA

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceConcurrentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/entitlements/EntitlementResourceConcurrentSpecTest.java
@@ -16,7 +16,6 @@ package org.candlepin.spec.entitlements;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.candlepin.dto.api.client.v1.AttributeDTO;
 import org.candlepin.dto.api.client.v1.ConsumerDTO;
 import org.candlepin.dto.api.client.v1.ConsumerTypeDTO;
 import org.candlepin.dto.api.client.v1.OwnerDTO;
@@ -30,9 +29,11 @@ import org.candlepin.spec.bootstrap.client.ApiClients;
 import org.candlepin.spec.bootstrap.client.SpecTest;
 import org.candlepin.spec.bootstrap.client.api.ConsumerClient;
 import org.candlepin.spec.bootstrap.client.api.OwnerClient;
+import org.candlepin.spec.bootstrap.data.builder.ConsumerTypes;
 import org.candlepin.spec.bootstrap.data.builder.Consumers;
 import org.candlepin.spec.bootstrap.data.builder.Owners;
 import org.candlepin.spec.bootstrap.data.builder.Pools;
+import org.candlepin.spec.bootstrap.data.builder.ProductAttributes;
 import org.candlepin.spec.bootstrap.data.builder.Products;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -70,68 +71,71 @@ public class EntitlementResourceConcurrentSpecTest {
     @Test
     public void shouldAllowConcurrentRequests() {
         ProductDTO product = Products.random();
-        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
+        product.setAttributes(List.of(ProductAttributes.MultiEntitlement.withValue("yes")));
         product = ownerProductApi.createProduct(owner.getKey(), product);
         PoolDTO pool = Pools.random().productId(product.getId()).quantity(50L);
         pool = ownerClient.createPool(owner.getKey(), pool);
 
         String poolId = pool.getId();
         List<Runnable> threads = List.of(
-            () -> registerAndConsume(poolId, "system", 5),
-            () -> registerAndConsume(poolId, "candlepin", 7),
-            () -> registerAndConsume(poolId, "system", 6),
-            () -> registerAndConsume(poolId, "candlepin", 11));
+            () -> registerAndConsume(poolId, ConsumerTypes.System.label(), 5),
+            () -> registerAndConsume(poolId, ConsumerTypes.Candlepin.label(), 7),
+            () -> registerAndConsume(poolId, ConsumerTypes.System.label(), 6),
+            () -> registerAndConsume(poolId, ConsumerTypes.Candlepin.label(), 11));
 
         runAllThreads(threads);
 
-        PoolDTO thePool = poolApi.getPool(pool.getId(), null, null);
-        assertEquals(29, thePool.getConsumed());
-        assertEquals(18, thePool.getExported());
+        PoolDTO actual = poolApi.getPool(pool.getId(), null, null);
+
+        assertEquals(29, actual.getConsumed());
+        assertEquals(18, actual.getExported());
     }
 
     @Test
     public void shouldNotAllowOverConsumption() {
         ProductDTO product = Products.random();
-        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
+        product.setAttributes(List.of(ProductAttributes.MultiEntitlement.withValue("yes")));
         product = ownerProductApi.createProduct(owner.getKey(), product);
         PoolDTO pool = Pools.random().productId(product.getId()).quantity(3L);
         pool = ownerClient.createPool(owner.getKey(), pool);
 
         String poolId = pool.getId();
         List<Runnable> threads = List.of(
-            () -> registerAndConsume(poolId, "candlepin", 1),
-            () -> registerAndConsume(poolId, "system", 1),
-            () -> registerAndConsume(poolId, "candlepin", 1),
-            () -> registerAndConsume(poolId, "candlepin", 1),
-            () -> registerAndConsume(poolId, "candlepin", 1));
+            () -> registerAndConsume(poolId, ConsumerTypes.Candlepin.label(), 1),
+            () -> registerAndConsume(poolId, ConsumerTypes.System.label(), 1),
+            () -> registerAndConsume(poolId, ConsumerTypes.Candlepin.label(), 1),
+            () -> registerAndConsume(poolId, ConsumerTypes.Candlepin.label(), 1),
+            () -> registerAndConsume(poolId, ConsumerTypes.Candlepin.label(), 1));
 
         runAllThreads(threads);
 
-        PoolDTO thePool = poolApi.getPool(pool.getId(), null, null);
-        assertEquals(3, thePool.getConsumed());
+        PoolDTO actual = poolApi.getPool(pool.getId(), null, null);
+
+        assertEquals(3, actual.getConsumed());
     }
 
     @Test
     public void shouldEndAtZeroConsumption() {
         ProductDTO product = Products.random();
-        product.setAttributes(List.of(new AttributeDTO().name("multi-entitlement").value("yes")));
+        product.setAttributes(List.of(ProductAttributes.MultiEntitlement.withValue("yes")));
         product = ownerProductApi.createProduct(owner.getKey(), product);
         PoolDTO pool = Pools.random().productId(product.getId()).quantity(3L);
         pool = ownerClient.createPool(owner.getKey(), pool);
 
         String poolId = pool.getId();
         List<Runnable> threads = List.of(
-            () -> registerConsumeUnregister(poolId, "candlepin", 1),
-            () -> registerConsumeUnregister(poolId, "system", 1),
-            () -> registerConsumeUnregister(poolId, "candlepin", 1),
-            () -> registerConsumeUnregister(poolId, "system", 1),
-            () -> registerConsumeUnregister(poolId, "candlepin", 1));
+            () -> registerConsumeUnregister(poolId, ConsumerTypes.Candlepin.label(), 1),
+            () -> registerConsumeUnregister(poolId, ConsumerTypes.System.label(), 1),
+            () -> registerConsumeUnregister(poolId, ConsumerTypes.Candlepin.label(), 1),
+            () -> registerConsumeUnregister(poolId, ConsumerTypes.System.label(), 1),
+            () -> registerConsumeUnregister(poolId, ConsumerTypes.Candlepin.label(), 1));
 
         runAllThreads(threads);
 
-        PoolDTO thePool = poolApi.getPool(pool.getId(), null, null);
-        assertEquals(0, thePool.getConsumed());
-        assertEquals(0, thePool.getExported());
+        PoolDTO actual = poolApi.getPool(pool.getId(), null, null);
+
+        assertEquals(0, actual.getConsumed());
+        assertEquals(0, actual.getExported());
     }
 
     private static void runAllThreads(Collection<Runnable> threads) {

--- a/src/main/java/org/candlepin/controller/OwnerManager.java
+++ b/src/main/java/org/candlepin/controller/OwnerManager.java
@@ -98,7 +98,8 @@ public class OwnerManager {
         log.info("Cleaning up owner: {}", owner);
 
         Collection<String> consumerIds = this.ownerCurator.getConsumerIds(owner);
-        Collection<Consumer> consumers = this.consumerCurator.lockAndLoad(consumerIds);
+        Collection<Consumer> consumers = this.consumerCurator.getConsumers(consumerIds);
+        this.consumerCurator.lock(consumers);
 
         for (Consumer consumer : consumers) {
             log.info("Removing all entitlements for consumer: {}", consumer);

--- a/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
+++ b/src/main/java/org/candlepin/model/AbstractHibernateCurator.java
@@ -30,8 +30,6 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
 
-import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
 import org.hibernate.Session;
 import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
@@ -1015,16 +1013,20 @@ public abstract class AbstractHibernateCurator<E extends Persisted> {
             .distinct()
             .toList();
 
-        // Fetch the entities from the DB...
-        if (ordered.size() > 0) {
-            return this.currentSession()
-                .byMultipleIds(entityClass)
-                .enableOrderedReturn(false)
-                .with(new LockOptions(LockMode.PESSIMISTIC_WRITE))
-                .multiLoad(ordered);
+        if (ordered.isEmpty()) {
+            return new ArrayList<>();
         }
 
-        return new ArrayList<>();
+        EntityManager entityManager = this.getEntityManager();
+        List<E> result = new ArrayList<>();
+        for (Serializable id : ids) {
+            E entity = entityManager.find(entityClass, id, LockModeType.PESSIMISTIC_WRITE);
+            if (entity != null) {
+                result.add(entity);
+            }
+        }
+
+        return result;
     }
 
     /**


### PR DESCRIPTION
    - It was discovered that the AbstractHibernateCurator.lockAndLoad
      method was not locking rows properly. Updating the method to use the
      JPA criteria API properly locks the rows.
    - Updated OwnerManager.cleanupAndDelete to lock the consumers using
      AbstractHibernateCurator.lock() instead of
      AbstractHibernateCurator.lockAndLoad().
    - Updated EntitlementResourceConcurrentSpecTest to use already defined
      enum values instead of hard coded strings.


### Additional Notes

This locking issue was surfaced by a flaky spec test `EntitlementResourceConcurrentSpecTest.shouldEndAtZeroConsumption` and it was discovered that the `AbstractHibernateCurator.lockAndLoad` method was not properly locking rows which caused race conditions with the updating of pool consumption counts. 

You can add the `@RepeatedTest(100)` to the `EntitlementResourceConcurrentSpecTest.shouldEndAtZeroConsumption` spec test to validate that the test no longer fails occasionally.