### PR TITLE
[4.8] CANDLEPIN-1253: Fixed import bug with legacy manifests

### DIFF
--- a/src/main/java/org/candlepin/pki/CryptoManager.java
+++ b/src/main/java/org/candlepin/pki/CryptoManager.java
@@ -137,6 +137,16 @@ public interface CryptoManager {
     Scheme getDefaultCryptoScheme();
 
     /**
+     * Fetches the legacy scheme, as it is currently configured. Note that this should only be used in very
+     * specific instances where fallback behavior is known to only use the legacy scheme (e.g. manifest
+     * import).
+     *
+     * @return
+     *  the legacy cryptographic scheme
+     */
+    Scheme getLegacyCryptoScheme();
+
+    /**
      * Fetches the set of "upstream" certificates, defined as those included in the Candlepin RPM, typically
      * aligned with the certificates used by hosted Candlepin. This method will never return null. If there
      * are no upstream certificates, this method returns an empty set.

--- a/src/main/java/org/candlepin/pki/SchemeReader.java
+++ b/src/main/java/org/candlepin/pki/SchemeReader.java
@@ -147,7 +147,17 @@ public class SchemeReader {
             .orElse(null);
     }
 
-    private Scheme readLegacyScheme() {
+    /**
+     * Fetches the legacy scheme from the Candlepin configuration or known legacy default values where
+     * applicable. This method will never return null.
+     *
+     * @throws ConfigurationException
+     *  if the legacy scheme is malformed, or otherwise cannot be loaded
+     *
+     * @return
+     *  the legacy crypto scheme
+     */
+    public Scheme readLegacyScheme() {
         // This is a bit of a mess. We need to load a scheme that mostly comes from old config values, but
         // could also come from new config values.
 
@@ -286,7 +296,7 @@ public class SchemeReader {
      * cannot be loaded, this method throws an exception. This method will never return null.
      *
      * @throws ConfigurationException
-     *  if the default scheme is malformed, or the default scheme cannot be loaded
+     *  if the default scheme is malformed, or otherwise cannot be loaded
      *
      * @return
      *  the default crypto scheme

--- a/src/main/java/org/candlepin/pki/impl/bc/BouncyCastleCryptoManager.java
+++ b/src/main/java/org/candlepin/pki/impl/bc/BouncyCastleCryptoManager.java
@@ -80,6 +80,8 @@ public class BouncyCastleCryptoManager implements CryptoManager {
 
     private final List<Scheme> schemes;
     private final Scheme defaultScheme;
+    private final Scheme legacyScheme;
+
     private final File upstreamCertificateRepo;
 
     // TODO: FIXME: This feature flag is temporary and should be removed once all dependent services have
@@ -101,10 +103,13 @@ public class BouncyCastleCryptoManager implements CryptoManager {
 
         this.schemes = Collections.unmodifiableList(schemeReader.readSchemes());
         this.defaultScheme = schemeReader.readDefaultScheme();
+        this.legacyScheme = schemeReader.readLegacyScheme();
+
         this.upstreamCertificateRepo = this.readUpstreamCertificateRepoConfig(config);
 
         // Validate the schemes we've loaded
-        Stream.concat(this.schemes.stream(), Stream.of(this.defaultScheme))
+        Stream.concat(this.schemes.stream(), Stream.of(this.defaultScheme, this.legacyScheme))
+            .distinct()
             .forEach(this::validateScheme);
 
         // Temporary feature flag
@@ -315,6 +320,11 @@ public class BouncyCastleCryptoManager implements CryptoManager {
     }
 
     @Override
+    public Scheme getLegacyCryptoScheme() {
+        return this.legacyScheme;
+    }
+
+    @Override
     public Set<X509Certificate> getUpstreamCertificates() throws CertificateException {
         // If the directory/file doesn't exist, log a warning and return an empty set
         if (!this.upstreamCertificateRepo.exists()) {
@@ -398,8 +408,9 @@ public class BouncyCastleCryptoManager implements CryptoManager {
         }
 
         Stream<X509Certificate> schemeCerts = Stream.concat(this.schemes.stream(),
-            Stream.of(this.defaultScheme))
-            .map(Scheme::certificate);
+            Stream.of(this.defaultScheme, this.legacyScheme))
+            .map(Scheme::certificate)
+            .distinct();
 
         Set<X509Certificate> upstreamCerts = this.getUpstreamCertificates();
 

--- a/src/main/java/org/candlepin/sync/Importer.java
+++ b/src/main/java/org/candlepin/sync/Importer.java
@@ -426,7 +426,7 @@ public class Importer {
         try {
             File consumerExport = this.getConsumerExport(exportDir);
             Scheme scheme = this.loadSchemeFromManifest(consumerExport)
-                .orElse(this.cryptoManager.getDefaultCryptoScheme());
+                .orElse(this.cryptoManager.getLegacyCryptoScheme());
 
             this.verifyCertificate(scheme.certificate(), overrides);
             this.verifySignature(scheme, exportDir, overrides);

--- a/src/test/java/org/candlepin/pki/CryptoManagerTest.java
+++ b/src/test/java/org/candlepin/pki/CryptoManagerTest.java
@@ -100,8 +100,7 @@ public abstract class CryptoManagerTest {
             .map(Scheme::name)
             .toList();
 
-        config.setProperty(ConfigProperties.CRYPTO_SCHEMES,
-            String.join(",", schemeNames));
+        config.setProperty(ConfigProperties.CRYPTO_SCHEMES, String.join(",", schemeNames));
 
         return config;
     }
@@ -840,14 +839,14 @@ public abstract class CryptoManagerTest {
     public void testGetDefaultCryptoScheme() throws Exception {
         CryptoManager cryptoManager = this.buildCryptoManager();
 
-        Scheme defaultScheme = cryptoManager.getDefaultCryptoScheme();
-        assertNotNull(defaultScheme);
+        Scheme scheme = cryptoManager.getDefaultCryptoScheme();
+        assertNotNull(scheme);
 
-        // This should not change from call to call. The exact instance *shouldn't* change, but it wouoldn't
+        // This should not change from call to call. The exact instance *shouldn't* change, but it wouldn't
         // break things if it does. We'll just verify that it's equal on each invocation.
         for (int i = 0; i < 3; ++i) {
             Scheme output = cryptoManager.getDefaultCryptoScheme();
-            assertEquals(defaultScheme, output);
+            assertEquals(scheme, output);
         }
     }
 
@@ -883,6 +882,61 @@ public abstract class CryptoManagerTest {
         CryptoManager cryptoManager = this.buildCryptoManager(config);
 
         Scheme output = cryptoManager.getDefaultCryptoScheme();
+        assertEquals(mldsaScheme, output);
+    }
+
+    @Test
+    public void testGetLegacyCryptoScheme() throws Exception {
+        CryptoManager cryptoManager = this.buildCryptoManager();
+
+        Scheme scheme = cryptoManager.getLegacyCryptoScheme();
+        assertNotNull(scheme);
+
+        // This should not change from call to call. The exact instance *shouldn't* change, but it wouldn't
+        // break things if it does. We'll just verify that it's equal on each invocation.
+        for (int i = 0; i < 3; ++i) {
+            Scheme output = cryptoManager.getLegacyCryptoScheme();
+            assertEquals(scheme, output);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("schemeSource")
+    public void testGetLegacyCryptoSchemeRespectsConfiguration(Scheme scheme) throws Exception {
+        // Configure the legacy scheme to match our input scheme
+        DevConfig config = TestConfig.defaults();
+        CryptoUtil.generateSchemeConfiguration(config, scheme, SchemeReader.LEGACY_SCHEME, null);
+
+        CryptoManager cryptoManager = this.buildCryptoManager(config);
+
+        Scheme actual = cryptoManager.getLegacyCryptoScheme();
+        assertThat(actual)
+            .returns(SchemeReader.LEGACY_SCHEME, Scheme::name)
+            .returns(scheme.privateKey(), Scheme::privateKey)
+            .returns(scheme.certificate(), Scheme::certificate)
+            .returns(scheme.signatureAlgorithm(), Scheme::signatureAlgorithm)
+            .returns(scheme.keyAlgorithm(), Scheme::keyAlgorithm)
+            .returns(scheme.keySize(), Scheme::keySize);
+    }
+
+    @Test
+    public void testGetLegacyCryptoSchemeDoesNotRequirePresenceInSchemeList() throws Exception {
+        // This test validates that CryptoManager::getLegacyCryptoScheme does not require that the scheme
+        // is present in the configured scheme list
+        Scheme rsaScheme = CryptoUtil.generateRsaScheme();
+        Scheme mldsaScheme = CryptoUtil.generateMldsaScheme(SchemeReader.LEGACY_SCHEME);
+
+        DevConfig config = TestConfig.defaults();
+
+        CryptoUtil.generateSchemeConfiguration(config, rsaScheme, null);
+        CryptoUtil.generateSchemeConfiguration(config, mldsaScheme, null);
+
+        // Only define the RSA scheme in the primary scheme list, and set the legacy scheme to MLDSA
+        config.setProperty(ConfigProperties.CRYPTO_SCHEMES, rsaScheme.name());
+
+        CryptoManager cryptoManager = this.buildCryptoManager(config);
+
+        Scheme output = cryptoManager.getLegacyCryptoScheme();
         assertEquals(mldsaScheme, output);
     }
 
@@ -1012,9 +1066,9 @@ public abstract class CryptoManagerTest {
 
         private void validateTestState() throws Exception {
             // Ensure we have separation of all of our cert sources
-            List<Scheme> schemes = cryptoManager.getCryptoSchemes();
-            Scheme defaultScheme = cryptoManager.getDefaultCryptoScheme();
-            Set<X509Certificate> upstreamCertificates = cryptoManager.getUpstreamCertificates();
+            List<Scheme> schemes = this.cryptoManager.getCryptoSchemes();
+            Scheme defaultScheme = this.cryptoManager.getDefaultCryptoScheme();
+            Set<X509Certificate> upstreamCertificates = this.cryptoManager.getUpstreamCertificates();
 
             // Verify the default scheme is not one of the schemes in the primary scheme list to ensure proper
             // separation and that we aren't accidentally re-validating the same cert from the primary scheme

--- a/src/test/java/org/candlepin/pki/SchemeReaderTest.java
+++ b/src/test/java/org/candlepin/pki/SchemeReaderTest.java
@@ -397,9 +397,11 @@ public class SchemeReaderTest {
         config.clearProperty(ConfigProperties.CRYPTO_DEFAULT_SCHEME);
 
         SchemeReader reader = this.buildSchemeReader(config);
-        Scheme output = reader.readDefaultScheme();
+        Scheme defaultScheme = reader.readDefaultScheme();
+        Scheme legacyScheme = reader.readLegacyScheme();
 
-        assertThat(output)
+        assertThat(defaultScheme)
+            .isEqualTo(legacyScheme)
             .returns(SchemeReader.LEGACY_SCHEME, Scheme::name)
             .returns(scheme.privateKey(), Scheme::privateKey)
             .returns(scheme.certificate(), Scheme::certificate)
@@ -511,10 +513,6 @@ public class SchemeReaderTest {
             .hasMessageContaining("Unable to read certificate");
     }
 
-    // Impl note: currently the "read legacy" tests all use readDefaultScheme with a configuration that points
-    // the default scheme to the legacy scheme. In the future if readScheme is made public, these tests should
-    // be updated to directly target it instead of fetching it indirectly.
-
     @Test
     public void testReadLegacySchemeDefaultsToLegacyConfigEntries() throws Exception {
         // At the time of writing, our legacy scheme is RSA
@@ -534,10 +532,10 @@ public class SchemeReaderTest {
         config.setProperty(ConfigProperties.CRYPTO_SCHEMES, SchemeReader.LEGACY_SCHEME);
         config.setProperty(ConfigProperties.CRYPTO_DEFAULT_SCHEME, SchemeReader.LEGACY_SCHEME);
 
-        SchemeReader schemeReader = this.buildSchemeReader(config);
-        Scheme defaultScheme = schemeReader.readDefaultScheme();
+        SchemeReader reader = this.buildSchemeReader(config);
+        Scheme output = reader.readLegacyScheme();
 
-        assertThat(defaultScheme)
+        assertThat(output)
             .isNotNull()
             .returns(legacyScheme.certificate(), Scheme::certificate)
             .returns(legacyScheme.privateKey(), Scheme::privateKey)
@@ -564,10 +562,10 @@ public class SchemeReaderTest {
         PrivateKeyReader mockPrivateKeyReader = mockPrivateKeyReader(
             SchemeReader.LEGACY_SCHEME_DEFAULT_KEY, legacyScheme.privateKey().get());
 
-        SchemeReader schemeReader = new SchemeReader(config, mockPrivateKeyReader, mockCertificateReader);
-        Scheme defaultScheme = schemeReader.readDefaultScheme();
+        SchemeReader reader = new SchemeReader(config, mockPrivateKeyReader, mockCertificateReader);
+        Scheme output = reader.readLegacyScheme();
 
-        assertThat(defaultScheme)
+        assertThat(output)
             .isNotNull()
             .returns(legacyScheme.certificate(), Scheme::certificate)
             .returns(legacyScheme.privateKey(), Scheme::privateKey)
@@ -595,11 +593,11 @@ public class SchemeReaderTest {
         PrivateKeyReader mockPrivateKeyReader = mockPrivateKeyReader(
             SchemeReader.LEGACY_SCHEME_DEFAULT_KEY, legacyScheme.privateKey().get());
 
-        SchemeReader schemeReader = new SchemeReader(config, mockPrivateKeyReader,
+        SchemeReader reader = new SchemeReader(config, mockPrivateKeyReader,
             CryptoUtil.getCertificateReader());
-        Scheme defaultScheme = schemeReader.readDefaultScheme();
+        Scheme output = reader.readLegacyScheme();
 
-        assertThat(defaultScheme)
+        assertThat(output)
             .isNotNull()
             .returns(legacyScheme.certificate(), Scheme::certificate)
             .returns(legacyScheme.privateKey(), Scheme::privateKey)
@@ -623,11 +621,11 @@ public class SchemeReaderTest {
         CertificateReader mockCertificateReader = mockCertificateReader(
             SchemeReader.LEGACY_SCHEME_DEFAULT_CERT, legacyScheme.certificate());
 
-        SchemeReader schemeReader = new SchemeReader(config, CryptoUtil.getPrivateKeyReader(),
+        SchemeReader reader = new SchemeReader(config, CryptoUtil.getPrivateKeyReader(),
             mockCertificateReader);
-        Scheme defaultScheme = schemeReader.readDefaultScheme();
+        Scheme output = reader.readLegacyScheme();
 
-        assertThat(defaultScheme)
+        assertThat(output)
             .isNotNull()
             .returns(legacyScheme.certificate(), Scheme::certificate)
             .returns(legacyScheme.privateKey(), Scheme::privateKey)
@@ -653,10 +651,10 @@ public class SchemeReaderTest {
         PrivateKeyReader mockPrivateKeyReader = mockPrivateKeyReader(
             SchemeReader.LEGACY_SCHEME_DEFAULT_KEY, legacyScheme.privateKey().get());
 
-        SchemeReader schemeReader = new SchemeReader(config, mockPrivateKeyReader, mockCertificateReader);
-        Scheme defaultScheme = schemeReader.readDefaultScheme();
+        SchemeReader reader = new SchemeReader(config, mockPrivateKeyReader, mockCertificateReader);
+        Scheme output = reader.readLegacyScheme();
 
-        assertThat(defaultScheme)
+        assertThat(output)
             .isNotNull()
             .returns(legacyScheme.certificate(), Scheme::certificate)
             .returns(legacyScheme.privateKey(), Scheme::privateKey)
@@ -682,10 +680,10 @@ public class SchemeReaderTest {
         PrivateKeyReader mockPrivateKeyReader = mockPrivateKeyReader(
             SchemeReader.LEGACY_SCHEME_DEFAULT_KEY, legacyScheme.privateKey().get());
 
-        SchemeReader schemeReader = new SchemeReader(config, mockPrivateKeyReader, mockCertificateReader);
-        Scheme defaultScheme = schemeReader.readDefaultScheme();
+        SchemeReader reader = new SchemeReader(config, mockPrivateKeyReader, mockCertificateReader);
+        Scheme output = reader.readLegacyScheme();
 
-        assertThat(defaultScheme)
+        assertThat(output)
             .isNotNull()
             .returns(legacyScheme.certificate(), Scheme::certificate)
             .returns(legacyScheme.privateKey(), Scheme::privateKey)
@@ -713,10 +711,10 @@ public class SchemeReaderTest {
         PrivateKeyReader mockPrivateKeyReader = mockPrivateKeyReader(
             SchemeReader.LEGACY_SCHEME_DEFAULT_KEY, legacyScheme.privateKey().get());
 
-        SchemeReader schemeReader = new SchemeReader(config, mockPrivateKeyReader, mockCertificateReader);
-        Scheme defaultScheme = schemeReader.readDefaultScheme();
+        SchemeReader reader = new SchemeReader(config, mockPrivateKeyReader, mockCertificateReader);
+        Scheme output = reader.readLegacyScheme();
 
-        assertThat(defaultScheme)
+        assertThat(output)
             .isNotNull()
             .returns(legacyScheme.certificate(), Scheme::certificate)
             .returns(legacyScheme.privateKey(), Scheme::privateKey)
@@ -743,7 +741,7 @@ public class SchemeReaderTest {
             ConfigProperties.CRYPTO_SCHEME_KEY_SIZE));
 
         SchemeReader reader = this.buildSchemeReader(config);
-        Scheme output = reader.readDefaultScheme();
+        Scheme output = reader.readLegacyScheme();
 
         assertThat(output)
             .returns(SchemeReader.LEGACY_SCHEME, Scheme::name)
@@ -770,7 +768,7 @@ public class SchemeReaderTest {
             ConfigProperties.CRYPTO_SCHEME_KEY_SIZE));
 
         SchemeReader reader = this.buildSchemeReader(config);
-        Scheme output = reader.readDefaultScheme();
+        Scheme output = reader.readLegacyScheme();
 
         assertThat(output)
             .returns(SchemeReader.LEGACY_SCHEME, Scheme::name)
@@ -796,7 +794,7 @@ public class SchemeReaderTest {
             ConfigProperties.CRYPTO_SCHEME_KEY_SIZE));
 
         SchemeReader reader = this.buildSchemeReader(config);
-        Scheme output = reader.readDefaultScheme();
+        Scheme output = reader.readLegacyScheme();
 
         assertThat(output)
             .returns(SchemeReader.LEGACY_SCHEME, Scheme::name)
@@ -817,7 +815,7 @@ public class SchemeReaderTest {
         config.setProperty(ConfigProperties.LEGACY_CA_KEY_PASSWORD, "legacy-ca-password");
 
         SchemeReader reader = this.buildSchemeReader(config);
-        Scheme output = reader.readDefaultScheme();
+        Scheme output = reader.readLegacyScheme();
 
         assertThat(output)
             .returns(SchemeReader.LEGACY_SCHEME, Scheme::name)
@@ -846,7 +844,7 @@ public class SchemeReaderTest {
         config.setProperty(ConfigProperties.LEGACY_CA_KEY_PASSWORD, actualPassword);
 
         SchemeReader reader = this.buildSchemeReader(config);
-        Scheme output = reader.readDefaultScheme();
+        Scheme output = reader.readLegacyScheme();
 
         assertThat(output)
             .returns(SchemeReader.LEGACY_SCHEME, Scheme::name)
@@ -855,6 +853,72 @@ public class SchemeReaderTest {
             .returns(SchemeReader.LEGACY_SCHEME_DEFAULT_KEY_ALGORITHM, Scheme::keyAlgorithm)
             .extracting(Scheme::keySize, as(InstanceOfAssertFactories.OPTIONAL))
             .hasValue(SchemeReader.LEGACY_SCHEME_DEFAULT_KEY_SIZE);
+    }
+
+    @Test
+    public void testReadLegacySchemeThrowsExceptionOnUnreadableKey() throws Exception {
+        DevConfig config = new DevConfig();
+        Scheme scheme = CryptoUtil.generateRsaScheme();
+        writeSchemeConfig(config, scheme, SchemeReader.LEGACY_SCHEME, null);
+
+        // set the key property to some non-existent file
+        config.setProperty(ConfigProperties.schemeConfig(SchemeReader.LEGACY_SCHEME,
+            ConfigProperties.CRYPTO_SCHEME_KEY), "path_does_not_exist");
+
+        SchemeReader reader = this.buildSchemeReader(config);
+
+        assertThatThrownBy(() -> reader.readLegacyScheme())
+            .isInstanceOf(ConfigurationException.class)
+            .hasMessageContaining("Unable to read private key");
+    }
+
+    @Test
+    public void testReadLegacySchemeThrowsExceptionOnEncryptedKeyWithWrongPassword() throws Exception {
+        DevConfig config = new DevConfig();
+        Scheme scheme = CryptoUtil.generateRsaScheme();
+        writeSchemeConfig(config, scheme, SchemeReader.LEGACY_SCHEME, "password");
+
+        config.setProperty(ConfigProperties.schemeConfig(SchemeReader.LEGACY_SCHEME,
+            ConfigProperties.CRYPTO_SCHEME_KEY_PASSWORD), "wrong_password");
+
+        SchemeReader reader = this.buildSchemeReader(config);
+
+        assertThatThrownBy(() -> reader.readLegacyScheme())
+            .isInstanceOf(ConfigurationException.class)
+            .hasMessageContaining("Unable to read private key");
+    }
+
+    @Test
+    public void testReadLegacySchemeThrowsExceptionOnEncryptedKeyWithNoPassword() throws Exception {
+        DevConfig config = new DevConfig();
+        Scheme scheme = CryptoUtil.generateRsaScheme();
+        writeSchemeConfig(config, scheme, SchemeReader.LEGACY_SCHEME, "password");
+
+        config.clearProperty(ConfigProperties.schemeConfig(SchemeReader.LEGACY_SCHEME,
+            ConfigProperties.CRYPTO_SCHEME_KEY_PASSWORD));
+
+        SchemeReader reader = this.buildSchemeReader(config);
+
+        assertThatThrownBy(() -> reader.readLegacyScheme())
+            .isInstanceOf(ConfigurationException.class)
+            .hasMessageContaining("Unable to read private key");
+    }
+
+    @Test
+    public void testReadLegacySchemeThrowsExceptionOnUnreadableCert() throws Exception {
+        DevConfig config = new DevConfig();
+        Scheme scheme = CryptoUtil.generateRsaScheme();
+        writeSchemeConfig(config, scheme, SchemeReader.LEGACY_SCHEME, null);
+
+        // set the key property to some non-existent file
+        config.setProperty(ConfigProperties.schemeConfig(SchemeReader.LEGACY_SCHEME,
+            ConfigProperties.CRYPTO_SCHEME_CERT), "path_does_not_exist");
+
+        SchemeReader reader = this.buildSchemeReader(config);
+
+        assertThatThrownBy(() -> reader.readLegacyScheme())
+            .isInstanceOf(ConfigurationException.class)
+            .hasMessageContaining("Unable to read certificate");
     }
 
 }

--- a/src/test/java/org/candlepin/sync/ImporterTest.java
+++ b/src/test/java/org/candlepin/sync/ImporterTest.java
@@ -143,11 +143,6 @@ import java.util.zip.ZipOutputStream;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class ImporterTest extends DatabaseTestFixture {
-    private static Stream<Arguments> schemeSource() {
-        return CryptoUtil.SUPPORTED_SCHEMES.values()
-            .stream()
-            .map(Arguments::of);
-    }
 
     @TempDir
     protected File tmpFolder;
@@ -232,6 +227,12 @@ public class ImporterTest extends DatabaseTestFixture {
     @AfterEach
     public void tearDown() throws Exception {
         this.updateReleaseVersion("${version}", "${release}");
+    }
+
+    private static Stream<Arguments> schemeSource() {
+        return CryptoUtil.SUPPORTED_SCHEMES.values()
+            .stream()
+            .map(Arguments::of);
     }
 
     private void updateReleaseVersion(String version, String release) throws URISyntaxException, IOException {
@@ -936,7 +937,63 @@ public class ImporterTest extends DatabaseTestFixture {
         Owner mockOwner = mock(Owner.class);
         Importer importer = this.buildImporter();
 
-        File legacyExport = this.toLegacyExport(export, this.cryptoManager.getDefaultCryptoScheme());
+        File legacyExport = this.toLegacyExport(export, this.cryptoManager.getLegacyCryptoScheme());
+
+        ImportRecord importRecord = importer
+            .loadExport(mockOwner, legacyExport, new ConflictOverrides(), "original_file.zip");
+
+        org.assertj.core.api.Assertions.assertThat(importRecord)
+            .isNotNull()
+            .returns(Status.SUCCESS_WITH_WARNING, ImportRecord::getStatus)
+            .returns(mockOwner, ImportRecord::getOwner)
+            .doesNotReturn(null, ImportRecord::getFileName);
+    }
+
+    @Test
+    public void testLoadExportWithLegacyExportUsingNonLegacyDefaultCryptoScheme() throws Exception {
+        this.config.setProperty(ConfigProperties.SYNC_WORK_DIR, "/tmp/");
+
+        // Impl note: this scheme can be anything *except* RSA
+        Scheme mldsaScheme = CryptoUtil.generateMldsaScheme("mldsa_default");
+        CryptoUtil.generateSchemeConfiguration(this.config, mldsaScheme, null);
+        this.config.setProperty(ConfigProperties.CRYPTO_DEFAULT_SCHEME, mldsaScheme.name());
+
+        // We have to recreate this so it receives the config changes. This is why we shouldn't use globally
+        // shared initializers in unit tests. :/
+        this.cryptoManager = spy(CryptoUtil.getCryptoManager(this.config));
+
+        Owner owner = this.createOwner();
+        ConsumerType consumerType = this.createConsumerType(true);
+        doReturn(consumerType).when(mockConsumerTypeCurator).getByLabel(any(String.class));
+
+        Consumer consumer = new Consumer()
+            .setName(TestUtil.randomString("name-"))
+            .setUsername(TestUtil.randomString("username-"))
+            .setOwner(owner)
+            .setType(consumerType);
+        consumer = this.consumerCurator.create(consumer);
+
+        IdentityCertificate idCert = this.identityCertificateGenerator.generate(consumer);
+        consumer.setIdCert(idCert);
+        consumer = this.consumerCurator.update(consumer);
+
+        Exporter exporter = this.createExporter();
+        File export = exporter.getFullExport(consumer, TestUtil.randomString(), TestUtil.randomString(),
+            TestUtil.randomString());
+        assertNotNull(export);
+        assertTrue(export.exists());
+        export.deleteOnExit();
+
+        Refresher mockRefresher = mock(Refresher.class);
+        doReturn(mockRefresher)
+            .when(this.refresherFactory)
+            .getRefresher(any(SubscriptionServiceAdapter.class));
+        doReturn(mockRefresher).when(mockRefresher).add(any(Owner.class));
+
+        Owner mockOwner = mock(Owner.class);
+        Importer importer = this.buildImporter();
+
+        File legacyExport = this.toLegacyExport(export, this.cryptoManager.getLegacyCryptoScheme());
 
         ImportRecord importRecord = importer
             .loadExport(mockOwner, legacyExport, new ConflictOverrides(), "original_file.zip");
@@ -1194,7 +1251,7 @@ public class ImporterTest extends DatabaseTestFixture {
         Importer importer = this.buildImporter();
         ManifestFile mockManifestFile = mock(ManifestFile.class);
 
-        File legacyExport = this.toLegacyExport(export, this.cryptoManager.getDefaultCryptoScheme());
+        File legacyExport = this.toLegacyExport(export, this.cryptoManager.getLegacyCryptoScheme());
 
         try (FileInputStream is = new FileInputStream(legacyExport)) {
             doReturn(is).when(mockManifestFile).getInputStream();

--- a/src/test/java/org/candlepin/test/CryptoUtil.java
+++ b/src/test/java/org/candlepin/test/CryptoUtil.java
@@ -717,11 +717,15 @@ public class CryptoUtil {
      * @param scheme
      *  the scheme to write to the configuration; cannot be null, and must contain a private key
      *
+     * @param alias
+     *  the scheme name or alias to use to in the config, overriding the name defined in the scheme object;
+     *  cannot be null
+     *
      * @param keyPassword
      *  the password or passphrase to use to encrypt the private key in the file
      *
      * @throws IllegalArgumentException
-     *  if config or scheme are null, or if the scheme lacks a private key
+     *  if config or scheme are null, the scheme alias is null or blank, or if the scheme lacks a private key
      *
      * @throws KeyException
      *  if an exception occurs while encoding the scheme's private key
@@ -729,8 +733,8 @@ public class CryptoUtil {
      * @throws IOException
      *  if an exception occurs while writing the key or certificate to temporary files
      */
-    public static void generateSchemeConfiguration(DevConfig config, Scheme scheme, String keyPassword)
-        throws KeyException, IOException {
+    public static void generateSchemeConfiguration(DevConfig config, Scheme scheme, String alias,
+        String keyPassword) throws KeyException, IOException {
 
         if (config == null) {
             throw new IllegalArgumentException("config is null");
@@ -740,11 +744,15 @@ public class CryptoUtil {
             throw new IllegalArgumentException("scheme is null");
         }
 
+        if (alias == null || alias.isBlank()) {
+            throw new IllegalArgumentException("scheme alias is null or empty");
+        }
+
         if (scheme.privateKey().isEmpty()) {
             throw new IllegalArgumentException("scheme lacks a private key");
         }
 
-        String prefix = ConfigProperties.schemePrefix(scheme.name());
+        String prefix = ConfigProperties.schemePrefix(alias);
 
         File keyFile = writePrivateKeyToFile(scheme.privateKey().get(), keyPassword);
         File certFile = writeCertificateToFile(scheme.certificate());
@@ -762,6 +770,37 @@ public class CryptoUtil {
 
         scheme.keySize().ifPresent(keySize ->
             config.setProperty(prefix + ConfigProperties.CRYPTO_SCHEME_KEY_SIZE, keySize.toString()));
+    }
+
+    /**
+     * Writes the specified scheme to the given configuration such that it should be well-formed and readable
+     * by any production-ready logic that loads schemes from the Candlepin configuration. This function will
+     * generate new temporary files for both the key and certificate used in the scheme, even if that scheme
+     * instance has already been written to a configuration object previously. If the config or scheme are
+     * null, or the scheme lacks a private key, this function throws an exception.
+     *
+     * @param config
+     *  the config instance to modify with the scheme configuration; cannot be null
+     *
+     * @param scheme
+     *  the scheme to write to the configuration; cannot be null, and must contain a private key
+     *
+     * @param keyPassword
+     *  the password or passphrase to use to encrypt the private key in the file
+     *
+     * @throws IllegalArgumentException
+     *  if config or scheme are null, or if the scheme lacks a private key
+     *
+     * @throws KeyException
+     *  if an exception occurs while encoding the scheme's private key
+     *
+     * @throws IOException
+     *  if an exception occurs while writing the key or certificate to temporary files
+     */
+    public static void generateSchemeConfiguration(DevConfig config, Scheme scheme, String keyPassword)
+        throws KeyException, IOException {
+
+        generateSchemeConfiguration(config, scheme, scheme.name(), keyPassword);
     }
 
     /**


### PR DESCRIPTION
- Added methods to explicitly fetch the legacy crypto scheme from the CryptoManager and SchemeReader classes
- Fixed a bug in the Importer that would prevent importing legacy manifests if the default crypto scheme was set to something other than RSA
- Added deduplication to the scheme and cert checking operations in BouncyCastleCryptoManager
- Fixed some miscellaneous typos and grammar issues