### PR TITLE
[M] CANDLEPIN-1224: Added separate system inactivity policy for anon owners

### DIFF
--- a/spec-tests/src/test/java/org/candlepin/spec/jobs/InactiveConsumerCleanerJobSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/jobs/InactiveConsumerCleanerJobSpecTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.candlepin.spec.bootstrap.assertions.JobStatusAssert.assertThatJob;
 import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.assertGone;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.candlepin.dto.api.client.v1.AsyncJobStatusDTO;
 import org.candlepin.dto.api.client.v1.ConsumerDTO;
@@ -48,8 +49,10 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
 
 /**
@@ -57,13 +60,13 @@ import java.util.UUID;
  * test can delete consumers from another test if they are run in parallel. This can lead to sporadic test
  * failures.
  */
-
 @Isolated
 @SpecTest
 public class InactiveConsumerCleanerJobSpecTest {
 
     private static final String JOB_KEY = "InactiveConsumerCleanerJob";
     private static final int DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS = 397;
+    private static final int DEFAULT_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS = 30;
 
     private static ConsumerClient consumerApi;
     private static DeletedConsumerApi deletedConsumerApi;
@@ -94,6 +97,17 @@ public class InactiveConsumerCleanerJobSpecTest {
             .minus(DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS + 10, ChronoUnit.DAYS);
         Instant activeTime = Instant.now()
             .minus(DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS - 10, ChronoUnit.DAYS);
+        Instant anonymousOwnerInactiveTime = Instant.now()
+            .minus(DEFAULT_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS + 10, ChronoUnit.DAYS);
+        Instant anonymousOwnerActiveTime = Instant.now()
+            .minus(DEFAULT_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS - 10, ChronoUnit.DAYS);
+
+        Map<String, ConsumerDTO> inactiveConsumers = new HashMap<>();
+        Map<String, ConsumerDTO> activeConsumers = new HashMap<>();
+
+        // Point in time before we create our consumers. We will use this date time for retrieving
+        // deleted consumers.
+        OffsetDateTime deletedConsumersCreationDate = OffsetDateTime.now();
 
         ConsumerDTO consumerWithManifest = Consumers.random(owner, ConsumerTypes.Candlepin)
             .lastCheckin(inactiveTime.atOffset(ZoneOffset.UTC));
@@ -104,48 +118,74 @@ public class InactiveConsumerCleanerJobSpecTest {
         ConsumerDTO activeConsumer2 = Consumers.random(owner)
             .lastCheckin(activeTime.atOffset(ZoneOffset.UTC));
 
-        ConsumerDTO inactiveConsumer = consumerApi.createConsumer(Consumers.random(owner)
-            .lastCheckin(inactiveTime.atOffset(ZoneOffset.UTC)));
         consumerWithManifest = consumerApi
             .createConsumer(consumerWithManifest, null, owner.getKey(), null, false);
         consumerWithEntitlement = consumerApi
             .createConsumer(consumerWithEntitlement, null, owner.getKey(), null, false);
         activeConsumer = consumerApi.createConsumer(activeConsumer, null, owner.getKey(), null, false);
         activeConsumer2 = consumerApi.createConsumer(activeConsumer2, null, owner.getKey(), null, false);
-
         createProductAndPoolForConsumer(consumerWithEntitlement);
+        activeConsumers.put(consumerWithManifest.getUuid(), consumerWithManifest);
+        activeConsumers.put(consumerWithEntitlement.getUuid(), consumerWithEntitlement);
+        activeConsumers.put(activeConsumer.getUuid(), activeConsumer);
+        activeConsumers.put(activeConsumer2.getUuid(), activeConsumer2);
+
+        ConsumerDTO inactiveConsumer = consumerApi.createConsumer(Consumers.random(owner)
+            .lastCheckin(inactiveTime.atOffset(ZoneOffset.UTC)));
+        inactiveConsumers.put(inactiveConsumer.getUuid(), inactiveConsumer);
+
+        // Create an active and inactive consumer for an anonymous owner.
+        // The retention policy is different for consumers in anonymous owners.
+        OwnerDTO anonOwner = ownerApi.createOwner(Owners.randomSca().anonymous(true));
+        ConsumerDTO activeConsumerFromAnonOwner = consumerApi.createConsumer(Consumers.random(anonOwner)
+            .lastCheckin(anonymousOwnerActiveTime.atOffset(ZoneOffset.UTC)));
+        activeConsumers.put(activeConsumerFromAnonOwner.getUuid(), activeConsumerFromAnonOwner);
+
+        ConsumerDTO inactiveConsumerFromAnonOwner = consumerApi.createConsumer(Consumers.random(anonOwner)
+            .lastCheckin(anonymousOwnerInactiveTime.atOffset(ZoneOffset.UTC)));
+        inactiveConsumers.put(inactiveConsumerFromAnonOwner.getUuid(), inactiveConsumerFromAnonOwner);
 
         String jobId = jobsClient.scheduleJob(JOB_KEY).getId();
         AsyncJobStatusDTO status = jobsClient.waitForJob(jobId);
         assertThatJob(status)
             .isFinished();
 
-        // Verify that the inactive consumer has been deleted.
-        final String inactiveConsumer1Uuid = inactiveConsumer.getUuid();
-        assertGone(() -> consumerApi.getConsumer(inactiveConsumer1Uuid));
-        // Verify that the inactive consumer has been moved to the deleted_consumers table.
-        List<DeletedConsumerDTO> deletedConsumers = deletedConsumerApi
-            .listByDate(inactiveConsumer.getCreated(), 1, 50, "desc", "created");
-        // Assert that other tests might have created an inactive consumer
-        assertThat(deletedConsumers).hasSizeGreaterThanOrEqualTo(1);
-        Optional<DeletedConsumerDTO> deletedConsumer = deletedConsumers.stream()
-            .filter(consumer -> inactiveConsumer.getUuid().equals(consumer.getConsumerUuid()))
-            .findFirst();
-        assertThat(deletedConsumer)
-            .isPresent()
-            .hasValueSatisfying(consumer -> {
-                assertThat(consumer.getConsumerName()).isEqualTo(inactiveConsumer.getName());
-                assertThat(consumer.getOwnerId()).isEqualTo(inactiveConsumer.getOwner().getId());
-                assertThat(consumer.getOwnerKey()).isEqualTo(inactiveConsumer.getOwner().getKey());
-                assertThat(consumer.getOwnerDisplayName())
-                    .isEqualTo(inactiveConsumer.getOwner().getDisplayName());
-            });
+        // Verify that the inactive consumers have been deleted
+        for (String uuid : inactiveConsumers.keySet()) {
+            assertGone(() -> consumerApi.getConsumer(uuid));
+        }
 
-        // Verify that the active consumers have not been deleted.
-        compareConsumers(consumerWithManifest, consumerApi.getConsumer(consumerWithManifest.getUuid()));
-        compareConsumers(consumerWithEntitlement, consumerApi.getConsumer(consumerWithEntitlement.getUuid()));
-        compareConsumers(activeConsumer, consumerApi.getConsumer(activeConsumer.getUuid()));
-        compareConsumers(activeConsumer2, consumerApi.getConsumer(activeConsumer2.getUuid()));
+        // Verify that the inactive consumers have been moved to the deleted_consumers table
+        List<DeletedConsumerDTO> deletedConsumers = deletedConsumerApi
+            .listByDate(deletedConsumersCreationDate, 1, 50, "desc", "created");
+        // Assert that other tests might have created an inactive consumer
+        assertThat(deletedConsumers).hasSizeGreaterThanOrEqualTo(inactiveConsumers.size());
+
+        List<DeletedConsumerDTO> actual = deletedConsumers.stream()
+            .filter(consumer -> inactiveConsumers.keySet().contains(consumer.getConsumerUuid()))
+            .toList();
+
+        // Make sure we have the exact size that we are expecting so that we do not have any extra or missing
+        // deletions
+        assertEquals(inactiveConsumers.size(), actual.size());
+
+        for (DeletedConsumerDTO deletedConsumer : actual) {
+            ConsumerDTO expected = inactiveConsumers.get(deletedConsumer.getConsumerUuid());
+            assertNotNull(expected);
+
+            assertThat(deletedConsumer)
+                .returns(expected.getUuid(), DeletedConsumerDTO::getConsumerUuid)
+                .returns(expected.getName(), DeletedConsumerDTO::getConsumerName)
+                .returns(expected.getOwner().getId(), DeletedConsumerDTO::getOwnerId)
+                .returns(expected.getOwner().getKey(), DeletedConsumerDTO::getOwnerKey)
+                .returns(expected.getOwner().getDisplayName(), DeletedConsumerDTO::getOwnerDisplayName)
+                .returns("admin", DeletedConsumerDTO::getPrincipalName);
+        }
+
+        // Verify that the active consumers have not been deleted
+        for (Entry<String, ConsumerDTO> entry : activeConsumers.entrySet()) {
+            compareConsumers(entry.getValue(), consumerApi.getConsumer(entry.getKey()));
+        }
     }
 
     @Test

--- a/src/main/java/org/candlepin/async/tasks/InactiveConsumerCleanerJob.java
+++ b/src/main/java/org/candlepin/async/tasks/InactiveConsumerCleanerJob.java
@@ -67,6 +67,10 @@ public class InactiveConsumerCleanerJob implements AsyncJob {
     public static final String CFG_LAST_UPDATED_IN_RETENTION_IN_DAYS = "last_updated_retention_in_days";
     public static final int DEFAULT_LAST_UPDATED_IN_RETENTION_IN_DAYS = 30;
 
+    public static final String CFG_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS =
+        "last_checked_in_anon_org_retention_in_days";
+    public static final int DEFAULT_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS = 30;
+
     public static final String CFG_ANON_CLOUD_CONSUMER_RETENTION = "anon_cloud_consumer_retention";
     public static final int DEFAULT_ANON_CLOUD_CONSUMER_RETENTION = 15; // In days
 
@@ -110,18 +114,24 @@ public class InactiveConsumerCleanerJob implements AsyncJob {
     public void execute(JobExecutionContext context) throws JobExecutionException {
         Instant lastCheckedInRetention = this.getRetentionDate(CFG_LAST_CHECKED_IN_RETENTION_IN_DAYS);
         Instant nonCheckedInRetention = this.getRetentionDate(CFG_LAST_UPDATED_IN_RETENTION_IN_DAYS);
+        Instant anonOrgLastCheckInRetention =
+            this.getRetentionDate(CFG_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS);
         int batchSize = this.getBatchSize();
 
         int deletedConsumers =
             this.deleteInactiveConsumers(lastCheckedInRetention, nonCheckedInRetention, batchSize);
+
+        int deletedConsumerFromAnonOrgs =
+            this.deleteInactiveConsumersFromAnonymousOwners(anonOrgLastCheckInRetention, batchSize);
 
         Instant anonymousConsumerRetention = this.getRetentionDate(CFG_ANON_CLOUD_CONSUMER_RETENTION);
         int deletedAnonymousCloudConsumers =
             this.deleteInactiveAnonymousCloudConsumers(anonymousConsumerRetention, batchSize);
 
         String result = String.format(
-            "%s complete; %d consumers removed and %d anonymous cloud consumers removed",
-            JOB_NAME, deletedConsumers, deletedAnonymousCloudConsumers);
+            "%s complete; %d consumers removed, %d consumers removed from anonymous owners, " +
+            "and %d anonymous cloud consumers removed",
+            JOB_NAME, deletedConsumers, deletedConsumerFromAnonOrgs, deletedAnonymousCloudConsumers);
 
         log.info(result);
         context.setJobResult(result);
@@ -152,6 +162,7 @@ public class InactiveConsumerCleanerJob implements AsyncJob {
      * @return
      *  the number of consumers that have been deleted.
      */
+    @SuppressWarnings("unchecked")
     private Integer deleteInactiveConsumers(Object... args) {
         if (args == null || args.length < 1) {
             log.trace("No arguments sent to transactional operation");
@@ -200,6 +211,19 @@ public class InactiveConsumerCleanerJob implements AsyncJob {
         }
 
         return deletedConsumers;
+    }
+
+    private int deleteInactiveConsumersFromAnonymousOwners(Instant lastCheckedInRetention, int batchSize) {
+        log.info("Fetching inactive consumers from anonymous owners using the last checkin retention date: {}",
+            lastCheckedInRetention);
+
+        List<InactiveConsumerRecord> inactiveConsumers = this.consumerCurator
+            .getInactiveConsumersFromAnonOwners(lastCheckedInRetention);
+
+        String entityDescription = "inactive consumers from anonymous owners";
+
+        return this.deleteInBatches(inactiveConsumers, batchSize, entityDescription,
+            this::deleteInactiveConsumers);
     }
 
     private int deleteInactiveAnonymousCloudConsumers(Instant retention, int batchSize) {

--- a/src/main/java/org/candlepin/config/ConfigProperties.java
+++ b/src/main/java/org/candlepin/config/ConfigProperties.java
@@ -636,6 +636,9 @@ public class ConfigProperties {
             this.put(jobConfig(InactiveConsumerCleanerJob.JOB_KEY,
                 InactiveConsumerCleanerJob.CFG_ANON_CLOUD_CONSUMER_RETENTION),
                 Integer.toString(InactiveConsumerCleanerJob.DEFAULT_ANON_CLOUD_CONSUMER_RETENTION));
+            this.put(jobConfig(InactiveConsumerCleanerJob.JOB_KEY,
+                InactiveConsumerCleanerJob.CFG_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS),
+                Integer.toString(InactiveConsumerCleanerJob.DEFAULT_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS));
 
             // JobCleaner
             this.put(jobConfig(JobCleaner.JOB_KEY, ASYNC_JOBS_JOB_SCHEDULE),

--- a/src/main/java/org/candlepin/model/ConsumerCurator.java
+++ b/src/main/java/org/candlepin/model/ConsumerCurator.java
@@ -1091,7 +1091,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
 
     /**
      * Retrieves records of inactive consumers based on the provided last check-in and last-updated retention
-     * dates.
+     * dates. This method does not consider consumers that belong to anonymous owners.
      * <p>
      * A given consumer is considered inactive if it is a non-manifest consumer, with no active entitlements,
      * and either (a) the consumer's last check-in is older than the provided last-checked-in retention date,
@@ -1127,6 +1127,7 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             "  JOIN consumer.owner owner " +
             "  LEFT JOIN consumer.entitlements ent " +
             "WHERE ent IS NULL " +
+            "  AND (owner.anonymous = false OR owner.anonymous IS NULL) " +
             "  AND LOWER(type.manifest) = 'n' " +
             "  AND (consumer.lastCheckin < :lastCheckedInRetention OR " +
             "    (consumer.lastCheckin IS NULL AND consumer.updated < :nonCheckedInRetention)) " +
@@ -1136,6 +1137,38 @@ public class ConsumerCurator extends AbstractHibernateCurator<Consumer> {
             .createQuery(jpql, InactiveConsumerRecord.class)
             .setParameter("lastCheckedInRetention", Date.from(lastCheckedInRetention))
             .setParameter("nonCheckedInRetention", Date.from(lastUpdatedRetention))
+            .getResultList();
+    }
+
+    /**
+     * Retrieves records of inactive consumers that belong to anonymous owners based on the provided last
+     * check-in retention date.
+     * <p>
+     * A consumer is considered inactive if their last check-in date is before the provided last check-in
+     * retention date, or if the consumer's updated date is before provided last check-in retention date if
+     * the consumer has not checked-in.
+     *
+     * @param lastCheckedInRetention
+     *  the point in time that dictates if a consumer in an anonymous owner is considered inactive or not
+     *
+     * @return a list of {@link InactiveConsumerRecord}s representing the consumers to be considered inactive
+     */
+    public List<InactiveConsumerRecord> getInactiveConsumersFromAnonOwners(Instant lastCheckedInRetention) {
+        if (lastCheckedInRetention == null) {
+            throw new IllegalArgumentException("Last checked-in retention date cannot be null.");
+        }
+
+        String jpql = "SELECT new org.candlepin.model.InactiveConsumerRecord(consumer.id, consumer.uuid, " +
+            "owner.key, owner.anonymous) " +
+            "FROM Consumer consumer " +
+            "  JOIN consumer.owner owner " +
+            "WHERE owner.anonymous = true " +
+            "  AND COALESCE(consumer.lastCheckin, consumer.updated) < :lastCheckedInRetention " +
+            "ORDER BY owner.key, consumer.uuid";
+
+        return this.getEntityManager()
+            .createQuery(jpql, InactiveConsumerRecord.class)
+            .setParameter("lastCheckedInRetention", Date.from(lastCheckedInRetention))
             .getResultList();
     }
 

--- a/src/main/java/org/candlepin/model/InactiveConsumerRecord.java
+++ b/src/main/java/org/candlepin/model/InactiveConsumerRecord.java
@@ -31,8 +31,9 @@ package org.candlepin.model;
  * @param isOwnerAnonymous
  *  The anonymous state of the owner that the inactive consumer belongs to
  */
-public record InactiveConsumerRecord(String consumerId, String consumerUuid, String ownerKey,
-    Boolean isOwnerAnonymous) {
-
-    // intentionally left empty
-}
+public record InactiveConsumerRecord(
+    String consumerId,
+    String consumerUuid,
+    String ownerKey,
+    Boolean isOwnerAnonymous
+) {}

--- a/src/test/java/org/candlepin/async/tasks/InactiveConsumerCleanerJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/InactiveConsumerCleanerJobTest.java
@@ -223,6 +223,11 @@ public class InactiveConsumerCleanerJobTest extends DatabaseTestFixture {
         int activeLastCheckin = InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS - 10;
         int inactiveLastCheckin = InactiveConsumerCleanerJob.DEFAULT_LAST_CHECKED_IN_RETENTION_IN_DAYS + 10;
 
+        int activeLastCheckinAnonymousOwner = InactiveConsumerCleanerJob
+            .DEFAULT_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS - 10;
+        int inactiveLastCheckinAnonymousOwner = InactiveConsumerCleanerJob
+            .DEFAULT_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS + 10;
+
         Map<Owner, List<Consumer>> activeConsumersMap = new HashMap<>();
         Map<Owner, List<Consumer>> inactiveConsumersMap = new HashMap<>();
         Map<String, Owner> ownerMap = new HashMap<>();
@@ -232,16 +237,21 @@ public class InactiveConsumerCleanerJobTest extends DatabaseTestFixture {
             Owner owner = this.createOwner(TestUtil.randomString(), TestUtil.randomString())
                 .setAnonymous(anonymous);
 
+            // Determine which date is considered active and which date is considered inactive since the
+            // retention date is different for consumers in anonymous owners.
+            int activeCheckIn = anonymous ? activeLastCheckinAnonymousOwner : activeLastCheckin;
+            int inactiveCheckIn = anonymous ? inactiveLastCheckinAnonymousOwner : inactiveLastCheckin;
+
             // Set half the owners to an anonymous state
             anonymous = !anonymous;
 
             List<Consumer> activeConsumers =
-                Stream.generate(() -> this.createConsumer(owner, activeLastCheckin))
+                Stream.generate(() -> this.createConsumer(owner, activeCheckIn))
                     .limit(10)
                     .toList();
 
             List<Consumer> inactiveConsumers =
-                Stream.generate(() -> this.createConsumer(owner, inactiveLastCheckin))
+                Stream.generate(() -> this.createConsumer(owner, inactiveCheckIn))
                     .limit(10)
                     .toList();
 

--- a/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
+++ b/src/test/java/org/candlepin/model/ConsumerCuratorTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
@@ -69,6 +68,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.persistence.EntityManager;
@@ -2163,13 +2164,13 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
             .returns(null, InactiveConsumerRecord::isOwnerAnonymous);
     }
 
-    @ParameterizedTest(name = "{displayName} {index}: {0}")
-    @ValueSource(booleans = {true, false})
-    public void testGetInactiveConsumersShouldPopulateAnonymousFieldBasedOnOwner(boolean anonymous) {
+    @Test
+    public void testGetInactiveConsumersShouldRetrieveConsumerFromNonAnonymousOwners() {
+        Owner owner = this.createOwner();
+
         Owner anonOwner = TestUtil.createOwner(TestUtil.randomString(), TestUtil.randomString())
             .setId(null)
-            .setAnonymous(anonymous);
-
+            .setAnonymous(true);
         anonOwner = this.ownerCurator.create(anonOwner);
 
         Instant lastCheckedInRetention = Instant.now()
@@ -2177,25 +2178,24 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
         Instant nonCheckedInRetention = Instant.now()
             .minus(InactiveConsumerCleanerJob.DEFAULT_LAST_UPDATED_IN_RETENTION_IN_DAYS, ChronoUnit.DAYS);
 
-        Consumer inactiveConsumer = new Consumer()
-            .setName("inactiveConsumer")
-            .setUsername("testUser")
-            .setOwner(anonOwner)
-            .setType(ct);
-        Instant lastCheckedIn = Instant.ofEpochMilli(lastCheckedInRetention.toEpochMilli() - 86400L);
-        inactiveConsumer.setLastCheckin(Date.from(lastCheckedIn));
-        inactiveConsumer = consumerCurator.create(inactiveConsumer);
+        Instant inactiveLastCheckedIn = lastCheckedInRetention.minus(5, ChronoUnit.DAYS);
 
-        List<InactiveConsumerRecord> actual = consumerCurator.getInactiveConsumers(lastCheckedInRetention,
-            nonCheckedInRetention);
+        // Create an inactive consumer in a regular SCA owner.
+        Consumer expectedInactiveConsumer = this.createConsumer(owner, inactiveLastCheckedIn);
+
+        // Create an inactive consumer in an anonymous owner. This consumer should not be returned.
+        this.createConsumer(anonOwner, inactiveLastCheckedIn);
+
+        List<InactiveConsumerRecord> actual = this.consumerCurator
+            .getInactiveConsumers(lastCheckedInRetention, nonCheckedInRetention);
 
         assertThat(actual)
             .isNotNull()
             .singleElement()
-            .returns(inactiveConsumer.getId(), InactiveConsumerRecord::consumerId)
-            .returns(inactiveConsumer.getUuid(), InactiveConsumerRecord::consumerUuid)
-            .returns(inactiveConsumer.getOwnerKey(), InactiveConsumerRecord::ownerKey)
-            .returns(anonymous, InactiveConsumerRecord::isOwnerAnonymous);
+            .returns(expectedInactiveConsumer.getId(), InactiveConsumerRecord::consumerId)
+            .returns(expectedInactiveConsumer.getUuid(), InactiveConsumerRecord::consumerUuid)
+            .returns(expectedInactiveConsumer.getOwnerKey(), InactiveConsumerRecord::ownerKey)
+            .returns(null, InactiveConsumerRecord::isOwnerAnonymous);
     }
 
     @Test
@@ -2249,6 +2249,141 @@ public class ConsumerCuratorTest extends DatabaseTestFixture {
             nonCheckedInRetention);
 
         assertEquals(0, actual.size());
+    }
+
+    @Test
+    public void testGetInactiveConsumersFromAnonOwnersWithNullLastCheckedInRetention() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            this.consumerCurator.getInactiveConsumersFromAnonOwners(null);
+        });
+    }
+
+    @Test
+    public void testGetInactiveConsumersFromAnonOwners() {
+        Instant lastCheckedInRetention = Instant.now()
+            .minus(InactiveConsumerCleanerJob.DEFAULT_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS,
+                ChronoUnit.DAYS);
+        Instant inactiveLastCheckedIn = lastCheckedInRetention.minus(5, ChronoUnit.DAYS);
+        Instant activeLastCheckedIn = lastCheckedInRetention.plus(5, ChronoUnit.DAYS);
+
+        int numberOfOwners = 4;
+        int numberOfConsumers = 3;
+        Map<String, Consumer> expectedConsumers = new HashMap<>();
+        boolean anonymous = true;
+
+        for (int i = 0; i < numberOfOwners; i++) {
+            Owner owner = this.ownerCurator.create(TestUtil.createOwner(TestUtil.randomString(), TestUtil.randomString())
+                .setId(null)
+                .setAnonymous(anonymous));
+
+            Map<String, Consumer> inactiveConsumers =
+                Stream.generate(() -> this.createConsumer(owner, inactiveLastCheckedIn))
+                    .limit(numberOfConsumers)
+                    .collect(Collectors.toMap(Consumer::getId, Function.identity()));
+
+            // Create active consumers
+            for (int j = 0; j < numberOfConsumers; j++) {
+                this.createConsumer(owner, activeLastCheckedIn);
+            }
+
+            // We expect only inactive consumers from anonymous owners to be returned
+            if (anonymous) {
+                expectedConsumers.putAll(inactiveConsumers);
+            }
+
+            // Make half of the owners anonymous
+            anonymous = !anonymous;
+        }
+
+        List<InactiveConsumerRecord> actual = this.consumerCurator
+            .getInactiveConsumersFromAnonOwners(lastCheckedInRetention);
+
+        assertEquals(expectedConsumers.size(), actual.size(), "unexpected number of inactive consumers");
+
+        // Verify that all of the expected consumers are returned
+        for (InactiveConsumerRecord inactiveRecord : actual) {
+            assertNotNull(inactiveRecord);
+
+            Consumer expected = expectedConsumers.get(inactiveRecord.consumerId());
+
+            assertNotNull(expected);
+            assertThat(inactiveRecord)
+                .returns(expected.getId(), InactiveConsumerRecord::consumerId)
+                .returns(expected.getUuid(), InactiveConsumerRecord::consumerUuid)
+                .returns(expected.getOwnerKey(), InactiveConsumerRecord::ownerKey)
+                .returns(true, InactiveConsumerRecord::isOwnerAnonymous);
+        }
+    }
+
+    @Test
+    public void testGetInactiveConsumersFromAnonOwnersWithNonCheckedInSystems() {
+        Instant lastCheckedInRetention = Instant.now()
+            .minus(InactiveConsumerCleanerJob.DEFAULT_ANON_OWNER_LAST_CHECKED_IN_RETENTION_IN_DAYS + 5,
+                ChronoUnit.DAYS);
+        Instant inactiveLastCheckedIn = lastCheckedInRetention.minus(5, ChronoUnit.DAYS);
+
+        Owner anonymousOwner = this.ownerCurator.create(TestUtil.createOwner(TestUtil.randomString(), TestUtil.randomString())
+            .setId(null)
+            .setAnonymous(true));
+
+        // Create a consumer with no check-in time and inactive updated date time
+        Consumer inactiveConsumer = new Consumer()
+            .setName(TestUtil.randomString("name-"))
+            .setUsername(TestUtil.randomString("user-"))
+            .setOwner(anonymousOwner)
+            .setType(ct);
+        inactiveConsumer = this.consumerCurator.create(inactiveConsumer);
+        this.setConsumerUpdateTime(inactiveConsumer.getUuid(), inactiveLastCheckedIn);
+
+        // Create a consumer with no check-in time and the updated date set to now which should be considered
+        // an active consumer.
+        Consumer activeConsumer = new Consumer()
+            .setName(TestUtil.randomString("name-"))
+            .setUsername(TestUtil.randomString("user-"))
+            .setOwner(anonymousOwner)
+            .setType(ct);
+        activeConsumer = this.consumerCurator.create(activeConsumer);
+
+        List<InactiveConsumerRecord> actual = this.consumerCurator
+            .getInactiveConsumersFromAnonOwners(lastCheckedInRetention);
+
+        assertThat(actual)
+            .isNotNull()
+            .singleElement()
+            .returns(inactiveConsumer.getUuid(), InactiveConsumerRecord::consumerUuid);
+    }
+
+    /**
+     * Directly sets a Consumer's updated date time to the privided instant using a native query.
+     * This method flushes and clears after executing the update statement.
+     *
+     * @param consumerUuid
+     *  the UUID of the consumer to update
+     *
+     * @param updated
+     *  the instant that the Consumer's updated date will be set to
+     */
+    private void setConsumerUpdateTime(String consumerUuid, Instant updated) {
+        String updateStatement = "UPDATE cp_consumer SET updated = :updated WHERE uuid = :uuid";
+
+        this.getEntityManager().createNativeQuery(updateStatement)
+            .setParameter("updated", Date.from(updated))
+            .setParameter("uuid", consumerUuid)
+            .executeUpdate();
+
+        this.consumerCurator.flush();
+        this.consumerCurator.clear();
+    }
+
+    private Consumer createConsumer(Owner owner, Instant checkIn) {
+        Consumer consumer = new Consumer()
+            .setName(TestUtil.randomString("name-"))
+            .setUsername(TestUtil.randomString("user-"))
+            .setOwner(owner)
+            .setType(ct)
+            .setLastCheckin(Date.from(checkIn));
+
+        return this.consumerCurator.create(consumer);
     }
 
     @Test


### PR DESCRIPTION
- Updated the InactiveConsumerCleanerJob to include a separate inactive policy for systems that belong to anonymous owners. I also updated the existing inactive policy for systems to exclude systems that belong to anonymous owners.