### PR TITLE
[M] Shortened test CN strings to fit BC 1.85 length limit

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 artemis = "2.55.0"
-bouncycastle = "1.84"
+bouncycastle = "1.85"
 guice = "7.0.0"
 hibernate = "7.4.5.Final"
 hibernate-validator = "9.1.3.Final"

--- a/src/test/java/org/candlepin/pki/impl/bc/BouncyCastleX509CertificateBuilderTest.java
+++ b/src/test/java/org/candlepin/pki/impl/bc/BouncyCastleX509CertificateBuilderTest.java
@@ -257,13 +257,11 @@ public class BouncyCastleX509CertificateBuilderTest {
         Instant end = LocalDate.now().plusDays(365).atStartOfDay(ZoneId.systemDefault()).toInstant();
         KeyPair keyPair = this.createKeyPair();
 
-        String junkChars = "#$%&'()*+,:;=?@[] \".<>\\^_`{|}~£円ßЯ∑#$%&'()*+,:;=?@[] \".<>\\^_`{|}~£円ßЯ∑";
+        String junkChars = "#$%&'()*+,:;=?@[] \".<>\\^_`{|}~£円ßЯ∑";
 
-        String cnComponent = "CN=\\#$%&'()*\\+\\,:\\;\\=?@[] \\\".\\<\\>\\\\^_`{|}~£円ßЯ∑" +
-            "\\#$%&'()*\\+\\,:\\;\\=?@[] \\\".\\<\\>\\\\^_`{|}~£円ßЯ∑";
+        String cnComponent = "CN=\\#$%&'()*\\+\\,:\\;\\=?@[] \\\".\\<\\>\\\\^_`{|}~£円ßЯ∑";
 
-        String oComponent = "O=\\#$%&'()*\\+\\,:\\;\\=?@[] \\\".\\<\\>\\\\^_`{|}~£円ßЯ∑" +
-            "\\#$%&'()*\\+\\,:\\;\\=?@[] \\\".\\<\\>\\\\^_`{|}~£円ßЯ∑";
+        String oComponent = "O=\\#$%&'()*\\+\\,:\\;\\=?@[] \\\".\\<\\>\\\\^_`{|}~£円ßЯ∑";
 
         DistinguishedName distinguishedName = new DistinguishedName(junkChars, junkChars);
 
@@ -312,11 +310,10 @@ public class BouncyCastleX509CertificateBuilderTest {
         KeyPair keyPair = this.createKeyPair();
 
         DistinguishedName distinguishedName = new DistinguishedName("candlepinproject.org");
-        String junkChars = "#$%&'()*+,:;=?@[] \".<>\\^_`{|}~£円ßЯ∑#$%&'()*+,:;=?@[] \".<>\\^_`{|}~£円ßЯ∑";
+        String junkChars = "#$%&'()*+,:;=?@[] \".<>\\^_`{|}~£円ßЯ∑";
 
         String expectedDN = "CN=candlepinproject.org";
-        String expectedSAN = "CN=\\#$%&'()*\\+\\,:\\;\\=?@[] \\\".\\<\\>\\\\^_`{|}~£円ßЯ∑" +
-            "\\#$%&'()*\\+\\,:\\;\\=?@[] \\\".\\<\\>\\\\^_`{|}~£円ßЯ∑";
+        String expectedSAN = "CN=\\#$%&'()*\\+\\,:\\;\\=?@[] \\\".\\<\\>\\\\^_`{|}~£円ßЯ∑";
 
         X509Certificate cert = this.builder
             .withDN(distinguishedName)


### PR DESCRIPTION
- BouncyCastle 1.85 enforces RFC 5280 ub-common-name (64 chars), breaking BouncyCastleX509CertificateBuilderTest with its 70-char test strings.