### PR TITLE
[M] CANDLEPIN-1263: Fixed issue when using OAuth for POST requests

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/OAuthUtil.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/util/OAuthUtil.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2009 - 2026 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.bootstrap.data.util;
+
+public class OAuthUtil {
+
+    public static final String CONSUMER_KEY = "rspec";
+    public static final String CONSUMER_SECRET = "rspec-oauth-secret";
+
+    private OAuthUtil() {
+        throw new UnsupportedOperationException();
+    }
+
+}
+

--- a/spec-tests/src/test/java/org/candlepin/spec/auth/OauthSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/auth/OauthSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2023 Red Hat, Inc.
+ * Copyright (c) 2009 - 2026 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -27,6 +27,7 @@ import org.candlepin.spec.bootstrap.client.SpecTest;
 import org.candlepin.spec.bootstrap.data.builder.Consumers;
 import org.candlepin.spec.bootstrap.data.builder.Owners;
 import org.candlepin.spec.bootstrap.data.builder.Users;
+import org.candlepin.spec.bootstrap.data.util.OAuthUtil;
 
 import org.junit.jupiter.api.Test;
 
@@ -34,40 +35,36 @@ import org.junit.jupiter.api.Test;
 @OnlyInHosted
 public class OauthSpecTest {
 
-    private final String OAUTH_CONSUMER = "rspec";
-    private final String OAUTH_SECRET = "rspec-oauth-secret";
-
-
     @Test
-    void shouldReturnsAUnauthorizedIfOauthUserIsNotConfigured() {
+    public void shouldReturnsAUnauthorizedIfOauthUserIsNotConfigured() {
         ApiClient oauth = ApiClients.oauth("baduser", "badsecret");
         assertUnauthorized(() -> oauth.users().listUsers());
     }
 
     @Test
-    void shouldReturnsAUnauthorizedIfOauthSecretDoesNotMatch() {
-        ApiClient oauth = ApiClients.oauth(OAUTH_CONSUMER, "badsecret");
+    public void shouldReturnsAUnauthorizedIfOauthSecretDoesNotMatch() {
+        ApiClient oauth = ApiClients.oauth(OAuthUtil.CONSUMER_KEY, "badsecret");
         assertUnauthorized(() -> oauth.users().listUsers());
     }
 
     @Test
-    void shouldLetACallerActAsAUser() {
+    public void shouldLetACallerActAsAUser() {
         ApiClient adminClient = ApiClients.admin();
         UserDTO user = adminClient.users().createUser(Users.random());
         ApiClient oauthUser = ApiClients.oauthUser(
-            OAUTH_CONSUMER, OAUTH_SECRET, user.getUsername());
+            OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET, user.getUsername());
         UserDTO userInfo = oauthUser.users().getUserInfo(user.getUsername());
         assertThat(userInfo)
             .isEqualTo(user);
     }
 
     @Test
-    void shouldLetACallerActAsAConsumer() {
+    public void shouldLetACallerActAsAConsumer() {
         ApiClient adminClient = ApiClients.admin();
         OwnerDTO owner = adminClient.owners().createOwner(Owners.random());
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient oauthConsumer = ApiClients.oauthConsumer(
-            OAUTH_CONSUMER, OAUTH_SECRET, consumer.getUuid());
+            OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET, consumer.getUuid());
         ConsumerDTO consumerFromServer = oauthConsumer.consumers().getConsumer(consumer.getUuid());
         assertThat(consumerFromServer)
             .isNotNull()
@@ -75,20 +72,20 @@ public class OauthSpecTest {
     }
 
     @Test
-    void shouldReturnsUnauthorizedIfAnUnknownConsumerIsRequested() {
+    public void shouldReturnsUnauthorizedIfAnUnknownConsumerIsRequested() {
         ApiClient adminClient = ApiClients.admin();
         OwnerDTO owner = adminClient.owners().createOwner(Owners.random());
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
         ApiClient oauthConsumer = ApiClients.oauthConsumer(
-            OAUTH_CONSUMER, OAUTH_SECRET, "some unknown consumer");
+            OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET, "some unknown consumer");
         assertUnauthorized(() -> oauthConsumer.consumers().getConsumer(consumer.getUuid()));
     }
 
     @Test
-    void shouldFallsBackToTrustedSystemAuthIfNoHeadersAreSet() {
+    public void shouldFallsBackToTrustedSystemAuthIfNoHeadersAreSet() {
         ApiClient adminClient = ApiClients.admin();
         OwnerDTO owner = adminClient.owners().createOwner(Owners.random());
-        ApiClient oauth = ApiClients.oauth(OAUTH_CONSUMER, OAUTH_SECRET);
+        ApiClient oauth = ApiClients.oauth(OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET);
         OwnerDTO ownerFromServer = oauth.owners().getOwner(owner.getKey());
         assertThat(ownerFromServer)
             .isEqualTo(owner);

--- a/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/owners/OwnerResourceSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 - 2025 Red Hat, Inc.
+ * Copyright (c) 2009 - 2026 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -61,6 +61,7 @@ import org.candlepin.spec.bootstrap.data.builder.ConsumerTypes;
 import org.candlepin.spec.bootstrap.data.builder.Consumers;
 import org.candlepin.spec.bootstrap.data.builder.Contents;
 import org.candlepin.spec.bootstrap.data.builder.Environments;
+import org.candlepin.spec.bootstrap.data.builder.ExportGenerator;
 import org.candlepin.spec.bootstrap.data.builder.Facts;
 import org.candlepin.spec.bootstrap.data.builder.Owners;
 import org.candlepin.spec.bootstrap.data.builder.Permissions;
@@ -70,6 +71,7 @@ import org.candlepin.spec.bootstrap.data.builder.Products;
 import org.candlepin.spec.bootstrap.data.builder.Subscriptions;
 import org.candlepin.spec.bootstrap.data.util.CertificateUtil;
 import org.candlepin.spec.bootstrap.data.util.DateUtil;
+import org.candlepin.spec.bootstrap.data.util.OAuthUtil;
 import org.candlepin.spec.bootstrap.data.util.StringUtil;
 import org.candlepin.spec.bootstrap.data.util.UserUtil;
 
@@ -87,6 +89,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import tools.jackson.databind.JsonNode;
 
+import java.io.File;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -1800,6 +1803,26 @@ public class OwnerResourceSpecTest {
             .extractingByKey("content_access", as(collection(String.class)))
             .singleElement()
             .isEqualTo(content2.getId());
+    }
+
+    @Test
+    public void shouldImportManifestUsingOAuthClient() throws Exception {
+        ApiClient adminClient = ApiClients.admin();
+        ApiClient oauthClient = ApiClients.oauth(OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET);
+
+        OwnerDTO owner = adminClient.owners().createOwner(Owners.randomSca());
+
+        File manifest = new ExportGenerator()
+            .addProduct(Products.random())
+            .export();
+
+        AsyncJobStatusDTO importJob = oauthClient.owners()
+            .importManifestAsync(owner.getKey(), List.of(), manifest);
+
+        AsyncJobStatusDTO jobStatus = adminClient.jobs().waitForJob(importJob);
+        assertThatJob(jobStatus)
+            .isFinished()
+            .contains("SUCCESS");
     }
 
 }

--- a/src/main/java/org/candlepin/resteasy/filter/RestEasyOAuthMessage.java
+++ b/src/main/java/org/candlepin/resteasy/filter/RestEasyOAuthMessage.java
@@ -60,37 +60,56 @@ public class RestEasyOAuthMessage extends OAuthMessage {
         }
     }
 
+    /**
+     * Retrieves a list of OAuth specific parameters from the provided HTTP request. This method returns all
+     * of the OAuth parameters in the 'Authorization' header. This method also returns all of the form
+     * parameters if the request has a Content-Type that is compatible with
+     * 'application/x-www-form-urlencoded'.
+     *
+     * @param request
+     *  the request to retrieve the OAuth parameters from
+     *
+     * @return a list of all the OAuth specific parameters
+     */
     public static List<OAuth.Parameter> getParameters(HttpRequest request) {
-        List<OAuth.Parameter> list = new ArrayList<>();
-        java.util.List<java.lang.String> headers =
-            request.getHttpHeaders().getRequestHeader("Authorization");
+        List<OAuth.Parameter> parameters = new ArrayList<>();
+        List<String> headers = request.getHttpHeaders().getRequestHeader("Authorization");
         if (headers != null) {
-            Iterator<String> itor = headers.iterator();
-            while (itor.hasNext()) {
-                String header = itor.next();
-                for (OAuth.Parameter parameter : OAuthMessage
-                    .decodeAuthorization(header)) {
-                    log.debug(parameter.getKey() + ":" + parameter.getValue());
+            for (String header : headers) {
+                for (OAuth.Parameter parameter : OAuthMessage.decodeAuthorization(header)) {
                     if (!"realm".equalsIgnoreCase(parameter.getKey())) {
-                        list.add(parameter);
+                        parameters.add(parameter);
                     }
                 }
             }
         }
 
-        // we can't call getFormParameters when it's a PUT and not a form.
-        if (request.getHttpMethod().equals("PUT") && !request.getHttpHeaders().getMediaType().isCompatible(
-            MediaType.valueOf("application/x-www-form-urlencoded"))) {
-            return list;
+        if (request.getHttpMethod() == null) {
+            log.debug("Not adding form parameters due to null HTTP method");
+            return parameters;
         }
 
+        MediaType requestMediaType = request.getHttpHeaders().getMediaType();
+        if (requestMediaType == null) {
+            log.debug("Not adding form parameters due to missing Content-Type");
+            return parameters;
+        }
+
+        // HttpRequest.getFormParameters requires that the request content-type is compatible with
+        // application/x-www-form-urlencoded or else we will run into an IllegalArgumentException.
+        if (!requestMediaType.isCompatible(MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
+            log.debug("Not adding form parameters due to incompatible Content-Type");
+            return parameters;
+        }
+
+        // Add all of the form parameters
         for (Map.Entry<String, List<String>> entry : request.getFormParameters().entrySet()) {
             String name = entry.getKey();
             for (String value : entry.getValue()) {
-                list.add(new OAuth.Parameter(name, value));
+                parameters.add(new OAuth.Parameter(name, value));
             }
         }
 
-        return list;
+        return parameters;
     }
 }

--- a/src/test/java/org/candlepin/resteasy/filter/RestEasyOAuthMessageTest.java
+++ b/src/test/java/org/candlepin/resteasy/filter/RestEasyOAuthMessageTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2009 - 2026 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.resteasy.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.candlepin.test.TestUtil;
+
+import net.oauth.OAuth.Parameter;
+
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.ws.rs.core.MediaType;
+
+public class RestEasyOAuthMessageTest {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String URL = "http://localhost/candlepin/status";
+
+    private static Set<String> httpMethods() {
+        return Set.of("DELETE", "GET", "HEAD", "PATCH", "POST", "PUT");
+    }
+
+    @ParameterizedTest
+    @MethodSource("httpMethods")
+    public void testGetParametersWithNullHTTPMethod(String verb) throws Exception {
+        MockHttpRequest request = MockHttpRequest.create(verb, URL);
+        request.contentType(MediaType.valueOf(MediaType.APPLICATION_FORM_URLENCODED));
+        request.header(AUTHORIZATION_HEADER, "OAuth oauth_consumer_key=\"testing\", oauth_version=\"1.0\"");
+
+        // Form parameters that should not be returned
+        request.addFormHeader(TestUtil.randomString("key-"), TestUtil.randomString("value-"));
+        request.addFormHeader(TestUtil.randomString("key-"), TestUtil.randomString("value-"));
+
+        request.setHttpMethod(null);
+
+        List<Parameter> actual = RestEasyOAuthMessage.getParameters(request);
+
+        assertThat(actual)
+            .isNotNull()
+            .hasSize(2)
+            .contains(new Parameter("oauth_consumer_key", "testing"))
+            .contains(new Parameter("oauth_version", "1.0"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("httpMethods")
+    public void testGetParametersWithNullContentType(String verb) throws Exception {
+        MockHttpRequest request = MockHttpRequest.create(verb, URL);
+        request.header(AUTHORIZATION_HEADER, "OAuth oauth_consumer_key=\"testing\", oauth_version=\"1.0\"");
+
+        // Form parameters that should not be returned
+        request.addFormHeader(TestUtil.randomString("key-"), TestUtil.randomString("value-"));
+        request.addFormHeader(TestUtil.randomString("key-"), TestUtil.randomString("value-"));
+
+        request.contentType((MediaType) null);
+
+        List<Parameter> actual = RestEasyOAuthMessage.getParameters(request);
+
+        assertThat(actual)
+            .isNotNull()
+            .hasSize(2)
+            .contains(new Parameter("oauth_consumer_key", "testing"))
+            .contains(new Parameter("oauth_version", "1.0"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("httpMethods")
+    public void testGetParameters(String verb) throws Exception {
+        MockHttpRequest request = MockHttpRequest.create(verb, URL);
+        request.contentType(MediaType.valueOf(MediaType.APPLICATION_FORM_URLENCODED));
+
+        List<Parameter> expectedParams = new ArrayList<>();
+        expectedParams.add(new Parameter(TestUtil.randomString("key-"), TestUtil.randomString("value-")));
+        expectedParams.add(new Parameter(TestUtil.randomString("key-"), TestUtil.randomString("value-")));
+        expectedParams.add(new Parameter(TestUtil.randomString("key-"), TestUtil.randomString("value-")));
+        expectedParams.add(new Parameter(TestUtil.randomString("key-"), TestUtil.randomString("value-")));
+
+        for (Parameter parameter : expectedParams) {
+            request.addFormHeader(parameter.getKey(), parameter.getValue());
+        }
+
+        // Add Authorization header and OAuth parameters. Realm parameter should not be returned.
+        String authValue = "OAuth realm=\"realm\", oauth_consumer_key=\"key\", oauth_version=\"2.0\"";
+        request.header(AUTHORIZATION_HEADER, authValue);
+        expectedParams.add(new Parameter("oauth_consumer_key", "key"));
+        expectedParams.add(new Parameter("oauth_version", "2.0"));
+
+        List<Parameter> actual = RestEasyOAuthMessage.getParameters(request);
+
+        assertThat(actual)
+            .isNotNull()
+            .containsExactlyInAnyOrderElementsOf(expectedParams);
+    }
+
+    @ParameterizedTest
+    @MethodSource("httpMethods")
+    public void testGetParametersWithIncompatibleMediaType(String verb) throws Exception {
+        MockHttpRequest request = MockHttpRequest.create(verb, URL);
+
+        // Set the Incompatible content type
+        request.contentType(MediaType.valueOf(MediaType.APPLICATION_JSON));
+
+        String authValue = "OAuth oauth_consumer_key=\"testing\", oauth_version=\"1.0\"";
+        request.header(AUTHORIZATION_HEADER, authValue);
+
+        // Form parameters that should not be returned
+        request.addFormHeader(TestUtil.randomString("key-"), TestUtil.randomString("value-"));
+        request.addFormHeader(TestUtil.randomString("key-"), TestUtil.randomString("value-"));
+
+        List<Parameter> actual = RestEasyOAuthMessage.getParameters(request);
+
+        assertThat(actual)
+            .isNotNull()
+            .hasSize(2)
+            .contains(new Parameter("oauth_consumer_key", "testing"))
+            .contains(new Parameter("oauth_version", "1.0"));
+    }
+
+}
+


### PR DESCRIPTION
- When upgrading our RESTEasy libraries, we introduced a behavioral change to the HttpRequest.getFormParameters() method where POST request are now required to be compatible with the application/x-www-form-urlencoded content-type. RestEasyOAuthMessage.getParameters() is updated to verify the content-type compatibility before getting the form parameters.