### PR TITLE
Fixed manifest imports stuck after concurrent race

### DIFF
--- a/api/candlepin-api-spec.yaml
+++ b/api/candlepin-api-spec.yaml
@@ -6665,7 +6665,7 @@ paths:
 
   /owners/{owner_key}/products/{product_id}/subscriptions:
     put:
-      description: Refreshes Pools by Product
+      description: Refreshes Pools by Product and certificated are regenerated for them immediately.
       tags:
         - owner_product
       operationId: refreshPoolsForProduct
@@ -6683,13 +6683,6 @@ paths:
           required: true
           schema:
             type: string
-        - name: lazy_regen
-          in: query
-          description: Regenerate certificates immediatelly or allow them to be regenerated on demand
-          required: true
-          schema:
-            type: boolean
-            default: true
       responses:
         200:
           description: A successful operation

--- a/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/OwnerProductResourceSpecTest.java
@@ -410,12 +410,12 @@ public class OwnerProductResourceSpecTest {
         pool3.setDerivedProvidedProducts(Set.of(new ProvidedProductDTO().productId(product3.getId())));
         ownerApi.createPool(owner3.getKey(), pool3);
 
-        verifyRefreshPoolJob(owner1.getKey(), prod4.getId(), true);
-        verifyRefreshPoolJob(owner2.getKey(), prod5d.getId(), true);
-        verifyRefreshPoolJob(owner3.getKey(), product1.getId(), true);
-        verifyRefreshPoolJob(owner3.getKey(), product3.getId(), true);
+        verifyRefreshPoolJob(owner1.getKey(), prod4.getId());
+        verifyRefreshPoolJob(owner2.getKey(), prod5d.getId());
+        verifyRefreshPoolJob(owner3.getKey(), product1.getId());
+        verifyRefreshPoolJob(owner3.getKey(), product3.getId());
 
-        assertNotFound(() -> ownerProductApi.refreshPoolsForProduct(owner1.getKey(), "bad_id", true));
+        assertNotFound(() -> ownerProductApi.refreshPoolsForProduct(owner1.getKey(), "bad_id"));
     }
 
     @Test
@@ -746,8 +746,8 @@ public class OwnerProductResourceSpecTest {
         return product;
     }
 
-    private void verifyRefreshPoolJob(String ownerKey, String productId, boolean lazyRegen) {
-        AsyncJobStatusDTO job = ownerProductApi.refreshPoolsForProduct(ownerKey, productId, lazyRegen);
+    private void verifyRefreshPoolJob(String ownerKey, String productId) {
+        AsyncJobStatusDTO job = ownerProductApi.refreshPoolsForProduct(ownerKey, productId);
         assertNotNull(job);
         AsyncJobStatusDTO status = jobsApi.waitForJob(job.getId());
         assertEquals("RefreshPoolsForProductJob", status.getKey());

--- a/spec-tests/src/test/java/org/candlepin/spec/imports/ImportConcurrentRefreshRaceSpecTest.java
+++ b/spec-tests/src/test/java/org/candlepin/spec/imports/ImportConcurrentRefreshRaceSpecTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2009 - 2026 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.spec.imports;
+
+import static org.candlepin.spec.bootstrap.assertions.JobStatusAssert.assertThatJob;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.candlepin.dto.api.client.v1.AsyncJobStatusDTO;
+import org.candlepin.dto.api.client.v1.ContentDTO;
+import org.candlepin.dto.api.client.v1.OwnerDTO;
+import org.candlepin.dto.api.client.v1.ProductContentDTO;
+import org.candlepin.dto.api.client.v1.ProductDTO;
+import org.candlepin.spec.bootstrap.assertions.CandlepinMode;
+import org.candlepin.spec.bootstrap.assertions.OnlyInStandalone;
+import org.candlepin.spec.bootstrap.client.ApiClient;
+import org.candlepin.spec.bootstrap.client.ApiClients;
+import org.candlepin.spec.bootstrap.client.SpecTest;
+import org.candlepin.spec.bootstrap.data.builder.Contents;
+import org.candlepin.spec.bootstrap.data.builder.ExportGenerator;
+import org.candlepin.spec.bootstrap.data.builder.Owners;
+import org.candlepin.spec.bootstrap.data.builder.Products;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+
+
+/**
+ * Reproduces the concurrent manifest import race: two or
+ * more organizations importing manifests that reference the same new shared product/content data can race
+ * to create that data during their respective pool refreshes, causing a database deadlock or constraint
+ * violation.
+ * <p></p>
+ * Before the fix, one side of that race was marked as a terminal, non-retryable import failure,
+ * permanently stranding that organization with unrefreshed pools. This test asserts that every
+ * concurrent import eventually finishes successfully, regardless of whether it lost the race.
+ */
+@SpecTest
+@OnlyInStandalone
+public class ImportConcurrentRefreshRaceSpecTest {
+
+    private static final int CONCURRENT_IMPORTS = 6;
+
+    private static ApiClient adminClient;
+
+    @BeforeAll
+    public static void beforeAll() {
+        assumeTrue(CandlepinMode::hasManifestGenTestExtension);
+
+        adminClient = ApiClients.admin();
+    }
+
+    @Test
+    public void shouldConcurrentImportsOfSharedNewProductEventuallySucceed() throws Exception {
+        ContentDTO content = Contents.random();
+        ProductDTO product = Products.random()
+            .addProductContentItem(new ProductContentDTO().content(content).enabled(true));
+
+        List<OwnerDTO> owners = new ArrayList<>();
+        List<File> manifests = new ArrayList<>();
+
+        for (int i = 0; i < CONCURRENT_IMPORTS; i++) {
+            owners.add(adminClient.owners().createOwner(Owners.random()));
+
+            manifests.add(new ExportGenerator().addProduct(product).export());
+        }
+
+        List<Callable<AsyncJobStatusDTO>> tasks = new ArrayList<>();
+        for (int i = 0; i < CONCURRENT_IMPORTS; i++) {
+            OwnerDTO owner = owners.get(i);
+            File manifest = manifests.get(i);
+
+            tasks.add(() -> adminClient.owners()
+                .importManifestAsync(owner.getKey(), List.of(), manifest));
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_IMPORTS);
+        List<Future<AsyncJobStatusDTO>> futures = executor.invokeAll(tasks);
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(1, TimeUnit.MINUTES));
+
+        for (Future<AsyncJobStatusDTO> future : futures) {
+            assertThatJob(future.get())
+                .terminates(adminClient)
+                .isFinished()
+                .contains("SUCCESS");
+        }
+    }
+
+}

--- a/src/main/java/org/candlepin/async/JobExecutionContext.java
+++ b/src/main/java/org/candlepin/async/JobExecutionContext.java
@@ -75,6 +75,18 @@ public class JobExecutionContext {
     }
 
     /**
+     * Returns whether this is the last attempt for the executing job. This is true when the current
+     * attempt number equals the maximum number of attempts, meaning no further retries will occur
+     * if this attempt fails with a non-terminal exception.
+     *
+     * @return
+     *  true if this is the last attempt; false otherwise
+     */
+    public boolean isLastAttempt() {
+        return this.job.getAttempts() >= this.job.getMaxAttempts();
+    }
+
+    /**
      * Sets the specified formatted string as the result of the job's execution.
      *
      * @param format

--- a/src/main/java/org/candlepin/async/tasks/ImportJob.java
+++ b/src/main/java/org/candlepin/async/tasks/ImportJob.java
@@ -35,6 +35,8 @@ import org.candlepin.sync.Importer;
 import org.candlepin.sync.ImporterException;
 import org.candlepin.sync.file.ManifestFileService;
 
+import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.exception.LockAcquisitionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +61,8 @@ public class ImportJob implements AsyncJob {
     protected static final String CONFLICT_OVERRIDES_KEY = "conflict_overrides";
     protected static final String UPLOADED_FILE_NAME_KEY = "uploaded_file_name";
 
+    private static final int IMPORT_RETRY_COUNT = 4;
+
     /**
      * Job configuration object for the import job
      */
@@ -66,7 +70,8 @@ public class ImportJob implements AsyncJob {
         public ImportJobConfig() {
             this.setJobKey(JOB_KEY)
                 .setJobName(JOB_NAME)
-                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY));
+                .addConstraint(JobConstraints.uniqueByArguments(OWNER_KEY))
+                .setRetryCount(IMPORT_RETRY_COUNT);
         }
 
         /**
@@ -248,22 +253,54 @@ public class ImportJob implements AsyncJob {
             caught = e;
         }
         catch (ImporterException e) {
-            toThrow = new JobExecutionException(e.getMessage(), e, true);
+            // A constraint violation or deadlock nested inside the import's transaction (two orgs
+            // racing to create the same shared product/content during a concurrent refresh)
+            // poisons that transaction outright; retrying inside it can't work. The whole import
+            // needs to be retried from scratch with a fresh transaction, so treat this specific
+            // cause as non-terminal instead of the usual (terminal) importer failure.
+            boolean transientRace = isCausedByTransientRace(e);
+            toThrow = new JobExecutionException(e.getMessage(), e, !transientRace);
             caught = e;
         }
         catch (Exception e) {
-            toThrow = new JobExecutionException(e.getMessage(), e, false);
+            boolean transientRace = isCausedByTransientRace(e);
+            toThrow = new JobExecutionException(e.getMessage(), e, !transientRace);
             caught = e;
         }
 
         manifestManager.recordImportFailure(targetOwner, caught, uploadedFileName);
 
-        // If an exception was thrown, the importer's transaction was rolled
-        // back. We want to make sure that the file gets deleted so that it
-        // doesn't take up disk space. It may be possible that the file was
-        // already deleted, but we attempt it anyway.
-        manifestManager.deleteStoredManifest(storedFileId);
+        // If this failure is terminal, or if the job has exhausted all retry attempts, the stored
+        // manifest file must be deleted so that it doesn't take up disk space. If the failure is
+        // non-terminal and retries remain, the job will be retried and needs the file to still be
+        // there.
+        if (toThrow.isTerminal() || context.isLastAttempt()) {
+            manifestManager.deleteStoredManifest(storedFileId);
+        }
+
         throw toThrow;
+    }
+
+    /**
+     * Checks whether the given exception's cause chain contains a transient constraint violation
+     * or deadlock, indicating the import failed only because it collided with another concurrent
+     * refresh of shared product or content data, rather than a genuine problem with the manifest.
+     *
+     * @param exception
+     *  the exception to inspect
+     *
+     * @return
+     *  true if the exception was caused by a transient constraint violation or deadlock; false
+     *  otherwise
+     */
+    private static boolean isCausedByTransientRace(Throwable exception) {
+        for (Throwable cause = exception; cause != null; cause = cause.getCause()) {
+            if (cause instanceof ConstraintViolationException || cause instanceof LockAcquisitionException) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/main/java/org/candlepin/async/tasks/RefreshPoolsForProductJob.java
+++ b/src/main/java/org/candlepin/async/tasks/RefreshPoolsForProductJob.java
@@ -20,10 +20,14 @@ import org.candlepin.async.JobArguments;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
 import org.candlepin.controller.RefresherFactory;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.service.SubscriptionServiceAdapter;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.exception.LockAcquisitionException;
 
 import java.util.Objects;
 
@@ -35,8 +39,9 @@ public class RefreshPoolsForProductJob implements AsyncJob {
     public static final String JOB_KEY = "RefreshPoolsForProductJob";
     public static final String JOB_NAME = "Refresh Pools For Product";
 
-    private static final String LAZY_KEY = "lazy_regen";
     private static final String PRODUCT_KEY = "product_key";
+
+    private static final int REFRESH_RETRY_COUNT = 4;
 
     private final ProductCurator productCurator;
     private final SubscriptionServiceAdapter subAdapter;
@@ -55,32 +60,59 @@ public class RefreshPoolsForProductJob implements AsyncJob {
     }
 
     @Override
-    public void execute(final JobExecutionContext context) {
+    public void execute(final JobExecutionContext context) throws JobExecutionException {
         final JobArguments args = context.getJobArguments();
 
         final String productUuid = args.getAsString(PRODUCT_KEY);
-        final Boolean lazy = args.getAsBoolean(LAZY_KEY);
         final StringBuilder result = new StringBuilder();
 
-        final Product product = this.productCurator.get(productUuid);
+        try {
+            final Product product = this.productCurator.get(productUuid);
 
-        if (product != null) {
-            this.refresherFactory.getRefresher(this.subAdapter)
-                .setLazyCertificateRegeneration(true)
-                .add(product)
-                .run();
+            if (product != null) {
+                this.refresherFactory.getRefresher(this.subAdapter)
+                    .setLazyCertificateRegeneration(true)
+                    .add(product)
+                    .run();
 
-            result.append("Pools refreshed for product: ")
-                .append(productUuid)
-                .append("\n");
+                result.append("Pools refreshed for product: ")
+                    .append(productUuid)
+                    .append("\n");
+            }
+            else {
+                result.append("Unable to refresh pools for product \"")
+                    .append(productUuid)
+                    .append("\": Could not find a product with the specified UUID");
+            }
+
+            context.setJobResult(result.toString());
         }
-        else {
-            result.append("Unable to refresh pools for product \"")
-                .append(productUuid)
-                .append("\": Could not find a product with the specified UUID");
+        catch (Exception e) {
+            boolean transientRace = isCausedByTransientRace(e);
+            throw new JobExecutionException(e.getMessage(), e, !transientRace);
+        }
+    }
+
+    /**
+     * Checks whether the given exception's cause chain contains a transient constraint violation
+     * or deadlock, indicating the job failed only because it collided with another concurrent
+     * operation, rather than a genuine problem.
+     *
+     * @param exception
+     *  the exception to inspect
+     *
+     * @return
+     *  true if the exception was caused by a transient constraint violation or deadlock; false
+     *  otherwise
+     */
+    private static boolean isCausedByTransientRace(Throwable exception) {
+        for (Throwable cause = exception; cause != null; cause = cause.getCause()) {
+            if (cause instanceof ConstraintViolationException || cause instanceof LockAcquisitionException) {
+                return true;
+            }
         }
 
-        context.setJobResult(result.toString());
+        return false;
     }
 
     /**
@@ -102,17 +134,13 @@ public class RefreshPoolsForProductJob implements AsyncJob {
 
         RefreshPoolsForProductJobConfig() {
             this.setJobKey(JOB_KEY)
-                .setJobName(JOB_NAME);
+                .setJobName(JOB_NAME)
+                .setRetryCount(REFRESH_RETRY_COUNT);
         }
 
         public RefreshPoolsForProductJobConfig setProduct(final Product product) {
             final String uuid = Objects.requireNonNull(product).getUuid();
             this.setJobArgument(PRODUCT_KEY, uuid);
-            return this;
-        }
-
-        public RefreshPoolsForProductJobConfig setLazy(final boolean lazy) {
-            this.setJobArgument(LAZY_KEY, lazy);
             return this;
         }
 
@@ -124,17 +152,12 @@ public class RefreshPoolsForProductJob implements AsyncJob {
                 final JobArguments args = this.getJobArguments();
 
                 final String productUuid = args.getAsString(PRODUCT_KEY);
-                final Boolean lazy = args.getAsBoolean(LAZY_KEY);
 
                 if (productUuid == null || productUuid.isEmpty()) {
                     final String errmsg = "Product UUID has not been set";
                     throw new JobConfigValidationException(errmsg);
                 }
 
-                if (lazy == null) {
-                    final String errmsg = "Lazy flag has not been set";
-                    throw new JobConfigValidationException(errmsg);
-                }
             }
             catch (ArgumentConversionException e) {
                 final String errmsg = "One or more required arguments are of the wrong type";

--- a/src/main/java/org/candlepin/controller/Refresher.java
+++ b/src/main/java/org/candlepin/controller/Refresher.java
@@ -14,7 +14,6 @@
  */
 package org.candlepin.controller;
 
-import org.candlepin.controller.util.ExpectedExceptionRetryWrapper;
 import org.candlepin.model.Owner;
 import org.candlepin.model.OwnerCurator;
 import org.candlepin.model.Pool;
@@ -26,8 +25,6 @@ import org.candlepin.service.exception.subscription.SubscriptionServiceException
 import org.candlepin.service.model.OwnerInfo;
 import org.candlepin.service.model.SubscriptionInfo;
 
-import org.hibernate.exception.ConstraintViolationException;
-import org.hibernate.exception.LockAcquisitionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,12 +43,6 @@ import java.util.Set;
 
 public class Refresher {
     private static final Logger log = LoggerFactory.getLogger(Refresher.class);
-
-    /**
-     * The number of times to retry the refresh operation if it fails as a result of a constraint
-     * violation.
-     */
-    private static final int CONSTRAINT_VIOLATION_RETRIES = 4;
 
     private final PoolManager poolManager;
     private final SubscriptionServiceAdapter subAdapter;
@@ -160,16 +151,16 @@ public class Refresher {
                 }
             };
 
-            // Retry this operation if we hit a unique constraint violation (two orgs creating the
-            // same products or content in simultaneous transactions), or we deadlock (same deal,
-            // but in a spicy entity order).
-            new ExpectedExceptionRetryWrapper()
-                .addException(ConstraintViolationException.class)
-                .addException(LockAcquisitionException.class)
-                .retries(CONSTRAINT_VIOLATION_RETRIES)
-                .execute(() -> this.poolCurator.transactional()
-                    .allowExistingTransactions()
-                    .execute(refreshTask));
+            // Impl note:
+            // We used to retry ConstraintViolationException and LockAcquisitionException here,
+            // but this method already runs inside an existing transaction. After one of these
+            // errors the transaction is aborted, so retrying here only fails again.
+            //
+            // Retry has to start with a new transaction, so it is now handled by the calling
+            // job. Let the exception propagate.
+            this.poolCurator.transactional()
+                .allowExistingTransactions()
+                .execute(refreshTask);
         }
     }
 

--- a/src/main/java/org/candlepin/resource/OwnerProductResource.java
+++ b/src/main/java/org/candlepin/resource/OwnerProductResource.java
@@ -712,7 +712,7 @@ public class OwnerProductResource implements OwnerProductApi {
 
     @Override
     @Transactional
-    public AsyncJobStatusDTO refreshPoolsForProduct(String ownerKey, String productId, Boolean lazyRegen) {
+    public AsyncJobStatusDTO refreshPoolsForProduct(String ownerKey, String productId) {
         if (config.getBoolean(ConfigProperties.STANDALONE)) {
             log.warn("Ignoring refresh pools request due to standalone config.");
             return null;
@@ -721,8 +721,7 @@ public class OwnerProductResource implements OwnerProductApi {
         Owner owner = this.getOwnerByKey(ownerKey);
         Product product = this.resolveProductId(owner, productId, null);
         JobConfig config = RefreshPoolsForProductJob.createJobConfig()
-            .setProduct(product)
-            .setLazy(lazyRegen);
+            .setProduct(product);
 
         try {
             AsyncJobStatus status = jobManager.queueJob(config);

--- a/src/main/java/org/candlepin/sync/Importer.java
+++ b/src/main/java/org/candlepin/sync/Importer.java
@@ -318,7 +318,14 @@ public class Importer {
     }
 
     public void recordImportFailure(Owner owner, Throwable error, String filename) {
-        ImportRecord record = new ImportRecord(owner);
+        // Impl note:
+        // The provided owner may have been loaded in a session/transaction that's since been rolled
+        // back (e.g. the import failed due to a deadlock or constraint violation on a shared
+        // product/content row). Its lazy associations, such as the upstream consumer, can no longer
+        // be initialized from that stale session, so we re-fetch a fresh copy before touching them.
+        Owner refreshedOwner = owner != null ? this.ownerCurator.get(owner.getId()) : null;
+
+        ImportRecord record = new ImportRecord(refreshedOwner);
         log.error("Recording import failure", error);
 
         if (error instanceof ImporterException) {
@@ -328,7 +335,7 @@ public class Importer {
                 record.setGeneratedDate(meta.getCreated());
             }
         }
-        record.setUpstreamConsumer(createImportUpstreamConsumer(owner, null));
+        record.setUpstreamConsumer(createImportUpstreamConsumer(refreshedOwner, null));
         record.setFileName(filename);
 
         record.recordStatus(ImportRecord.Status.FAILURE, error.getMessage());

--- a/src/test/java/org/candlepin/async/tasks/ImportJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/ImportJobTest.java
@@ -19,11 +19,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -49,9 +51,13 @@ import org.candlepin.sync.Importer;
 import org.candlepin.sync.ImporterException;
 import org.candlepin.test.TestUtil;
 
+import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.exception.LockAcquisitionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -275,8 +281,139 @@ public class ImportJobTest {
         Exception e = assertThrows(JobExecutionException.class, () -> job.execute(context));
         assertEquals(expectedMessage, e.getMessage());
         verify(manifestManager).recordImportFailure(eq(owner), eq(e.getCause()), eq(uploadedFileName));
+        assertTrue(((JobExecutionException) e).isTerminal());
+        verify(manifestManager).deleteStoredManifest(archiveFilePath);
     }
 
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @ValueSource(classes = {ConstraintViolationException.class, LockAcquisitionException.class})
+    public void testJobFailureIsNonTerminalWhenCausedByTransientRace(
+        Class<? extends Exception> exceptionClass) throws Exception {
+
+        Owner owner = this.createTestOwner("my-test-owner", "info");
+        doReturn(owner).when(ownerCurator).getByKey("my-test-owner");
+
+        String archiveFilePath = "/path/to/some/file.zip";
+        ConflictOverrides co = new ConflictOverrides(Importer.Conflict.SIGNATURE_CONFLICT);
+        String uploadedFileName = "test.zip";
+        String expectedMessage = "Expected Exception Message";
+
+        JobConfig jobConfig = ImportJob.createJobConfig()
+            .setOwner(owner)
+            .setUploadedFileName(uploadedFileName)
+            .setStoredFileId(archiveFilePath)
+            .setConflictOverrides(co);
+
+        ImportJob job = this.buildImportJob();
+
+        AsyncJobStatus status = mock(AsyncJobStatus.class);
+        JobExecutionContext context = spy(new JobExecutionContext(status));
+        doReturn(jobConfig.getJobArguments()).when(status).getJobArguments();
+
+        doReturn(1).when(status).getAttempts();
+        doReturn(4).when(status).getMaxAttempts();
+
+        Exception cause;
+        if (exceptionClass == ConstraintViolationException.class) {
+            cause = new ConstraintViolationException(expectedMessage, null, null);
+        }
+        else {
+            cause = new LockAcquisitionException(expectedMessage, null);
+        }
+
+        when(manifestManager.importStoredManifest(eq(owner), eq(archiveFilePath),
+            any(ConflictOverrides.class), eq(uploadedFileName)))
+            .thenThrow(new ImporterException(expectedMessage, cause));
+
+        JobExecutionException e = assertThrows(JobExecutionException.class, () -> job.execute(context));
+        assertFalse(e.isTerminal());
+
+        verify(manifestManager, never()).deleteStoredManifest(any());
+    }
+
+    @Test
+    public void testJobConfigHasRetryCountForTransientRaceRetries() {
+        JobConfig jobConfig = ImportJob.createJobConfig();
+        assertTrue(jobConfig.getRetryCount() > 0);
+    }
+
+    @Test
+    public void testGenericExceptionIsTerminal() throws Exception {
+        Owner owner = this.createTestOwner("my-test-owner", "info");
+        doReturn(owner).when(ownerCurator).getByKey("my-test-owner");
+
+        String archiveFilePath = "/path/to/some/file.zip";
+        ConflictOverrides co = new ConflictOverrides(Importer.Conflict.SIGNATURE_CONFLICT);
+        String uploadedFileName = "test.zip";
+        String expectedMessage = "Something unexpected happened";
+
+        JobConfig jobConfig = ImportJob.createJobConfig()
+            .setOwner(owner)
+            .setUploadedFileName(uploadedFileName)
+            .setStoredFileId(archiveFilePath)
+            .setConflictOverrides(co);
+
+        ImportJob job = this.buildImportJob();
+
+        AsyncJobStatus status = mock(AsyncJobStatus.class);
+        JobExecutionContext context = spy(new JobExecutionContext(status));
+        doReturn(jobConfig.getJobArguments()).when(status).getJobArguments();
+
+        when(manifestManager.importStoredManifest(eq(owner), eq(archiveFilePath),
+            any(ConflictOverrides.class), eq(uploadedFileName)))
+            .thenThrow(new RuntimeException(expectedMessage));
+
+        JobExecutionException e = assertThrows(JobExecutionException.class, () -> job.execute(context));
+        assertEquals(expectedMessage, e.getMessage());
+        assertTrue(e.isTerminal());
+        verify(manifestManager).deleteStoredManifest(archiveFilePath);
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @ValueSource(classes = {ConstraintViolationException.class, LockAcquisitionException.class})
+    public void testGenericExceptionIsNonTerminalWhenCausedByTransientRace(
+        Class<? extends Exception> exceptionClass) throws Exception {
+
+        Owner owner = this.createTestOwner("my-test-owner", "info");
+        doReturn(owner).when(ownerCurator).getByKey("my-test-owner");
+
+        String archiveFilePath = "/path/to/some/file.zip";
+        ConflictOverrides co = new ConflictOverrides(Importer.Conflict.SIGNATURE_CONFLICT);
+        String uploadedFileName = "test.zip";
+        String expectedMessage = "Expected Exception Message";
+
+        JobConfig jobConfig = ImportJob.createJobConfig()
+            .setOwner(owner)
+            .setUploadedFileName(uploadedFileName)
+            .setStoredFileId(archiveFilePath)
+            .setConflictOverrides(co);
+
+        ImportJob job = this.buildImportJob();
+
+        AsyncJobStatus status = mock(AsyncJobStatus.class);
+        JobExecutionContext context = spy(new JobExecutionContext(status));
+        doReturn(jobConfig.getJobArguments()).when(status).getJobArguments();
+
+        doReturn(1).when(status).getAttempts();
+        doReturn(4).when(status).getMaxAttempts();
+
+        Exception cause;
+        if (exceptionClass == ConstraintViolationException.class) {
+            cause = new ConstraintViolationException(expectedMessage, null, null);
+        }
+        else {
+            cause = new LockAcquisitionException(expectedMessage, null);
+        }
+
+        when(manifestManager.importStoredManifest(eq(owner), eq(archiveFilePath),
+            any(ConflictOverrides.class), eq(uploadedFileName)))
+            .thenThrow(new RuntimeException(expectedMessage, cause));
+
+        JobExecutionException e = assertThrows(JobExecutionException.class, () -> job.execute(context));
+        assertFalse(e.isTerminal());
+
+        verify(manifestManager, never()).deleteStoredManifest(any());
+    }
 
     @Test
     public void ensureJobExceptionThrownIfOwnerNotFound() {

--- a/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
+++ b/src/test/java/org/candlepin/async/tasks/RefreshPoolsForProductJobTest.java
@@ -15,11 +15,14 @@
 package org.candlepin.async.tasks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -29,14 +32,19 @@ import org.candlepin.async.AsyncJob;
 import org.candlepin.async.JobConfig;
 import org.candlepin.async.JobConfigValidationException;
 import org.candlepin.async.JobExecutionContext;
+import org.candlepin.async.JobExecutionException;
 import org.candlepin.controller.Refresher;
 import org.candlepin.controller.RefresherFactory;
 import org.candlepin.model.Product;
 import org.candlepin.model.ProductCurator;
 import org.candlepin.service.SubscriptionServiceAdapter;
 
+import org.hibernate.exception.ConstraintViolationException;
+import org.hibernate.exception.LockAcquisitionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 
@@ -63,8 +71,7 @@ public class RefreshPoolsForProductJobTest {
         final Product product = new Product(INVALID_ID, VALID_NAME);
         product.setUuid(VALID_ID);
         final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig()
-            .setProduct(product)
-            .setLazy(false);
+            .setProduct(product);
         final JobExecutionContext context = mock(JobExecutionContext.class);
         doReturn(jobConfig.getJobArguments()).when(context).getJobArguments();
         doReturn(product).when(productCurator).get(eq(VALID_ID));
@@ -90,8 +97,7 @@ public class RefreshPoolsForProductJobTest {
         product.setUuid(VALID_ID);
 
         final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig()
-            .setProduct(product)
-            .setLazy(false);
+            .setProduct(product);
 
         try {
             jobConfig.validate();
@@ -106,8 +112,7 @@ public class RefreshPoolsForProductJobTest {
         final AsyncJob job = new RefreshPoolsForProductJob(productCurator, subAdapter, refresherFactory);
         final Product product = new Product(INVALID_ID, VALID_NAME);
         final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig()
-            .setProduct(product)
-            .setLazy(false);
+            .setProduct(product);
         final JobExecutionContext context = mock(JobExecutionContext.class);
         doReturn(jobConfig.getJobArguments()).when(context).getJobArguments();
 
@@ -125,8 +130,7 @@ public class RefreshPoolsForProductJobTest {
 
     @Test
     public void productMustBePresent() {
-        final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig()
-            .setLazy(false);
+        final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig();
 
         assertThrows(JobConfigValidationException.class, jobConfig::validate);
     }
@@ -136,21 +140,63 @@ public class RefreshPoolsForProductJobTest {
         final Product product = new Product(INVALID_ID, VALID_NAME);
 
         final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig()
-            .setProduct(product)
-            .setLazy(false);
+            .setProduct(product);
 
         assertThrows(JobConfigValidationException.class, jobConfig::validate);
     }
 
     @Test
-    public void lazyFlagMustBePresent() {
-        final Product product = new Product(VALID_ID, VALID_NAME);
+    public void testExceptionIsTerminalWhenNotCausedByTransientRace() {
+        final AsyncJob job = new RefreshPoolsForProductJob(productCurator, subAdapter, refresherFactory);
+        final Product product = new Product(INVALID_ID, VALID_NAME);
         product.setUuid(VALID_ID);
-
         final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig()
             .setProduct(product);
+        final JobExecutionContext context = mock(JobExecutionContext.class);
+        doReturn(jobConfig.getJobArguments()).when(context).getJobArguments();
+        doReturn(product).when(productCurator).get(eq(VALID_ID));
 
-        assertThrows(JobConfigValidationException.class, jobConfig::validate);
+        Refresher mockRefresher = mock(Refresher.class);
+        doReturn(mockRefresher).when(this.refresherFactory).getRefresher(any());
+        doReturn(mockRefresher).when(mockRefresher).add(any(Product.class));
+        doReturn(mockRefresher).when(mockRefresher).setLazyCertificateRegeneration(anyBoolean());
+        doThrow(new RuntimeException("unexpected failure")).when(mockRefresher).run();
+
+        JobExecutionException e = assertThrows(JobExecutionException.class, () -> job.execute(context));
+        assertTrue(e.isTerminal());
+    }
+
+    @ParameterizedTest(name = "{displayName} {index}: {0}")
+    @ValueSource(classes = {ConstraintViolationException.class, LockAcquisitionException.class})
+    public void testExceptionIsNonTerminalWhenCausedByTransientRace(
+        Class<? extends Exception> exceptionClass) {
+
+        final AsyncJob job = new RefreshPoolsForProductJob(productCurator, subAdapter, refresherFactory);
+        final Product product = new Product(INVALID_ID, VALID_NAME);
+        product.setUuid(VALID_ID);
+        final JobConfig jobConfig = RefreshPoolsForProductJob.createJobConfig()
+            .setProduct(product);
+        final JobExecutionContext context = mock(JobExecutionContext.class);
+        doReturn(jobConfig.getJobArguments()).when(context).getJobArguments();
+        doReturn(product).when(productCurator).get(eq(VALID_ID));
+
+        Refresher mockRefresher = mock(Refresher.class);
+        doReturn(mockRefresher).when(this.refresherFactory).getRefresher(any());
+        doReturn(mockRefresher).when(mockRefresher).add(any(Product.class));
+        doReturn(mockRefresher).when(mockRefresher).setLazyCertificateRegeneration(anyBoolean());
+
+        Exception cause;
+        if (exceptionClass == ConstraintViolationException.class) {
+            cause = new ConstraintViolationException("race", null, null);
+        }
+        else {
+            cause = new LockAcquisitionException("race", null);
+        }
+
+        doThrow(new RuntimeException("transient failure", cause)).when(mockRefresher).run();
+
+        JobExecutionException e = assertThrows(JobExecutionException.class, () -> job.execute(context));
+        assertFalse(e.isTerminal());
     }
 
 }

--- a/src/test/java/org/candlepin/controller/RefresherTest.java
+++ b/src/test/java/org/candlepin/controller/RefresherTest.java
@@ -32,6 +32,7 @@ import org.candlepin.model.dto.Subscription;
 import org.candlepin.service.SubscriptionServiceAdapter;
 import org.candlepin.test.DatabaseTestFixture;
 import org.candlepin.test.TestUtil;
+import org.candlepin.util.TransactionExecutionException;
 
 import com.google.inject.Inject;
 
@@ -168,7 +169,16 @@ public class RefresherTest extends DatabaseTestFixture {
 
     @ParameterizedTest(name = "{displayName} {index}: {0}")
     @ValueSource(classes = {ConstraintViolationException.class, LockAcquisitionException.class})
-    public void testRunShouldRetryTransactionForCertainException(Class<? extends Throwable> exception) {
+    public void testRunShouldNotRetryTransactionInPlaceForCertainException(
+        Class<? extends Throwable> exception) {
+
+        // Impl note:
+        // Refresher.run() used to retry here, but this method already runs inside an existing
+        // transaction. After a constraint violation or deadlock, that transaction is aborted,
+        // so retrying here would just fail again.
+        //
+        // Let the exception propagate so the caller can retry the whole operation with a fresh
+        // transaction.
         PoolManager mockPoolManager = Mockito.mock(PoolManager.class);
         refresher = new Refresher(mockPoolManager, this.subAdapter, this.ownerCurator, this.poolCurator,
             this.poolConverter);
@@ -192,23 +202,14 @@ public class RefresherTest extends DatabaseTestFixture {
         this.refresher.add(owner)
             .add(product);
 
-        // The transaction should be retried when the exception is thrown.
-        // So, throw the exception on the first invocation, but then succeed on the second invocation.
         doThrow(exception)
-            .doNothing()
             .when(mockPoolManager)
             .refreshPoolsWithRegeneration(any(SubscriptionServiceAdapter.class), any(Owner.class),
                 any(boolean.class));
 
-        this.refresher.run();
+        assertThrows(TransactionExecutionException.class, () -> this.refresher.run());
 
-        List<Pool> pools = this.poolCurator.listByOwner(owner);
-        assertThat(pools)
-            .isNotNull()
-            .singleElement()
-            .returns(product.getUuid(), Pool::getProductUuid);
-
-        verify(mockPoolManager, times(2))
+        verify(mockPoolManager, times(1))
             .refreshPoolsWithRegeneration(any(SubscriptionServiceAdapter.class), any(Owner.class),
                 any(boolean.class));
     }


### PR DESCRIPTION
For a reviewer lazy flag at refresh was 2 years ago set to true and the paramater was unused and it was itentionall and i check in the splunk nobody used that endpoint in past 30days so it should be safe to remove