### PR TITLE
[M] CANDLEPIN-1225: Unignore resteasy dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "main"
-    ignore:
-      - dependency-name: "org.jboss.resteasy"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,13 +15,6 @@ dependencies {
 
     // Plugins are not yet available in convention plugins, so we have to load it here.
     implementation(libs.test.logger.plugin)
-
-    // Fix for transitive dependency conflict between openapi and owasp
-    configurations.configureEach {
-        resolutionStrategy {
-            force 'org.yaml:snakeyaml:1.33'
-        }
-    }
 }
 
 gradlePlugin {


### PR DESCRIPTION
- Also, remove snakeyaml version restriction since it no longer is needed. The OWASP dependency analyze plugin works with the latest snakeyaml version.