### PR TITLE
[M] CANDLEPIN-1270: Improved OAuth spec tests

### DIFF
--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClientFactory.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/ApiClientFactory.java
@@ -144,11 +144,9 @@ public class ApiClientFactory {
         return apiClient;
     }
 
-    public ApiClient createOauthClient(
-        String oauthConsumer, String oauthSecret) {
+    public ApiClient createOauthClient(String oauthConsumer, String oauthSecret) {
         ApiClient apiClient = createDefaultClient();
-        apiClient.setHttpClient(createOkHttpClient(
-            new OauthInterceptor(oauthConsumer, oauthSecret)));
+        apiClient.setHttpClient(createOkHttpClient(new OauthInterceptor(oauthConsumer, oauthSecret)));
 
         return apiClient;
     }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Request.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/client/request/Request.java
@@ -39,6 +39,18 @@ import java.util.stream.Collectors;
  */
 public class Request {
 
+    public static enum Method {
+        GET,
+        HEAD,
+        POST,
+        PUT,
+        DELETE,
+        CONNECT,
+        OPTIONS,
+        TRACE,
+        PATCH
+    }
+
     private static final Pattern PATH_PARAM_REGEX = Pattern.compile("\\{([^}]+)\\}");
 
     private static final String CONTENT_TYPE_HEADER = "Content-Type";
@@ -48,7 +60,7 @@ public class Request {
 
     private String basePath;
     private String endpoint;
-    private String method;
+    private Method method;
     private Object body;
 
     private Map<String, String> pathParams;
@@ -121,16 +133,22 @@ public class Request {
     }
 
     /**
-     * Sets the HTTP method, or verb, to use for this request. If the method is not explicitly set,
-     * it will default to "GET".
+     * Sets the HTTP method, or verb, to use for this request.
      *
      * @param method
      *  the HTTP method to use for this request, such as GET, PUT, DELETE, etc.
      *
+     * @throws IllegalArgumentException
+     *  if the provided method is null
+     *
      * @return
      *  a reference to this Request
      */
-    public Request setMethod(String method) {   // TODO: change to an enum
+    public Request setMethod(Method method) {
+        if (method == null) {
+            throw new IllegalArgumentException("method is null");
+        }
+
         this.method = method;
         return this;
     }
@@ -320,7 +338,8 @@ public class Request {
     }
 
     /**
-     * Executes this request synchronously, returning the response as a container object.
+     * Executes this request synchronously, returning the response as a container object. If the request
+     * method (or HTTP verb) has not yet been set, the request will be sent as a GET request.
      * <p></p>
      * <strong>Note:</strong> This method will <strong>not</strong> throw an exception as a result
      * of a non-200 response code.
@@ -336,11 +355,11 @@ public class Request {
             throw new IllegalStateException("endpoint has not been set");
         }
 
+        String method = (this.method != null ? this.method : Method.GET).toString();
+
         // Translate the bits we need to translate...
         String path = PATH_PARAM_REGEX.matcher(this.endpoint)
             .replaceAll((match) -> this.pathParams.getOrDefault(match.group(1), ""));
-
-        String method = this.method != null ? this.method : "GET";
 
         List<Pair> qparams = this.queryParams.entrySet()
             .stream()
@@ -354,7 +373,7 @@ public class Request {
 
         try {
             Call call = this.client.buildCall(this.basePath, path, method, qparams, List.of(), this.body,
-                this.headers, Map.of(), Map.of(), new String[] {  }, null);
+                this.headers, Map.of(), Map.of(), new String[] {}, null);
 
             return new Response(call.execute());
         }

--- a/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ExportGenerator.java
+++ b/spec-tests/src/main/java/org/candlepin/spec/bootstrap/data/builder/ExportGenerator.java
@@ -279,7 +279,7 @@ public class ExportGenerator {
 
         Request request = Request.from(this.client)
             .setPath(MANIFEST_GENERATOR_ENDPOINT)
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .setBody(body);
 
         // Add in optional query bits

--- a/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/CloudRegistrationSpecTest.java
@@ -671,7 +671,7 @@ class CloudRegistrationSpecTest {
         // the GSON serializer being helpful and throwing out null values on our behalf against our wishes.
         Response response = Request.from(ApiClients.bearerToken(cloudAuthDTO.getToken()))
             .setPath("/consumers")
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .setBody(ApiClient.MAPPER.writeValueAsString(consumer))
             .execute();
 
@@ -714,7 +714,7 @@ class CloudRegistrationSpecTest {
         // the GSON serializer being helpful and throwing out null values on our behalf against our wishes.
         Response response = Request.from(ApiClients.bearerToken(cloudAuthDTO.getToken()))
             .setPath("/consumers")
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .setBody(ApiClient.MAPPER.writeValueAsString(consumer))
             .execute();
 

--- a/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
@@ -632,7 +632,7 @@ public class OwnerProductResourceSpecTest {
         Response response = Request.from(client)
             .setPath("/owners/{owner_key}/products")
             .setPathParam("owner_key", owner.getKey())
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .setBody(productNode.toString())
             .execute();
 
@@ -660,7 +660,7 @@ public class OwnerProductResourceSpecTest {
         Response response = Request.from(client)
             .setPath("/owners/{owner_key}/products")
             .setPathParam("owner_key", owner.getKey())
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .setBody(productNode.toString())
             .execute();
 

--- a/spec-tests/src/test/java/org/candlepin/spec/auth/OauthSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/auth/OauthSpecTest.java
@@ -20,40 +20,50 @@ import static org.candlepin.spec.bootstrap.assertions.StatusCodeAssertions.asser
 import org.candlepin.dto.api.client.v1.ConsumerDTO;
 import org.candlepin.dto.api.client.v1.OwnerDTO;
 import org.candlepin.dto.api.client.v1.UserDTO;
-import org.candlepin.spec.bootstrap.assertions.OnlyInHosted;
 import org.candlepin.spec.bootstrap.client.ApiClient;
 import org.candlepin.spec.bootstrap.client.ApiClients;
 import org.candlepin.spec.bootstrap.client.SpecTest;
+import org.candlepin.spec.bootstrap.client.request.Request;
+import org.candlepin.spec.bootstrap.client.request.Response;
 import org.candlepin.spec.bootstrap.data.builder.Consumers;
 import org.candlepin.spec.bootstrap.data.builder.Owners;
 import org.candlepin.spec.bootstrap.data.builder.Users;
 import org.candlepin.spec.bootstrap.data.util.OAuthUtil;
+import org.candlepin.spec.bootstrap.data.util.StringUtil;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.util.Map;
+
+// TODO: FIXME: Some of these tests have questionable value and don't really seem to test or validate much of
+// anything. They should be pruned or updated as time permits.
 
 @SpecTest
-@OnlyInHosted
 public class OauthSpecTest {
 
     @Test
     public void shouldReturnsAUnauthorizedIfOauthUserIsNotConfigured() {
-        ApiClient oauth = ApiClients.oauth("baduser", "badsecret");
-        assertUnauthorized(() -> oauth.users().listUsers());
+        ApiClient client = ApiClients.oauth("baduser", "badsecret");
+        assertUnauthorized(() -> client.users().listUsers());
     }
 
     @Test
     public void shouldReturnsAUnauthorizedIfOauthSecretDoesNotMatch() {
-        ApiClient oauth = ApiClients.oauth(OAuthUtil.CONSUMER_KEY, "badsecret");
-        assertUnauthorized(() -> oauth.users().listUsers());
+        ApiClient client = ApiClients.oauth(OAuthUtil.CONSUMER_KEY, "badsecret");
+        assertUnauthorized(() -> client.users().listUsers());
     }
 
     @Test
     public void shouldLetACallerActAsAUser() {
         ApiClient adminClient = ApiClients.admin();
         UserDTO user = adminClient.users().createUser(Users.random());
-        ApiClient oauthUser = ApiClients.oauthUser(
+        ApiClient oauthClient = ApiClients.oauthUser(
             OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET, user.getUsername());
-        UserDTO userInfo = oauthUser.users().getUserInfo(user.getUsername());
+        UserDTO userInfo = oauthClient.users().getUserInfo(user.getUsername());
         assertThat(userInfo)
             .isEqualTo(user);
     }
@@ -63,9 +73,9 @@ public class OauthSpecTest {
         ApiClient adminClient = ApiClients.admin();
         OwnerDTO owner = adminClient.owners().createOwner(Owners.random());
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
-        ApiClient oauthConsumer = ApiClients.oauthConsumer(
+        ApiClient oauthClient = ApiClients.oauthConsumer(
             OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET, consumer.getUuid());
-        ConsumerDTO consumerFromServer = oauthConsumer.consumers().getConsumer(consumer.getUuid());
+        ConsumerDTO consumerFromServer = oauthClient.consumers().getConsumer(consumer.getUuid());
         assertThat(consumerFromServer)
             .isNotNull()
             .returns(consumer.getId(), ConsumerDTO::getId);
@@ -76,18 +86,316 @@ public class OauthSpecTest {
         ApiClient adminClient = ApiClients.admin();
         OwnerDTO owner = adminClient.owners().createOwner(Owners.random());
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
-        ApiClient oauthConsumer = ApiClients.oauthConsumer(
+        ApiClient oauthClient = ApiClients.oauthConsumer(
             OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET, "some unknown consumer");
-        assertUnauthorized(() -> oauthConsumer.consumers().getConsumer(consumer.getUuid()));
+        assertUnauthorized(() -> oauthClient.consumers().getConsumer(consumer.getUuid()));
     }
 
     @Test
     public void shouldFallsBackToTrustedSystemAuthIfNoHeadersAreSet() {
         ApiClient adminClient = ApiClients.admin();
         OwnerDTO owner = adminClient.owners().createOwner(Owners.random());
-        ApiClient oauth = ApiClients.oauth(OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET);
-        OwnerDTO ownerFromServer = oauth.owners().getOwner(owner.getKey());
+        ApiClient oauthClient = ApiClients.oauth(OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET);
+        OwnerDTO ownerFromServer = oauthClient.owners().getOwner(owner.getKey());
         assertThat(ownerFromServer)
             .isEqualTo(owner);
+    }
+
+    // These tests verify that the oauth interceptor still functions as expected with various types of
+    // requests and inputs. Because our target is the interceptor and not the underlying request itself,
+    // these tests are free to include any arbitrary query params or body, even if the target endpoint
+    // won't recognize them or otherwise do anything with the data. So long as the endpoint returns a
+    // success, we know the oauth interceptor properly signed and cleared the request.
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    public class OAuthRequestTests {
+
+        private ApiClient adminClient;
+        private ApiClient oauthClient;
+        private UserDTO clientUserDto;
+
+        @BeforeAll
+        public void setup() throws Exception {
+            this.adminClient = ApiClients.admin();
+            this.clientUserDto = adminClient.users().createUser(new UserDTO()
+                .username(StringUtil.random("oauth_superadmin_user"))
+                .password("password")
+                .superAdmin(true));
+
+            this.oauthClient = ApiClients.oauthUser(OAuthUtil.CONSUMER_KEY, OAuthUtil.CONSUMER_SECRET,
+                this.clientUserDto.getUsername());
+        }
+
+        @Test
+        public void shouldAllowSimpleDeleteRequests() {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.DELETE)
+                .setPath("/owners/{owner_key}")
+                .setPathParam("owner_key", owner.getKey())
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowDeleteRequestsWithQueryParams() {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.DELETE)
+                .setPath("/owners/{owner_key}")
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("p1", "v1")
+                .addQueryParam("p2", "v2")
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowSimpleGetRequests() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.GET)
+                .setPath("/owners/{owner_key}")
+                .setPathParam("owner_key", owner.getKey())
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowGetRequestsWithQueryParams() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.GET)
+                .setPath("/owners/{owner_key}")
+                .setPathParam("owner_key", owner.getKey())
+                .addQueryParam("p1", "v1")
+                .addQueryParam("p2", "v2")
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowSimpleHeadRequests() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            ConsumerDTO consumer = this.adminClient.consumers()
+                .createConsumer(Consumers.random(owner));
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.HEAD)
+                .setPath("/consumers/{consumer_uuid}/exists")
+                .setPathParam("consumer_uuid", consumer.getUuid())
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowHeadRequestsWithQueryParams() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            ConsumerDTO consumer = this.adminClient.consumers()
+                .createConsumer(Consumers.random(owner));
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.HEAD)
+                .setPath("/consumers/{consumer_uuid}/exists")
+                .setPathParam("consumer_uuid", consumer.getUuid())
+                .addQueryParam("p1", "v1")
+                .addQueryParam("p2", "v2")
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowSimplePostRequests() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            ConsumerDTO consumer = this.adminClient.consumers()
+                .createConsumer(Consumers.random(owner));
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.POST)
+                .setPath("/consumers/{consumer_uuid}")
+                .setPathParam("consumer_uuid", consumer.getUuid())
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowPostRequestsWithQueryParams() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            ConsumerDTO consumer = this.adminClient.consumers()
+                .createConsumer(Consumers.random(owner));
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.POST)
+                .setPath("/consumers/{consumer_uuid}")
+                .setPathParam("consumer_uuid", consumer.getUuid())
+                .addQueryParam("p1", "v1")
+                .addQueryParam("p2", "v2")
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowPostRequestsWithRequestBody() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            ConsumerDTO consumer = this.adminClient.consumers()
+                .createConsumer(Consumers.random(owner));
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.POST)
+                .setPath("/consumers/{consumer_uuid}")
+                .setPathParam("consumer_uuid", consumer.getUuid())
+                .setBody(Map.of("b1", "v1", "b2", "v2"))
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowPostRequestsWithRequestBodyAndQueryParams() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            ConsumerDTO consumer = this.adminClient.consumers()
+                .createConsumer(Consumers.random(owner));
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.POST)
+                .setPath("/consumers/{consumer_uuid}")
+                .setPathParam("consumer_uuid", consumer.getUuid())
+                .addQueryParam("p1", "v1")
+                .addQueryParam("p2", "v2")
+                .setBody(Map.of("b1", "v1", "b2", "v2"))
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowSimplePutRequests() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            ConsumerDTO consumer = this.adminClient.consumers()
+                .createConsumer(Consumers.random(owner));
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.PUT)
+                .setPath("/consumers/{consumer_uuid}/certificates")
+                .setPathParam("consumer_uuid", consumer.getUuid())
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowPutRequestsWithQueryParams() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            ConsumerDTO consumer = this.adminClient.consumers()
+                .createConsumer(Consumers.random(owner));
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.PUT)
+                .setPath("/consumers/{consumer_uuid}/certificates")
+                .setPathParam("consumer_uuid", consumer.getUuid())
+                .addQueryParam("p1", "v1")
+                .addQueryParam("p2", "v2")
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowPutRequestsWithRequestBody() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            ConsumerDTO consumer = this.adminClient.consumers()
+                .createConsumer(Consumers.random(owner));
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.PUT)
+                .setPath("/consumers/{consumer_uuid}/certificates")
+                .setPathParam("consumer_uuid", consumer.getUuid())
+                .setBody(Map.of("b1", "v1", "b2", "v2"))
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
+
+        @Test
+        public void shouldAllowPutRequestsWithRequestBodyAndQueryParams() throws Exception {
+            OwnerDTO owner = this.adminClient.owners()
+                .createOwner(Owners.random());
+
+            ConsumerDTO consumer = this.adminClient.consumers()
+                .createConsumer(Consumers.random(owner));
+
+            Response response = Request.from(this.oauthClient)
+                .setMethod(Request.Method.PUT)
+                .setPath("/consumers/{consumer_uuid}/certificates")
+                .setPathParam("consumer_uuid", consumer.getUuid())
+                .addQueryParam("p1", "v1")
+                .addQueryParam("p2", "v2")
+                .setBody(Map.of("b1", "v1", "b2", "v2"))
+                .execute();
+
+            assertThat(response)
+                .isNotNull()
+                .returns(true, Response::wasSuccessful);
+        }
     }
 }

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/ConsumerResourceSpecTest.java
@@ -242,7 +242,7 @@ public class ConsumerResourceSpecTest {
         // the GSON serializer being helpful and throwing out null values on our behalf against our wishes.
         Response response = Request.from(this.adminClient)
             .setPath("/consumers")
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .addQueryParam("owner", owner.getKey())
             .setBody(ApiClient.MAPPER.writeValueAsString(consumer))
             .execute();
@@ -278,7 +278,7 @@ public class ConsumerResourceSpecTest {
         // the GSON serializer being helpful and throwing out null values on our behalf against our wishes.
         Response response = Request.from(this.adminClient)
             .setPath("/consumers")
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .addQueryParam("owner", owner.getKey())
             .setBody(ApiClient.MAPPER.writeValueAsString(consumer))
             .execute();
@@ -395,7 +395,7 @@ public class ConsumerResourceSpecTest {
 
         Response response = Request.from(adminClient)
             .setPath("/consumers/{consumer_uuid}")
-            .setMethod("PUT")
+            .setMethod(Request.Method.PUT)
             .setPathParam("consumer_uuid", consumer.getUuid())
             .setBody(objectNode.toString())
             .execute();
@@ -785,7 +785,7 @@ public class ConsumerResourceSpecTest {
         ConsumerDTO consumer = adminClient.consumers().createConsumer(Consumers.random(owner));
         Response response = Request.from(adminClient)
             .setPath("/consumers/{consumer_uuid}/exists")
-            .setMethod("HEAD")
+            .setMethod(Request.Method.HEAD)
             .setPathParam("consumer_uuid", consumer.getUuid())
             .execute();
 
@@ -839,7 +839,7 @@ public class ConsumerResourceSpecTest {
         ConsumerDTO consumer1 = adminClient.consumers().createConsumer(Consumers.random(owner));
         Response response = Request.from(adminClient)
             .setPath("/consumers/exists")
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .setBody(List.of(consumer1.getUuid()))
             .execute();
         assertThat(response.getBody()).isEmpty();

--- a/spec-tests/src/test/java/org/candlepin/spec/consumers/LocalizationSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/consumers/LocalizationSpecTest.java
@@ -35,7 +35,7 @@ public class LocalizationSpecTest {
     public void shouldReturnranslatedErrorMessage() {
         String expectedMessage = "Ungültige Berechtigungsnachweise";
         Request request = Request.from(ApiClients.basic("admin", "badpass"))
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .addHeader("Accept-Language", "de-DE")
             .setPath("/consumers");
         assertThatStatus(request::execute)

--- a/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/ContentAccessSpecTest.java
@@ -252,7 +252,7 @@ public class ContentAccessSpecTest {
         Response response = Request.from(adminClient)
             .setPath("/owners/{owner_key}")
             .setPathParam("owner_key", owner.getKey())
-            .setMethod("PUT")
+            .setMethod(Request.Method.PUT)
             .setBody(ownerNode.toString().getBytes())
             .execute();
 

--- a/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/content/OwnerContentResourceSpecTest.java
@@ -270,7 +270,7 @@ class OwnerContentResourceSpecTest {
         Response response = Request.from(adminClient)
             .setPath("/owners/{owner_key}/content")
             .setPathParam("owner_key", owner.getKey())
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .setBody(jsonNode.toString())
             .execute();
 
@@ -304,7 +304,7 @@ class OwnerContentResourceSpecTest {
         Response response = Request.from(adminClient)
             .setPath("/owners/{owner_key}/content")
             .setPathParam("owner_key", owner.getKey())
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .setBody(jsonNode.toString())
             .execute();
 
@@ -331,7 +331,7 @@ class OwnerContentResourceSpecTest {
         Response response = Request.from(adminClient)
             .setPath("/owners/{owner_key}/content")
             .setPathParam("owner_key", owner.getKey())
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .setBody(jsonNode.toString())
             .execute();
 
@@ -359,7 +359,7 @@ class OwnerContentResourceSpecTest {
         Response response = Request.from(adminClient)
             .setPath("/owners/{owner_key}/content/batch")
             .setPathParam("owner_key", owner.getKey())
-            .setMethod("POST")
+            .setMethod(Request.Method.POST)
             .setBody("[" + jsonNode.toString() + "]")
             .execute();
 

--- a/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/environments/EnvironmentSpecTest.java
@@ -529,7 +529,7 @@ public class EnvironmentSpecTest {
 
             ConsumerDTO consumer = Request.from(ApiClients.noAuth())
                 .setPath("/environments/{env_id}/consumers")
-                .setMethod("POST")
+                .setMethod(Request.Method.POST)
                 .setPathParam("env_id", environment.getId())
                 .addQueryParam("owner", owner.getKey())
                 .addQueryParam("activation_keys", activationKey.getName())


### PR DESCRIPTION
Updated the Request.setMethod method to use enums
- Request.setMethod no longer accepts a string for the method,
  instead requiring use of the new Request.Method enum
- Updated all affected setMethod call sites to use enums instead
  of strings

 CANDLEPIN-1270: Improved OAuth spec tests
- Improved the OAuth spec tests to include a suite of tests to verify
  the OAuth interceptor does not interfere with any type of request
  with or without query params or the request body (where applicable)