### PR TITLE
[M] CANDLEPIN-1240: Fixed InactiveConsumerCleanerJobSpecTest flaky tests

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/InactiveConsumerCleanerJobSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/InactiveConsumerCleanerJobSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2026 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -41,6 +41,7 @@ import org.candlepin.spec.bootstrap.data.util.StringUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -51,6 +52,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * These tests are run in insolation because it is possible that an inactive consumer cleaner job from one
+ * test can delete consumers from another test if they are run in parallel. This can lead to sporadic test
+ * failures.
+ */
+
+@Isolated
 @SpecTest
 public class InactiveConsumerCleanerJobSpecTest {
 


### PR DESCRIPTION
- Added the isolated annotation to InactiveConsumerCleanerJobSpecTest class so that the tests are not run in parallel with other tests and the tests in the class are run sequentially. The reason for this is that the shouldCreateNewConsumerDeletionRecordWhenConsumerUuidReused test is concurrently deleting a consumer used by the shouldDeleteInactiveConsumers test and causing sporadic failures.

## Additional Notes

InactiveConsumerCleanerJobSpecTest test class has the problematic `shouldDeleteInactiveConsumers` test and the `shouldCreateNewConsumerDeletionRecordWhenConsumerUuidReused` test. The problem is that both of these tests are being run in parallel sometimes and while the `shouldDeleteInactiveConsumers` test is creating the `consumerWithEntitlement` consumer and then doing a bind operating on a pool, the `shouldCreateNewConsumerDeletionRecordWhenConsumerUuidReused` test has scheduled an InactiveConsumerCleanerJob and is concurrently deleting the `consumerWithEntitlement` consumer because it has an inactive last check-in time.

## How to recreate the issue

1. Add a `Thread.sleep(30000L)` in `HandleCertificatesOp.preProcess` right before `this.entitlementCertificateService.generateEntitlementCertificates`.
2. Add a `Thread.sleep(10000)`  as the first line in `InactiveConsumerCleanerJobSpecTest.shouldCreateNewConsumerDeletionRecordWhenConsumerUuidReused`.
3. Run `./gradlew spec --tests InactiveConsumerCleanerJobSpecTest` without the isolated annotation on the class. This will cause both tests to run in parallel.